### PR TITLE
Add cspell to CI and VS Code

### DIFF
--- a/.github/cspell-problem-matcher.json
+++ b/.github/cspell-problem-matcher.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "cspell",
+      "pattern": [
+        {
+          "regexp": "^\\s*(.+):(\\d+):(\\d+) - (.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches: ["*"]
 
 jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn spellcheck
+
   conformance:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           cache: yarn
 
       - run: yarn install --frozen-lockfile
+      - run: echo '::add-matcher::.github/cspell-problem-matcher.json'
       - run: yarn spellcheck
 
   conformance:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "esbenp.prettier-vscode",
     "orta.vscode-jest",
     "ms-vscode.cpptools-extension-pack",
-    "ms-vscode-remote.vscode-remote-extensionpack"
+    "ms-vscode-remote.vscode-remote-extensionpack",
+    "streetsidesoftware.code-spell-checker"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,8 @@
   },
   "jest.jestCommandLine": "yarn workspace @foxglove/mcap test",
 
+  "cSpell.enabled": true,
+
   "search.exclude": {
     "**/node_modules": true,
     "tests/conformance/data": true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MCAP file format
 
-* [Draft specification](./docs/specification)
+- [Draft specification](./docs/specification)
 
-## Developer quickstart
+## Developer quick start
 
 ### TypeScript
 

--- a/cpp/scripts/format.py
+++ b/cpp/scripts/format.py
@@ -35,7 +35,7 @@ def main(dirs: List[str], fix: bool):
                         orig,
                         stdout,
                         fromfile=path,
-                        tofile=f"clang-format {path}",
+                        tofile=f"clang-format {path}",  # cspell:disable-line
                         lineterm="",
                     )
                     had_diff = False
@@ -58,7 +58,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run clang-format and display changed files."
     )
-    parser.add_argument("dirs", help="List of directories to search", nargs="+")
+    parser.add_argument(
+        "dirs", help="List of directories to search", nargs="+")
     parser.add_argument("--fix", action="store_true")
     args = parser.parse_args()
     sys.exit(main(**vars(args)))

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,50 @@
+$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+version: "0.2"
+ignorePaths:
+  - cspell.config.yaml
+  - node_modules
+  - go.mod
+  - go.sum
+  - testdata
+  - "*.Dockerfile"
+  - "*.mcap"
+
+words:
+  - cbor
+  - cmake
+  - crc
+  - crcs
+  - deserialization
+  - golangci
+  - libmcap
+  - mcap
+  - nsec
+  - nsecs
+  - proto
+  - protobuf
+  - rosbag
+  - rosmsg
+  - typecheck
+  - unchunked
+  - unindexed
+  - velodyne
+  - zstd
+
+overrides:
+  - filename: "**/*.go"
+    words:
+      - libmcap
+    ignoreRegExpList:
+      - '"github\.com.+?"'
+
+  - filename: "CMakeLists.txt"
+    words:
+      - conanbuildinfo
+
+  - filename: "cpp/**"
+    words:
+      - cppstd
+
+  - filename: "**/{*.js,*.ts,*.tsx}"
+    ignoreRegExpList:
+      - "0x[0-9a-f]+n?"

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -37,6 +37,12 @@ overrides:
     ignoreRegExpList:
       - '"github\.com.+?"'
 
+  - filename: "go/**/Makefile"
+    words:
+      - memprofile
+      - cpuprofile
+      - benchmem
+
   - filename: "CMakeLists.txt"
     words:
       - conanbuildinfo

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -259,7 +259,7 @@ A Statistics record contains summary information about the recorded data. The st
 
 When using a Statistics record with channel_message_counts, the Summary Data section MUST contain a copy of all Channel Info records. The Channel Info records MUST occur prior to the statistics record.
 
-> Why? The typical usecase for tools is to provide a listing of the types and quantities of messages stored in the file. Without an easy to access copy of the Channel Info records, tools would need to linearly scan the file for Channel Info records to display what types of messages exist in the file.
+> Why? The typical use case for tools is to provide a listing of the types and quantities of messages stored in the file. Without an easy to access copy of the Channel Info records, tools would need to linearly scan the file for Channel Info records to display what types of messages exist in the file.
 
 ### Metadata (op=0x0B)
 
@@ -294,7 +294,7 @@ A Summary Offset record contains the location of records within the summary sect
 
 A Data End record indicates the end of the data section.
 
-> Why? When reading a file from start to end, there is ambiguity when the data section ends and the summary section starts because some records (i.e. Channel Info) can repeat for summary data. The Data End record provides a clear dilineation the data section has ended.
+> Why? When reading a file from start to end, there is ambiguity when the data section ends and the summary section starts because some records (i.e. Channel Info) can repeat for summary data. The Data End record provides a clear delineation the data section has ended.
 
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -147,7 +147,7 @@ Channel Info records are uniquely identified within a file by their channel ID. 
 | 4 + N | topic | String | The channel topic. |
 | 4 + N | message_encoding | String | Encoding for messages on this channel. The value should be one of the [well-known message encodings](./well-known-encodings.md). Custom values should use `x-` prefix. |
 | 4 + N | schema_encoding | String | Format for the schema. The value should be one of the [well-known schema formats](./well-known-schema-formats.md). Custom values should use the `x-` prefix. |
-| 4 + N | schema | uint32 lengh prefixed Bytes | Schema should conform to the schema_encoding. |
+| 4 + N | schema | uint32 length-prefixed Bytes | Schema should conform to the schema_encoding. |
 | 4 + N | schema_name | String | An identifier for the schema. The schema name should conform to any schema_encoding requirements. |
 | 4 + N | metadata | Map<string, string> | Metadata about this channel |
 

--- a/docs/specification/notes/explanatory-notes.md
+++ b/docs/specification/notes/explanatory-notes.md
@@ -30,12 +30,12 @@ Which of these options is preferable will tend to depend on the proportion of to
 
 ### Listing and accessing attachments
 
-The format provides the ability to list attachments contained wihtin the file, and quickly extract them from the file contents. To list/select attachments in the file:
+The format provides the ability to list attachments contained within the file, and quickly extract them from the file contents. To list/select attachments in the file:
 
 1. Read the fixed-length footer and seek to the start of the index data section.
 2. Scan forward until encountering the attachment index, then read attachment index records until encountering a record that is not an attachment index.
-3. The rcords covered in the previous read will include attachment names, types, sizes, and timestamps. These can be used to fill out a list of attachments for selection.
-4. To select an attachment from th efile, seek to the associated offset in the file and unpack the file content from the attachment record.
+3. The records covered in the previous read will include attachment names, types, sizes, and timestamps. These can be used to fill out a list of attachments for selection.
+4. To select an attachment from the file, seek to the associated offset in the file and unpack the file content from the attachment record.
 
 ### Accessing summary statistics
 

--- a/docs/specification/profiles/ros1.md
+++ b/docs/specification/profiles/ros1.md
@@ -16,5 +16,5 @@ MUST be `ros1msg`
 
 #### user_data
 
-- callerid (optional, string)
+- callerid (optional, string) <!-- cspell:disable-line -->
 - latching (optional, bool stringified as "true" or "false")

--- a/go/libmcap/lexer_test.go
+++ b/go/libmcap/lexer_test.go
@@ -337,8 +337,8 @@ func BenchmarkLexer(b *testing.B) {
 					bytecount += int64(n)
 				}
 				elapsed := time.Since(t0)
-				mbread := bytecount / (1024 * 1024)
-				b.ReportMetric(float64(mbread)/elapsed.Seconds(), "MB/sec")
+				mbRead := bytecount / (1024 * 1024)
+				b.ReportMetric(float64(mbRead)/elapsed.Seconds(), "MB/sec")
 				b.ReportMetric(float64(tokens)/elapsed.Seconds(), "tokens/sec")
 				b.ReportMetric(float64(elapsed.Nanoseconds())/float64(tokens), "ns/token")
 			}

--- a/go/libmcap/writer_test.go
+++ b/go/libmcap/writer_test.go
@@ -116,7 +116,7 @@ func TestChunkedReadWrite(t *testing.T) {
 				SchemaName:      "foo",
 				Schema:          []byte{},
 				Metadata: map[string]string{
-					"callerid": "100",
+					"callerid": "100", // cspell:disable-line
 				},
 			})
 			assert.Nil(t, err)
@@ -223,7 +223,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 		SchemaName:      "foo",
 		Schema:          []byte{},
 		Metadata: map[string]string{
-			"callerid": "100",
+			"callerid": "100", // cspell:disable-line
 		},
 	})
 	assert.Nil(t, err)

--- a/go/mcap/Makefile
+++ b/go/mcap/Makefile
@@ -1,4 +1,5 @@
 build:
+# cspell:disable-next-line
 	go build -ldflags="-extldflags=-static" -tags sqlite_omit_load_extension,netgo
 
 lint:

--- a/go/mcap/README.md
+++ b/go/mcap/README.md
@@ -9,39 +9,40 @@ for details:
 
     Usage:
       mcap [command]
-    
+
     Available Commands:
       cat         Cat the messages in an mcap file to stdout
       completion  Generate the autocompletion script for the specified shell
       convert     Convert a bag file to an mcap file
       help        Help about any command
       info        Report statistics about an mcap file
-    
+
     Flags:
           --config string   config file (default is $HOME/.mcap.yaml)
       -h, --help            help for mcap
       -t, --toggle          Help message for toggle
-    
+
     Use "mcap [command] --help" for more information about a command.
-
-
 
 Examples:
 
-
 Convert a bag file to mcap:
+
+<!-- cspell: disable -->
 
     [~/work/mcap/go/mcap] (task/mcap-client) $ mcap convert ../../testdata/bags/demo.bag demo.mcap
 
+<!-- cspell: enable -->
+
 Report summary statistics on an mcap file:
 
-    [~/work/mcap/go/mcap] (task/mcap-client) $ mcap info demo.mcap 
+    [~/work/mcap/go/mcap] (task/mcap-client) $ mcap info demo.mcap
     duration: 7.780758504s
     start: 2017-03-21T19:26:20.103843113-07:00
     end: 2017-03-21T19:26:27.884601617-07:00
     messages: 1606
     chunks:
-    	lz4: [27/27 chunks] (44.32%) 
+    	lz4: [27/27 chunks] (44.32%)
     channels
     	(0) /diagnostics: 52 msgs
     	(1) /image_color/compressed: 234 msgs

--- a/go/mcap/cmd/convert.go
+++ b/go/mcap/cmd/convert.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	rosMagic = []byte("#ROSBAG V2.0")
+	bagMagic = []byte("#ROSBAG V2.0")
 	db3Magic = []byte{0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00}
 )
 
@@ -28,17 +28,17 @@ func checkMagic(path string) (string, error) {
 	}
 	defer f.Close()
 
-	rosmagic := make([]byte, len(rosMagic))
-	_, err = f.Read(rosmagic)
+	magic := make([]byte, len(bagMagic))
+	_, err = f.Read(magic)
 	if err != nil {
 		die("failed to read magic bytes: %s", err)
 	}
-	if bytes.Equal(rosmagic, rosMagic) {
+	if bytes.Equal(magic, bagMagic) {
 		return "ros1", nil
 	}
 
 	db3magic := make([]byte, len(db3Magic))
-	n := copy(db3magic, rosmagic)
+	n := copy(db3magic, magic)
 	_, err = f.Read(db3magic[n:])
 	if err != nil {
 		die("failed to read magic bytes: %s", err)

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -39,8 +39,8 @@ func BenchmarkBag2MCAP(b *testing.B) {
 				err = Bag2MCAP(writer, reader)
 				assert.Nil(b, err)
 				elapsed := time.Since(t0)
-				mbread := stats.Size() / (1024 * 1024)
-				b.ReportMetric(float64(mbread)/elapsed.Seconds(), "MB/sec")
+				megabytesRead := stats.Size() / (1024 * 1024)
+				b.ReportMetric(float64(megabytesRead)/elapsed.Seconds(), "MB/sec")
 			}
 		})
 	}

--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -27,7 +27,7 @@ func collectMessageSchemas(directories []string, types []string) (map[string][]b
 	interfaceDirs := make(map[string]string)
 	for _, dir := range directories {
 		err := filepath.Walk(dir, func(filepath string, info os.FileInfo, err error) error {
-			if info.IsDir() && info.Name() == "rosidl_interfaces" {
+			if info.IsDir() && info.Name() == "rosidl_interfaces" { // cspell:disable-line
 				interfaceDirs[dir] = filepath
 			}
 			return nil

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   },
   "scripts": {
     "lint:docs": "prettier docs --check",
+    "spellcheck": "cspell --no-progress --relative '**'",
     "test:conformance:generate-inputs": "yarn workspace @foxglove/mcap-conformance generate-inputs --data-dir \"$(pwd)/tests/conformance/data\"",
     "test:conformance": "yarn workspace @foxglove/mcap-conformance run-tests --data-dir \"$(pwd)/tests/conformance/data\""
   },
   "devDependencies": {
+    "cspell": "^5.18.0",
     "prettier": "^2.5.1"
   }
 }

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.expected.txt
@@ -1,7 +1,7 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 SummaryOffset group_length=0 group_opcode=12 group_start=161
 SummaryOffset group_length=36 group_opcode=10 group_start=125
 SummaryOffset group_length=82 group_opcode=9 group_start=161

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8af2a72b8375b44760283d7cb8c45ff7346734966d07dd513123cabb7cad3ef5
+oid sha256:e971e94576e5a727475a38dcf9bebdad3992d4c26247c24fa56948bb45d07b90
 size 396

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.expected.txt
@@ -1,5 +1,5 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 Footer summary_offset_start=0 summary_start=125

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1d58f41d538659aadff884ee933fa5ebbc9c9772a96c9f6673466be6c66d994
+oid sha256:60c2fc3e6349f49bdea529e6f6e634a8a428265a69be5bc5fa1d4247c16007b9
 size 280

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.expected.txt
@@ -1,6 +1,6 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 SummaryOffset group_length=0 group_opcode=12 group_start=125
 SummaryOffset group_length=82 group_opcode=9 group_start=125
 SummaryOffset group_length=0 group_opcode=7 group_start=207

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e6da3cf14b545d904679ddead2efefeff767843f725036d7176c7e12bcb017b
+oid sha256:1ccff3b8dfdaa1ef7f1bcb7cbf9a92fc13c59d06c066ac69afeac972092f8133
 size 331

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.expected.txt
@@ -1,4 +1,4 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 Footer summary_offset_start=0 summary_start=125

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae8a2bdbf3a58cc554e315ecce52ce5bb817d17bba30e3eb2b17eff0ccc2f935
+oid sha256:353639c6973e702ee5b53903cd4c8444b03a24abf19da073b5c37f57ed6c1b82
 size 244

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-st-sum.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-st-sum.expected.txt
@@ -1,7 +1,7 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 SummaryOffset group_length=0 group_opcode=12 group_start=149
 SummaryOffset group_length=33 group_opcode=10 group_start=116
 SummaryOffset group_length=79 group_opcode=9 group_start=149

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-st-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-st-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2798d37c19d51f8da5b3fd2ecc44ad0415c17d578d6140569711350ea260ad08
+oid sha256:00bcee0aa468707a6bbc7f18d4487869a7c86c8f3f373e7f81dd0255f2be89dd
 size 369

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-st.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-st.expected.txt
@@ -1,5 +1,5 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 Footer summary_offset_start=0 summary_start=116

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-st.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-st.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9a232ee54460da4c0d9e763a5082d8a5cba384b41426d5cd263ce64036fe729
+oid sha256:978d565180fe864be841377f86638efd628a8be4998b2d9cda96cb9b993e717d
 size 265

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-sum.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-sum.expected.txt
@@ -1,6 +1,6 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 SummaryOffset group_length=0 group_opcode=12 group_start=116
 SummaryOffset group_length=79 group_opcode=9 group_start=116
 SummaryOffset group_length=0 group_opcode=7 group_start=195

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3f91ebb48dc3d8fe9e6851dca3251cacf9ea8f1c95dbf004c2128e47c039de0
+oid sha256:48af102ee5043f74dd61ffe85cc0ca4aef4e20a3a476b1a455db9037bbad1df5
 size 310

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax.expected.txt
@@ -1,4 +1,4 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 Footer summary_offset_start=0 summary_start=116

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ec840a47990e92311ebce14b5d980b10e9230612f2d51b0d2eb35b0595055b3
+oid sha256:04d76698e633afaacb0596df8fb98c4e2e4da6baef38e9d811ccb899ab6b5219
 size 232

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad-st-sum.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad-st-sum.expected.txt
@@ -1,7 +1,7 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 SummaryOffset group_length=0 group_opcode=12 group_start=161
 SummaryOffset group_length=36 group_opcode=10 group_start=125
 SummaryOffset group_length=82 group_opcode=9 group_start=161

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad-st-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad-st-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8af2a72b8375b44760283d7cb8c45ff7346734966d07dd513123cabb7cad3ef5
+oid sha256:e971e94576e5a727475a38dcf9bebdad3992d4c26247c24fa56948bb45d07b90
 size 396

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad-st.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad-st.expected.txt
@@ -1,5 +1,5 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 Footer summary_offset_start=0 summary_start=125

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad-st.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad-st.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1d58f41d538659aadff884ee933fa5ebbc9c9772a96c9f6673466be6c66d994
+oid sha256:60c2fc3e6349f49bdea529e6f6e634a8a428265a69be5bc5fa1d4247c16007b9
 size 280

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad.expected.txt
@@ -1,4 +1,4 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
-AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myfile offset=28
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
+AttachmentIndex content_type=application/octet-stream data_size=3 length=81 log_time=2 name=myFile offset=28
 Footer summary_offset_start=0 summary_start=125

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae8a2bdbf3a58cc554e315ecce52ce5bb817d17bba30e3eb2b17eff0ccc2f935
+oid sha256:353639c6973e702ee5b53903cd4c8444b03a24abf19da073b5c37f57ed6c1b82
 size 244

--- a/tests/conformance/data/OneAttachment/OneAttachment-st-sum.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-st-sum.expected.txt
@@ -1,7 +1,7 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 SummaryOffset group_length=0 group_opcode=12 group_start=149
 SummaryOffset group_length=33 group_opcode=10 group_start=116
 SummaryOffset group_length=79 group_opcode=9 group_start=149

--- a/tests/conformance/data/OneAttachment/OneAttachment-st-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-st-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2798d37c19d51f8da5b3fd2ecc44ad0415c17d578d6140569711350ea260ad08
+oid sha256:00bcee0aa468707a6bbc7f18d4487869a7c86c8f3f373e7f81dd0255f2be89dd
 size 369

--- a/tests/conformance/data/OneAttachment/OneAttachment-st.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment-st.expected.txt
@@ -1,5 +1,5 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
 Statistics attachment_count=1 channel_count=0 channel_message_counts={} chunk_count=0 message_count=0
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 Footer summary_offset_start=0 summary_start=116

--- a/tests/conformance/data/OneAttachment/OneAttachment-st.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-st.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9a232ee54460da4c0d9e763a5082d8a5cba384b41426d5cd263ce64036fe729
+oid sha256:978d565180fe864be841377f86638efd628a8be4998b2d9cda96cb9b993e717d
 size 265

--- a/tests/conformance/data/OneAttachment/OneAttachment.expected.txt
+++ b/tests/conformance/data/OneAttachment/OneAttachment.expected.txt
@@ -1,4 +1,4 @@
 Header library="" profile=""
-Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myfile
-AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myfile offset=25
+Attachment content_type=application/octet-stream created_at=1 data=<010203> log_time=2 name=myFile
+AttachmentIndex content_type=application/octet-stream data_size=3 length=78 log_time=2 name=myFile offset=25
 Footer summary_offset_start=0 summary_start=116

--- a/tests/conformance/data/OneAttachment/OneAttachment.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ec840a47990e92311ebce14b5d980b10e9230612f2d51b0d2eb35b0595055b3
+oid sha256:04d76698e633afaacb0596df8fb98c4e2e4da6baef38e9d811ccb899ab6b5219
 size 232

--- a/tests/conformance/scripts/generate-inputs.ts
+++ b/tests/conformance/scripts/generate-inputs.ts
@@ -256,7 +256,7 @@ const inputs: { name: string; records: TestDataRecord[] }[] = [
     records: [
       {
         type: "Attachment",
-        name: "myfile",
+        name: "myFile",
         contentType: "application/octet-stream",
         createdAt: 1n,
         recordTime: 2n,

--- a/typescript/scripts/bag2proto.ts
+++ b/typescript/scripts/bag2proto.ts
@@ -145,7 +145,7 @@ function convertTypedArrays(msg: Record<string, unknown>): Record<string, unknow
   return msg;
 }
 
-// IWrtiable interface for FileHandle
+// IWritable interface for FileHandle
 class FileHandleWritable implements IWritable {
   private handle: FileHandle;
   private totalBytesWritten = 0;

--- a/typescript/src/pre0/McapPre0Reader.test.ts
+++ b/typescript/src/pre0/McapPre0Reader.test.ts
@@ -298,7 +298,7 @@ describe("McapReader", () => {
   it("rejects message in chunk with no prior channel info in the same chunk", () => {
     const channelInfo = record(RecordType.CHANNEL_INFO, [
       ...uint32LE(42), // channel id
-      ...string("mytopic"), // topic
+      ...string("myTopic"), // topic
       ...string("utf12"), // encoding
       ...string("some data"), // schema name
       ...string("stuff"), // schema
@@ -340,7 +340,7 @@ describe("McapReader", () => {
     const expectedChannelInfo = {
       type: "ChannelInfo",
       id: 42,
-      topic: "mytopic",
+      topic: "myTopic",
       encoding: "utf12",
       schemaName: "some data",
       schema: "stuff",
@@ -361,7 +361,7 @@ describe("McapReader", () => {
   it("parses message and returns reference-equal channel info on the same channel in different chunks", () => {
     const channelInfo = record(RecordType.CHANNEL_INFO, [
       ...uint32LE(42), // channel id
-      ...string("mytopic"), // topic
+      ...string("myTopic"), // topic
       ...string("utf12"), // encoding
       ...string("some data"), // schema name
       ...string("stuff"), // schema
@@ -404,7 +404,7 @@ describe("McapReader", () => {
     const expectedChannelInfo = {
       type: "ChannelInfo",
       id: 42,
-      topic: "mytopic",
+      topic: "myTopic",
       encoding: "utf12",
       schemaName: "some data",
       schema: "stuff",
@@ -436,7 +436,7 @@ describe("McapReader", () => {
 
         ...record(RecordType.CHANNEL_INFO, [
           ...uint32LE(1), // channel id
-          ...string("mytopic"), // topic
+          ...string("myTopic"), // topic
           ...string("utf12"), // encoding
           ...string("some data"), // schema name
           ...string("stuff"), // schema
@@ -454,7 +454,7 @@ describe("McapReader", () => {
     expect(reader.nextRecord()).toEqual({
       type: "ChannelInfo",
       id: 1,
-      topic: "mytopic",
+      topic: "myTopic",
       encoding: "utf12",
       schemaName: "some data",
       schema: "stuff",
@@ -471,7 +471,7 @@ describe("McapReader", () => {
   it.each([true, false])("parses channel info in chunk (compressed: %s)", (compressed) => {
     const channelInfo = record(RecordType.CHANNEL_INFO, [
       ...uint32LE(1), // channel id
-      ...string("mytopic"), // topic
+      ...string("myTopic"), // topic
       ...string("utf12"), // encoding
       ...string("some data"), // schema name
       ...string("stuff"), // schema
@@ -502,7 +502,7 @@ describe("McapReader", () => {
     expect(reader.nextRecord()).toEqual({
       type: "ChannelInfo",
       id: 1,
-      topic: "mytopic",
+      topic: "myTopic",
       encoding: "utf12",
       schemaName: "some data",
       schema: "stuff",
@@ -535,7 +535,7 @@ describe("McapReader", () => {
           key: "encoding",
           channelInfo2: record(RecordType.CHANNEL_INFO, [
             ...uint32LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("XXXXXXXX"), // encoding
             ...string("some data"), // schema name
             ...string("stuff"), // schema
@@ -546,7 +546,7 @@ describe("McapReader", () => {
           key: "schema name",
           channelInfo2: record(RecordType.CHANNEL_INFO, [
             ...uint32LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("utf12"), // encoding
             ...string("XXXXXXXX"), // schema name
             ...string("stuff"), // schema
@@ -557,7 +557,7 @@ describe("McapReader", () => {
           key: "schema",
           channelInfo2: record(RecordType.CHANNEL_INFO, [
             ...uint32LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("utf12"), // encoding
             ...string("some data"), // schema name
             ...string("XXXXXXXX"), // schema
@@ -568,7 +568,7 @@ describe("McapReader", () => {
           key: "data",
           channelInfo2: record(RecordType.CHANNEL_INFO, [
             ...uint32LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("utf12"), // encoding
             ...string("some data"), // schema name
             ...string("stuff"), // schema
@@ -578,7 +578,7 @@ describe("McapReader", () => {
       ])("differing in $key", ({ channelInfo2 }) => {
         const channelInfo = record(RecordType.CHANNEL_INFO, [
           ...uint32LE(42), // channel id
-          ...string("mytopic"), // topic
+          ...string("myTopic"), // topic
           ...string("utf12"), // encoding
           ...string("some data"), // schema name
           ...string("stuff"), // schema
@@ -628,7 +628,7 @@ describe("McapReader", () => {
         expect(reader.nextRecord()).toEqual({
           type: "ChannelInfo",
           id: 42,
-          topic: "mytopic",
+          topic: "myTopic",
           encoding: "utf12",
           schemaName: "some data",
           schema: "stuff",

--- a/typescript/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/src/v0/Mcap0IndexedReader.test.ts
@@ -125,7 +125,7 @@ describe("Mcap0IndexedReader", () => {
     data.push(
       ...record(Opcode.CHANNEL_INFO, [
         ...uint16LE(42), // channel id
-        ...string("mytopic"), // topic
+        ...string("myTopic"), // topic
         ...string("utf12"), // encoding
         ...string("json"), // schema format
         ...string("stuff"), // schema
@@ -150,7 +150,7 @@ describe("Mcap0IndexedReader", () => {
             type: "ChannelInfo",
             channelId: 42,
             schemaEncoding: "json",
-            topicName: "mytopic",
+            topicName: "myTopic",
             messageEncoding: "utf12",
             schemaName: "some data",
             schema: "stuff",
@@ -198,7 +198,7 @@ describe("Mcap0IndexedReader", () => {
       async ({ startTime, endTime, expected }) => {
         const channelInfo = record(Opcode.CHANNEL_INFO, [
           ...uint16LE(42), // channel id
-          ...string("mytopic"), // topic
+          ...string("myTopic"), // topic
           ...string("utf12"), // message encoding
           ...string("json"), // schema format
           ...string("stuff"), // schema

--- a/typescript/src/v0/Mcap0RecordBuilder.test.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.test.ts
@@ -64,7 +64,7 @@ describe("Mcap0RecordBuilder", () => {
     const buffer = new BufferBuilder();
     buffer
       .uint8(3) // opcode
-      .uint64(BigInt(67)) // record content byte length
+      .uint64(BigInt(68)) // record content byte length
       .uint16(1)
       .string("/topic")
       .string("encoding")

--- a/typescript/src/v0/Mcap0RecordBuilder.test.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.test.ts
@@ -55,7 +55,7 @@ describe("Mcap0RecordBuilder", () => {
       channelId: 1,
       topicName: "/topic",
       messageEncoding: "encoding",
-      schemaEncoding: "someformat",
+      schemaEncoding: "some format",
       schemaName: "schema name",
       schema: "schema",
       userData: [],
@@ -68,7 +68,7 @@ describe("Mcap0RecordBuilder", () => {
       .uint16(1)
       .string("/topic")
       .string("encoding")
-      .string("someformat")
+      .string("some format")
       .string("schema")
       .string("schema name")
       .uint32(0); // user data length

--- a/typescript/src/v0/Mcap0RecordBuilder.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.ts
@@ -24,7 +24,7 @@ type Options = {
 /**
  * Mcap0RecordBuilder provides methods to serialize mcap records to a buffer in memory.
  *
- * It makes no effort to ensure spec compatability on the order of records, this is the responsibility
+ * It makes no effort to ensure spec compatibility on the order of records, this is the responsibility
  * of the caller.
  *
  * You'll likely want to use one of the higher level writer interfaces unless you are building your
@@ -187,7 +187,7 @@ export class Mcap0RecordBuilder {
 
     const startPosition = this.bufferBuilder.length;
     this.bufferBuilder
-      .uint64(0n) // palceholder
+      .uint64(0n) // placeholder
       .uint64(chunk.startTime)
       .uint64(chunk.endTime)
       .uint64(chunk.uncompressedSize)

--- a/typescript/src/v0/Mcap0StreamReader.test.ts
+++ b/typescript/src/v0/Mcap0StreamReader.test.ts
@@ -255,7 +255,7 @@ describe("Mcap0StreamReader", () => {
 
         ...record(Opcode.CHANNEL_INFO, [
           ...uint16LE(1), // channel id
-          ...string("mytopic"), // topic
+          ...string("myTopic"), // topic
           ...string("utf12"), // message encoding
           ...string("json"), // schema encoding
           ...string("stuff"), // schema
@@ -274,7 +274,7 @@ describe("Mcap0StreamReader", () => {
     expect(reader.nextRecord()).toEqual({
       type: "ChannelInfo",
       channelId: 1,
-      topicName: "mytopic",
+      topicName: "myTopic",
       messageEncoding: "utf12",
       schemaEncoding: "json",
       schemaName: "some data",
@@ -293,7 +293,7 @@ describe("Mcap0StreamReader", () => {
   it.each([true, false])("parses channel info in chunk (compressed: %s)", (compressed) => {
     const channelInfo = record(Opcode.CHANNEL_INFO, [
       ...uint16LE(1), // channel id
-      ...string("mytopic"), // topic
+      ...string("myTopic"), // topic
       ...string("utf12"), // message encoding
       ...string("json"), // schema encoding
       ...string("stuff"), // schema
@@ -326,7 +326,7 @@ describe("Mcap0StreamReader", () => {
     expect(reader.nextRecord()).toEqual({
       type: "ChannelInfo",
       channelId: 1,
-      topicName: "mytopic",
+      topicName: "myTopic",
       messageEncoding: "utf12",
       schemaEncoding: "json",
       schemaName: "some data",
@@ -362,7 +362,7 @@ describe("Mcap0StreamReader", () => {
           key: "encoding",
           channelInfo2: record(Opcode.CHANNEL_INFO, [
             ...uint16LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("XXXXXXXX"), // message encoding
             ...string("json"), // schema encoding
             ...string("stuff"), // schema
@@ -374,7 +374,7 @@ describe("Mcap0StreamReader", () => {
           key: "schema name",
           channelInfo2: record(Opcode.CHANNEL_INFO, [
             ...uint16LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("utf12"), // message encoding
             ...string("json"), // schema encoding
             ...string("stuff"), // schema
@@ -386,7 +386,7 @@ describe("Mcap0StreamReader", () => {
           key: "schema",
           channelInfo2: record(Opcode.CHANNEL_INFO, [
             ...uint16LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("utf12"), // message encoding
             ...string("json"), // schema encoding
             ...string("XXXXXXXX"), // schema
@@ -398,7 +398,7 @@ describe("Mcap0StreamReader", () => {
           key: "data",
           channelInfo2: record(Opcode.CHANNEL_INFO, [
             ...uint16LE(42), // channel id
-            ...string("mytopic"), // topic
+            ...string("myTopic"), // topic
             ...string("utf12"), // message encoding
             ...string("json"), // schema encoding
             ...string("stuff"), // schema
@@ -412,7 +412,7 @@ describe("Mcap0StreamReader", () => {
       ])("differing in $key", ({ channelInfo2 }) => {
         const channelInfo = record(Opcode.CHANNEL_INFO, [
           ...uint16LE(42), // channel id
-          ...string("mytopic"), // topic
+          ...string("myTopic"), // topic
           ...string("utf12"), // message encoding
           ...string("json"), // schema encoding
           ...string("stuff"), // schema
@@ -468,7 +468,7 @@ describe("Mcap0StreamReader", () => {
         expect(reader.nextRecord()).toEqual({
           type: "ChannelInfo",
           channelId: 42,
-          topicName: "mytopic",
+          topicName: "myTopic",
           messageEncoding: "utf12",
           schemaEncoding: "json",
           schemaName: "some data",
@@ -488,7 +488,7 @@ describe("Mcap0StreamReader", () => {
         ...record(
           Opcode.ATTACHMENT,
           crcSuffix([
-            ...string("myfile"), // name
+            ...string("myFile"), // name
             ...uint64LE(1n), // created at
             ...uint64LE(2n), // log time
             ...string("text/plain"), // content type
@@ -506,7 +506,7 @@ describe("Mcap0StreamReader", () => {
     );
     expect(reader.nextRecord()).toEqual({
       type: "Attachment",
-      name: "myfile",
+      name: "myFile",
       createdAt: 1n,
       recordTime: 2n,
       contentType: "text/plain",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/code-frame@^7.0.0":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
@@ -153,6 +160,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
@@ -173,6 +185,15 @@
   integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.16.7":
+  version "7.16.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
+  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -308,6 +329,244 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@cspell/cspell-bundled-dicts@^5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.18.0.tgz#c3d1ebf9f3cb10138fdaa0946e8ca7287834b42a"
+  integrity sha512-daPt57gRhtGB7wQiIo59P4MZAOTn4HhJFVY3wNVgMInsEqh/HPnkLdx+w26Z0j+hl87hxbCHKphd/bp8JqyOaA==
+  dependencies:
+    "@cspell/dict-ada" "^1.1.2"
+    "@cspell/dict-aws" "^1.0.14"
+    "@cspell/dict-bash" "^1.0.17"
+    "@cspell/dict-companies" "^2.0.2"
+    "@cspell/dict-cpp" "^1.1.40"
+    "@cspell/dict-cryptocurrencies" "^1.0.10"
+    "@cspell/dict-csharp" "^2.0.1"
+    "@cspell/dict-css" "^1.0.13"
+    "@cspell/dict-django" "^1.0.26"
+    "@cspell/dict-dotnet" "^1.0.32"
+    "@cspell/dict-elixir" "^1.0.26"
+    "@cspell/dict-en-gb" "^1.1.33"
+    "@cspell/dict-en_us" "^2.1.4"
+    "@cspell/dict-filetypes" "^2.0.1"
+    "@cspell/dict-fonts" "^1.0.14"
+    "@cspell/dict-fullstack" "^2.0.4"
+    "@cspell/dict-golang" "^1.1.24"
+    "@cspell/dict-haskell" "^1.0.13"
+    "@cspell/dict-html" "^2.0.3"
+    "@cspell/dict-html-symbol-entities" "^1.0.23"
+    "@cspell/dict-java" "^1.0.23"
+    "@cspell/dict-latex" "^1.0.25"
+    "@cspell/dict-lorem-ipsum" "^1.0.22"
+    "@cspell/dict-lua" "^1.0.16"
+    "@cspell/dict-node" "^1.0.12"
+    "@cspell/dict-npm" "^1.0.16"
+    "@cspell/dict-php" "^1.0.25"
+    "@cspell/dict-powershell" "^1.0.19"
+    "@cspell/dict-public-licenses" "^1.0.4"
+    "@cspell/dict-python" "^2.0.5"
+    "@cspell/dict-ruby" "^1.0.15"
+    "@cspell/dict-rust" "^1.0.23"
+    "@cspell/dict-scala" "^1.0.21"
+    "@cspell/dict-software-terms" "^2.0.12"
+    "@cspell/dict-swift" "^1.0.1"
+    "@cspell/dict-typescript" "^1.0.19"
+    "@cspell/dict-vue" "^2.0.1"
+
+"@cspell/cspell-pipe@^5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@cspell/cspell-pipe/-/cspell-pipe-5.18.0.tgz#2b50a7c9857d2650addc4917bcb207471712a5ac"
+  integrity sha512-CC3CuqMbTNWCc2kJHm7aEp5o3yEbIHY5FdgiJL7TpqN/dCtagvYZLDZwMPWQuMNgYM5PmeStauTqnwtgW3AkuA==
+
+"@cspell/cspell-types@^5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@cspell/cspell-types/-/cspell-types-5.18.0.tgz#00935c80b118241caa4abd9a74b6a66dcde1f9f0"
+  integrity sha512-fMihVNgUpC9i/SS84nBk1XCmWLCUAVOxp1PXZqoR0R0ozCwrUvZY8sw7lj+TNiDT1TvpibtL1gZPmlvi9TSNzQ==
+
+"@cspell/dict-ada@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-ada/-/dict-ada-1.1.2.tgz#89556226c1d5f856ce1f7afa85543b04fa477092"
+  integrity sha512-UDrcYcKIVyXDz5mInJabRNQpJoehjBFvja5W+GQyu9pGcx3BS3cAU8mWENstGR0Qc/iFTxB010qwF8F3cHA/aA==
+
+"@cspell/dict-aws@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-aws/-/dict-aws-1.0.14.tgz#beddede1053ce3622400e36c65da9fd2954e939d"
+  integrity sha512-K21CfB4ZpKYwwDQiPfic2zJA/uxkbsd4IQGejEvDAhE3z8wBs6g6BwwqdVO767M9NgZqc021yAVpr79N5pWe3w==
+
+"@cspell/dict-bash@^1.0.17":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-bash/-/dict-bash-1.0.18.tgz#1a2a07075c1ea97923f405e32713bf23d26d67ab"
+  integrity sha512-kJIqQ+FD2TCSgaaP5XLEDgy222+pVWTc+VhveNO++gnTWU3BCVjkD5LjfW7g/CmGONnz+nwXDueWspProaSdJw==
+
+"@cspell/dict-companies@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-companies/-/dict-companies-2.0.2.tgz#de315b8315b868f877e6161f9fe70e8efc769931"
+  integrity sha512-LPKwBMAWRz+p1R8q+TV6E1sGOOTvxJOaJeXNN++CZQ7i6JMn5Rf+BSxagwkeK6z3o9vIC5ZE4AcQ5BMkvyjqGw==
+
+"@cspell/dict-cpp@^1.1.40":
+  version "1.1.40"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-cpp/-/dict-cpp-1.1.40.tgz#f9a859e19d31b83f07a106e4c3c8720a2d93595b"
+  integrity sha512-sscfB3woNDNj60/yGXAdwNtIRWZ89y35xnIaJVDMk5TPMMpaDvuk0a34iOPIq0g4V+Y8e3RyAg71SH6ADwSjGw==
+
+"@cspell/dict-cryptocurrencies@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-1.0.10.tgz#04426fdfee8752818b375686d34a154b2fb40c7d"
+  integrity sha512-47ABvDJOkaST/rXipNMfNvneHUzASvmL6K/CbOFpYKfsd0x23Jc9k1yaOC7JAm82XSC/8a7+3Yu+Fk2jVJNnsA==
+
+"@cspell/dict-csharp@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-csharp/-/dict-csharp-2.0.1.tgz#86ec4fa42ba9a4cc57df28ec7a335b56bf751c5b"
+  integrity sha512-ZzAr+WRP2FUtXHZtfhe8f3j9vPjH+5i44Hcr5JqbWxmqciGoTbWBPQXwu9y+J4mbdC69HSWRrVGkNJ8rQk8pSw==
+
+"@cspell/dict-css@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-css/-/dict-css-1.0.13.tgz#805a5844dd9739b6cd026b5f1b4ce8e4213d560b"
+  integrity sha512-HU8RbFRoGanFH85mT01Ot/Ay48ixr/gG25VPLtdq56QTrmPsw79gxYm/5Qay16eQbpoPIxaj5CAWNam+DX4GbA==
+
+"@cspell/dict-django@^1.0.26":
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-django/-/dict-django-1.0.26.tgz#b97ce0112fbe8c3c3ada0387c68971b5e27483ab"
+  integrity sha512-mn9bd7Et1L2zuibc08GVHTiD2Go3/hdjyX5KLukXDklBkq06r+tb0OtKtf1zKodtFDTIaYekGADhNhA6AnKLkg==
+
+"@cspell/dict-dotnet@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-dotnet/-/dict-dotnet-1.0.32.tgz#412af0bf1f65c5902c8ef8a4f1decae2892790e2"
+  integrity sha512-9H9vXrgJB4KF8xsyTToXO53cXD33iyfrpT4mhCds+YLUw3P3x3E9myszgJzshnrxYBvQZ+QMII57Qr6SjZVk4Q==
+
+"@cspell/dict-elixir@^1.0.26":
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-elixir/-/dict-elixir-1.0.26.tgz#dd86697b351a9c74a7d033b6f2d37a5088587aa6"
+  integrity sha512-hz1yETUiRJM7yjN3mITSnxcmZaEyaBbyJhpZPpg+cKUil+xhHeZ2wwfbRc83QHGmlqEuDWbdCFqKSpCDJYpYhg==
+
+"@cspell/dict-en-gb@^1.1.33":
+  version "1.1.33"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz#7f1fd90fc364a5cb77111b5438fc9fcf9cc6da0e"
+  integrity sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==
+
+"@cspell/dict-en_us@^2.1.4":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-en_us/-/dict-en_us-2.1.5.tgz#456914e631d10d936fe1a20313c5f9cce78e8b60"
+  integrity sha512-Q+LgFjrQw4gJnP+aHbVW5/TZlx9ccOCcjBsZYpTEXT/VW04NUX7+EN8bOri+wTEppSQVfl6NQ3bVkzPIjGXLzA==
+
+"@cspell/dict-filetypes@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-filetypes/-/dict-filetypes-2.0.1.tgz#a77467dad8fee31c28d623f85a15ce6fca3e2fdc"
+  integrity sha512-bQ7K3U/3hKO2lpQjObf0veNP/n50qk5CVezSwApMBckf/sAVvDTR1RGAvYdr+vdQnkdQrk6wYmhbshXi0sLDVg==
+
+"@cspell/dict-fonts@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-fonts/-/dict-fonts-1.0.14.tgz#7b18129910d30bd23cd9187d0c0009dfc3fef4ba"
+  integrity sha512-VhIX+FVYAnqQrOuoFEtya6+H72J82cIicz9QddgknsTqZQ3dvgp6lmVnsQXPM3EnzA8n1peTGpLDwHzT7ociLA==
+
+"@cspell/dict-fullstack@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-fullstack/-/dict-fullstack-2.0.4.tgz#d7d1c80863d9fd9bda51346edcc5a72de2cf81b4"
+  integrity sha512-+JtYO58QAXnetRN+MGVzI8YbkbFTLpYfl/Cw/tmNqy7U1IDVC4sTXQ2pZvbbeKQWFHBqYvBs0YASV+mTouXYBw==
+
+"@cspell/dict-golang@^1.1.24":
+  version "1.1.24"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-golang/-/dict-golang-1.1.24.tgz#3830812aec816eca46a6d793fcc7710c09d4f5b9"
+  integrity sha512-qq3Cjnx2U1jpeWAGJL1GL0ylEhUMqyaR36Xij6Y6Aq4bViCRp+HRRqk0x5/IHHbOrti45h3yy7ii1itRFo+Xkg==
+
+"@cspell/dict-haskell@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-haskell/-/dict-haskell-1.0.13.tgz#bd159ef474ef427757dd4bc6a66cda977946c927"
+  integrity sha512-kvl8T84cnYRPpND/P3D86P6WRSqebsbk0FnMfy27zo15L5MLAb3d3MOiT1kW3vEWfQgzUD7uddX/vUiuroQ8TA==
+
+"@cspell/dict-html-symbol-entities@^1.0.23":
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-1.0.23.tgz#0efbdbc7712c9fbe545e14acac637226ac948f2d"
+  integrity sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw==
+
+"@cspell/dict-html@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-html/-/dict-html-2.0.3.tgz#a2bf84fca5b2bb5a0d922287d98eb67bcd60760c"
+  integrity sha512-6sORumQ9E7YpJ4vzYb0hHBgiXpehPAawuqmueGmx/PSRkqzMNLEwhYZuTHuIZSO291RTirPMfCkUahRoKdXOOQ==
+
+"@cspell/dict-java@^1.0.23":
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-java/-/dict-java-1.0.23.tgz#ec95ff2f2c34d5e8e08ba817980b37e387e608cb"
+  integrity sha512-LcOg9srYLDoNGd8n3kbfDBlZD+LOC9IVcnFCdua1b/luCHNVmlgBx7e677qPu7olpMYOD5TQIVW2OmM1+/6MFA==
+
+"@cspell/dict-latex@^1.0.25":
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-latex/-/dict-latex-1.0.25.tgz#6ecf5b8b8fdf46cb8a0f070052dd687e25089e59"
+  integrity sha512-cEgg91Migqcp1SdVV7dUeMxbPDhxdNo6Fgq2eygAXQjIOFK520FFvh/qxyBvW90qdZbIRoU2AJpchyHfGuwZFA==
+
+"@cspell/dict-lorem-ipsum@^1.0.22":
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-1.0.22.tgz#a89f53dadda7d5bfdb978ab61f19d74d2fb69eab"
+  integrity sha512-yqzspR+2ADeAGUxLTfZ4pXvPl7FmkENMRcGDECmddkOiuEwBCWMZdMP5fng9B0Q6j91hQ8w9CLvJKBz10TqNYg==
+
+"@cspell/dict-lua@^1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-lua/-/dict-lua-1.0.16.tgz#c0ca43628f8927fc10731fd27cd9ee0af651bf6a"
+  integrity sha512-YiHDt8kmHJ8nSBy0tHzaxiuitYp+oJ66ffCYuFWTNB3//Y0SI4OGHU3omLsQVeXIfCeVrO4DrVvRDoCls9B5zQ==
+
+"@cspell/dict-node@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-node/-/dict-node-1.0.12.tgz#a7236be30340ff8fe365f62c8d13121fdbe7f51c"
+  integrity sha512-RPNn/7CSkflAWk0sbSoOkg0ORrgBARUjOW3QjB11KwV1gSu8f5W/ij/S50uIXtlrfoBLqd4OyE04jyON+g/Xfg==
+
+"@cspell/dict-npm@^1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-npm/-/dict-npm-1.0.16.tgz#86870686cd0af6354a206ab297872db1d84e9c1b"
+  integrity sha512-RwkuZGcYBxL3Yux3cSG/IOWGlQ1e9HLCpHeyMtTVGYKAIkFAVUnGrz20l16/Q7zUG7IEktBz5O42kAozrEnqMQ==
+
+"@cspell/dict-php@^1.0.25":
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-php/-/dict-php-1.0.25.tgz#b065314c43b668b982356de59986e10fc26bc390"
+  integrity sha512-RoBIP5MRdByyPaXcznZMfOY1JdCMYPPLua5E9gkq0TJO7bX5mC9hyAKfYBSWVQunZydd82HZixjb5MPkDFU1uw==
+
+"@cspell/dict-powershell@^1.0.19":
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-powershell/-/dict-powershell-1.0.19.tgz#b50d14b3b20e33f86b80318ccd7ef986ecba2549"
+  integrity sha512-zF/raM/lkhXeHf4I43OtK0gP9rBeEJFArscTVwLWOCIvNk21MJcNoTYoaGw+c056+Q+hJL0psGLO7QN+mxYH1A==
+
+"@cspell/dict-public-licenses@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-public-licenses/-/dict-public-licenses-1.0.4.tgz#13c2af357e7139bf3896eba58e0feb9f51053b3f"
+  integrity sha512-h4xULfVEDUeWyvp1OO19pcGDqWcBEQ7WGMp3QBHyYpjsamlzsyYYjCRSY2ZvpM7wruDmywSRFmRHJ/+uNFT7nA==
+
+"@cspell/dict-python@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-python/-/dict-python-2.0.5.tgz#eebe6f53a8b5f29addd963951a701a7afedfe6b0"
+  integrity sha512-WkyGYtNmUsOHsWixck7AxNvveDgVPqw0H51hzIY+/5u3c94wZUweIj0vfFOGIfOBq8e1ZxpjumKBxVDGXTmQkw==
+
+"@cspell/dict-ruby@^1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-ruby/-/dict-ruby-1.0.15.tgz#5da9f54d97deed31cc35772502282b45b20e7aa7"
+  integrity sha512-I76hJA///lc1pgmDTGUFHN/O8KLIZIU/8TgIYIGI6Ix/YzSEvWNdQYbANn6JbCynS0X+7IbZ2Ft+QqvmGtIWuA==
+
+"@cspell/dict-rust@^1.0.23":
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-rust/-/dict-rust-1.0.23.tgz#bcef79f74932d90a07f86efa11a8696788079ad8"
+  integrity sha512-lR4boDzs79YD6+30mmiSGAMMdwh7HTBAPUFSB0obR3Kidibfc3GZ+MHWZXay5dxZ4nBKM06vyjtanF9VJ8q1Iw==
+
+"@cspell/dict-scala@^1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-scala/-/dict-scala-1.0.21.tgz#bfda392329061e2352fbcd33d228617742c93831"
+  integrity sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA==
+
+"@cspell/dict-software-terms@^2.0.12":
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-software-terms/-/dict-software-terms-2.0.13.tgz#63be8fe7e4881ecdf84aee838108aa83b7697b51"
+  integrity sha512-GoyP2fv1EUvc/eNgbnNA/Fo7FE6U5q8Rjb7GLLZYwt6cn5rI3U2eHMqGglJkxkFXJ6YYcDpgNk2r3IK6oYtbqg==
+
+"@cspell/dict-swift@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-swift/-/dict-swift-1.0.1.tgz#e289680bf79538096eb7c36b21aeb97e97fdd9fc"
+  integrity sha512-M4onLt10Ptld8Q1BwBit8BBYVZ0d2ZEiBTW1AXekIVPQkPKkwa/RkGlR0GESWNTC2Zbmt/qge7trksVdaYVWFQ==
+
+"@cspell/dict-typescript@^1.0.19":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-typescript/-/dict-typescript-1.0.20.tgz#2a28bb94a06490b25bbb9180b875d6f16ebb8400"
+  integrity sha512-yIuGeeZtQA2gqpGefGjZqBl8iGJpIYWz0QzDqsscNi2qfSnLsbjM0RkRbTehM8y9gGGe7xfgUP5adxceJa5Krg==
+
+"@cspell/dict-vue@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@cspell/dict-vue/-/dict-vue-2.0.1.tgz#7514875f760ae755d2a6ef1fd00917d107682fe1"
+  integrity sha512-n9So2C2Zw+uSDRzb2h9wq3PjZBqoHx+vBvu6a34H2qpumNjZ6HaEronrzX5tXJJXzOtocIQYrLxdd128TAU3+g==
 
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
@@ -813,6 +1072,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.11.tgz#6ea7342dfb379ea1210835bada87b3c512120234"
   integrity sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
 "@types/prettier@^2.1.5":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
@@ -1037,6 +1301,11 @@ array-includes@^3.1.4:
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
+array-timsort@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-timsort/-/array-timsort-1.0.3.tgz#3c9e4199e54fb2b9c3fe5976396a21614ef0d926"
+  integrity sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
@@ -1185,7 +1454,7 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -1214,7 +1483,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1236,6 +1505,14 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+clear-module@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/clear-module/-/clear-module-4.1.2.tgz#5a58a5c9f8dccf363545ad7284cad3c887352a80"
+  integrity sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==
+  dependencies:
+    parent-module "^2.0.0"
+    resolve-from "^5.0.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -1287,15 +1564,38 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@8.3.0:
+commander@8.3.0, commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+comment-json@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-4.1.1.tgz#49df4948704bebb1cc0ffa6910e25669b668b7c5"
+  integrity sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==
+  dependencies:
+    array-timsort "^1.0.3"
+    core-util-is "^1.0.2"
+    esprima "^4.0.1"
+    has-own-prop "^2.0.0"
+    repeat-string "^1.6.1"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+configstore@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
+  integrity sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==
+  dependencies:
+    dot-prop "^5.2.0"
+    graceful-fs "^4.1.2"
+    make-dir "^3.0.0"
+    unique-string "^2.0.0"
+    write-file-atomic "^3.0.0"
+    xdg-basedir "^4.0.0"
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
@@ -1303,6 +1603,22 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+core-util-is@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cosmiconfig@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -1317,6 +1633,85 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
+cspell-gitignore@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/cspell-gitignore/-/cspell-gitignore-5.18.0.tgz#626c3ea7f8c5dd225a674b9b305626a98059270e"
+  integrity sha512-nHdMhGDlDYN2dwh/LPGNVYqWDr7SL9N0zn4Bs9qOjNE6OkHMOvm+otjwEv4sS5b+pK+prrilK0OINkZFdftMvA==
+  dependencies:
+    cspell-glob "^5.18.0"
+    find-up "^5.0.0"
+
+cspell-glob@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/cspell-glob/-/cspell-glob-5.18.0.tgz#6d6ff58db6457d8babf77e647071b1089e398d25"
+  integrity sha512-GLN45ntiB2oT1UewOHFf73gKujdSOr8Mb4OSa8r6JJrkACRzqe1Qr8mUrV/wY5/bDK6QjtLQylMpDw6nkaPWWw==
+  dependencies:
+    micromatch "^4.0.4"
+
+cspell-io@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/cspell-io/-/cspell-io-5.18.0.tgz#acd542dccf47d96c10f59e07291aa364c8fa3048"
+  integrity sha512-kkIBZ27KNzQ7R4BpXs9xkRpsM8TRMtH0/ozCBBxGCFFqV9TMDmTp3zoqgN0AWlOFNmLRClc6rpeFs3xswhnOLA==
+
+cspell-lib@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/cspell-lib/-/cspell-lib-5.18.0.tgz#7423f71ff2c971027b49fe6c9205fdfe80bc366f"
+  integrity sha512-cAVRbO/WKK1/ad8UDOxOD6+5MkdwW3u2WaLwzaNbQulHHshFoKgp5hM4WoJeZkV+2+zWH8BDV0e4XPKdrXvnmQ==
+  dependencies:
+    "@cspell/cspell-bundled-dicts" "^5.18.0"
+    "@cspell/cspell-types" "^5.18.0"
+    clear-module "^4.1.2"
+    comment-json "^4.1.1"
+    configstore "^5.0.1"
+    cosmiconfig "^7.0.1"
+    cspell-glob "^5.18.0"
+    cspell-io "^5.18.0"
+    cspell-trie-lib "^5.18.0"
+    fast-equals "^2.0.4"
+    find-up "^5.0.0"
+    fs-extra "^10.0.0"
+    gensequence "^3.1.1"
+    import-fresh "^3.3.0"
+    resolve-from "^5.0.0"
+    resolve-global "^1.0.0"
+    vscode-uri "^3.0.3"
+
+cspell-trie-lib@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/cspell-trie-lib/-/cspell-trie-lib-5.18.0.tgz#83289768af296142d949b4aef1dbd772d635b1ec"
+  integrity sha512-WUxZEM175z+72cL65VG7rgNZMc4OkVfyAkit7CQKkcaYTOZ8M15XmPvPWnqgFPg4z6HYwesiybL+J6hFxf5Syg==
+  dependencies:
+    "@cspell/cspell-pipe" "^5.18.0"
+    fs-extra "^10.0.0"
+    gensequence "^3.1.1"
+
+cspell@^5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/cspell/-/cspell-5.18.0.tgz#8c85bfdea81cf5b47af10f0bc75f1a2eba2ba89f"
+  integrity sha512-0QVcIc+I+2VM2N+piB4p+rC8MU5OU7Og3jsHW4xSzxqA7sZBLNSQnp+vtBBBsjkldog3j/o+rXpnKSymamgG/g==
+  dependencies:
+    "@cspell/cspell-pipe" "^5.18.0"
+    chalk "^4.1.2"
+    commander "^8.3.0"
+    comment-json "^4.1.1"
+    cspell-gitignore "^5.18.0"
+    cspell-glob "^5.18.0"
+    cspell-lib "^5.18.0"
+    fast-json-stable-stringify "^2.1.0"
+    file-entry-cache "^6.0.1"
+    fs-extra "^10.0.0"
+    get-stdin "^8.0.0"
+    glob "^7.2.0"
+    imurmurhash "^0.1.4"
+    semver "^7.3.5"
+    strip-ansi "^6.0.1"
+    vscode-uri "^3.0.3"
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -1445,6 +1840,13 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+dot-prop@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
+  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
+  dependencies:
+    is-obj "^2.0.0"
+
 electron-to-chromium@^1.3.896:
   version "1.3.903"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.903.tgz#e2d3c3809f4ef05fdbe5cc88969dfc94b1bd15b9"
@@ -1466,6 +1868,13 @@ enquirer@^2.3.5:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1:
   version "1.19.1"
@@ -1775,6 +2184,11 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-equals@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.4.tgz#3add9410585e2d7364c2deeb6a707beadb24b927"
+  integrity sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==
+
 fast-glob@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
@@ -1786,7 +2200,7 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -1839,6 +2253,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -1861,6 +2283,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1880,6 +2311,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+gensequence@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/gensequence/-/gensequence-3.1.1.tgz#95c1afc7c0680f92942c17f2d6f83f3d26ea97af"
+  integrity sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -1905,6 +2341,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
@@ -1925,7 +2366,7 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -1936,6 +2377,13 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-dirs@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
+  dependencies:
+    ini "^1.3.4"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -1961,6 +2409,11 @@ globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+
 graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
@@ -1980,6 +2433,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-own-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-own-prop/-/has-own-prop-2.0.0.tgz#f0f95d58f65804f5d218db32563bb85b8e0417af"
+  integrity sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==
 
 has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
@@ -2061,7 +2519,7 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -2095,6 +2553,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -2103,6 +2566,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -2176,6 +2644,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -2744,6 +3217,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -2773,6 +3251,15 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -2799,6 +3286,11 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -2813,6 +3305,13 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 lodash.camelcase@4.3.0:
   version "4.3.0"
@@ -3070,6 +3569,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -3083,6 +3589,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -3100,6 +3613,23 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parent-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-2.0.0.tgz#fa71f88ff1a50c27e15d8ff74e0e3a9523bf8708"
+  integrity sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==
+  dependencies:
+    callsites "^3.1.0"
+
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
 
 parse5@6.0.1:
   version "6.0.1"
@@ -3261,6 +3791,11 @@ regexpp@^3.0.0, regexpp@^3.1.0, regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -3287,6 +3822,13 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-global@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-global/-/resolve-global-1.0.0.tgz#a2a79df4af2ca3f49bf77ef9ddacd322dad19255"
+  integrity sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==
+  dependencies:
+    global-dirs "^0.1.1"
 
 resolve.exports@^1.1.0:
   version "1.1.0"
@@ -3714,10 +4256,22 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
+
 universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -3739,6 +4293,11 @@ v8-to-istanbul@^8.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+vscode-uri@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
+  integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -3849,6 +4408,11 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
 
+xdg-basedir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -3868,6 +4432,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"
@@ -3891,3 +4460,8 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
Check spelling of code and markdown using [cspell](https://cspell.org).

For adding words to the dictionary, per-language suppressions, etc. you can edit [cspell.config.yaml](https://github.com/foxglove/mcap/pull/101/files#diff-ba28c8d282ca58005aabe5a8d32713d35c2710f00219765dceae9b9895ab8277).

For one-off suppressions you can use comments like `// cspell:disable-line` or `// cspell:words foo` to adjust settings within the scope of a line or file: https://cspell.org/configuration/document-settings/