### PR TITLE
Add name to metadata and metadata index

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -256,6 +256,7 @@ A metadata record contains arbitrary user data in key-value pairs.
 
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |
+| 4 + N | name | String | Example: `map_metadata`. |
 | 4 + N | metadata | Array<Tuple<string, string>> | Example keys: `robot_id`, `git_sha`, `timezone`, `run_id`. |
 
 ### Metadata Index (op=0x0C)
@@ -266,6 +267,7 @@ A metadata record contains arbitrary user data in key-value pairs.
 | --- | --- | --- | --- |
 | 8 | offset | uint64 | Byte offset from the start of the file to the metadata record. |
 | 8 | length | uint64 | Total byte length of the record. |
+| 4 + N | name | String | Name of the metadata record. |
 
 ### Summary Offset (op=0x0D)
 


### PR DESCRIPTION
Adds a name field to the metadata and metadata index records. This may
be used to separate metadata records logically (map metadata, launch
metadata) and refer to them by name from the index.