### PR TITLE
Run prettier on all Markdown in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCAP file format
 
-* [Draft specification](./docs/specification)
+- [Draft specification](./docs/specification)
 
 ## Developer quickstart
 

--- a/go/README.md
+++ b/go/README.md
@@ -3,5 +3,5 @@
 [libmcap]: ./libmcap
 [mcap]: ./mcap
 
-* [Library for parsing mcap files][libmcap]
-* [Command line tool for format demonstration][mcap]
+- [Library for parsing mcap files][libmcap]
+- [Command line tool for format demonstration][mcap]

--- a/go/mcap/README.md
+++ b/go/mcap/README.md
@@ -9,25 +9,22 @@ for details:
 
     Usage:
       mcap [command]
-    
+
     Available Commands:
       cat         Cat the messages in an mcap file to stdout
       completion  Generate the autocompletion script for the specified shell
       convert     Convert a bag file to an mcap file
       help        Help about any command
       info        Report statistics about an mcap file
-    
+
     Flags:
           --config string   config file (default is $HOME/.mcap.yaml)
       -h, --help            help for mcap
       -t, --toggle          Help message for toggle
-    
+
     Use "mcap [command] --help" for more information about a command.
 
-
-
 Examples:
-
 
 Convert a bag file to mcap:
 
@@ -35,13 +32,13 @@ Convert a bag file to mcap:
 
 Report summary statistics on an mcap file:
 
-    [~/work/mcap/go/mcap] (task/mcap-client) $ mcap info demo.mcap 
+    [~/work/mcap/go/mcap] (task/mcap-client) $ mcap info demo.mcap
     duration: 7.780758504s
     start: 2017-03-21T19:26:20.103843113-07:00
     end: 2017-03-21T19:26:27.884601617-07:00
     messages: 1606
     chunks:
-    	lz4: [27/27 chunks] (44.32%) 
+    	lz4: [27/27 chunks] (44.32%)
     channels
     	(0) /diagnostics: 52 msgs
     	(1) /image_color/compressed: 234 msgs

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "scripts": {
-    "lint:docs": "prettier docs --check",
+    "lint:docs": "prettier '**/*.md' --check",
     "test:conformance:generate-inputs": "yarn workspace @foxglove/mcap-conformance generate-inputs --data-dir \"$(pwd)/tests/conformance/data\"",
     "test:conformance": "yarn workspace @foxglove/mcap-conformance run-tests --data-dir \"$(pwd)/tests/conformance/data\""
   },


### PR DESCRIPTION
We had some Markdown files that weren't in `docs` so they weren't getting linted.