### PR TITLE
TypeScript reader/writer updates

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,6 +5,9 @@ export * as McapPre0Types from "./pre0/types";
 
 export { default as Mcap0IndexedReader } from "./v0/Mcap0IndexedReader";
 export { default as Mcap0StreamReader } from "./v0/Mcap0StreamReader";
+export { Mcap0RecordBuilder } from "./v0/Mcap0RecordBuilder";
+export { ChunkBuilder as Mcap0ChunkBuilder } from "./v0/ChunkBuilder";
 export * as Mcap0Types from "./v0/types";
+export * as Mcap0Constants from "./v0/constants";
 
 export * from "./common/detectVersion";

--- a/typescript/src/v0/BufferBuilder.ts
+++ b/typescript/src/v0/BufferBuilder.ts
@@ -93,14 +93,19 @@ export class BufferBuilder {
     this.offset += buffer.length;
     return this;
   }
-  array(array: [string, string][]): BufferBuilder {
+  tupleArray<T1, T2>(
+    write1: (_: T1) => void,
+    write2: (_: T2) => void,
+    array: Iterable<[T1, T2]>,
+  ): BufferBuilder {
     // We placeholder the byte length of the array and will come back to
     // set it once we have written the array items
     const sizeOffset = this.offset;
     this.uint32(0); // placeholder length of 0
 
     for (const [key, value] of array) {
-      this.string(key).string(value);
+      write1.call(this, key);
+      write2.call(this, value);
     }
     const currentOffset = this.offset;
 

--- a/typescript/src/v0/Mcap0RecordBuilder.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.ts
@@ -1,4 +1,4 @@
-import { SummaryOffset } from ".";
+import { Statistics, SummaryOffset } from ".";
 import { BufferBuilder } from "./BufferBuilder";
 import { MCAP0_MAGIC, Opcode } from "./constants";
 import {
@@ -13,7 +13,13 @@ import {
   MessageIndex,
   Metadata,
   MetadataIndex,
+  DataEnd,
 } from "./types";
+
+type Options = {
+  /** Add an unspecified number of extra padding bytes at the end of each record */
+  padRecords: boolean;
+};
 
 /**
  * Mcap0RecordBuilder provides methods to serialize mcap records to a buffer in memory.
@@ -26,6 +32,8 @@ import {
  */
 export class Mcap0RecordBuilder {
   private bufferBuilder = new BufferBuilder();
+
+  constructor(private options?: Options) {}
 
   get length(): number {
     return this.bufferBuilder.length;
@@ -52,6 +60,10 @@ export class Mcap0RecordBuilder {
       .string(header.profile)
       .string(header.library);
 
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
+
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
       .seek(startPosition)
@@ -68,7 +80,7 @@ export class Mcap0RecordBuilder {
       .uint64(footer.summaryStart)
       .uint64(footer.summaryOffsetStart)
       .uint32(footer.crc);
-
+    // footer record cannot be padded
     return 20n;
   }
 
@@ -84,8 +96,14 @@ export class Mcap0RecordBuilder {
       .string(info.schemaEncoding)
       .string(info.schema)
       .string(info.schemaName)
-      .array(info.userData);
-
+      .tupleArray(
+        (key) => this.bufferBuilder.string(key),
+        (value) => this.bufferBuilder.string(value),
+        info.userData,
+      );
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
       .seek(startPosition)
@@ -96,14 +114,24 @@ export class Mcap0RecordBuilder {
   }
 
   writeMessage(message: Message): void {
+    this.bufferBuilder.uint8(Opcode.MESSAGE);
+    const startPosition = this.bufferBuilder.length;
     this.bufferBuilder
-      .uint8(Opcode.MESSAGE)
-      .uint64(BigInt(22 + message.messageData.byteLength))
+      .uint64(0n) // placeholder
       .uint16(message.channelId)
       .uint32(message.sequence)
       .uint64(message.publishTime)
       .uint64(message.recordTime)
       .bytes(message.messageData);
+
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
+      .seek(startPosition)
+      .uint64(BigInt(endPosition - startPosition - 8))
+      .seek(endPosition);
   }
 
   writeAttachment(attachment: Attachment): bigint {
@@ -116,6 +144,9 @@ export class Mcap0RecordBuilder {
       .uint64(attachment.recordTime)
       .string(attachment.contentType)
       .bytes(attachment.data);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
@@ -138,6 +169,9 @@ export class Mcap0RecordBuilder {
       .uint64(attachmentIndex.attachmentSize)
       .string(attachmentIndex.name)
       .string(attachmentIndex.contentType);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
@@ -160,6 +194,9 @@ export class Mcap0RecordBuilder {
       .uint32(chunk.uncompressedCrc)
       .string(chunk.compression)
       .bytes(chunk.records);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
@@ -192,6 +229,9 @@ export class Mcap0RecordBuilder {
       .uint64(chunkIndex.compressedSize)
       .uint64(chunkIndex.uncompressedSize)
       .uint32(0);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
@@ -202,20 +242,31 @@ export class Mcap0RecordBuilder {
     return BigInt(endPosition - startPosition + 1);
   }
 
-  writeMessageIndex(messageIndex: MessageIndex): void {
+  writeMessageIndex(messageIndex: MessageIndex): bigint {
     this.bufferBuilder.uint8(Opcode.MESSAGE_INDEX);
+    const startPosition = this.bufferBuilder.length;
 
     // each records tuple is a fixed byte length
     const messageIndexRecordsByteLength = messageIndex.records.length * 16;
 
     this.bufferBuilder
-      .uint64(BigInt(2 + 4 + messageIndexRecordsByteLength))
+      .uint64(0n) // placeholder
       .uint16(messageIndex.channelId)
       .uint32(messageIndexRecordsByteLength);
 
     for (const record of messageIndex.records) {
       this.bufferBuilder.uint64(record[0]).uint64(record[1]);
     }
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
+
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
+      .seek(startPosition)
+      .uint64(BigInt(endPosition - startPosition - 8))
+      .seek(endPosition);
+    return BigInt(endPosition - startPosition + 1);
   }
 
   writeMetadata(metadata: Metadata): bigint {
@@ -225,7 +276,14 @@ export class Mcap0RecordBuilder {
     this.bufferBuilder
       .uint64(0n) // placeholder size
       .string(metadata.name)
-      .array(metadata.metadata);
+      .tupleArray(
+        (key) => this.bufferBuilder.string(key),
+        (value) => this.bufferBuilder.string(value),
+        metadata.metadata,
+      );
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
@@ -245,6 +303,9 @@ export class Mcap0RecordBuilder {
       .uint64(metadataIndex.offset)
       .uint64(metadataIndex.length)
       .string(metadataIndex.name);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
     const endPosition = this.bufferBuilder.length;
     this.bufferBuilder
@@ -256,12 +317,73 @@ export class Mcap0RecordBuilder {
   }
 
   writeSummaryOffset(summaryOffset: SummaryOffset): bigint {
+    this.bufferBuilder.uint8(Opcode.SUMMARY_OFFSET);
+
+    const startPosition = this.bufferBuilder.length;
     this.bufferBuilder
-      .uint8(Opcode.SUMMARY_OFFSET)
+      .uint64(0n) // placeholder size
       .uint8(summaryOffset.groupOpcode)
       .uint64(summaryOffset.groupStart)
       .uint64(summaryOffset.groupLength);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
 
-    return 24n;
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
+      .seek(startPosition)
+      .uint64(BigInt(endPosition - startPosition - 8))
+      .seek(endPosition);
+
+    return BigInt(endPosition - startPosition + 1);
+  }
+
+  writeStatistics(statistics: Statistics): bigint {
+    this.bufferBuilder.uint8(Opcode.STATISTICS);
+
+    const startPosition = this.bufferBuilder.length;
+
+    this.bufferBuilder
+      .uint64(0n) // placeholder size
+      .uint64(statistics.messageCount)
+      .uint32(statistics.channelCount)
+      .uint32(statistics.attachmentCount)
+      .uint32(statistics.chunkCount)
+      .tupleArray(
+        (key) => this.bufferBuilder.uint16(key),
+        (value) => this.bufferBuilder.uint64(value),
+        statistics.channelMessageCounts.entries(),
+      );
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
+
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
+      .seek(startPosition)
+      .uint64(BigInt(endPosition - startPosition - 8))
+      .seek(endPosition);
+
+    return BigInt(endPosition - startPosition + 1);
+  }
+
+  writeDataEnd(dataEnd: DataEnd): bigint {
+    this.bufferBuilder.uint8(Opcode.DATA_END);
+
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
+      .uint64(0n) // placeholder size
+      .uint32(dataEnd.dataSectionCrc);
+    if (this.options?.padRecords === true) {
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+    }
+
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
+      .seek(startPosition)
+      .uint64(BigInt(endPosition - startPosition - 8))
+      .seek(endPosition);
+
+    return BigInt(endPosition - startPosition + 1);
   }
 }

--- a/typescript/src/v0/Mcap0StreamReader.test.ts
+++ b/typescript/src/v0/Mcap0StreamReader.test.ts
@@ -68,6 +68,9 @@ describe("Mcap0StreamReader", () => {
           ...string("lz4"), // compression
           // no chunk data
         ]),
+        ...record(Opcode.DATA_END, [
+          ...uint32LE(0), // data section crc
+        ]),
         ...record(Opcode.FOOTER, [
           ...uint64LE(0n), // summary start
           ...uint64LE(0n), // summary offset start
@@ -250,18 +253,15 @@ describe("Mcap0StreamReader", () => {
       new Uint8Array([
         ...MCAP0_MAGIC,
 
-        ...record(
-          Opcode.CHANNEL_INFO,
-          crcSuffix([
-            ...uint16LE(1), // channel id
-            ...string("mytopic"), // topic
-            ...string("utf12"), // message encoding
-            ...string("json"), // schema encoding
-            ...string("stuff"), // schema
-            ...string("some data"), // schema name
-            ...keyValues(string, string, [["foo", "bar"]]), // user data
-          ]),
-        ),
+        ...record(Opcode.CHANNEL_INFO, [
+          ...uint16LE(1), // channel id
+          ...string("mytopic"), // topic
+          ...string("utf12"), // message encoding
+          ...string("json"), // schema encoding
+          ...string("stuff"), // schema
+          ...string("some data"), // schema name
+          ...keyValues(string, string, [["foo", "bar"]]), // user data
+        ]),
 
         ...record(Opcode.FOOTER, [
           ...uint64LE(0n), // summary start
@@ -291,18 +291,15 @@ describe("Mcap0StreamReader", () => {
   });
 
   it.each([true, false])("parses channel info in chunk (compressed: %s)", (compressed) => {
-    const channelInfo = record(
-      Opcode.CHANNEL_INFO,
-      crcSuffix([
-        ...uint16LE(1), // channel id
-        ...string("mytopic"), // topic
-        ...string("utf12"), // message encoding
-        ...string("json"), // schema encoding
-        ...string("stuff"), // schema
-        ...string("some data"), // schema name
-        ...keyValues(string, string, [["foo", "bar"]]), // user data
-      ]),
-    );
+    const channelInfo = record(Opcode.CHANNEL_INFO, [
+      ...uint16LE(1), // channel id
+      ...string("mytopic"), // topic
+      ...string("utf12"), // message encoding
+      ...string("json"), // schema encoding
+      ...string("stuff"), // schema
+      ...string("some data"), // schema name
+      ...keyValues(string, string, [["foo", "bar"]]), // user data
+    ]);
     const decompressHandlers = { xyz: () => channelInfo };
     const reader = new Mcap0StreamReader(compressed ? { decompressHandlers } : undefined);
     reader.append(
@@ -351,95 +348,77 @@ describe("Mcap0StreamReader", () => {
       it.each([
         {
           key: "topic",
-          channelInfo2: record(
-            Opcode.CHANNEL_INFO,
-            crcSuffix([
-              ...uint16LE(42), // channel id
-              ...string("XXXXXXXX"), // topic
-              ...string("utf12"), // message encoding
-              ...string("json"), // schema encoding
-              ...string("stuff"), // schema
-              ...string("some data"), // schema name
-              ...keyValues(string, string, [["foo", "bar"]]), // user data
-            ]),
-          ),
-        },
-        {
-          key: "encoding",
-          channelInfo2: record(
-            Opcode.CHANNEL_INFO,
-            crcSuffix([
-              ...uint16LE(42), // channel id
-              ...string("mytopic"), // topic
-              ...string("XXXXXXXX"), // message encoding
-              ...string("json"), // schema encoding
-              ...string("stuff"), // schema
-              ...string("some data"), // schema name
-              ...keyValues(string, string, [["foo", "bar"]]), // user data
-            ]),
-          ),
-        },
-        {
-          key: "schema name",
-          channelInfo2: record(
-            Opcode.CHANNEL_INFO,
-            crcSuffix([
-              ...uint16LE(42), // channel id
-              ...string("mytopic"), // topic
-              ...string("utf12"), // message encoding
-              ...string("json"), // schema encoding
-              ...string("stuff"), // schema
-              ...string("XXXXXXXX"), // schema name
-              ...keyValues(string, string, [["foo", "bar"]]), // user data
-            ]),
-          ),
-        },
-        {
-          key: "schema",
-          channelInfo2: record(
-            Opcode.CHANNEL_INFO,
-            crcSuffix([
-              ...uint16LE(42), // channel id
-              ...string("mytopic"), // topic
-              ...string("utf12"), // message encoding
-              ...string("json"), // schema encoding
-              ...string("XXXXXXXX"), // schema
-              ...string("some data"), // schema name
-              ...keyValues(string, string, [["foo", "bar"]]), // user data
-            ]),
-          ),
-        },
-        {
-          key: "data",
-          channelInfo2: record(
-            Opcode.CHANNEL_INFO,
-            crcSuffix([
-              ...uint16LE(42), // channel id
-              ...string("mytopic"), // topic
-              ...string("utf12"), // message encoding
-              ...string("json"), // schema encoding
-              ...string("stuff"), // schema
-              ...string("some data"), // schema name
-              ...keyValues(string, string, [
-                ["foo", "bar"],
-                ["baz", "quux"],
-              ]), // user data
-            ]),
-          ),
-        },
-      ])("differing in $key", ({ channelInfo2 }) => {
-        const channelInfo = record(
-          Opcode.CHANNEL_INFO,
-          crcSuffix([
+          channelInfo2: record(Opcode.CHANNEL_INFO, [
             ...uint16LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("XXXXXXXX"), // topic
             ...string("utf12"), // message encoding
             ...string("json"), // schema encoding
             ...string("stuff"), // schema
             ...string("some data"), // schema name
             ...keyValues(string, string, [["foo", "bar"]]), // user data
           ]),
-        );
+        },
+        {
+          key: "encoding",
+          channelInfo2: record(Opcode.CHANNEL_INFO, [
+            ...uint16LE(42), // channel id
+            ...string("mytopic"), // topic
+            ...string("XXXXXXXX"), // message encoding
+            ...string("json"), // schema encoding
+            ...string("stuff"), // schema
+            ...string("some data"), // schema name
+            ...keyValues(string, string, [["foo", "bar"]]), // user data
+          ]),
+        },
+        {
+          key: "schema name",
+          channelInfo2: record(Opcode.CHANNEL_INFO, [
+            ...uint16LE(42), // channel id
+            ...string("mytopic"), // topic
+            ...string("utf12"), // message encoding
+            ...string("json"), // schema encoding
+            ...string("stuff"), // schema
+            ...string("XXXXXXXX"), // schema name
+            ...keyValues(string, string, [["foo", "bar"]]), // user data
+          ]),
+        },
+        {
+          key: "schema",
+          channelInfo2: record(Opcode.CHANNEL_INFO, [
+            ...uint16LE(42), // channel id
+            ...string("mytopic"), // topic
+            ...string("utf12"), // message encoding
+            ...string("json"), // schema encoding
+            ...string("XXXXXXXX"), // schema
+            ...string("some data"), // schema name
+            ...keyValues(string, string, [["foo", "bar"]]), // user data
+          ]),
+        },
+        {
+          key: "data",
+          channelInfo2: record(Opcode.CHANNEL_INFO, [
+            ...uint16LE(42), // channel id
+            ...string("mytopic"), // topic
+            ...string("utf12"), // message encoding
+            ...string("json"), // schema encoding
+            ...string("stuff"), // schema
+            ...string("some data"), // schema name
+            ...keyValues(string, string, [
+              ["foo", "bar"],
+              ["baz", "quux"],
+            ]), // user data
+          ]),
+        },
+      ])("differing in $key", ({ channelInfo2 }) => {
+        const channelInfo = record(Opcode.CHANNEL_INFO, [
+          ...uint16LE(42), // channel id
+          ...string("mytopic"), // topic
+          ...string("utf12"), // message encoding
+          ...string("json"), // schema encoding
+          ...string("stuff"), // schema
+          ...string("some data"), // schema name
+          ...keyValues(string, string, [["foo", "bar"]]), // user data
+        ]);
         const reader = new Mcap0StreamReader();
         reader.append(
           new Uint8Array([
@@ -500,4 +479,45 @@ describe("Mcap0StreamReader", () => {
       });
     },
   );
+
+  it("validates attachment crc", () => {
+    const reader = new Mcap0StreamReader();
+    reader.append(
+      new Uint8Array([
+        ...MCAP0_MAGIC,
+        ...record(
+          Opcode.ATTACHMENT,
+          crcSuffix([
+            ...string("myfile"), // name
+            ...uint64LE(1n), // created at
+            ...uint64LE(2n), // log time
+            ...string("text/plain"), // content type
+            ...uint64LE(BigInt(new TextEncoder().encode("hello").byteLength)), // data length
+            ...new TextEncoder().encode("hello"), // data
+          ]),
+        ),
+        ...record(Opcode.FOOTER, [
+          ...uint64LE(0n), // summary start
+          ...uint64LE(0n), // summary offset start
+          ...uint32LE(0), // summary crc
+        ]),
+        ...MCAP0_MAGIC,
+      ]),
+    );
+    expect(reader.nextRecord()).toEqual({
+      type: "Attachment",
+      name: "myfile",
+      createdAt: 1n,
+      recordTime: 2n,
+      contentType: "text/plain",
+      data: new TextEncoder().encode("hello"),
+    } as TypedMcapRecords["Attachment"]);
+    expect(reader.nextRecord()).toEqual({
+      type: "Footer",
+      summaryStart: 0n,
+      summaryOffsetStart: 0n,
+      crc: 0,
+    });
+    expect(reader.done()).toBe(true);
+  });
 });

--- a/typescript/src/v0/Mcap0StreamReader.ts
+++ b/typescript/src/v0/Mcap0StreamReader.ts
@@ -128,6 +128,7 @@ export default class Mcap0StreamReader implements McapStreamReader {
         this.buffer.consume(usedBytes);
       }
       switch (record.type) {
+        case "DataEnd":
         case "Unknown":
           break;
         case "Header":
@@ -191,6 +192,7 @@ export default class Mcap0StreamReader implements McapStreamReader {
               case "Metadata":
               case "MetadataIndex":
               case "SummaryOffset":
+              case "DataEnd":
                 throw new Error(`${chunkResult.record.type} record not allowed inside a chunk`);
               case "ChannelInfo":
               case "Message":

--- a/typescript/src/v0/constants.ts
+++ b/typescript/src/v0/constants.ts
@@ -16,7 +16,8 @@ export enum Opcode {
   METADATA = 0x0b,
   METADATA_INDEX = 0x0c,
   SUMMARY_OFFSET = 0x0d,
-  MAX = 0x0d,
+  DATA_END = 0x0e,
+  MAX = 0x0e,
 }
 
 export function isKnownOpcode(opcode: number): opcode is Opcode {

--- a/typescript/src/v0/types.ts
+++ b/typescript/src/v0/types.ts
@@ -52,6 +52,7 @@ export type ChunkIndex = {
 };
 export type Attachment = {
   name: string;
+  createdAt: bigint;
   recordTime: bigint;
   contentType: string;
   data: Uint8Array;
@@ -85,6 +86,9 @@ export type SummaryOffset = {
   groupStart: bigint;
   groupLength: bigint;
 };
+export type DataEnd = {
+  dataSectionCrc: number;
+};
 export type UnknownRecord = {
   opcode: number;
   data: Uint8Array;
@@ -104,6 +108,7 @@ export type McapRecords = {
   Metadata: Metadata;
   MetadataIndex: MetadataIndex;
   SummaryOffset: SummaryOffset;
+  DataEnd: DataEnd;
   Unknown: UnknownRecord;
 };
 


### PR DESCRIPTION
- Remove CRC parsing for Channel Info, Attachment Index, Chunk Index (#55)
- Add record padding to `Mcap0RecordBuilder` (split from #79)
- Add Data End record
- Add `createdAt` to Attachment record
- Add `writeStatistics` and `writeDataEnd` to `Mcap0RecordBuilder`
- Add test & fix attachment CRC validation