### PR TITLE
Add tests for integer reading functions

### DIFF
--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -30,7 +30,6 @@ linters:
     - goconst
     - goimports
     - unparam
-    - dupl
     - errorlint
     - lll
 

--- a/go/libmcap/mcap.go
+++ b/go/libmcap/mcap.go
@@ -101,27 +101,30 @@ func (w *WriteSizer) Reset() {
 	w.w.crc = crc32.NewIEEE()
 }
 
-func putByte(buf []byte, x byte) int {
+func putByte(buf []byte, x byte) (int, error) {
+	if len(buf) < 1 {
+		return 0, io.ErrShortBuffer
+	}
 	buf[0] = x
-	return 1
+	return 1, nil
 }
 
 func getUint16(buf []byte, offset int) (x uint16, newoffset int, err error) {
-	if len(buf) < 2 {
+	if offset > len(buf)-2 {
 		return 0, 0, io.ErrShortBuffer
 	}
 	return binary.LittleEndian.Uint16(buf[offset:]), offset + 2, nil
 }
 
 func getUint32(buf []byte, offset int) (x uint32, newoffset int, err error) {
-	if len(buf) < 4 {
+	if offset > len(buf)-4 {
 		return 0, 0, io.ErrShortBuffer
 	}
 	return binary.LittleEndian.Uint32(buf[offset:]), offset + 4, nil
 }
 
 func getUint64(buf []byte, offset int) (x uint64, newoffset int, err error) {
-	if len(buf) < 8 {
+	if offset > len(buf)-8 {
 		return 0, 0, io.ErrShortBuffer
 	}
 	return binary.LittleEndian.Uint64(buf[offset:]), offset + 8, nil

--- a/go/libmcap/mcap_test.go
+++ b/go/libmcap/mcap_test.go
@@ -1,0 +1,86 @@
+package libmcap
+
+import (
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUint16(t *testing.T) {
+	buf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf, 123)
+	t.Run("uint16 successful read", func(t *testing.T) {
+		x, offset, err := getUint16(buf, 0)
+		assert.Nil(t, err)
+		assert.Equal(t, uint16(123), x)
+		assert.Equal(t, 2, offset)
+	})
+	t.Run("uint16 insufficient space", func(t *testing.T) {
+		x, offset, err := getUint16(buf, 1)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+		assert.Equal(t, uint16(0), x)
+		assert.Equal(t, 0, offset)
+	})
+	t.Run("uint16 offset outside buffer", func(t *testing.T) {
+		x, offset, err := getUint16(buf, 10)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+		assert.Equal(t, uint16(0), x)
+		assert.Equal(t, 0, offset)
+	})
+}
+
+func TestGetUint32(t *testing.T) {
+	buf := make([]byte, 4)
+	t.Run("uint32 successful read", func(t *testing.T) {
+		binary.LittleEndian.PutUint32(buf, 123)
+		x, offset, err := getUint32(buf, 0)
+		assert.Nil(t, err)
+		assert.Equal(t, uint32(123), x)
+		assert.Equal(t, 4, offset)
+	})
+	t.Run("uint32 insufficient space", func(t *testing.T) {
+		x, offset, err := getUint32(buf, 1)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+		assert.Equal(t, uint32(0), x)
+		assert.Equal(t, 0, offset)
+	})
+	t.Run("uint32 offset outside buffer", func(t *testing.T) {
+		x, offset, err := getUint32(buf, 10)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+		assert.Equal(t, uint32(0), x)
+		assert.Equal(t, 0, offset)
+	})
+}
+func TestGetUint64(t *testing.T) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, 123)
+	t.Run("uint64 successful read", func(t *testing.T) {
+		x, offset, err := getUint64(buf, 0)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(123), x)
+		assert.Equal(t, 8, offset)
+	})
+	t.Run("uint64 insufficient space", func(t *testing.T) {
+		x, offset, err := getUint64(buf, 1)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+		assert.Equal(t, uint64(0), x)
+		assert.Equal(t, 0, offset)
+	})
+	t.Run("uint64 offset outside buffer", func(t *testing.T) {
+		x, offset, err := getUint64(buf, 10)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+		assert.Equal(t, uint64(0), x)
+		assert.Equal(t, 0, offset)
+	})
+}
+
+func TestPutByte(t *testing.T) {
+	offset, err := putByte(make([]byte, 1), 123)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, offset)
+	offset, err = putByte(make([]byte, 0), 123)
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+	assert.Equal(t, 0, offset)
+}

--- a/go/libmcap/testutils.go
+++ b/go/libmcap/testutils.go
@@ -80,7 +80,8 @@ func chunk(t *testing.T, compression CompressionFormat, records ...[]byte) []byt
 	uncompressedLen := len(data)
 	msglen := uint64(8 + 8 + 8 + 4 + 4 + compressionLen + compressedLen)
 	record := make([]byte, msglen+9)
-	offset := putByte(record, byte(OpChunk))
+	offset, err := putByte(record, byte(OpChunk))
+	assert.Nil(t, err)
 	offset += putUint64(record[offset:], msglen)
 
 	offset += putUint64(record[offset:], 0)   // start

--- a/go/libmcap/writer.go
+++ b/go/libmcap/writer.go
@@ -75,7 +75,10 @@ func (w *Writer) writeChunk() error {
 	if len(w.chunk) < recordlen {
 		w.chunk = make([]byte, recordlen)
 	}
-	offset := putByte(w.chunk, byte(OpChunk))
+	offset, err := putByte(w.chunk, byte(OpChunk))
+	if err != nil {
+		return err
+	}
 	offset += putUint64(w.chunk[offset:], uint64(msglen))
 	offset += putUint64(w.chunk[offset:], start)
 	offset += putUint64(w.chunk[offset:], end)


### PR DESCRIPTION
Adds some tests for the integer reading functions, and also corrects a
bug with the bounds check introduced previously: the check was comparing
against the length of buf, rather than the length of buf[:offset],
which rendered it ineffective.