### PR TITLE
[C++] Add lz4 and zlib compression to McapWriter

### DIFF
--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -8,6 +8,48 @@
 #include <fstream>
 
 constexpr char StringSchema[] = "string data";
+constexpr size_t WriteIterations = 10000;
+
+static void BM_McapWriterBufferedWriterUnchunkedUnindexed(benchmark::State& state) {
+  // Create a message payload
+  std::array<std::byte, 4 + 13> payload;
+  const uint32_t length = 13;
+  std::memcpy(payload.data(), &length, 4);
+  std::memcpy(payload.data() + 4, "Hello, world!", 13);
+
+  // Create an unchunked writer using the ros1 profile
+  mcap::McapWriter writer;
+  auto options = mcap::McapWriterOptions("ros1");
+  options.noChunking = true;
+  options.noIndexing = true;
+
+  // Open an output memory buffer and write the file header
+  mcap::BufferedWriter out{};
+  writer.open(out, options);
+
+  // Register a Channel Info record
+  mcap::ChannelInfo topic("/chatter", "ros1", "std_msgs/String", StringSchema);
+  writer.addChannel(topic);
+
+  // Create a message
+  mcap::Message msg;
+  msg.channelId = topic.channelId;
+  msg.sequence = 0;
+  msg.publishTime = 0;
+  msg.recordTime = msg.publishTime;
+  msg.data = payload.data();
+  msg.dataSize = payload.size();
+
+  while (state.KeepRunning()) {
+    for (size_t i = 0; i < WriteIterations; i++) {
+      writer.write(msg);
+      benchmark::ClobberMemory();
+    }
+  }
+
+  // Finish writing the file to memory
+  writer.close();
+}
 
 static void BM_McapWriterBufferedWriterUnchunked(benchmark::State& state) {
   // Create a message payload
@@ -38,10 +80,8 @@ static void BM_McapWriterBufferedWriterUnchunked(benchmark::State& state) {
   msg.data = payload.data();
   msg.dataSize = payload.size();
 
-  const auto iterations = size_t(state.range(0));
-
   while (state.KeepRunning()) {
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < WriteIterations; i++) {
       writer.write(msg);
       benchmark::ClobberMemory();
     }
@@ -61,8 +101,7 @@ static void BM_McapWriterBufferedWriterChunked(benchmark::State& state) {
   // Create a chunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.noChunking = false;
-  options.chunkSize = uint64_t(state.range(1));
+  options.chunkSize = uint64_t(state.range(0));
 
   // Open an output memory buffer and write the file header
   mcap::BufferedWriter out{};
@@ -81,10 +120,8 @@ static void BM_McapWriterBufferedWriterChunked(benchmark::State& state) {
   msg.data = payload.data();
   msg.dataSize = payload.size();
 
-  const auto iterations = size_t(state.range(0));
-
   while (state.KeepRunning()) {
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < WriteIterations; i++) {
       writer.write(msg);
       benchmark::ClobberMemory();
     }
@@ -104,9 +141,8 @@ static void BM_McapWriterBufferedWriterChunkedUnindexed(benchmark::State& state)
   // Create a chunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.noChunking = false;
   options.noIndexing = true;
-  options.chunkSize = uint64_t(state.range(1));
+  options.chunkSize = uint64_t(state.range(0));
 
   // Open an output memory buffer and write the file header
   mcap::BufferedWriter out{};
@@ -125,10 +161,92 @@ static void BM_McapWriterBufferedWriterChunkedUnindexed(benchmark::State& state)
   msg.data = payload.data();
   msg.dataSize = payload.size();
 
-  const auto iterations = size_t(state.range(0));
+  while (state.KeepRunning()) {
+    for (size_t i = 0; i < WriteIterations; i++) {
+      writer.write(msg);
+      benchmark::ClobberMemory();
+    }
+  }
+
+  // Finish writing the file to memory
+  writer.close();
+}
+
+static void BM_McapWriterBufferedWriterLZ4(benchmark::State& state) {
+  // Create a message payload
+  std::array<std::byte, 4 + 13> payload;
+  const uint32_t length = 13;
+  std::memcpy(payload.data(), &length, 4);
+  std::memcpy(payload.data() + 4, "Hello, world!", 13);
+
+  // Create a chunked writer using the ros1 profile
+  mcap::McapWriter writer;
+  auto options = mcap::McapWriterOptions("ros1");
+  options.chunkSize = uint64_t(state.range(0));
+  options.compression = mcap::Compression::Lz4;
+  options.compressionLevel = mcap::CompressionLevel(state.range(1));
+
+  // Open an output memory buffer and write the file header
+  mcap::BufferedWriter out{};
+  writer.open(out, options);
+
+  // Register a Channel Info record
+  mcap::ChannelInfo topic("/chatter", "ros1", "std_msgs/String", StringSchema);
+  writer.addChannel(topic);
+
+  // Create a message
+  mcap::Message msg;
+  msg.channelId = topic.channelId;
+  msg.sequence = 0;
+  msg.publishTime = 0;
+  msg.recordTime = msg.publishTime;
+  msg.data = payload.data();
+  msg.dataSize = payload.size();
 
   while (state.KeepRunning()) {
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < WriteIterations; i++) {
+      writer.write(msg);
+      benchmark::ClobberMemory();
+    }
+  }
+
+  // Finish writing the file to memory
+  writer.close();
+}
+
+static void BM_McapWriterBufferedWriterZStd(benchmark::State& state) {
+  // Create a message payload
+  std::array<std::byte, 4 + 13> payload;
+  const uint32_t length = 13;
+  std::memcpy(payload.data(), &length, 4);
+  std::memcpy(payload.data() + 4, "Hello, world!", 13);
+
+  // Create a chunked writer using the ros1 profile
+  mcap::McapWriter writer;
+  auto options = mcap::McapWriterOptions("ros1");
+  options.chunkSize = uint64_t(state.range(0));
+  options.compression = mcap::Compression::Zstd;
+  options.compressionLevel = mcap::CompressionLevel(state.range(1));
+
+  // Open an output memory buffer and write the file header
+  mcap::BufferedWriter out{};
+  writer.open(out, options);
+
+  // Register a Channel Info record
+  mcap::ChannelInfo topic("/chatter", "ros1", "std_msgs/String", StringSchema);
+  writer.addChannel(topic);
+
+  // Create a message
+  mcap::Message msg;
+  msg.channelId = topic.channelId;
+  msg.sequence = 0;
+  msg.publishTime = 0;
+  msg.recordTime = msg.publishTime;
+  msg.data = payload.data();
+  msg.dataSize = payload.size();
+
+  while (state.KeepRunning()) {
+    for (size_t i = 0; i < WriteIterations; i++) {
       writer.write(msg);
       benchmark::ClobberMemory();
     }
@@ -167,10 +285,8 @@ static void BM_McapWriterStreamWriterUnchunked(benchmark::State& state) {
   msg.data = payload.data();
   msg.dataSize = payload.size();
 
-  const auto iterations = size_t(state.range(0));
-
   while (state.KeepRunning()) {
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < WriteIterations; i++) {
       writer.write(msg);
       benchmark::ClobberMemory();
     }
@@ -191,8 +307,7 @@ static void BM_McapWriterStreamWriterChunked(benchmark::State& state) {
   // Create a chunked writer using the ros1 profile
   mcap::McapWriter writer;
   auto options = mcap::McapWriterOptions("ros1");
-  options.noChunking = false;
-  options.chunkSize = uint64_t(state.range(1));
+  options.chunkSize = uint64_t(state.range(0));
 
   // Open an output file stream and write the file header
   std::ofstream out("benchmark.mcap", std::ios::binary);
@@ -211,10 +326,8 @@ static void BM_McapWriterStreamWriterChunked(benchmark::State& state) {
   msg.data = payload.data();
   msg.dataSize = payload.size();
 
-  const auto iterations = size_t(state.range(0));
-
   while (state.KeepRunning()) {
-    for (size_t i = 0; i < iterations; i++) {
+    for (size_t i = 0; i < WriteIterations; i++) {
       writer.write(msg);
       benchmark::ClobberMemory();
     }
@@ -226,41 +339,61 @@ static void BM_McapWriterStreamWriterChunked(benchmark::State& state) {
 }
 
 int main(int argc, char* argv[]) {
+  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterUnchunkedUnindexed",
+                               BM_McapWriterBufferedWriterUnchunkedUnindexed);
   benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterUnchunked",
-                               BM_McapWriterBufferedWriterUnchunked)
-    ->Arg(10000);
+                               BM_McapWriterBufferedWriterUnchunked);
   benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterChunked",
                                BM_McapWriterBufferedWriterChunked)
-    ->Args({10000, 1})
-    ->Args({10000, 10})
-    ->Args({10000, 100})
-    ->Args({10000, 1000})
-    ->Args({10000, 10000})
-    ->Args({10000, 100000})
-    ->Args({10000, 1000000})
-    ->Args({10000, 10000000});
+    ->Arg(1)
+    ->Arg(10)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000)
+    ->Arg(1000000)
+    ->Arg(10000000);
   benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterChunkedUnindexed",
                                BM_McapWriterBufferedWriterChunkedUnindexed)
-    ->Args({10000, 1})
-    ->Args({10000, 10})
-    ->Args({10000, 100})
-    ->Args({10000, 1000})
-    ->Args({10000, 10000})
-    ->Args({10000, 100000})
-    ->Args({10000, 1000000})
-    ->Args({10000, 10000000});
+    ->Arg(1)
+    ->Arg(10)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000)
+    ->Arg(1000000)
+    ->Arg(10000000);
+  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterLZ4",
+                               BM_McapWriterBufferedWriterLZ4)
+    ->Args({1, 0})
+    ->Args({1, 1})
+    ->Args({1, 2})
+    ->Args({100000, 0})
+    ->Args({100000, 1})
+    ->Args({100000, 2});
+  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterZStd",
+                               BM_McapWriterBufferedWriterZStd)
+    ->Args({1, 0})
+    ->Args({1, 1})
+    ->Args({1, 2})
+    ->Args({1, 3})
+    ->Args({1, 4})
+    ->Args({100000, 0})
+    ->Args({100000, 1})
+    ->Args({100000, 2})
+    ->Args({100000, 3})
+    ->Args({100000, 4});
   benchmark::RegisterBenchmark("BM_McapWriterStreamWriterUnchunked",
-                               BM_McapWriterStreamWriterUnchunked)
-    ->Arg(10000);
+                               BM_McapWriterStreamWriterUnchunked);
   benchmark::RegisterBenchmark("BM_McapWriterStreamWriterChunked", BM_McapWriterStreamWriterChunked)
-    ->Args({10000, 1})
-    ->Args({10000, 10})
-    ->Args({10000, 100})
-    ->Args({10000, 1000})
-    ->Args({10000, 10000})
-    ->Args({10000, 100000})
-    ->Args({10000, 1000000})
-    ->Args({10000, 10000000});
+    ->Arg(1)
+    ->Arg(10)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000)
+    ->Arg(1000000)
+    ->Arg(10000000);
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
 

--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -363,16 +363,14 @@ int main(int argc, char* argv[]) {
     ->Arg(100000)
     ->Arg(1000000)
     ->Arg(10000000);
-  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterLZ4",
-                               BM_McapWriterBufferedWriterLZ4)
+  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterLZ4", BM_McapWriterBufferedWriterLZ4)
     ->Args({1, 0})
     ->Args({1, 1})
     ->Args({1, 2})
     ->Args({100000, 0})
     ->Args({100000, 1})
     ->Args({100000, 2});
-  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterZStd",
-                               BM_McapWriterBufferedWriterZStd)
+  benchmark::RegisterBenchmark("BM_McapWriterBufferedWriterZStd", BM_McapWriterBufferedWriterZStd)
     ->Args({1, 0})
     ->Args({1, 1})
     ->Args({1, 2})

--- a/cpp/examples/bag2mcap.cpp
+++ b/cpp/examples/bag2mcap.cpp
@@ -17,6 +17,7 @@ int main() {
   mcap::McapWriter writer;
 
   auto options = mcap::McapWriterOptions("ros1");
+  options.compression = mcap::Compression::Zstd;
 
   std::ofstream out("output.mcap", std::ios::binary);
   writer.open(out, options);
@@ -37,7 +38,15 @@ int main() {
   msg.data = payload.data();
   msg.dataSize = payload.size();
 
-  writer.write(msg);
+  const auto res = writer.write(msg);
+  if (!res.ok()) {
+    std::cerr << "Failed to write message: " << res.message << "\n";
+    writer.terminate();
+    out.close();
+    std::remove("output.mcap");
+    return 1;
+  }
+
   writer.close();
 
   return 0;

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -11,7 +11,7 @@ class McapConan(ConanFile):
     topics = ("mcap", "serialization", "deserialization", "recording")
 
     settings = ("os", "compiler", "build_type", "arch")
-    requires = ("zlib/1.2.11", "zstd/1.5.1")
+    requires = ("lz4/1.9.3", "zstd/1.5.1")
     generators = "cmake"
 
     def validate(self):

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -8,6 +8,7 @@ enum class StatusCode {
   Success = 0,
   NotOpen = 1,
   InvalidChannelId = 2,
+  CompressionError = 3,
 };
 
 struct Status {
@@ -33,6 +34,10 @@ struct Status {
         break;
     }
   }
+
+  Status(StatusCode code, const std::string& message)
+      : code(code)
+      , message(message) {}
 
   bool ok() const {
     return code == StatusCode::Success;

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -8,7 +8,6 @@ enum class StatusCode {
   Success = 0,
   NotOpen = 1,
   InvalidChannelId = 2,
-  CompressionError = 3,
 };
 
 struct Status {

--- a/cpp/mcap/include/mcap/mcap.hpp
+++ b/cpp/mcap/include/mcap/mcap.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "errors.hpp"
+#include <assert.h>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -9,6 +10,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+#include <zstd_errors.h>
 
 namespace mcap {
 
@@ -29,6 +34,14 @@ enum struct Compression {
   None,
   Lz4,
   Zstd,
+};
+
+enum struct CompressionLevel {
+  Fastest,
+  Fast,
+  Default,
+  Slow,
+  Slowest,
 };
 
 enum struct OpCode : uint8_t {
@@ -148,6 +161,7 @@ struct McapWriterOptions {
   bool noIndexing;
   uint64_t chunkSize;
   Compression compression;
+  CompressionLevel compressionLevel;
   std::string profile;
   std::string library;
   mcap::KeyValueMap metadata;
@@ -157,6 +171,7 @@ struct McapWriterOptions {
       , noIndexing(false)
       , chunkSize(DefaultChunkSize)
       , compression(Compression::None)
+      , compressionLevel(CompressionLevel::Default)
       , profile(profile)
       , library("libmcap " LIBRARY_VERSION) {}
 };
@@ -176,15 +191,28 @@ struct IReadable {
   virtual uint64_t read(std::byte* output, uint64_t size) = 0;
 };
 
+struct IChunkWriter {
+  virtual inline ~IChunkWriter() = default;
+
+  virtual void write(const std::byte* data, uint64_t size) = 0;
+  virtual void end() = 0;
+  virtual uint64_t size() const = 0;
+  virtual bool empty() const = 0;
+  virtual void clear() = 0;
+  virtual const std::byte* data() const = 0;
+};
+
 /**
  * @brief An in-memory IWritable implementation backed by a growable buffer.
  */
-class BufferedWriter final : public IWritable {
+class BufferedWriter final : public IWritable, public IChunkWriter {
 public:
   void write(const std::byte* data, uint64_t size) override;
-  uint64_t size() const override;
   void end() override;
-  const std::byte* data() const;
+  uint64_t size() const override;
+  bool empty() const override;
+  void clear() override;
+  const std::byte* data() const override;
 
 private:
   std::vector<std::byte> buffer_;
@@ -206,6 +234,25 @@ public:
 private:
   std::ostream& stream_;
   uint64_t size_ = 0;
+};
+
+class ZStdWriter final : public IWritable, public IChunkWriter {
+public:
+  ZStdWriter(uint64_t bufferSize, CompressionLevel compressionLevel);
+  ~ZStdWriter() override;
+
+  void write(const std::byte* data, uint64_t size) override;
+  void end() override;
+  uint64_t size() const override;
+  bool empty() const override;
+  void clear() override;
+  const std::byte* data() const override;
+
+private:
+  std::vector<std::byte> preWriteBuffer_;
+  std::vector<std::byte> buffer_;
+  ZSTD_CCtx* zstdContext_ = nullptr;
+  bool hasUnflushedData_ = false;
 };
 
 class McapWriter final {
@@ -230,9 +277,17 @@ public:
   void open(std::ostream& stream, const McapWriterOptions& options);
 
   /**
-   * @brief Write the MCAP footer and close the output stream.
+   * @brief Write the MCAP footer, flush pending writes to the output stream,
+   * and reset internal state.
    */
   void close();
+
+  /**
+   * @brief Reset internal state without writing the MCAP footer or flushing
+   * pending writes. This should only be used in error cases as the output MCAP
+   * file will be truncated.
+   */
+  void terminate();
 
   /**
    * @brief Add channel info and set `info.channelId` to a generated channel id.
@@ -263,17 +318,24 @@ private:
   uint64_t chunkSize_ = DefaultChunkSize;
   mcap::IWritable* output_ = nullptr;
   std::unique_ptr<mcap::StreamWriter> streamOutput_;
+  std::unique_ptr<mcap::BufferedWriter> uncompressedChunk_;
+  std::unique_ptr<mcap::ZStdWriter> zstdChunk_;
   std::vector<mcap::ChannelInfo> channels_;
   std::vector<mcap::AttachmentIndex> attachmentIndex_;
   std::vector<mcap::ChunkIndex> chunkIndex_;
   Statistics statistics_{};
-  mcap::BufferedWriter currentChunk_;
   std::unordered_map<mcap::ChannelId, mcap::MessageIndex> currentMessageIndex_;
   uint64_t currentChunkStart_ = std::numeric_limits<uint64_t>::max();
   uint64_t currentChunkEnd_ = std::numeric_limits<uint64_t>::min();
+  Compression compression_ = Compression::None;
+  uint64_t uncompressedSize_ = 0;
+  uint32_t uncompressedCrc_ = 0;
   bool indexing_ = true;
+  bool opened_ = false;
 
-  void writeChunk(mcap::IWritable& output, const mcap::BufferedWriter& chunkData);
+  mcap::IWritable& getOutput();
+  mcap::IChunkWriter* getChunkWriter();
+  void writeChunk(mcap::IWritable& output, mcap::IChunkWriter& chunkData);
 
   static void writeMagic(mcap::IWritable& output);
 

--- a/cpp/mcap/include/mcap/mcap.inl
+++ b/cpp/mcap/include/mcap/mcap.inl
@@ -3,157 +3,7 @@ static_assert(std::numeric_limits<unsigned char>::digits == 8);
 
 namespace mcap {
 
-// Public API //////////////////////////////////////////////////////////////////
-
-McapWriter::~McapWriter() {
-  close();
-}
-
-void McapWriter::open(mcap::IWritable& writer, const McapWriterOptions& options) {
-  chunkSize_ = options.noChunking ? 0 : options.chunkSize;
-  indexing_ = !options.noIndexing;
-  output_ = &writer;
-  writeMagic(writer);
-  write(writer, Header{options.profile, options.library, options.metadata});
-}
-
-void McapWriter::open(std::ostream& stream, const McapWriterOptions& options) {
-  streamOutput_ = std::make_unique<mcap::StreamWriter>(stream);
-  open(*streamOutput_, options);
-}
-
-void McapWriter::close() {
-  if (!output_) {
-    return;
-  }
-  auto& output = *output_;
-
-  // Check if there is an open chunk that needs to be closed
-  if (currentChunk_.size() > 0) {
-    writeChunk(output, currentChunk_);
-    currentChunk_.end();
-  }
-
-  uint64_t indexOffset = 0;
-  uint32_t indexCrc = 0;
-
-  if (indexing_) {
-    // Get the offset of the End Of File section
-    indexOffset = output.size();
-
-    // Write all channel info records
-    for (const auto& channel : channels_) {
-      write(output, channel);
-    }
-
-    // Write chunk index records
-    for (const auto& chunkIndexRecord : chunkIndex_) {
-      write(output, chunkIndexRecord);
-    }
-
-    // Write attachment index records
-    for (const auto& attachmentIndexRecord : attachmentIndex_) {
-      write(output, attachmentIndexRecord);
-    }
-
-    // Write the statistics record
-    write(output, statistics_);
-  }
-
-  // TODO: Calculate the index CRC
-
-  // Write the footer and trailing magic
-  write(output, mcap::Footer{indexOffset, indexCrc});
-  writeMagic(output);
-
-  output.end();
-  output_ = nullptr;
-  streamOutput_.reset();
-}
-
-void McapWriter::addChannel(mcap::ChannelInfo& info) {
-  info.channelId = uint16_t(channels_.size() + 1);
-  channels_.push_back(info);
-}
-
-mcap::Status McapWriter::write(const mcap::Message& message) {
-  if (!output_) {
-    return StatusCode::NotOpen;
-  }
-  auto& output = chunkSize_ > 0 ? currentChunk_ : *output_;
-  auto& channelMessageCounts = statistics_.channelMessageCounts;
-
-  // Write out channel info if we have not yet done so
-  if (channelMessageCounts.find(message.channelId) == channelMessageCounts.end()) {
-    const size_t index = message.channelId - 1;
-    if (index >= channels_.size()) {
-      return StatusCode::InvalidChannelId;
-    }
-
-    write(output, channels_[index]);
-    channelMessageCounts.emplace(message.channelId, 0);
-    ++statistics_.channelCount;
-  }
-
-  const uint64_t messageOffset = output.size();
-
-  // Write the message
-  write(output, message);
-
-  // Update statistics
-  if (indexing_) {
-    ++statistics_.messageCount;
-    channelMessageCounts[message.channelId] += 1;
-  }
-
-  if (chunkSize_ > 0) {
-    if (indexing_) {
-      // Update the message index
-      auto& messageIndex = currentMessageIndex_[message.channelId];
-      messageIndex.channelId = message.channelId;
-      ++messageIndex.count;
-      messageIndex.records.emplace_back(message.recordTime, messageOffset);
-
-      // Update the chunk index start/end times
-      currentChunkStart_ = std::min(currentChunkStart_, message.recordTime);
-      currentChunkEnd_ = std::max(currentChunkEnd_, message.recordTime);
-    }
-
-    // Check if the current chunk is ready to close
-    if (currentChunk_.size() >= chunkSize_) {
-      writeChunk(*output_, currentChunk_);
-      currentChunk_.end();
-    }
-  }
-
-  return StatusCode::Success;
-}
-
-mcap::Status McapWriter::write(const mcap::Attachment& attachment) {
-  if (!output_) {
-    return StatusCode::NotOpen;
-  }
-  auto& output = *output_;
-
-  // Check if we have an open chunk that needs to be closed
-  if (currentChunk_.size() > 0) {
-    writeChunk(output, currentChunk_);
-    currentChunk_.end();
-  }
-
-  const uint64_t fileOffset = output.size();
-
-  write(output, attachment);
-
-  if (indexing_) {
-    ++statistics_.attachmentCount;
-    attachmentIndex_.emplace_back(attachment, fileOffset);
-  }
-
-  return StatusCode::Success;
-}
-
-// Private methods /////////////////////////////////////////////////////////////
+// Internal methods ////////////////////////////////////////////////////////////
 
 namespace internal {
 
@@ -165,18 +15,253 @@ uint32_t KeyValueMapSize(const KeyValueMap& map) {
   return size;
 }
 
+const std::string& CompressionString(Compression compression) {
+  static std::string none = "";
+  static std::string lz4 = "lz4";
+  static std::string zstd = "zstd";
+  switch (compression) {
+    case Compression::None:
+      return none;
+    case Compression::Lz4:
+      return lz4;
+    case Compression::Zstd:
+      return zstd;
+  }
+}
+
 }  // namespace internal
 
-void McapWriter::writeChunk(mcap::IWritable& output, const mcap::BufferedWriter& chunkData) {
-  uint64_t uncompressedSize = chunkData.size();
-  uint32_t uncompressedCrc = 0;
-  std::string compression = "";
-  uint64_t recordsSize = uncompressedSize;
-  const std::byte* records = chunkData.data();
+// Public API //////////////////////////////////////////////////////////////////
+
+McapWriter::~McapWriter() {
+  close();
+}
+
+void McapWriter::open(mcap::IWritable& writer, const McapWriterOptions& options) {
+  opened_ = true;
+  chunkSize_ = options.noChunking ? 0 : options.chunkSize;
+  indexing_ = !options.noIndexing;
+  compression_ = chunkSize_ > 0 ? options.compression : Compression::None;
+  switch (compression_) {
+    case Compression::None:
+      uncompressedChunk_ = std::make_unique<mcap::BufferedWriter>();
+      break;
+    case Compression::Lz4:
+      // FIXME
+      break;
+    case Compression::Zstd:
+      zstdChunk_ = std::make_unique<mcap::ZStdWriter>(options.chunkSize, options.compressionLevel);
+      break;
+  }
+  output_ = &writer;
+  writeMagic(writer);
+  write(writer, Header{options.profile, options.library, options.metadata});
+}
+
+void McapWriter::open(std::ostream& stream, const McapWriterOptions& options) {
+  streamOutput_ = std::make_unique<mcap::StreamWriter>(stream);
+  open(*streamOutput_, options);
+}
+
+void McapWriter::close() {
+  if (!opened_ || !output_) {
+    return;
+  }
+  auto* chunkWriter = getChunkWriter();
+  auto& fileOutput = *output_;
+
+  // Check if there is an open chunk that needs to be closed
+  if (chunkWriter && !chunkWriter->empty()) {
+    writeChunk(fileOutput, *chunkWriter);
+  }
+
+  uint64_t indexOffset = 0;
+  uint32_t indexCrc = 0;
+
+  if (indexing_) {
+    // Get the offset of the End Of File section
+    indexOffset = fileOutput.size();
+
+    // Write all channel info records
+    for (const auto& channel : channels_) {
+      write(fileOutput, channel);
+    }
+
+    // Write chunk index records
+    for (const auto& chunkIndexRecord : chunkIndex_) {
+      write(fileOutput, chunkIndexRecord);
+    }
+
+    // Write attachment index records
+    for (const auto& attachmentIndexRecord : attachmentIndex_) {
+      write(fileOutput, attachmentIndexRecord);
+    }
+
+    // Write the statistics record
+    write(fileOutput, statistics_);
+  }
+
+  // TODO: Calculate the index CRC
+
+  // Write the footer and trailing magic
+  write(fileOutput, mcap::Footer{indexOffset, indexCrc});
+  writeMagic(fileOutput);
+
+  // Flush output
+  fileOutput.end();
+
+  terminate();
+}
+
+void McapWriter::terminate() {
+  output_ = nullptr;
+  streamOutput_.reset();
+  uncompressedChunk_.reset();
+  zstdChunk_.reset();
+
+  channels_.clear();
+  attachmentIndex_.clear();
+  chunkIndex_.clear();
+  statistics_ = {};
+  currentMessageIndex_.clear();
+  currentChunkStart_ = std::numeric_limits<uint64_t>::max();
+  currentChunkEnd_ = std::numeric_limits<uint64_t>::min();
+
+  opened_ = false;
+}
+
+void McapWriter::addChannel(mcap::ChannelInfo& info) {
+  info.channelId = uint16_t(channels_.size() + 1);
+  channels_.push_back(info);
+}
+
+mcap::Status McapWriter::write(const mcap::Message& message) {
+  if (!output_) {
+    return StatusCode::NotOpen;
+  }
+  auto& output = getOutput();
+  auto& channelMessageCounts = statistics_.channelMessageCounts;
+
+  // Write out channel info if we have not yet done so
+  if (channelMessageCounts.find(message.channelId) == channelMessageCounts.end()) {
+    const size_t index = message.channelId - 1;
+    if (index >= channels_.size()) {
+      return StatusCode::InvalidChannelId;
+    }
+
+    // Write the channel info record
+    write(output, channels_[index]);
+
+    // Update channel statistics
+    channelMessageCounts.emplace(message.channelId, 0);
+    ++statistics_.channelCount;
+  }
+
+  // Write the message
+  write(output, message);
+
+  // Update message statistics
+  if (indexing_) {
+    ++statistics_.messageCount;
+    channelMessageCounts[message.channelId] += 1;
+  }
+
+  auto* chunkWriter = getChunkWriter();
+  if (chunkWriter) {
+    if (indexing_) {
+      // Update the message index
+      auto& messageIndex = currentMessageIndex_[message.channelId];
+      messageIndex.channelId = message.channelId;
+      ++messageIndex.count;
+      messageIndex.records.emplace_back(message.recordTime, uncompressedSize_);
+
+      // Update the chunk index start/end times
+      currentChunkStart_ = std::min(currentChunkStart_, message.recordTime);
+      currentChunkEnd_ = std::max(currentChunkEnd_, message.recordTime);
+    }
+
+    uncompressedSize_ += message.dataSize;
+
+    // TODO
+    uncompressedCrc_ = 0;
+
+    // Check if the current chunk is ready to close
+    if (uncompressedSize_ >= chunkSize_) {
+      auto& fileOutput = *output_;
+      writeChunk(fileOutput, *chunkWriter);
+    }
+  }
+
+  return StatusCode::Success;
+}
+
+mcap::Status McapWriter::write(const mcap::Attachment& attachment) {
+  if (!output_) {
+    return StatusCode::NotOpen;
+  }
+  auto& fileOutput = *output_;
+
+  // Check if we have an open chunk that needs to be closed
+  auto* chunkWriter = getChunkWriter();
+  if (chunkWriter && !chunkWriter->empty()) {
+    writeChunk(fileOutput, *chunkWriter);
+  }
+
+  const uint64_t fileOffset = fileOutput.size();
+
+  // Write the attachment
+  write(fileOutput, attachment);
+
+  // Update statistics and attachment index
+  if (indexing_) {
+    ++statistics_.attachmentCount;
+    attachmentIndex_.emplace_back(attachment, fileOffset);
+  }
+
+  return StatusCode::Success;
+}
+
+// Private methods /////////////////////////////////////////////////////////////
+
+mcap::IWritable& McapWriter::getOutput() {
+  if (chunkSize_ == 0) {
+    return *output_;
+  }
+  switch (compression_) {
+    case Compression::None:
+      return *uncompressedChunk_;
+    case Compression::Lz4:
+      // FIXME
+      return *zstdChunk_;
+    case Compression::Zstd:
+      return *zstdChunk_;
+  }
+}
+
+mcap::IChunkWriter* McapWriter::getChunkWriter() {
+  switch (compression_) {
+    case Compression::None:
+      return uncompressedChunk_.get();
+    case Compression::Lz4:
+      // FIXME
+      return nullptr;
+    case Compression::Zstd:
+      return zstdChunk_.get();
+  }
+}
+
+void McapWriter::writeChunk(mcap::IWritable& output, mcap::IChunkWriter& chunkData) {
+  const auto& compression = internal::CompressionString(compression_);
+
+  // Flush any in-progress compression stream
+  chunkData.end();
+
+  const uint64_t compressedSize = chunkData.size();
+  const std::byte* data = chunkData.data();
 
   // Write the chunk
   const uint64_t chunkOffset = output.size();
-  write(output, Chunk{uncompressedSize, uncompressedCrc, compression, recordsSize, records});
+  write(output, Chunk{uncompressedSize_, uncompressedCrc_, compression, compressedSize, data});
 
   if (indexing_) {
     // Update statistics
@@ -200,14 +285,17 @@ void McapWriter::writeChunk(mcap::IWritable& output, const mcap::BufferedWriter&
     chunkIndexRecord.chunkOffset = chunkOffset;
     chunkIndexRecord.messageIndexLength = messageIndexLength;
     chunkIndexRecord.compression = compression;
-    chunkIndexRecord.compressedSize = recordsSize;
-    chunkIndexRecord.uncompressedSized = uncompressedSize;
+    chunkIndexRecord.compressedSize = compressedSize;
+    chunkIndexRecord.uncompressedSized = uncompressedSize_;
     chunkIndexRecord.crc = 0;
 
-    // Reset start/end times for the next chunk
+    // Reset uncompressedSize and start/end times for the next chunk
+    uncompressedSize_ = 0;
     currentChunkStart_ = std::numeric_limits<uint64_t>::max();
     currentChunkEnd_ = std::numeric_limits<uint64_t>::min();
   }
+
+  chunkData.clear();
 }
 
 void McapWriter::writeMagic(mcap::IWritable& output) {
@@ -405,11 +493,19 @@ void BufferedWriter::write(const std::byte* data, uint64_t size) {
   buffer_.insert(buffer_.end(), data, data + size);
 }
 
+void BufferedWriter::end() {
+  // no-op
+}
+
 uint64_t BufferedWriter::size() const {
   return buffer_.size();
 }
 
-void BufferedWriter::end() {
+bool BufferedWriter::empty() const {
+  return buffer_.empty();
+}
+
+void BufferedWriter::clear() {
   buffer_.clear();
 }
 
@@ -434,6 +530,85 @@ void StreamWriter::end() {
 
 uint64_t StreamWriter::size() const {
   return size_;
+}
+
+// ZStdWriter //////////////////////////////////////////////////////////////////
+
+namespace internal {
+
+int ZStdCompressionLevel(CompressionLevel level) {
+  switch (level) {
+    case CompressionLevel::Fastest:
+      return ZSTD_minCLevel();
+    case CompressionLevel::Fast:
+      return -3;
+    case CompressionLevel::Default:
+      return 1;
+    case CompressionLevel::Slow:
+      return 3;
+    case CompressionLevel::Slowest:
+      return ZSTD_maxCLevel();
+  }
+}
+
+}  // namespace internal
+
+ZStdWriter::ZStdWriter(uint64_t bufferSize, CompressionLevel compressionLevel) {
+  preWriteBuffer_.resize(bufferSize);
+  zstdContext_ = ZSTD_createCStream();
+  ZSTD_CCtx_setParameter(zstdContext_, ZSTD_c_stableOutBuffer, 1);
+  ZSTD_CCtx_setParameter(zstdContext_, ZSTD_c_compressionLevel,
+                         internal::ZStdCompressionLevel(compressionLevel));
+}
+
+ZStdWriter::~ZStdWriter() {
+  ZSTD_freeCStream(zstdContext_);
+}
+
+void ZStdWriter::write(const std::byte* data, uint64_t size) {
+  ZSTD_inBuffer in{data, size, 0};
+  size_t result;
+
+  do {
+    ZSTD_outBuffer out{preWriteBuffer_.data(), preWriteBuffer_.size(), 0};
+    result = ZSTD_compressStream2(zstdContext_, &out, &in, ZSTD_e_continue);
+    assert(!ZSTD_isError(result) && ZSTD_getErrorString(ZSTD_getErrorCode(result)));
+    buffer_.insert(buffer_.end(), preWriteBuffer_.begin(), preWriteBuffer_.begin() + out.pos);
+  } while (in.pos != in.size);
+
+  hasUnflushedData_ = true;
+}
+
+void ZStdWriter::end() {
+  ZSTD_inBuffer in{nullptr, 0, 0};
+  size_t result;
+
+  do {
+    ZSTD_outBuffer out{preWriteBuffer_.data(), preWriteBuffer_.size(), 0};
+    result = ZSTD_compressStream2(zstdContext_, &out, &in, ZSTD_e_end);
+    assert(!ZSTD_isError(result) && ZSTD_getErrorString(ZSTD_getErrorCode(result)));
+    buffer_.insert(buffer_.end(), preWriteBuffer_.begin(), preWriteBuffer_.begin() + out.pos);
+  } while (result != 0);
+
+  hasUnflushedData_ = false;
+}
+
+uint64_t ZStdWriter::size() const {
+  return buffer_.size();
+}
+
+bool ZStdWriter::empty() const {
+  return buffer_.empty() && !hasUnflushedData_;
+}
+
+void ZStdWriter::clear() {
+  buffer_.clear();
+  ZSTD_CCtx_reset(zstdContext_, ZSTD_reset_session_only);
+  hasUnflushedData_ = false;
+}
+
+const std::byte* ZStdWriter::data() const {
+  return buffer_.data();
 }
 
 }  // namespace mcap


### PR DESCRIPTION
Add lz4 and zstd compression to McapWriter. The compressors work similarly: they hold an accumulating buffer of uncompressed chunk data until it meets or exceeds the target chunk size, then perform a single shot compression. For zstd, this was benchmarked to be 2x faster than incrementally feeding data in with the streaming compression API.
