### PR TITLE
go: Ensure chunk length is written to chunk indexes

### DIFF
--- a/go/libmcap/indexed_message_iterator.go
+++ b/go/libmcap/indexed_message_iterator.go
@@ -296,8 +296,6 @@ func (it *indexedMessageIterator) Next() (*ChannelInfo, *Message, error) {
 		}
 	}
 
-	fmt.Println(it.messageOffsetIdx, len(it.messageOffsets))
-
 	messageOffset := it.messageOffsets[it.messageOffsetIdx]
 	it.messageOffsetIdx++
 

--- a/go/libmcap/writer.go
+++ b/go/libmcap/writer.go
@@ -115,6 +115,7 @@ func (w *Writer) writeChunk() error {
 		StartTime:           w.currentChunkStartTime,
 		EndTime:             w.currentChunkEndTime,
 		ChunkStartOffset:    chunkStartOffset,
+		ChunkLength:         messageIndexStart - chunkStartOffset,
 		MessageIndexOffsets: messageIndexOffsets,
 		MessageIndexLength:  messageIndexLength,
 		Compression:         w.compression,


### PR DESCRIPTION
Prior to this commit, chunk length in the chunk indexes was getting set
to zero.