### PR TITLE
typescript: update metadata and channel info to use Maps

### DIFF
--- a/tests/conformance/scripts/generate-inputs.ts
+++ b/tests/conformance/scripts/generate-inputs.ts
@@ -270,7 +270,7 @@ const inputs: { name: string; records: TestDataRecord[] }[] = [
         topic: "example",
         schemaId: 1,
         messageEncoding: "a",
-        metadata: [["foo", "bar"]],
+        metadata: new Map([["foo", "bar"]]),
       },
       {
         type: "Message",

--- a/typescript/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/src/v0/Mcap0IndexedReader.test.ts
@@ -165,7 +165,7 @@ describe("Mcap0IndexedReader", () => {
             schemaId: 1,
             topic: "myTopic",
             messageEncoding: "utf12",
-            metadata: [["foo", "bar"]],
+            metadata: new Map([["foo", "bar"]]),
           },
         ],
       ]),

--- a/typescript/src/v0/Mcap0RecordBuilder.test.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.test.ts
@@ -80,7 +80,7 @@ describe("Mcap0RecordBuilder", () => {
       topic: "/topic",
       messageEncoding: "encoding",
       schemaId: 1,
-      metadata: [],
+      metadata: new Map(),
     });
 
     const buffer = new BufferBuilder();
@@ -126,7 +126,7 @@ describe("Mcap0RecordBuilder", () => {
 
     const written = writer.writeMetadata({
       name: "name",
-      metadata: [["something", "magical"]],
+      metadata: new Map([["something", "magical"]]),
     });
 
     const buffer = new BufferBuilder();

--- a/typescript/src/v0/Mcap0RecordBuilder.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.ts
@@ -373,7 +373,7 @@ export class Mcap0RecordBuilder {
       .tupleArray(
         (key) => this.bufferBuilder.uint16(key),
         (value) => this.bufferBuilder.uint64(value),
-        statistics.channelMessageCounts.entries(),
+        statistics.channelMessageCounts,
       );
     if (this.options?.padRecords === true) {
       this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);

--- a/typescript/src/v0/Mcap0StreamReader.test.ts
+++ b/typescript/src/v0/Mcap0StreamReader.test.ts
@@ -343,7 +343,7 @@ describe("Mcap0StreamReader", () => {
       topic: "myTopic",
       messageEncoding: "utf12",
       schemaId: 1,
-      metadata: [["foo", "bar"]],
+      metadata: new Map([["foo", "bar"]]),
     } as TypedMcapRecords["ChannelInfo"]);
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
@@ -394,7 +394,7 @@ describe("Mcap0StreamReader", () => {
       topic: "myTopic",
       messageEncoding: "utf12",
       schemaId: 1,
-      metadata: [["foo", "bar"]],
+      metadata: new Map([["foo", "bar"]]),
     } as TypedMcapRecords["ChannelInfo"]);
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
@@ -502,7 +502,7 @@ describe("Mcap0StreamReader", () => {
           topic: "myTopic",
           messageEncoding: "utf12",
           schemaId: 1,
-          metadata: [["foo", "bar"]],
+          metadata: new Map([["foo", "bar"]]),
         } as TypedMcapRecords["ChannelInfo"]);
         expect(() => reader.nextRecord()).toThrow("differing channel infos for 42");
       });

--- a/typescript/src/v0/parse.ts
+++ b/typescript/src/v0/parse.ts
@@ -133,7 +133,7 @@ export function parseRecord({
       const topicName = reader.string();
       const messageEncoding = reader.string();
       const schemaId = reader.uint16();
-      const metadata = reader.keyValuePairs(
+      const metadata = reader.map(
         (r) => r.string(),
         (r) => r.string(),
       );
@@ -321,7 +321,7 @@ export function parseRecord({
     }
     case Opcode.METADATA: {
       const name = reader.string();
-      const metadata = reader.keyValuePairs(
+      const metadata = reader.map(
         (r) => r.string(),
         (r) => r.string(),
       );

--- a/typescript/src/v0/types.ts
+++ b/typescript/src/v0/types.ts
@@ -23,7 +23,7 @@ export type ChannelInfo = {
   topic: string;
   messageEncoding: string;
   schemaId: number;
-  metadata: [key: string, value: string][];
+  metadata: Map<string, string>;
 };
 export type Message = {
   channelId: number;
@@ -79,7 +79,7 @@ export type Statistics = {
 };
 export type Metadata = {
   name: string;
-  metadata: [key: string, value: string][];
+  metadata: Map<string, string>;
 };
 export type MetadataIndex = {
   offset: bigint;


### PR DESCRIPTION
**Public-Facing Changes**
Metadata and ChannelInfo records now use `Map<K, V>` instead of `[K, V][]` to match latest spec

**Description**
Split/adapted from https://github.com/foxglove/mcap/pull/117.