### PR TITLE
Spec: Rename Channel Info record to Channel

### DIFF
--- a/docs/specification/profiles/ros1.md
+++ b/docs/specification/profiles/ros1.md
@@ -4,7 +4,7 @@ Profile: **`ros1`**
 
 The `ros1` profile describes how to create mcap files for v1 of the [ROS](https://ros.org/) framework.
 
-### Channel Info
+### Channel
 
 #### message_encoding
 

--- a/docs/specification/profiles/ros2.md
+++ b/docs/specification/profiles/ros2.md
@@ -4,7 +4,7 @@ Profile: **`ros2`**
 
 The `ros2` profile describes how to create MCAP files for v2 of the [ROS](https://ros.org/) framework.
 
-### Channel Info
+### Channel
 
 #### message_encoding
 


### PR DESCRIPTION
Proposal: Rename `Channel Info` to `Channel`.

Rationale:
- Most records are "info" - it's not clear why we treat `Channel` differently than, say, `Schema`.
- This change also makes "primary key" fields such as `Channel.id` more consistent with their "foreign key" relationship fields such as `Message.channel_id`.

Non-binary breaking, although this change would require updates in client libraries.