### PR TITLE
Swap arg order for bag conversion functions

### DIFF
--- a/go/mcap/cmd/cat.go
+++ b/go/mcap/cmd/cat.go
@@ -18,8 +18,9 @@ var (
 )
 
 var catCmd = &cobra.Command{
-	Use:   "cat",
+	Use:   "cat [file]",
 	Short: "Cat the messages in an mcap file to stdout",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		topics := strings.FieldsFunc(topics, func(c rune) bool { return c == ',' })
 		f, err := os.Open(args[0])
@@ -47,7 +48,7 @@ var catCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(catCmd)
 
-	catCmd.PersistentFlags().Int64VarP(&start, "start seconds", "", 0, "start time (epoch seconds)")
-	catCmd.PersistentFlags().Int64VarP(&end, "end seconds", "", math.MaxInt64, "end time (epoch seconds)")
+	catCmd.PersistentFlags().Int64VarP(&start, "start-secs", "", 0, "start time")
+	catCmd.PersistentFlags().Int64VarP(&end, "end-secs", "", math.MaxInt64, "end time")
 	catCmd.PersistentFlags().StringVarP(&topics, "topics", "", "", "comma-separated list of topics")
 }

--- a/go/mcap/cmd/convert.go
+++ b/go/mcap/cmd/convert.go
@@ -56,7 +56,7 @@ var convertCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		filetype, err := checkMagic(args[0])
 		if err != nil {
-			die("Magic number check failed: %s", err)
+			die("magic number check failed: %s", err)
 		}
 
 		f, err := os.Open(args[0])
@@ -72,7 +72,7 @@ var convertCmd = &cobra.Command{
 
 		switch filetype {
 		case "ros1":
-			err = ros.Bag2MCAP(f, w)
+			err = ros.Bag2MCAP(w, f)
 			if err != nil && !errors.Is(err, io.EOF) {
 				die("failed to convert file: %s", err)
 			}
@@ -87,7 +87,7 @@ var convertCmd = &cobra.Command{
 			if prefix != "" {
 				dirs = append(dirs, prefix)
 			}
-			err = ros.DB3ToMCAP(db, w, dirs)
+			err = ros.DB3ToMCAP(w, db, dirs)
 			if err != nil {
 				die("failed to convert file: %s", err)
 			}

--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -159,7 +159,7 @@ func processBag(
 	return nil
 }
 
-func Bag2MCAP(r io.Reader, w io.Writer) error {
+func Bag2MCAP(w io.Writer, r io.Reader) error {
 	writer, err := libmcap.NewWriter(w, &libmcap.WriterOptions{
 		Chunked:     true,
 		ChunkSize:   4 * 1024 * 1024,

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -36,7 +36,7 @@ func BenchmarkBag2MCAP(b *testing.B) {
 				t0 := time.Now()
 				reader.Reset(input)
 				writer.Reset()
-				err = Bag2MCAP(reader, writer)
+				err = Bag2MCAP(writer, reader)
 				assert.Nil(b, err)
 				elapsed := time.Since(t0)
 				mbread := stats.Size() / (1024 * 1024)

--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -135,7 +135,7 @@ func transformMessages(db *sql.DB, f func(*sql.Rows) error) error {
 	return nil
 }
 
-func DB3ToMCAP(db *sql.DB, w io.Writer, searchdirs []string) error {
+func DB3ToMCAP(w io.Writer, db *sql.DB, searchdirs []string) error {
 	writer, err := libmcap.NewWriter(w, &libmcap.WriterOptions{
 		Chunked:     true,
 		ChunkSize:   4 * 1024 * 1024,

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -16,7 +16,7 @@ func TestDB3MCAPConversion(t *testing.T) {
 	db, err := sql.Open("sqlite3", db3file)
 	assert.Nil(t, err)
 
-	err = DB3ToMCAP(db, buf, []string{"./testdata/galactic"})
+	err = DB3ToMCAP(buf, db, []string{"./testdata/galactic"})
 	assert.Nil(t, err)
 
 	reader, err := libmcap.NewReader(bytes.NewReader(buf.Bytes()))


### PR DESCRIPTION
Swaps the argument order for the bag to mcap conversion function so that
the writer is the first argument, which is more conventional in Go. Also
addresses two issues with the CLI tool - the cat command now indicates
where the input file goes in its help output, and the start and end
flags are now start-secs and end-secs.