### PR TITLE
[C++] Add noChunking and noIndexing options

### DIFF
--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -19,7 +19,7 @@ static void BM_McapWriterBufferedWriterUnchunked(benchmark::State& state) {
   // Create an unchunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.chunked = false;
+  options.noChunking = true;
 
   // Open an output memory buffer and write the file header
   mcap::BufferedWriter out{};
@@ -61,7 +61,51 @@ static void BM_McapWriterBufferedWriterChunked(benchmark::State& state) {
   // Create a chunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.chunked = true;
+  options.noChunking = false;
+  options.chunkSize = uint64_t(state.range(1));
+
+  // Open an output memory buffer and write the file header
+  mcap::BufferedWriter out{};
+  writer.open(out, options);
+
+  // Register a Channel Info record
+  mcap::ChannelInfo topic("/chatter", "ros1", "std_msgs/String", StringSchema);
+  writer.addChannel(topic);
+
+  // Create a message
+  mcap::Message msg;
+  msg.channelId = topic.channelId;
+  msg.sequence = 0;
+  msg.publishTime = 0;
+  msg.recordTime = msg.publishTime;
+  msg.data = payload.data();
+  msg.dataSize = payload.size();
+
+  const auto iterations = size_t(state.range(0));
+
+  while (state.KeepRunning()) {
+    for (size_t i = 0; i < iterations; i++) {
+      writer.write(msg);
+      benchmark::ClobberMemory();
+    }
+  }
+
+  // Finish writing the file to memory
+  writer.close();
+}
+
+static void BM_McapWriterBufferedWriterChunkedUnindexed(benchmark::State& state) {
+  // Create a message payload
+  std::array<std::byte, 4 + 13> payload;
+  const uint32_t length = 13;
+  std::memcpy(payload.data(), &length, 4);
+  std::memcpy(payload.data() + 4, "Hello, world!", 13);
+
+  // Create a chunked writer using the ros1 profile
+  mcap::McapWriter writer;
+  auto options = mcap::McapWriterOptions("ros1");
+  options.noChunking = false;
+  options.noIndexing = true;
   options.chunkSize = uint64_t(state.range(1));
 
   // Open an output memory buffer and write the file header
@@ -104,7 +148,7 @@ static void BM_McapWriterStreamWriterUnchunked(benchmark::State& state) {
   // Create an unchunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.chunked = false;
+  options.noChunking = true;
 
   // Open an output file stream and write the file header
   std::ofstream out("benchmark.mcap", std::ios::binary);
@@ -147,7 +191,7 @@ static void BM_McapWriterStreamWriterChunked(benchmark::State& state) {
   // Create a chunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.chunked = true;
+  options.noChunking = false;
   options.chunkSize = uint64_t(state.range(1));
 
   // Open an output file stream and write the file header
@@ -187,6 +231,16 @@ int main(int argc, char* argv[]) {
     ->Arg(10000);
   benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterChunked",
                                BM_McapWriterBufferedWriterChunked)
+    ->Args({10000, 1})
+    ->Args({10000, 10})
+    ->Args({10000, 100})
+    ->Args({10000, 1000})
+    ->Args({10000, 10000})
+    ->Args({10000, 100000})
+    ->Args({10000, 1000000})
+    ->Args({10000, 10000000});
+  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterChunkedUnindexed",
+                               BM_McapWriterBufferedWriterChunkedUnindexed)
     ->Args({10000, 1})
     ->Args({10000, 10})
     ->Args({10000, 100})

--- a/cpp/examples/bag2mcap.cpp
+++ b/cpp/examples/bag2mcap.cpp
@@ -17,7 +17,6 @@ int main() {
   mcap::McapWriter writer;
 
   auto options = mcap::McapWriterOptions("ros1");
-  options.chunked = true;  // set this to false to write an unchunked file
 
   std::ofstream out("output.mcap", std::ios::binary);
   writer.open(out, options);


### PR DESCRIPTION
```
-----------------------------------------------------------------------------------------------------
Benchmark                                                           Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------
BM_McapWriterBufferedWriterUnchunked/10000                     527408 ns       505043 ns         1059
BM_McapWriterBufferedWriterChunked/10000/1                    3149211 ns      3060438 ns          256
BM_McapWriterBufferedWriterChunked/10000/10                   3027427 ns      2984569 ns          267
BM_McapWriterBufferedWriterChunked/10000/100                  1531306 ns      1531300 ns          454
BM_McapWriterBufferedWriterChunked/10000/1000                  854305 ns       854271 ns          846
BM_McapWriterBufferedWriterChunked/10000/10000                 764178 ns       750305 ns         1053
BM_McapWriterBufferedWriterChunked/10000/100000                679867 ns       679862 ns         1033
BM_McapWriterBufferedWriterChunked/10000/1000000               694254 ns       689724 ns         1135
BM_McapWriterBufferedWriterChunked/10000/10000000              771078 ns       757178 ns         1078
BM_McapWriterBufferedWriterChunkedUnindexed/10000/1            934455 ns       934431 ns          708
BM_McapWriterBufferedWriterChunkedUnindexed/10000/10          1040633 ns      1025128 ns          743
BM_McapWriterBufferedWriterChunkedUnindexed/10000/100          714908 ns       709739 ns         1083
BM_McapWriterBufferedWriterChunkedUnindexed/10000/1000         564772 ns       558905 ns         1364
BM_McapWriterBufferedWriterChunkedUnindexed/10000/10000        496412 ns       496373 ns         1371
BM_McapWriterBufferedWriterChunkedUnindexed/10000/100000       523430 ns       523421 ns         1000
BM_McapWriterBufferedWriterChunkedUnindexed/10000/1000000      517064 ns       509593 ns         1453
BM_McapWriterBufferedWriterChunkedUnindexed/10000/10000000     500410 ns       500407 ns         1000
BM_McapWriterStreamWriterUnchunked/10000                      1410408 ns      1401746 ns          497
BM_McapWriterStreamWriterChunked/10000/1                      4892328 ns      4877507 ns          144
BM_McapWriterStreamWriterChunked/10000/10                     4943471 ns      4942349 ns          146
BM_McapWriterStreamWriterChunked/10000/100                    3066109 ns      2972791 ns          235
BM_McapWriterStreamWriterChunked/10000/1000                   2108015 ns      2070677 ns          341
BM_McapWriterStreamWriterChunked/10000/10000                  1828879 ns      1817512 ns          391
BM_McapWriterStreamWriterChunked/10000/100000                 1768920 ns      1757709 ns          378
BM_McapWriterStreamWriterChunked/10000/1000000                1559889 ns      1550117 ns          452
BM_McapWriterStreamWriterChunked/10000/10000000               1791214 ns      1754818 ns          495
```