### PR TITLE
Unwrap lines in Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           cache: yarn
 
       - run: yarn install --frozen-lockfile
-      - run: yarn run prettier docs --check
+      - run: yarn lint:docs
 
   typescript:
     runs-on: ubuntu-latest
@@ -29,6 +29,5 @@ jobs:
           cache: yarn
 
       - run: yarn install --frozen-lockfile
-      - run: yarn run prettier docs/* --check
       - run: yarn workspace @foxglove/mcap lint:ci
       - run: yarn workspace @foxglove/mcap test

--- a/docs/.prettierrc.yml
+++ b/docs/.prettierrc.yml
@@ -1,0 +1,1 @@
+proseWrap: never

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -12,11 +12,7 @@
 
 ## Overview
 
-MCAP is a container file format for append-only storage of
-heterogeneously-schematized data. It is inspired by the ROS1 bag format and is
-intended to support flexible serialization options, while also generalizing to
-non-ROS systems and retaining characteristics such as self-containment and
-chunk compression. Features include:
+MCAP is a container file format for append-only storage of heterogeneously-schematized data. It is inspired by the ROS1 bag format and is intended to support flexible serialization options, while also generalizing to non-ROS systems and retaining characteristics such as self-containment and chunk compression. Features include:
 
 - Single-pass, indexed writes (no backward seeking)
 - Flexible message serialization options (e.g. ros1, protobuf, …)
@@ -30,37 +26,20 @@ chunk compression. Features include:
 
 Some helpful terms to understand in the following sections are:
 
-- **Record**: A [TLV triplet][tlv wiki] with type and value corresponding to one
-  of the opcodes and schemas below.
+- **Record**: A [TLV triplet][tlv wiki] with type and value corresponding to one of the opcodes and schemas below.
 - **Topic**: A named message type and associated schema.
-- **Channel**: A logical stream that contains messages on a single topic.
-  Channels are associated with a numeric ID by the recorder - the **Channel ID**.
-- **Channel Info**: A type of record describing information about a channel,
-  notably containing the name and schema of the topic.
-- **Message**: A type of record representing a timestamped message on a channel
-  (and therefore associated with a topic/schema). A message can be parsed by a
-  reader that has also read the channel info for the channel on which the
-  message appears.
-- **Chunk**: A record type that wraps a compressed set of channel info and
-  message records.
-- **Attachment**: Extra data that may be included in the file, outside the
-  chunks. Attachments may be quickly listed and accessed via an index at the
-  end of the file.
-- **Index**: The format contains indexes for both messages and attachments. For
-  messages, there are two levels of indexing - a **Chunk Index** at the end of
-  the file points to chunks by offset, enabling fast location of chunks based
-  on topic and timerange. A second index - the **Message Index** - after each
-  chunk contains, for each channel in the chunk, and offset and timestamp for
-  every message to allow fast location of messages within the decompressed
-  chunk data.
+- **Channel**: A logical stream that contains messages on a single topic. Channels are associated with a numeric ID by the recorder - the **Channel ID**.
+- **Channel Info**: A type of record describing information about a channel, notably containing the name and schema of the topic.
+- **Message**: A type of record representing a timestamped message on a channel (and therefore associated with a topic/schema). A message can be parsed by a reader that has also read the channel info for the channel on which the message appears.
+- **Chunk**: A record type that wraps a compressed set of channel info and message records.
+- **Attachment**: Extra data that may be included in the file, outside the chunks. Attachments may be quickly listed and accessed via an index at the end of the file.
+- **Index**: The format contains indexes for both messages and attachments. For messages, there are two levels of indexing - a **Chunk Index** at the end of the file points to chunks by offset, enabling fast location of chunks based on topic and timerange. A second index - the **Message Index** - after each chunk contains, for each channel in the chunk, and offset and timestamp for every message to allow fast location of messages within the decompressed chunk data.
 
-  The attachment index at the end of the file allows for fast listing and
-  location of attachments based on name, timestamp, or attachment type.
+  The attachment index at the end of the file allows for fast listing and location of attachments based on name, timestamp, or attachment type.
 
 ## Format Description
 
-An MCAP file is physically structured as a series of concatenated, type- and
-length-prefixed **"records"**, capped on each end with magic bytes:
+An MCAP file is physically structured as a series of concatenated, type- and length-prefixed **"records"**, capped on each end with magic bytes:
 
     <MAGIC>[<record type><record len><record>...]<MAGIC>
 
@@ -68,16 +47,9 @@ These are the magic bytes:
 
     0x89, M, C, A, P, 0x30, \r, \n
 
-> Note: The version byte (ASCII zero 0x30) following "MCAP" will be updated to
-> 1 (0x31) upon ratification of this specification. Until then, backward
-> compatibility is not guaranteed.
+> Note: The version byte (ASCII zero 0x30) following "MCAP" will be updated to 1 (0x31) upon ratification of this specification. Until then, backward compatibility is not guaranteed.
 
-MCAP files may be **"chunked"** or **"unchunked"**. Chunked and unchunked files
-have different constraints on the layout of record types in the file. In
-chunked files, messages are grouped into optionally-compressed blocks of data
-before being written to disk. In an unchunked file, each message is written out
-uncompressed. See the diagrams below for clarity (the record types shown are
-described in the following section):
+MCAP files may be **"chunked"** or **"unchunked"**. Chunked and unchunked files have different constraints on the layout of record types in the file. In chunked files, messages are grouped into optionally-compressed blocks of data before being written to disk. In an unchunked file, each message is written out uncompressed. See the diagrams below for clarity (the record types shown are described in the following section):
 
 #### Chunked
 
@@ -92,36 +64,26 @@ Benefits of chunked files include:
 - Support for random access via time- and topic-based indexing.
 - Reduced storage requirements when recording or processing data.
 - Reduced bandwidth requirements when transferring over a network.
-- Possibly higher write performance if the cost of IO outweighs the cost of
-  compression.
+- Possibly higher write performance if the cost of IO outweighs the cost of compression.
 
 Benefits of unchunked files include:
 
 - Higher write performance on CPU-constrained systems.
-- Less potential for data los in case of a recording crash. No
-  "to-be-compressed" buffer is dropped by the recorder -- though the protocol
-  makes no specification on how the process syncs unchunked messages to disk.
+- Less potential for data los in case of a recording crash. No "to-be-compressed" buffer is dropped by the recorder -- though the protocol makes no specification on how the process syncs unchunked messages to disk.
 
-Unchunked files are less friendly to readers than chunked files due to their
-lack of an index and greater size. When unchunked files are in use, they may be
-converted to chunked files in post-processing to mitigate this.
+Unchunked files are less friendly to readers than chunked files due to their lack of an index and greater size. When unchunked files are in use, they may be converted to chunked files in post-processing to mitigate this.
 
 ### Record Types
 
-Record types are identified by single-byte **opcodes**. Record opcodes in the
-range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are
-reserved for application extensions and user proposals.
+Record types are identified by single-byte **opcodes**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for application extensions and user proposals.
 
 ##### Serialization and Notation
 
-The section below uses the following data types and serialization choices. In
-all cases integers are serialized little endian:
+The section below uses the following data types and serialization choices. In all cases integers are serialized little endian:
 
-- **Timestamp**: uint64 nanoseconds since a user-understood epoch (i.e unix
-  epoch, robot boot time, etc)
+- **Timestamp**: uint64 nanoseconds since a user-understood epoch (i.e unix epoch, robot boot time, etc)
 - **String**: a uint32-prefixed UTF8 string
-- **KeyValues<T1, T2>**: A uint32 length-prefixed association of key-value pairs,
-  serialized as
+- **KeyValues<T1, T2>**: A uint32 length-prefixed association of key-value pairs, serialized as
 
 ```
 <length><T1 (key)><T2 (value)><T1 (key)><T2 (value)>
@@ -129,151 +91,131 @@ all cases integers are serialized little endian:
 
 An empty KeyValues consists of a zero-value length prefix.
 
-- **Bytes**: refers to an array of bytes, without a length prefix. If a length
-  prefix is required a designation like "uint32 length-prefixed bytes" will be
-  used.
+- **Bytes**: refers to an array of bytes, without a length prefix. If a length prefix is required a designation like "uint32 length-prefixed bytes" will be used.
 
 #### Header (op=0x01)
 
 The first record in every mcap file is a header.
 
-| Bytes | Name     | Type                      | Description                                                                                                                                                                                                                                                                                                                                           |
-| ----- | -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4+n   | profile  | String                    | The profile to use for interpretation of channel info user data. If the value matches one of the [supported profiles][profiles], the channel info user data section should be structured to match the description in the corresponding profile. This field may also be supplied empty, or containing a framework that is not one of those recognized. |
-| N     | library  | String                    | freeform string for writer to specify its name, version, or other information for use in debugging                                                                                                                                                                                                                                                    |
-| N     | metadata | KeyValues<string, string> | Example keys: robot_id, git_sha, timezone, run_id.                                                                                                                                                                                                                                                                                                    |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 4+n | profile | String | The profile to use for interpretation of channel info user data. If the value matches one of the [supported profiles][profiles], the channel info user data section should be structured to match the description in the corresponding profile. This field may also be supplied empty, or containing a framework that is not one of those recognized. |
+| N | library | String | freeform string for writer to specify its name, version, or other information for use in debugging |
+| N | metadata | KeyValues<string, string> | Example keys: robot_id, git_sha, timezone, run_id. |
 
 #### Footer (op=0x02)
 
-| Bytes | Name         | Type   | Description                                                                                           |
-| ----- | ------------ | ------ | ----------------------------------------------------------------------------------------------------- |
-| 8     | index_offset | uint64 | Pointer to start of index section. If there are no records in the index section, this should be zero. |
-| 4     | index_crc    | uint32 | CRC of all data from index_offset through the byte immediately preceding this CRC. Optionally zero.   |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 8 | index_offset | uint64 | Pointer to start of index section. If there are no records in the index section, this should be zero. |
+| 4 | index_crc | uint32 | CRC of all data from index_offset through the byte immediately preceding this CRC. Optionally zero. |
 
-A file without a footer is **corrupt**, indicating the writer process encountered
-an unclean shutdown. It may be possible to recover data from a corrupt file.
+A file without a footer is **corrupt**, indicating the writer process encountered an unclean shutdown. It may be possible to recover data from a corrupt file.
 
 #### Channel Info (op=0x03)
 
-Identifies a stream of messages on a particular topic and includes information
-about how the messages should be decoded by readers. A channel info record must
-occur in the file prior to any message that references its Channel ID. Channel
-IDs must uniquely identify a channel across the entire file.
+Identifies a stream of messages on a particular topic and includes information about how the messages should be decoded by readers. A channel info record must occur in the file prior to any message that references its Channel ID. Channel IDs must uniquely identify a channel across the entire file.
 
-| Bytes | Name        | Type                         | Description                                                                                                                                                                | Example                                                                                                                    |
-| ----- | ----------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 2     | channel_id  | uint16                       | Channel ID 1                                                                                                                                                               | 1                                                                                                                          |
-| 4 + N | topic_name  | String                       | Topic                                                                                                                                                                      | /diagnostics                                                                                                               |
-| 4 + N | encoding    | String                       | Message Encoding                                                                                                                                                           | cdr, cbor, ros1, protobuf, etc.                                                                                            |
-| 4 + N | schema_name | String                       | Schema Name                                                                                                                                                                | std_msgs/Header                                                                                                            |
-| 4+N   | schema      | uint32 length-prefixed bytes | Schema                                                                                                                                                                     |                                                                                                                            |
-| N     | user_data   | KeyValues<string, string>    | Metadata about this channel                                                                                                                                                | used to encode protocol-specific details like callerid, latching, QoS profiles... Refer to [supported profiles][profiles]. |
-| 4     | crc         | uint32                       | CRC checksum of preceding fields in the record. If advantageous for performance, zero may be recorded. Readers will need to skip checksum validation to parse such a file. |                                                                                                                            |
+| Bytes | Name | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| 2 | channel_id | uint16 | Channel ID 1 | 1 |
+| 4 + N | topic_name | String | Topic | /diagnostics |
+| 4 + N | encoding | String | Message Encoding | cdr, cbor, ros1, protobuf, etc. |
+| 4 + N | schema_name | String | Schema Name | std_msgs/Header |
+| 4+N | schema | uint32 length-prefixed bytes | Schema |  |
+| N | user_data | KeyValues<string, string> | Metadata about this channel | used to encode protocol-specific details like callerid, latching, QoS profiles... Refer to [supported profiles][profiles]. |
+| 4 | crc | uint32 | CRC checksum of preceding fields in the record. If advantageous for performance, zero may be recorded. Readers will need to skip checksum validation to parse such a file. |  |
 
 #### Message (op=0x04)
 
-A message record encodes a single timestamped message on a particular channel.
-Message records may occur inside a Chunk, or outside the chunk in the
-case of an unchunked file. A chunked file may not have messages outside the
-chunks.
+A message record encodes a single timestamped message on a particular channel. Message records may occur inside a Chunk, or outside the chunk in the case of an unchunked file. A chunked file may not have messages outside the chunks.
 
-Message records must be preceded by a Channel Info record for the given channel
-ID. That Channel Info record may appear inside the same chunk as the message,
-or in an earlier chunk in the file. In an unchunked file, both the channel info
-and message records will be outside chunks, as there will be no chunks.
+Message records must be preceded by a Channel Info record for the given channel ID. That Channel Info record may appear inside the same chunk as the message, or in an earlier chunk in the file. In an unchunked file, both the channel info and message records will be outside chunks, as there will be no chunks.
 
-| Bytes | Name         | Type      | Description                                                                                                     |
-| ----- | ------------ | --------- | --------------------------------------------------------------------------------------------------------------- |
-| 2     | channel_id   | uint16    | Channel ID                                                                                                      |
-| 4     | sequence     | uint32    | Optional message counter assigned by publisher. If not assigned by publisher, must be recorded by the recorder. |
-| 8     | publish_time | Timestamp | Time at which the message was published. If not available, must be set to the record time.                      |
-| 8     | record_time  | Timestamp | Time at which the message was recorded by the recorder process.                                                 |
-| N     | message_data | Bytes     | Message data, to be decoded according to the schema of the channel.                                             |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 2 | channel_id | uint16 | Channel ID |
+| 4 | sequence | uint32 | Optional message counter assigned by publisher. If not assigned by publisher, must be recorded by the recorder. |
+| 8 | publish_time | Timestamp | Time at which the message was published. If not available, must be set to the record time. |
+| 8 | record_time | Timestamp | Time at which the message was recorded by the recorder process. |
+| N | message_data | Bytes | Message data, to be decoded according to the schema of the channel. |
 
 #### Chunk (op=0x05)
 
 A Chunk is a collection of compressed channel info and message records.
 
-| Bytes | Name              | Type   | Description                                                                                            | Example                                                                                                                      |
-| ----- | ----------------- | ------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| 8     | uncompressed_size | uint64 | Uncompressed size of of the "records" section.                                                         |
-| 4     | uncompressed_crc  | uint32 | CRC32 checksum of decompressed "records" section. May be set to zero if CRC validation isn't required. |
-| 4 + N | compression       | String | compression algorithm                                                                                  | lz4, zstd, "". A zero-length string indicates no compression. Refer to [supported compression formats][compression formats]. |
-| N     | records           | Bytes  | Concatenated records, compressed with the algorithm in the "compression" field.                        |
+| Bytes | Name | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| 8 | uncompressed_size | uint64 | Uncompressed size of of the "records" section. |
+| 4 | uncompressed_crc | uint32 | CRC32 checksum of decompressed "records" section. May be set to zero if CRC validation isn't required. |
+| 4 + N | compression | String | compression algorithm | lz4, zstd, "". A zero-length string indicates no compression. Refer to [supported compression formats][compression formats]. |
+| N | records | Bytes | Concatenated records, compressed with the algorithm in the "compression" field. |
 
 #### Message Index (op=0x06)
 
-The Message Index record maps timestamps to message offsets. One message index
-record is written for each channel in the preceding chunk. All message index
-records for a chunk must immediately follow the chunk.
+The Message Index record maps timestamps to message offsets. One message index record is written for each channel in the preceding chunk. All message index records for a chunk must immediately follow the chunk.
 
-| Bytes | Name       | Type                         | Description                                                                                                    |
-| ----- | ---------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| 2     | channel_id | uint16                       | Channel ID.                                                                                                    |
-| 4     | count      | uint32                       | Number of records in the chunk, on this channel.                                                               |
-| N     | records    | KeyValues<Timestamp, uint64> | Array of timestamp and offset for each record. Offset is relative to the start of the decompressed chunk data. |
-| 4     | crc        | uint32                       | CRC of preceding fields in the record. May be zeroed if not required.                                          |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 2 | channel_id | uint16 | Channel ID. |
+| 4 | count | uint32 | Number of records in the chunk, on this channel. |
+| N | records | KeyValues<Timestamp, uint64> | Array of timestamp and offset for each record. Offset is relative to the start of the decompressed chunk data. |
+| 4 | crc | uint32 | CRC of preceding fields in the record. May be zeroed if not required. |
 
 #### Chunk Index (op=0x07)
 
-The Chunk Index records form a coarse index of timestamps to chunk offsets,
-along with the locations of the message index records associatiated with those
-chunks.
+The Chunk Index records form a coarse index of timestamps to chunk offsets, along with the locations of the message index records associatiated with those chunks.
 
-| Bytes | Name                  | Type                      | Description                                                                                                                      |
-| ----- | --------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| 8     | start_time            | Timestamp                 | First message record timestamp in the chunk.                                                                                     |
-| 8     | end_time              | Timestamp                 | Last message record timestamp in the chunk.                                                                                      |
-| 8     | chunk_offset          | uint64                    | Offset to the chunk record from the start of the file.                                                                           |
-| N     | message_index_offsets | KeyValues<uint16, uint64> | Mapping from channel ID, to the offset of the message index record for that channel after the chunk, from the start of the file. |
-| 8     | message_index_length  | uint64                    | Total length in bytes of the message index records after the chunk, including lengths and opcodes.                               |
-| 4 + N | compression           | String                    | The compression used on this chunk. Refer to [supported compression formats][compression formats].                               |
-| 8     | compressed_size       | uint64                    | The compressed size of the chunk.                                                                                                |
-| 8     | decompressed_size     | uint64                    | The decompressed size of the chunk.                                                                                              |
-| 4     | crc                   | uint32                    | CRC of the preceding fields within the record.                                                                                   |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 8 | start_time | Timestamp | First message record timestamp in the chunk. |
+| 8 | end_time | Timestamp | Last message record timestamp in the chunk. |
+| 8 | chunk_offset | uint64 | Offset to the chunk record from the start of the file. |
+| N | message_index_offsets | KeyValues<uint16, uint64> | Mapping from channel ID, to the offset of the message index record for that channel after the chunk, from the start of the file. |
+| 8 | message_index_length | uint64 | Total length in bytes of the message index records after the chunk, including lengths and opcodes. |
+| 4 + N | compression | String | The compression used on this chunk. Refer to [supported compression formats][compression formats]. |
+| 8 | compressed_size | uint64 | The compressed size of the chunk. |
+| 8 | decompressed_size | uint64 | The decompressed size of the chunk. |
+| 4 | crc | uint32 | CRC of the preceding fields within the record. |
 
 #### Attachment (op=0x08)
 
-Attachments can be used to attach artifacts such as calibration data, text, or
-core dumps. Attachment records must not appear within a chunk.
+Attachments can be used to attach artifacts such as calibration data, text, or core dumps. Attachment records must not appear within a chunk.
 
-| Bytes | Name         | Type                         | Description                                             |
-| ----- | ------------ | ---------------------------- | ------------------------------------------------------- |
-| 4+N   | name         | String                       | Name of the attachment, e.g "scene1.jpg".               |
-| 8     | record_time  | Timestamp                    | Time at which the attachment was recorded.              |
-| 4+N   | content_type | String                       | MIME Type (e.g "text/plain").                           |
-| 8+N   | data         | uint64 length-prefixed bytes | Size of the attachment.                                 |
-| 4     | crc          | uint32                       | CRC of preceding fields in the record. Optionally zero. |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 4+N | name | String | Name of the attachment, e.g "scene1.jpg". |
+| 8 | record_time | Timestamp | Time at which the attachment was recorded. |
+| 4+N | content_type | String | MIME Type (e.g "text/plain"). |
+| 8+N | data | uint64 length-prefixed bytes | Size of the attachment. |
+| 4 | crc | uint32 | CRC of preceding fields in the record. Optionally zero. |
 
 #### Attachment Index (op=0x09)
 
-The attachment index is an index to named attachments within the file. One
-record is recorded per attachment in the file.
+The attachment index is an index to named attachments within the file. One record is recorded per attachment in the file.
 
-| Bytes | Name            | Type      | Description                                                |
-| ----- | --------------- | --------- | ---------------------------------------------------------- |
-| 8     | record_time     | Timestamp | Timestamp at which the attachment was recorded.            |
-| 8     | attachment_size | uint64    | Size of the attachment.                                    |
-| 4 + N | name            | String    | Name of the attachment.                                    |
-| 4 + N | content_type    | String    | MIME type of the attachment.                               |
-| 8     | offset          | uint64    | Byte offset to the attachment, from the start of the file. |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 8 | record_time | Timestamp | Timestamp at which the attachment was recorded. |
+| 8 | attachment_size | uint64 | Size of the attachment. |
+| 4 + N | name | String | Name of the attachment. |
+| 4 + N | content_type | String | MIME type of the attachment. |
+| 8 | offset | uint64 | Byte offset to the attachment, from the start of the file. |
 
 #### Statistics (op=0x0A)
 
-The statistics record contains statistics about the recorded data. It is the
-last record in the file before the footer.
+The statistics record contains statistics about the recorded data. It is the last record in the file before the footer.
 
-| Bytes | Name             | Type                      | Description                                                    |
-| ----- | ---------------- | ------------------------- | -------------------------------------------------------------- |
-| 8     | message_count    | uint64                    | Number of messages in the file across all topics.              |
-| 4     | channel_count    | uint32                    | Number of channels in the file across all topics.              |
-| 4     | attachment_count | uint32                    | Number of attachments in the file.                             |
-| 4     | chunk_count      | uint32                    | Number of chunks in the file.                                  |
-| N     | channel_stats    | KeyValues<uint16, uint64> | Array of channel IDs and total message counts for the channel. |
+| Bytes | Name | Type | Description |
+| --- | --- | --- | --- |
+| 8 | message_count | uint64 | Number of messages in the file across all topics. |
+| 4 | channel_count | uint32 | Number of channels in the file across all topics. |
+| 4 | attachment_count | uint32 | Number of attachments in the file. |
+| 4 | chunk_count | uint32 | Number of chunks in the file. |
+| N | channel_stats | KeyValues<uint16, uint64> | Array of channel IDs and total message counts for the channel. |
 
 ## Further Reading
 
 Useful links below:
 
-- [Feature explanations][feature explanations]: includes usage details that may
-  be useful to implementers of readers or writers.
+- [Feature explanations][feature explanations]: includes usage details that may be useful to implementers of readers or writers.

--- a/docs/specification/compression/supported-compression-formats.md
+++ b/docs/specification/compression/supported-compression-formats.md
@@ -5,7 +5,5 @@
 
 MCAP-supported chunk compression formats are listed below:
 
-- [lz4][lz4]: an algorithm that prioritizes compression/decompression speed over
-  compression ratio.
-- [zstd][zstd]: an algorithm that prioritizes compression ratio over
-  compression/decompression speed.
+- [lz4][lz4]: an algorithm that prioritizes compression/decompression speed over compression ratio.
+- [zstd][zstd]: an algorithm that prioritizes compression ratio over compression/decompression speed.

--- a/docs/specification/notes/explanatory-notes.md
+++ b/docs/specification/notes/explanatory-notes.md
@@ -1,26 +1,18 @@
 # Explanatory Notes
 
-The following notes may be useful for users of the MCAP format, including
-implementers of readers and writers.
+The following notes may be useful for users of the MCAP format, including implementers of readers and writers.
 
 ## Feature Explanations
 
-The format is intended to support efficient, indexed reading of messages and
-generation of summary data in both local and remote contexts. "Seeking" should
-be imagined to incur either a disk seek or an HTTP range request to an object
-store -- the latter being significantly more costly.
+The format is intended to support efficient, indexed reading of messages and generation of summary data in both local and remote contexts. "Seeking" should be imagined to incur either a disk seek or an HTTP range request to an object store -- the latter being significantly more costly.
 
 ### Scanning for records on specific topics within an interval
 
-The index is designed to support fast local and remote seek/filter operations
-with minimal seeking or range request overhead. The operation of the index for
-message reading is as follows:
+The index is designed to support fast local and remote seek/filter operations with minimal seeking or range request overhead. The operation of the index for message reading is as follows:
 
 1. Client queries for all messages on topics /a, /b, /c between t0 and t1
 2. Reader reads the fixed-length footer off the end of the file
-3. Reader parses the index_offset from the footer, and starts reading from that
-   offset to the end of the file. During this read it will encounter the
-   following in order:
+3. Reader parses the index_offset from the footer, and starts reading from that offset to the end of the file. During this read it will encounter the following in order:
    - A run of channel info records, one per channel in the file
    - A run of Message Group Index records, one per chunk in the file
    - The attachment index records
@@ -28,46 +20,26 @@ message reading is as follows:
 
 The reader in this case will stop after the chunk index records.
 
-4. Using the channel info records at the start of the read, the reader converts
-   topic names to channel IDs.
-5. Using the chunk index records, the reader locates the chunks that must be read,
-   based on the requested start times, channel IDs, and end times. These chunks
-   will be a contiguous run.
+4. Using the channel info records at the start of the read, the reader converts topic names to channel IDs.
+5. Using the chunk index records, the reader locates the chunks that must be read, based on the requested start times, channel IDs, and end times. These chunks will be a contiguous run.
 6. Readers may access the message data in at least two ways,
-   - “full scan”: Seek from the chunk index to the start of the chunk using
-     chunk_offset. Read/decompress the entire chunk, discarding messages not on
-     the requested channels. Skip through the index data and into the next
-     chunk if it is targeted too.
-   - “index scan”: Consult the message_index_offsets field in the chunk index
-     record, and use it to locate specific message indexes after the chunk for
-     the channels of interest. These message indexes can be used to obtain a
-     list of offsets, which the reader can seek to and extract messages from.
+   - “full scan”: Seek from the chunk index to the start of the chunk using chunk_offset. Read/decompress the entire chunk, discarding messages not on the requested channels. Skip through the index data and into the next chunk if it is targeted too.
+   - “index scan”: Consult the message_index_offsets field in the chunk index record, and use it to locate specific message indexes after the chunk for the channels of interest. These message indexes can be used to obtain a list of offsets, which the reader can seek to and extract messages from.
 
-Which of these options is preferable will tend to depend on the proportion of
-topics in use, as well as potentially whether the storage system is local or
-remote.
+Which of these options is preferable will tend to depend on the proportion of topics in use, as well as potentially whether the storage system is local or remote.
 
 ### Listing and accessing attachments
 
-The format provides the ability to list attachments contained wihtin the file,
-and quickly extract them from the file contents. To list/select attachments
-in the file:
+The format provides the ability to list attachments contained wihtin the file, and quickly extract them from the file contents. To list/select attachments in the file:
 
-1. Read the fixed-length footer and seek to the start of the index data
-   section.
-2. Scan forward until encountering the attachment index, then read attachment
-   index records until encountering a record that is not an attachment index.
-3. The rcords covered in the previous read will include attachment names,
-   types, sizes, and timestamps. These can be used to fill out a list of
-   attachments for selection.
-4. To select an attachment from th efile, seek to the associated offset in the
-   file and unpack the file content from the attachment record.
+1. Read the fixed-length footer and seek to the start of the index data section.
+2. Scan forward until encountering the attachment index, then read attachment index records until encountering a record that is not an attachment index.
+3. The rcords covered in the previous read will include attachment names, types, sizes, and timestamps. These can be used to fill out a list of attachments for selection.
+4. To select an attachment from th efile, seek to the associated offset in the file and unpack the file content from the attachment record.
 
 ### Accessing summary statistics
 
-The format provides for fast local or remote access to summary information in
-the same style as "rosbag info", with the intent of functional parity with
-rosbag info. For reference, here is an example of the rosbag info output:
+The format provides for fast local or remote access to summary information in the same style as "rosbag info", with the intent of functional parity with rosbag info. For reference, here is an example of the rosbag info output:
 
 ```
 path:         demo.bag
@@ -98,30 +70,11 @@ topics:        /diagnostics               52 msgs    : diagnostic_msgs/Diagnosti
 The reader will recover this data from the index as follows:
 
 1. Read the fixed length footer and seek to the index_offset.
-2. Read the run of channel info records that follow to get topic names, types,
-   and MD5 data (which in case of ROS1 will be in the user data section), as well
-   as channel IDs to interpret the chunk index records.
-3. After the channel infos are the chunk index records, if the file is chunked.
-   From each chunk index record extract the compression algorithm and
-   compressed/uncompressed size. From these the reader can compute the compression
-   statistics shown in the rosbag info summary. For unchunked files this field is
-   omitted.
-4. The MCAP version of “rosbag info” will display information about included
-   attachments as well. After reading the chunk index records, the attachment
-   index records will be scanned and incorporated into the summary.
-5. Finally, the statistics record is used to compute the start, end, total, and
-   per-channel message counts. The per-channel message counts must be
-   grouped/summed over topics for display.
+2. Read the run of channel info records that follow to get topic names, types, and MD5 data (which in case of ROS1 will be in the user data section), as well as channel IDs to interpret the chunk index records.
+3. After the channel infos are the chunk index records, if the file is chunked. From each chunk index record extract the compression algorithm and compressed/uncompressed size. From these the reader can compute the compression statistics shown in the rosbag info summary. For unchunked files this field is omitted.
+4. The MCAP version of “rosbag info” will display information about included attachments as well. After reading the chunk index records, the attachment index records will be scanned and incorporated into the summary.
+5. Finally, the statistics record is used to compute the start, end, total, and per-channel message counts. The per-channel message counts must be grouped/summed over topics for display.
 
-The only difference between the chunked and unchunked versions of this output
-will be the chunk compression statistics (“compressed”, “uncompressed”,
-“compression”), which will be omitted in the case of unchunked files. The
-summary should be very fast to generate in either local or remote contexts,
-requiring no seeking around the file to visit chunks.
+The only difference between the chunked and unchunked versions of this output will be the chunk compression statistics (“compressed”, “uncompressed”, “compression”), which will be omitted in the case of unchunked files. The summary should be very fast to generate in either local or remote contexts, requiring no seeking around the file to visit chunks.
 
-The above is not meant to prescribe a summary formatting, but to demonstrate
-that parity with the rosbag summary is supported by MCAP. There are other
-details we may consider including, like references to per-channel encryption or
-compression if these features get uptake. We could also enable more interaction
-with the channel info records, such as quickly obtaining schemas from the file
-for particular topics.
+The above is not meant to prescribe a summary formatting, but to demonstrate that parity with the rosbag summary is supported by MCAP. There are other details we may consider including, like references to per-channel encryption or compression if these features get uptake. We could also enable more interaction with the channel info records, such as quickly obtaining schemas from the file for particular topics.

--- a/docs/specification/profiles/README.md
+++ b/docs/specification/profiles/README.md
@@ -3,18 +3,9 @@
 [ros1]: ./ros1.md
 [ros2]: ./ros2.md
 
-This directory contains supported "profiles" for MCAP channel info user data.
-Usage of these profiles is not mandatory, but may be helpful to third party
-tooling in better understanding and displaying your data. For instance, an
-application that reads a "latching" key from a channel info record will not
-necessarily know what to do with the value - however if the reader knows the
-MCAP file is recorded with the "ros1" profile, it can make an inference that
-this is indicating a "latching topic" and behave accordingly.
+This directory contains supported "profiles" for MCAP channel info user data. Usage of these profiles is not mandatory, but may be helpful to third party tooling in better understanding and displaying your data. For instance, an application that reads a "latching" key from a channel info record will not necessarily know what to do with the value - however if the reader knows the MCAP file is recorded with the "ros1" profile, it can make an inference that this is indicating a "latching topic" and behave accordingly.
 
-To make use of a profile, simply include the name of the profile in the
-"profile" field in the file header, and include the required keys in the user
-data section of all channel info records in the file. Additional keys can be
-added beyond those required by the profile as desired.
+To make use of a profile, simply include the name of the profile in the "profile" field in the file header, and include the required keys in the user data section of all channel info records in the file. Additional keys can be added beyond those required by the profile as desired.
 
 Supported profiles are listed below:
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
       "typescript"
     ]
   },
+  "scripts": {
+    "lint:docs": "prettier docs --check"
+  },
   "devDependencies": {
     "prettier": "^2.5.1"
   }


### PR DESCRIPTION
Prettier has a setting to unwrap lines of text in Markdown. Not wrapping allows editors to display text at the user's desired width, and also reduces the number of lines that have diffs with each edit.