### PR TITLE
typescript: remove stray import from inspector

### DIFF
--- a/typescript/src/v0/types.ts
+++ b/typescript/src/v0/types.ts
@@ -1,5 +1,3 @@
-import { Schema } from "inspector";
-
 export type McapMagic = {
   specVersion: "0";
 };


### PR DESCRIPTION
Seems to have been added accidentally in https://github.com/foxglove/mcap/pull/112.