### PR TITLE
Remove channel from golang lexer

### DIFF
--- a/go/libmcap/benchmark_test.go
+++ b/go/libmcap/benchmark_test.go
@@ -20,7 +20,8 @@ func BenchmarkMessageIteration(b *testing.B) {
 		mcapfile := &bytes.Buffer{}
 		err = Bag2MCAP(bagfile, mcapfile)
 		assert.Nil(b, err)
-		r := NewReader(bytes.NewReader(mcapfile.Bytes()))
+		r, err := NewReader(bytes.NewReader(mcapfile.Bytes()))
+		assert.Nil(b, err)
 		it, err := r.Messages(0, time.Now().UnixNano(), []string{}, true)
 		assert.Nil(b, err)
 		c := 0

--- a/go/libmcap/mcap.go
+++ b/go/libmcap/mcap.go
@@ -302,7 +302,7 @@ func (i Info) String() string {
 		compressionRatio := 100 * (1 - float64(v.compressedSize)/float64(v.uncompressedSize))
 		fmt.Fprintf(buf, "\t%s: [%d/%d chunks] (%.2f%%) \n", k, v.count, chunkCount, compressionRatio)
 	}
-	fmt.Fprintf(buf, "channels\n")
+	fmt.Fprintf(buf, "channels:\n")
 
 	chanIDs := []uint16{}
 	for chanID := range i.Channels {

--- a/go/libmcap/reader_test.go
+++ b/go/libmcap/reader_test.go
@@ -141,7 +141,8 @@ func TestMessageReading(t *testing.T) {
 					w.Close()
 					t.Run("read all messages", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
-						r := NewReader(reader)
+						r, err := NewReader(reader)
+						assert.Nil(t, err)
 						it, err := r.Messages(0, 10000, []string{}, useIndex)
 						assert.Nil(t, err)
 						c := 0
@@ -160,7 +161,8 @@ func TestMessageReading(t *testing.T) {
 					})
 					t.Run("read messages on one topic", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
-						r := NewReader(reader)
+						r, err := NewReader(reader)
+						assert.Nil(t, err)
 						it, err := r.Messages(0, 10000, []string{"/test1"}, useIndex)
 						assert.Nil(t, err)
 						c := 0
@@ -179,7 +181,8 @@ func TestMessageReading(t *testing.T) {
 					})
 					t.Run("read messages on multiple topics", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
-						r := NewReader(reader)
+						r, err := NewReader(reader)
+						assert.Nil(t, err)
 						it, err := r.Messages(0, 10000, []string{"/test1", "/test2"}, useIndex)
 						assert.Nil(t, err)
 						c := 0
@@ -198,7 +201,8 @@ func TestMessageReading(t *testing.T) {
 					})
 					t.Run("read messages in time range", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
-						r := NewReader(reader)
+						r, err := NewReader(reader)
+						assert.Nil(t, err)
 						it, err := r.Messages(100, 200, []string{}, useIndex)
 						assert.Nil(t, err)
 						c := 0
@@ -227,7 +231,8 @@ func TestReaderCounting(t *testing.T) {
 			mcapfile := &bytes.Buffer{}
 			err = Bag2MCAP(bagfile, mcapfile)
 			assert.Nil(t, err)
-			r := NewReader(bytes.NewReader(mcapfile.Bytes()))
+			r, err := NewReader(bytes.NewReader(mcapfile.Bytes()))
+			assert.Nil(t, err)
 			it, err := r.Messages(0, time.Now().UnixNano(), []string{}, indexed)
 			assert.Nil(t, err)
 			c := 0
@@ -251,7 +256,8 @@ func TestMCAPInfo(t *testing.T) {
 	mcapfile := &bytes.Buffer{}
 	err = Bag2MCAP(bagfile, mcapfile)
 	assert.Nil(t, err)
-	r := NewReader(bytes.NewReader(mcapfile.Bytes()))
+	r, err := NewReader(bytes.NewReader(mcapfile.Bytes()))
+	assert.Nil(t, err)
 	info, err := r.Info()
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(1606), info.Statistics.MessageCount)

--- a/go/libmcap/writer_test.go
+++ b/go/libmcap/writer_test.go
@@ -15,8 +15,10 @@ func TestMCAPReadWrite(t *testing.T) {
 		assert.Nil(t, err)
 		err = w.WriteHeader("ros1", "", map[string]string{"foo": "bar"})
 		assert.Nil(t, err)
-		lexer := NewLexer(buf)
-		token := lexer.Next()
+		lexer, err := NewLexer(buf)
+		assert.Nil(t, err)
+		token, err := lexer.Next()
+		assert.Nil(t, err)
 		// body of the header is the profile, followed by the metadata map
 		offset := 0
 		data := token.bytes()
@@ -75,7 +77,8 @@ func TestChunkedReadWrite(t *testing.T) {
 			})
 			assert.Nil(t, w.Close())
 			assert.Nil(t, err)
-			lexer := NewLexer(buf)
+			lexer, err := NewLexer(buf)
+			assert.Nil(t, err)
 			for i, expected := range []TokenType{
 				TokenHeader,
 				TokenChannelInfo,
@@ -83,9 +86,9 @@ func TestChunkedReadWrite(t *testing.T) {
 				TokenChannelInfo,
 				TokenStatistics,
 				TokenFooter,
-				TokenEOF,
 			} {
-				tok := lexer.Next()
+				tok, err := lexer.Next()
+				assert.Nil(t, err)
 				_ = tok.bytes() // need to read the data
 				assert.Equal(t, expected, tok.TokenType, fmt.Sprintf("want %s got %s at %d", Token{expected, 0, nil}, tok.TokenType, i))
 			}
@@ -131,9 +134,10 @@ func TestUnchunkedReadWrite(t *testing.T) {
 		Data:        []byte{0x01, 0x02, 0x03, 0x04},
 	})
 	assert.Nil(t, err)
-	w.Close()
+	assert.Nil(t, w.Close())
 
-	lexer := NewLexer(buf)
+	lexer, err := NewLexer(buf)
+	assert.Nil(t, err)
 	for _, expected := range []TokenType{
 		TokenHeader,
 		TokenChannelInfo,
@@ -143,9 +147,9 @@ func TestUnchunkedReadWrite(t *testing.T) {
 		TokenAttachmentIndex,
 		TokenStatistics,
 		TokenFooter,
-		TokenEOF,
 	} {
-		tok := lexer.Next()
+		tok, err := lexer.Next()
+		assert.Nil(t, err)
 		_ = tok.bytes()
 		assert.Equal(t, expected, tok.TokenType, fmt.Sprintf("want %s got %s", Token{expected, 0, nil}, tok))
 	}

--- a/go/mcap/cmd/cat.go
+++ b/go/mcap/cmd/cat.go
@@ -26,7 +26,10 @@ var catCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		reader := libmcap.NewReader(f)
+		reader, err := libmcap.NewReader(f)
+		if err != nil {
+			log.Fatal(err)
+		}
 		it, err := reader.Messages(start, end, topics, true)
 		if err != nil {
 			log.Fatal(err)

--- a/go/mcap/cmd/info.go
+++ b/go/mcap/cmd/info.go
@@ -20,7 +20,10 @@ var infoCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		reader := libmcap.NewReader(r)
+		reader, err := libmcap.NewReader(r)
+		if err != nil {
+			log.Fatal(err)
+		}
 		info, err := reader.Info()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Changes the lexer to no longer return errors as tokens, and instead
return an error value on calls to next.