### PR TITLE
Move name earlier in Schema record

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -149,9 +149,9 @@ Schema records are uniquely identified within a file by their schema ID. A Schem
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |
 | 2 | id | uint16 | A unique identifier for this schema within the file. |
+| 4 + N | name | String | An identifier for the schema. |
 | 4 + N | encoding | String | Format for the schema. The value should be one of the [well-known schema formats](./well-known-schema-formats.md). Custom values should use the `x-` prefix. |
-| 4 + N | schema | uint32 length-prefixed Bytes | Schema should conform to the encoding. |
-| 4 + N | name | String | An identifier for the schema. The schema name should conform to any encoding requirements. |
+| 4 + N | data | uint32 length-prefixed Bytes | Must conform to the schema encoding. |
 
 Schema records may be duplicated in the summary section.
 
@@ -166,7 +166,7 @@ Channel Info records are uniquely identified within a file by their channel ID. 
 | 2 | id | uint16 | A unique identifier for this channel within the file. |
 | 4 + N | topic | String | The channel topic. |
 | 4 + N | message_encoding | String | Encoding for messages on this channel. The value should be one of the [well-known message encodings](./well-known-encodings.md). Custom values should use `x-` prefix. |
-| 2 | schema_id | uint16 | The schema for messages on this channel. |
+| 2 | schema_id | uint16 | The schema for messages on this channel. Can be `0` if schema is not required for this message_encoding. |
 | 4 + N | metadata | Map<string, string> | Metadata about this channel |
 
 Channel Info records may be duplicated in the summary section.
@@ -183,7 +183,7 @@ The message encoding and schema must match that of the channel info record corre
 | 4 | sequence | uint32 | Optional message counter assigned by publisher. If not assigned by publisher, must be recorded by the recorder. |
 | 8 | publish_time | Timestamp | Time at which the message was published. If not available, must be set to the log time. |
 | 8 | log_time | Timestamp | Time at which the message was recorded. |
-| N | message_data | Bytes | Message data, to be decoded according to the schema of the channel. |
+| N | data | Bytes | Message data, to be decoded according to the schema of the channel. |
 
 ### Chunk (op=0x06)
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -166,7 +166,7 @@ Channel Info records are uniquely identified within a file by their channel ID. 
 | 2 | id | uint16 | A unique identifier for this channel within the file. |
 | 4 + N | topic | String | The channel topic. |
 | 4 + N | message_encoding | String | Encoding for messages on this channel. The value should be one of the [well-known message encodings](./well-known-encodings.md). Custom values should use `x-` prefix. |
-| 2 | schema_id | uint16 | The schema for messages on this channel. Can be `0` if schema is not required for this message_encoding. |
+| 2 | schema_id | uint16 | The schema for messages on this channel. |
 | 4 + N | metadata | Map<string, string> | Metadata about this channel |
 
 Channel Info records may be duplicated in the summary section.


### PR DESCRIPTION
**Public-Facing Changes**
- Schema `name` appears earlier in the record, for aesthetic purposes.
- A few other strings in the spec are updated (non-breaking).