### PR TITLE
Minor allocation reductions for go bag transcoder

### DIFF
--- a/go/ros/Makefile
+++ b/go/ros/Makefile
@@ -3,3 +3,6 @@ test:
 
 lint:
 	golangci-lint run ./...
+
+bench:
+	go test -benchmem -run=^$$ -count 5 -bench ^Benchmark -memprofile mem.prof -cpuprofile cpu.prof

--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -75,6 +75,7 @@ func processBag(
 
 	headerbuf := make([]byte, 1024)
 	buf := make([]byte, 8)
+	data := make([]byte, 1024*1024)
 	for {
 		// header len
 		_, err := io.ReadFull(r, buf[:4])
@@ -111,8 +112,10 @@ func processBag(
 		}
 
 		// data
-		data := make([]byte, datalen)
-		_, err = io.ReadFull(r, data)
+		if len(data) < int(datalen) {
+			data = make([]byte, datalen*2)
+		}
+		_, err = io.ReadFull(r, data[:datalen])
 		if err != nil {
 			return err
 		}
@@ -127,9 +130,9 @@ func processBag(
 			var reader io.Reader
 			switch string(compression) {
 			case "lz4":
-				reader = lz4.NewReader(bytes.NewReader(data))
+				reader = lz4.NewReader(bytes.NewReader(data[:datalen]))
 			case "none":
-				reader = bytes.NewReader(data)
+				reader = bytes.NewReader(data[:datalen])
 			default:
 				return fmt.Errorf("unsupported compression: %s", compression)
 			}
@@ -138,12 +141,12 @@ func processBag(
 				return err
 			}
 		case OpBagConnection:
-			err := connectionCallback(header, data)
+			err := connectionCallback(header, data[:datalen])
 			if err != nil {
 				return err
 			}
 		case OpBagMessageData:
-			err := msgcallback(header, data)
+			err := msgcallback(header, data[:datalen])
 			if err != nil {
 				return err
 			}

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -1,0 +1,47 @@
+package ros
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func BenchmarkBag2MCAP(b *testing.B) {
+	cases := []struct {
+		assertion string
+		inputfile string
+	}{
+		{
+			"demo bag",
+			"../../testdata/bags/demo.bag",
+		},
+		// {
+		// 	"cal loop",
+		// 	"~/data/bags/cal_loop.bag",
+		// },
+	}
+	for _, c := range cases {
+		stats, err := os.Stat(c.inputfile)
+		assert.Nil(b, err)
+		input, err := os.ReadFile(c.inputfile)
+		assert.Nil(b, err)
+		reader := &bytes.Reader{}
+		writer := &bytes.Buffer{}
+		b.ResetTimer()
+		b.Run(c.assertion, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				t0 := time.Now()
+				reader.Reset(input)
+				writer.Reset()
+				err = Bag2MCAP(reader, writer)
+				assert.Nil(b, err)
+				elapsed := time.Since(t0)
+				mbread := stats.Size() / (1024 * 1024)
+				b.ReportMetric(float64(mbread)/elapsed.Seconds(), "MB/sec")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a basic benchmark test for the mcap to bag conversion, and reuses a
message buffer across messages when transcoding.