### PR TITLE
typescript: add json and protobuf encoding support to validate script

### DIFF
--- a/typescript/typings/protobufjs.d.ts
+++ b/typescript/typings/protobufjs.d.ts
@@ -8,4 +8,7 @@ declare module "protobufjs" {
       protoVersion: string,
     ): protobufjs.Message<descriptor.IFileDescriptorSet> & descriptor.IFileDescriptorSet;
   }
+  declare namespace ReflectionObject {
+    export const fromDescriptor: (desc: protobufjs.Message) => protobufjs.Root;
+  }
 }


### PR DESCRIPTION
`validate` script now supports `protobuf` and `json` encodings (similar to [ws-protocol](https://github.com/foxglove/ws-protocol)).