### PR TITLE
spec: cleanup profiles

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -101,7 +101,7 @@ The first record in every MCAP file is a header.
 
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |
-| 4 + N | profile | String | The profile to use for interpretation of channel info user data. If the value matches one of the [supported profiles][profiles], the channel info user data section should be structured to match the description in the corresponding profile. This field may also be supplied empty, or containing a framework that is not one of those recognized. |
+| 4 + N | profile | String | The profile to use for interpretation of open-ended fields within records (i.e. encoding, user data, schema, etc). If the value matches one of the [supported profiles][profiles], the file should conform to the profile. This field may also be supplied empty or containing a framework that is not one of those recognized. When specifying a custom profile prefer the `x-` prefix to avoid conflict with future supported profiles. |
 | N | library | String | freeform string for writer to specify its name, version, or other information for use in debugging |
 | N | metadata | KeyValues<string, string> | Example keys: robot_id, git_sha, timezone, run_id. |
 
@@ -127,7 +127,7 @@ Identifies a stream of messages on a particular topic and includes information a
 | 4 + N | encoding | String | Message Encoding | cdr, cbor, ros1, protobuf, etc. |
 | 4 + N | schema_name | String | Schema Name | std_msgs/Header |
 | 4 + N | schema | uint32 length-prefixed bytes | Schema |  |
-| N | user_data | KeyValues<string, string> | Metadata about this channel | used to encode protocol-specific details like callerid, latching, QoS profiles... Refer to [supported profiles][profiles]. |
+| N | user_data | KeyValues<string, string> | Metadata about this channel | user specifed data |
 | 4 | crc | uint32 | CRC32 checksum of preceding fields in the record (not including the record opcode and length prefix). A value of zero indicates that CRC validation should not be performed. |  |
 
 #### Message (op=0x04)

--- a/docs/specification/profiles/README.md
+++ b/docs/specification/profiles/README.md
@@ -1,13 +1,6 @@
-## Supported profiles
+## Profiles
 
-[ros1]: ./ros1.md
-[ros2]: ./ros2.md
+Well-known MCAP profiles:
 
-This directory contains supported "profiles" for MCAP channel info user data. Usage of these profiles is not mandatory, but may be helpful to third party tooling in better understanding and displaying your data. For instance, an application that reads a "latching" key from a channel info record will not necessarily know what to do with the value - however if the reader knows the MCAP file is recorded with the "ros1" profile, it can make an inference that this is indicating a "latching topic" and behave accordingly.
-
-To make use of a profile, simply include the name of the profile in the "profile" field in the file header, and include the required keys in the user data section of all channel info records in the file. Additional keys can be added beyond those required by the profile as desired.
-
-Supported profiles are listed below:
-
-- [ros1][ros1]
-- [ros2][ros2]
+- [ros1](./ros1.md)
+- [ros2](./ros2.md)

--- a/docs/specification/profiles/ros1.md
+++ b/docs/specification/profiles/ros1.md
@@ -1,8 +1,19 @@
-## ROS1 Profile
+## ROS1
 
-Profile name: "ros1".
+Profile: **ros1**
 
-Channel info records serialized with the "ros1" profile may include the following fields:
+The `ros1` profile describes how to create mcap files for v1 of the [ROS](https://ros.org/) framework.
+
+### Channel Info
+
+| field       | value            |
+| ----------- | ---------------- |
+| encoding    | ros1             |
+| schema      | .MSG             |
+| schema_name | package/datatype |
+| user_data   | See below        |
+
+#### user_data
 
 - callerid (optional, string)
 - latching (optional, bool stringified as "true" or "false")

--- a/docs/specification/profiles/ros1.md
+++ b/docs/specification/profiles/ros1.md
@@ -6,12 +6,12 @@ The `ros1` profile describes how to create mcap files for v1 of the [ROS](https:
 
 ### Channel Info
 
-| field       | value            |
-| ----------- | ---------------- |
-| encoding    | ros1             |
-| schema      | .MSG             |
-| schema_name | package/datatype |
-| user_data   | See below        |
+| field       | value                                    |
+| ----------- | ---------------------------------------- |
+| encoding    | ros1                                     |
+| schema      | [.msg](http://wiki.ros.org/msg)          |
+| schema_name | `package/datatype`, e.g. `my_msgs/Thing` |
+| user_data   | See below                                |
 
 #### user_data
 

--- a/docs/specification/profiles/ros2.md
+++ b/docs/specification/profiles/ros2.md
@@ -8,9 +8,9 @@ The `ros2` profile describes how to create mcap files for v2 of the [ROS](https:
 
 | field       | value            |
 | ----------- | ---------------- |
-| encoding    | cdr              |
-| schema      | .MSG             |
-| schema_name | package/datatype |
+| encoding    | CDR              |
+| schema      | [.msg](https://docs.ros.org/en/galactic/Concepts/About-ROS-Interfaces.html)             |
+| schema_name | `package/subtype/datatype`, e.g. `my_msgs/msg/Thing` |
 | user_data   | See below        |
 
 #### user_data

--- a/docs/specification/profiles/ros2.md
+++ b/docs/specification/profiles/ros2.md
@@ -6,12 +6,12 @@ The `ros2` profile describes how to create mcap files for v2 of the [ROS](https:
 
 ### Channel Info
 
-| field       | value            |
-| ----------- | ---------------- |
-| encoding    | CDR              |
-| schema      | [.msg](https://docs.ros.org/en/galactic/Concepts/About-ROS-Interfaces.html)             |
+| field | value |
+| --- | --- |
+| encoding | cdr |
+| schema | [.msg](https://docs.ros.org/en/galactic/Concepts/About-ROS-Interfaces.html) |
 | schema_name | `package/subtype/datatype`, e.g. `my_msgs/msg/Thing` |
-| user_data   | See below        |
+| user_data | See below |
 
 #### user_data
 

--- a/docs/specification/profiles/ros2.md
+++ b/docs/specification/profiles/ros2.md
@@ -1,7 +1,18 @@
-## ROS2 Profile
+## ROS2
 
-Profile name: "ros2"
+Profile: **ros2**
 
-Channel info records serialized with the "ros1" profile may include the following fields:
+The `ros2` profile describes how to create mcap files for v2 of the [ROS](https://ros.org/) framework.
+
+### Channel Info
+
+| field       | value            |
+| ----------- | ---------------- |
+| encoding    | cdr              |
+| schema      | .MSG             |
+| schema_name | package/datatype |
+| user_data   | See below        |
+
+#### user_data
 
 - offered_qos_profiles (required, string)


### PR DESCRIPTION
Profiles are for more than user data. They also specify values for other fields within the file. This change updates the language to allow for this and the ros1, and ros2 profiles to specify other required values.

Fixes: #24