### PR TITLE
Support per-channel encryption

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -7,6 +7,7 @@
 [diagram unchunked]: ./diagrams/unchunked.png
 [diagram chunked]: ./diagrams/chunked.png
 [feature explanations]: ./notes/explanatory-notes.md#feature-explanations
+[rfc5652 padding]: https://datatracker.ietf.org/doc/html/rfc5652#section-6.3
 
 > Status: DRAFT
 
@@ -164,9 +165,16 @@ IDs must uniquely identify a channel across the entire file.
 | 4 + N | topic_name  | String                       | Topic                                                                                                                                                                      | /diagnostics                                                                                                               |
 | 4 + N | encoding    | String                       | Message Encoding                                                                                                                                                           | cdr, cbor, ros1, protobuf, etc.                                                                                            |
 | 4 + N | schema_name | String                       | Schema Name                                                                                                                                                                | std_msgs/Header                                                                                                            |
+| 4 + N | encryption  | String                       | Encryption algorithm                                                                                                                                                       | aes-128-gcm                                                                                                                |
+| 4 + N | key_id      | String                       | Key ID                                                                                                                                                                     | "1", "2", "68354227", etc                                                                                                  |
 | 4+N   | schema      | uint32 length-prefixed bytes | Schema                                                                                                                                                                     |                                                                                                                            |
 | N     | user_data   | KeyValues<string, string>    | Metadata about this channel                                                                                                                                                | used to encode protocol-specific details like callerid, latching, QoS profiles... Refer to [supported profiles][profiles]. |
 | 4     | crc         | uint32                       | CRC checksum of preceding fields in the record. If advantageous for performance, zero may be recorded. Readers will need to skip checksum validation to parse such a file. |                                                                                                                            |
+
+Encryption and key ID are for per-channel encryption. To use these, the writer
+must associate an encryption key with a key ID, and the reader must be
+initialized with a decryption key and matching key ID. The currently-supported
+encryption algorithm is GCM mode AES with a 128 bit key.
 
 #### Message (op=0x04)
 

--- a/docs/specification/notes/explanatory-notes.md
+++ b/docs/specification/notes/explanatory-notes.md
@@ -3,6 +3,8 @@
 The following notes may be useful for users of the MCAP format, including
 implementers of readers and writers.
 
+[rfc5652 padding]: https://datatracker.ietf.org/doc/html/rfc5652#section-6.3
+
 ## Feature Explanations
 
 The format is intended to support efficient, indexed reading of messages and
@@ -125,3 +127,22 @@ details we may consider including, like references to per-channel encryption or
 compression if these features get uptake. We could also enable more interaction
 with the channel info records, such as quickly obtaining schemas from the file
 for particular topics.
+
+### Per-channel Encryption
+
+Per-channel encryption may be useful in situations where different topics are
+subject to different access controls. To encrypt a channel, the writer selects
+an encryption algorithm and generates an encryption key for that algorithm. The
+key is associated with a key ID, which is a free-form string.
+
+The key ID and algorithm are recorded in the channel info record for the
+channel to be encrypted. To read the channel, the reader must be initialized
+with a mapping from key ID to decryption key, with a key ID matching the one in
+the file.
+
+When the reader encounters a channel info record that indicates encryption will
+be required, it may decrypt messages on that channel prior to parsing them if
+it has a matching key ID, or skip over those messages if it does not.
+
+The currently-supported encryption algorithm is GCM mode AES with a 128 bit
+key.


### PR DESCRIPTION
Add support for per-channel encryption via key_id and encryption fields
in the channel info record.