### PR TITLE
Add variant key to expected outputs.

### DIFF
--- a/python/tests/run_reader_test.py
+++ b/python/tests/run_reader_test.py
@@ -13,7 +13,7 @@ def main():
         for r in reader.records()
         if not isinstance(r, DataEnd) and not isinstance(r, MessageIndex)
     ]
-    print(json.dumps(records, indent=2))
+    print(json.dumps({"records": records}, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/conformance/data/NoData/NoData-pad-st-sum.json
+++ b/tests/conformance/data/NoData/NoData-pad-st-sum.json
@@ -1,45 +1,48 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "80"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "36"],
-      ["group_opcode", "11"],
-      ["group_start", "44"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "80"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "80"],
-      ["summary_start", "44"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "80"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "36"],
+        ["group_opcode", "11"],
+        ["group_start", "44"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "80"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "80"],
+        ["summary_start", "44"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/NoData/NoData-pad-st.json
+++ b/tests/conformance/data/NoData/NoData-pad-st.json
@@ -1,21 +1,24 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "44"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "44"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "pad"]}}
+}

--- a/tests/conformance/data/NoData/NoData-pad.json
+++ b/tests/conformance/data/NoData/NoData-pad.json
@@ -1,11 +1,14 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["pad"]}}
+}

--- a/tests/conformance/data/NoData/NoData-st-sum.json
+++ b/tests/conformance/data/NoData/NoData-st-sum.json
@@ -1,45 +1,48 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "71"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "33"],
-      ["group_opcode", "11"],
-      ["group_start", "38"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "71"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "71"],
-      ["summary_start", "38"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "71"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "33"],
+        ["group_opcode", "11"],
+        ["group_start", "38"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "71"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "71"],
+        ["summary_start", "38"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum"]}}
+}

--- a/tests/conformance/data/NoData/NoData-st.json
+++ b/tests/conformance/data/NoData/NoData-st.json
@@ -1,21 +1,24 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "38"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "38"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st"]}}
+}

--- a/tests/conformance/data/NoData/NoData.json
+++ b/tests/conformance/data/NoData/NoData.json
@@ -1,11 +1,14 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": []}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "81"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "28"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "161"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "36"],
-      ["group_opcode", "11"],
-      ["group_start", "125"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "82"],
-      ["group_opcode", "10"],
-      ["group_start", "161"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "243"],
-      ["summary_start", "125"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "81"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "28"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "161"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "36"],
+        ["group_opcode", "11"],
+        ["group_start", "125"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "82"],
+        ["group_opcode", "10"],
+        ["group_start", "161"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "243"],
+        ["summary_start", "125"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "ax", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.json
@@ -1,42 +1,45 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "81"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "28"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "125"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "81"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "28"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "125"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "ax", "pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.json
@@ -1,56 +1,59 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "81"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "28"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "125"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "82"],
-      ["group_opcode", "10"],
-      ["group_start", "125"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "207"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "207"],
-      ["summary_start", "125"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "81"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "28"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "125"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "82"],
+        ["group_opcode", "10"],
+        ["group_start", "125"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "207"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "207"],
+        ["summary_start", "125"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ax", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.json
@@ -1,32 +1,35 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "81"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "28"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "125"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "81"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "28"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "125"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ax", "pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-st-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "78"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "25"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "149"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "33"],
-      ["group_opcode", "11"],
-      ["group_start", "116"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "79"],
-      ["group_opcode", "10"],
-      ["group_start", "149"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "228"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "228"],
-      ["summary_start", "116"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "78"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "25"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "149"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "33"],
+        ["group_opcode", "11"],
+        ["group_start", "116"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "79"],
+        ["group_opcode", "10"],
+        ["group_start", "149"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "228"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "228"],
+        ["summary_start", "116"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "ax", "sum"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-st.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-st.json
@@ -1,42 +1,45 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "78"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "25"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "116"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "78"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "25"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "116"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "ax"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-sum.json
@@ -1,56 +1,59 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "78"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "25"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "116"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "79"],
-      ["group_opcode", "10"],
-      ["group_start", "116"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "195"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "195"],
-      ["summary_start", "116"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "78"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "25"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "116"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "79"],
+        ["group_opcode", "10"],
+        ["group_start", "116"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "195"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "195"],
+        ["summary_start", "116"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ax", "sum"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax.json
@@ -1,32 +1,35 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "AttachmentIndex",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["data_size", "3"],
-      ["length", "78"],
-      ["log_time", "2"],
-      ["name", "myFile"],
-      ["offset", "25"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "116"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "AttachmentIndex",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["data_size", "3"],
+        ["length", "78"],
+        ["log_time", "2"],
+        ["name", "myFile"],
+        ["offset", "25"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "116"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ax"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad-st-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad-st-sum.json
@@ -1,55 +1,58 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "161"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "36"],
-      ["group_opcode", "11"],
-      ["group_start", "125"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "161"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "161"],
-      ["summary_start", "125"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "161"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "36"],
+        ["group_opcode", "11"],
+        ["group_start", "125"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "161"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "161"],
+        ["summary_start", "125"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad-st.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad-st.json
@@ -1,31 +1,34 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "125"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "125"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-pad.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-pad.json
@@ -1,21 +1,24 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["pad"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-st-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-st-sum.json
@@ -1,55 +1,58 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "149"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "33"],
-      ["group_opcode", "11"],
-      ["group_start", "116"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "149"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "149"],
-      ["summary_start", "116"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "149"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "33"],
+        ["group_opcode", "11"],
+        ["group_start", "116"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "149"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "149"],
+        ["summary_start", "116"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment-st.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-st.json
@@ -1,31 +1,34 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "1"],
-      ["channel_count", "0"],
-      ["channel_message_counts", {}],
-      ["chunk_count", "0"],
-      ["message_count", "0"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "116"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "1"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "116"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st"]}}
+}

--- a/tests/conformance/data/OneAttachment/OneAttachment.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment.json
@@ -1,21 +1,24 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Attachment",
-    "fields": [
-      ["content_type", "application/octet-stream"],
-      ["created_at", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["name", "myFile"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Attachment",
+      "fields": [
+        ["content_type", "application/octet-stream"],
+        ["created_at", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["name", "myFile"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": []}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.json
@@ -1,123 +1,130 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "375"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "329"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "375"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "465"],
-      ["summary_start", "242"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "375"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "329"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "375"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "465"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {
+      "features": ["ch", "mx", "st", "rsh", "rch", "chx", "sum", "pad"]
+    }
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st.json
@@ -1,83 +1,88 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "mx", "st", "rsh", "rch", "chx", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-sum.json
@@ -1,105 +1,110 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "329"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "329"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "419"],
-      ["summary_start", "242"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "329"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "329"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "419"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "mx", "rsh", "rch", "chx", "sum", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-st-sum.json
@@ -1,106 +1,111 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "338"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "338"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "428"],
-      ["summary_start", "242"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "338"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "338"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "428"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "mx", "st", "rch", "chx", "sum", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "382"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "382"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh-st-sum.json
@@ -1,105 +1,110 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "325"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "325"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "415"],
-      ["summary_start", "242"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "325"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "325"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "415"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "mx", "st", "rsh", "chx", "sum", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "369"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "369"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "288"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "288"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "378"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "288"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "288"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "378"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-sum.json
@@ -1,70 +1,73 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "332"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "332"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh-st-sum.json
@@ -1,123 +1,128 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "357"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "314"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "357"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "444"],
-      ["summary_start", "233"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "357"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "314"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "357"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "444"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "mx", "st", "rsh", "rch", "chx", "sum"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "314"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "314"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "401"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "314"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "314"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "401"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "323"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "280"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "323"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "410"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "323"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "280"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "323"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "410"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "280"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "280"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "367"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "280"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "280"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "367"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "310"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "310"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "397"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "310"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "310"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "397"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "354"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "354"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "276"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "276"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "363"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "276"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "276"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "363"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-sum.json
@@ -1,70 +1,73 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "320"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "320"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh-st-sum.json
@@ -1,123 +1,128 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "341"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "295"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "341"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "421"],
-      ["summary_start", "208"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "341"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "295"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "341"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "421"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "st", "rsh", "rch", "chx", "sum", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "295"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "295"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "375"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "295"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "295"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "375"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "304"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "258"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "304"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "384"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "304"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "258"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "304"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "384"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "258"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "258"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "338"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "258"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "258"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "338"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "291"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "291"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "371"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "291"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "291"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "371"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "325"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "325"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "254"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "254"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "334"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "254"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "254"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "334"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-sum.json
@@ -1,70 +1,73 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "288"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "288"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-pad.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh-st-sum.json
@@ -1,123 +1,126 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "326"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "283"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "326"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "403"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "326"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "283"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "326"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "403"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "283"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "283"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "360"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "283"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "283"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "360"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "249"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "369"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "249"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "369"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "249"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "249"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "326"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "249"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "249"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "326"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "356"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "356"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "313"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "313"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "322"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "322"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx-sum.json
@@ -1,70 +1,73 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "279"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "279"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-chx.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-chx.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh-st-sum.json
@@ -1,123 +1,128 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "375"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "329"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "375"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "465"],
-      ["summary_start", "242"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "375"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "329"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "375"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "465"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["ch", "mx", "st", "rsh", "rch", "sum", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "329"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "329"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "419"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "329"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "329"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "419"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "338"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "338"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "428"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "338"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "338"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "428"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "382"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "382"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "325"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "325"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "415"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "325"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "325"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "415"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "369"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "369"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "288"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "242"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "90"],
-      ["group_opcode", "8"],
-      ["group_start", "288"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "378"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "288"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "242"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "90"],
+        ["group_opcode", "8"],
+        ["group_start", "288"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "378"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-pad.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "34"],
-      ["message_index_offsets", {"1": "192"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "242"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "34"],
+        ["message_index_offsets", {"1": "192"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "242"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh-st-sum.json
@@ -1,123 +1,126 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "357"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "314"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "357"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "444"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "357"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "314"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "357"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "444"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "314"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "314"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "401"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "314"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "314"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "401"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "323"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "280"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "323"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "410"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "323"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "280"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "323"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "410"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "280"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "280"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "367"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "280"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "280"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "367"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "310"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "310"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "397"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "310"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "310"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "397"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "267"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "354"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "267"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "354"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "276"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "233"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "87"],
-      ["group_opcode", "8"],
-      ["group_start", "276"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "363"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "276"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "233"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "87"],
+        ["group_opcode", "8"],
+        ["group_start", "276"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "363"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx", "st"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-mx.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-mx.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "31"],
-      ["message_index_offsets", {"1": "189"}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "233"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "31"],
+        ["message_index_offsets", {"1": "189"}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "233"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "mx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh-st-sum.json
@@ -1,123 +1,126 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "341"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "295"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "341"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "421"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "341"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "295"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "341"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "421"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "295"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "295"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "375"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "295"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "295"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "375"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "304"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "258"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "304"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "384"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "304"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "258"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "304"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "384"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "258"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "258"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "338"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "258"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "258"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "338"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "291"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "291"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "371"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "291"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "291"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "371"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "325"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "325"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "254"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "208"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "80"],
-      ["group_opcode", "8"],
-      ["group_start", "254"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "334"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "254"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "208"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "80"],
+        ["group_opcode", "8"],
+        ["group_start", "254"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "334"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-pad.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "28"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "208"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "28"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "208"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh-st-sum.json
@@ -1,123 +1,126 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "326"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "283"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "326"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "403"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "326"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "283"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "326"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "403"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh-st.json
@@ -1,83 +1,86 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "283"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "283"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "360"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "283"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "283"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "360"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-rsh.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-st-sum.json
@@ -1,106 +1,109 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "249"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "292"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "369"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "249"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "292"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "369"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-st.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "249"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "249"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "326"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "249"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "249"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "326"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rch.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rsh-st-sum.json
@@ -1,105 +1,108 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "279"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "356"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "279"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "356"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rsh-st.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rsh-sum.json
@@ -1,87 +1,90 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "236"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "313"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "236"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "313"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-rsh.json
@@ -1,63 +1,66 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-st-sum.json
@@ -1,88 +1,91 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "77"],
-      ["group_opcode", "8"],
-      ["group_start", "245"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "322"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "77"],
+        ["group_opcode", "8"],
+        ["group_start", "245"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "322"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch-st.json
@@ -1,64 +1,67 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "1"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "1"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch", "st"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-ch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-ch.json
@@ -1,54 +1,57 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChunkIndex",
-    "fields": [
-      ["chunk_length", "162"],
-      ["chunk_start_offset", "25"],
-      ["compressed_size", "115"],
-      ["compression", ""],
-      ["end_time", "2"],
-      ["message_index_length", "0"],
-      ["message_index_offsets", {}],
-      ["start_time", "2"],
-      ["uncompressed_size", "115"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "202"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChunkIndex",
+      "fields": [
+        ["chunk_length", "162"],
+        ["chunk_start_offset", "25"],
+        ["compressed_size", "115"],
+        ["compression", ""],
+        ["end_time", "2"],
+        ["message_index_length", "0"],
+        ["message_index_offsets", {}],
+        ["start_time", "2"],
+        ["uncompressed_size", "115"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "202"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["ch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh-st-sum.json
@@ -1,109 +1,114 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "298"],
-      ["summary_start", "165"]
-    ]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "298"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {
+    "variant": {"features": ["mx", "st", "rsh", "rch", "chx", "sum", "pad"]}
   }
-]
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "252"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "252"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "261"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "261"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "215"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "215"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "248"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "248"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "202"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "202"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "211"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "211"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad-sum.json
@@ -1,56 +1,59 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "165"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "165"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-pad.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "277"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "277"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "234"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "234"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "243"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "243"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "200"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "200"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "230"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "230"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "187"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "187"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "196"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "196"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx-sum.json
@@ -1,56 +1,59 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "153"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "153"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-mx.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-mx.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "298"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "298"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "252"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "252"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "261"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "261"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "215"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "215"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "248"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "248"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "202"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "202"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "211"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "211"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad-sum.json
@@ -1,56 +1,59 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "165"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "165"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["chx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-pad.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["chx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "277"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "277"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "234"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "234"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "243"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "243"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "200"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "200"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "230"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "230"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "187"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "187"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "196"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "196"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx-sum.json
@@ -1,56 +1,59 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "153"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "153"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["chx", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-chx.json
+++ b/tests/conformance/data/OneMessage/OneMessage-chx.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["chx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "298"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "298"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "252"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "252"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "261"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "261"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "215"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "215"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "248"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "248"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "202"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "202"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "211"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "211"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-pad.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "277"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "277"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "234"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "234"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "243"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "243"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "200"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "200"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "230"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "230"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "187"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "187"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "196"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "196"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx", "st"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-mx.json
+++ b/tests/conformance/data/OneMessage/OneMessage-mx.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mx"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "298"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "298"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "298"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "298"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "252"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "252"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "252"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "252"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "261"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "261"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "261"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "261"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "50"],
-      ["group_opcode", "4"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "215"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "215"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "50"],
+        ["group_opcode", "4"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "215"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "215"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "248"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "248"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "248"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "248"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "37"],
-      ["group_opcode", "3"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "202"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "202"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "37"],
+        ["group_opcode", "3"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "202"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "202"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "46"],
-      ["group_opcode", "11"],
-      ["group_start", "165"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "211"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "211"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "46"],
+        ["group_opcode", "11"],
+        ["group_start", "165"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "211"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "211"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "165"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "165"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-pad.json
+++ b/tests/conformance/data/OneMessage/OneMessage-pad.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["pad"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-rsh-st-sum.json
@@ -1,109 +1,112 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "277"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "277"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "277"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "277"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-rsh-st.json
@@ -1,69 +1,72 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-rsh-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "234"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "234"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "234"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "234"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-rsh.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-st-sum.json
@@ -1,92 +1,95 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "243"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "243"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "243"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "243"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-st.json
@@ -1,60 +1,63 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "47"],
-      ["group_opcode", "4"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "200"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "200"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "47"],
+        ["group_opcode", "4"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "200"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "200"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rch.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rch.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rch"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rsh-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rsh-st-sum.json
@@ -1,91 +1,94 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "230"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "230"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "230"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "230"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rsh-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rsh-st.json
@@ -1,59 +1,62 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rsh-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rsh-sum.json
@@ -1,73 +1,76 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "34"],
-      ["group_opcode", "3"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "187"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "187"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "34"],
+        ["group_opcode", "3"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "187"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "187"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-rsh.json
+++ b/tests/conformance/data/OneMessage/OneMessage-rsh.json
@@ -1,49 +1,52 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["rsh"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-st-sum.json
+++ b/tests/conformance/data/OneMessage/OneMessage-st-sum.json
@@ -1,74 +1,77 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "13"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "43"],
-      ["group_opcode", "11"],
-      ["group_start", "153"]
-    ]
-  },
-  {
-    "type": "SummaryOffset",
-    "fields": [
-      ["group_length", "0"],
-      ["group_opcode", "8"],
-      ["group_start", "196"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "196"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "13"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "43"],
+        ["group_opcode", "11"],
+        ["group_start", "153"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "0"],
+        ["group_opcode", "8"],
+        ["group_start", "196"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "196"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage-st.json
+++ b/tests/conformance/data/OneMessage/OneMessage-st.json
@@ -1,50 +1,53 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Statistics",
-    "fields": [
-      ["attachment_count", "0"],
-      ["channel_count", "1"],
-      ["channel_message_counts", {"1": "1"}],
-      ["chunk_count", "0"],
-      ["message_count", "1"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "153"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "1"],
+        ["channel_message_counts", {"1": "1"}],
+        ["chunk_count", "0"],
+        ["message_count", "1"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "153"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st"]}}
+}

--- a/tests/conformance/data/OneMessage/OneMessage.json
+++ b/tests/conformance/data/OneMessage/OneMessage.json
@@ -1,40 +1,43 @@
-[
-  {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
-  {
-    "type": "Schema",
-    "fields": [
-      ["data", ["4", "5", "6"]],
-      ["encoding", "c"],
-      ["id", "1"],
-      ["name", "Example"]
-    ]
-  },
-  {
-    "type": "ChannelInfo",
-    "fields": [
-      ["id", "1"],
-      ["message_encoding", "a"],
-      ["metadata", {"foo": "bar"}],
-      ["schema_id", "1"],
-      ["topic", "example"]
-    ]
-  },
-  {
-    "type": "Message",
-    "fields": [
-      ["channel_id", "1"],
-      ["data", ["1", "2", "3"]],
-      ["log_time", "2"],
-      ["publish_time", "1"],
-      ["sequence", "10"]
-    ]
-  },
-  {
-    "type": "Footer",
-    "fields": [
-      ["summary_crc", "0"],
-      ["summary_offset_start", "0"],
-      ["summary_start", "0"]
-    ]
-  }
-]
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Schema",
+      "fields": [
+        ["data", ["4", "5", "6"]],
+        ["encoding", "c"],
+        ["id", "1"],
+        ["name", "Example"]
+      ]
+    },
+    {
+      "type": "ChannelInfo",
+      "fields": [
+        ["id", "1"],
+        ["message_encoding", "a"],
+        ["metadata", {"foo": "bar"}],
+        ["schema_id", "1"],
+        ["topic", "example"]
+      ]
+    },
+    {
+      "type": "Message",
+      "fields": [
+        ["channel_id", "1"],
+        ["data", ["1", "2", "3"]],
+        ["log_time", "2"],
+        ["publish_time", "1"],
+        ["sequence", "10"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "0"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": []}}
+}

--- a/tests/conformance/scripts/run-tests/index.ts
+++ b/tests/conformance/scripts/run-tests/index.ts
@@ -8,8 +8,11 @@ import generateTestVariants from "variants/generateTestVariants";
 import runners from "./runners";
 
 function normalizeJson(json: string): string {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-  return stringify(JSON.parse(json));
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data = JSON.parse(json);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  delete data.meta;
+  return stringify(data);
 }
 
 async function main(options: {
@@ -55,7 +58,7 @@ async function main(options: {
 
       let output: string;
       try {
-        output = await runner.run(filePath);
+        output = await runner.run(filePath, variant);
       } catch (error) {
         console.error(error);
         hadError = true;

--- a/tests/conformance/scripts/run-tests/runners/ITestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/ITestRunner.ts
@@ -3,5 +3,5 @@ import { TestVariant } from "../../../variants/types";
 export default interface ITestRunner {
   readonly name: string;
   supportsVariant(variant: TestVariant): boolean;
-  run(filePath: string): Promise<string>;
+  run(filePath: string, variant: TestVariant): Promise<string>;
 }

--- a/tests/conformance/scripts/run-tests/runners/TypescriptIndexedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptIndexedTestRunner.ts
@@ -7,10 +7,10 @@ import { stringifyRecords } from "./stringifyRecords";
 
 export default class TypescriptIndexedTestRunner implements ITestRunner {
   name = "ts-indexed";
-  async run(filePath: string): Promise<string> {
+  async run(filePath: string, variant: TestVariant): Promise<string> {
     const handle = await fs.open(filePath, "r");
     try {
-      return await this._run(handle);
+      return await this._run(handle, variant);
     } finally {
       await handle.close();
     }
@@ -38,7 +38,7 @@ export default class TypescriptIndexedTestRunner implements ITestRunner {
     return true;
   }
 
-  private async _run(fileHandle: fs.FileHandle): Promise<string> {
+  private async _run(fileHandle: fs.FileHandle, variant: TestVariant): Promise<string> {
     const testResult = [];
     let buffer = new ArrayBuffer(4096);
     const readable = {
@@ -104,6 +104,6 @@ export default class TypescriptIndexedTestRunner implements ITestRunner {
     }
     testResult.push(reader.footer);
 
-    return stringifyRecords(testResult);
+    return stringifyRecords(testResult, variant);
   }
 }

--- a/tests/conformance/scripts/run-tests/runners/TypescriptStreamedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptStreamedTestRunner.ts
@@ -12,7 +12,7 @@ export default class TypescriptStreamedTestRunner implements ITestRunner {
     return true;
   }
 
-  async run(filePath: string): Promise<string> {
+  async run(filePath: string, variant: TestVariant): Promise<string> {
     const result = [];
     const reader = new Mcap0StreamReader({ validateCrcs: true });
     reader.append(await fs.readFile(filePath));
@@ -27,6 +27,6 @@ export default class TypescriptStreamedTestRunner implements ITestRunner {
       throw new Error("Reader not done");
     }
 
-    return stringifyRecords(result);
+    return stringifyRecords(result, variant);
   }
 }

--- a/tests/conformance/scripts/run-tests/runners/stringifyRecords.ts
+++ b/tests/conformance/scripts/run-tests/runners/stringifyRecords.ts
@@ -1,6 +1,7 @@
 import { Mcap0Types } from "@foxglove/mcap";
 import stringify from "json-stringify-pretty-compact";
 import { chain, snakeCase } from "lodash";
+import { TestVariant } from "variants/types";
 
 function replacer(_key: string, value: unknown): unknown {
   if (value instanceof Uint8Array) {
@@ -18,7 +19,7 @@ function replacer(_key: string, value: unknown): unknown {
   return value;
 }
 
-function normalizeRecord(record: Mcap0Types.TypedMcapRecord): { type: string; fields: unknown } {
+function normalizeRecord(record: Mcap0Types.TypedMcapRecord) {
   return chain(record)
     .toPairs()
     .filter(([k]) => k !== "type")
@@ -28,6 +29,19 @@ function normalizeRecord(record: Mcap0Types.TypedMcapRecord): { type: string; fi
     .value();
 }
 
-export function stringifyRecords(records: Mcap0Types.TypedMcapRecord[]): string {
-  return stringify(records.map(normalizeRecord), { replacer }) + "\n";
+export function stringifyRecords(
+  records: Mcap0Types.TypedMcapRecord[],
+  variant: TestVariant,
+): string {
+  const normalizedRecords = records.map(normalizeRecord);
+  const features = Array.from(variant.features.values());
+  return (
+    stringify(
+      {
+        records: normalizedRecords,
+        meta: { variant: { features } },
+      },
+      { replacer },
+    ) + "\n"
+  );
 }


### PR DESCRIPTION
**Public-Facing Changes**
This adds a new `meta` key to the expected output json.

**Description**
This is used to help writer tests more precisely duplicate the mcap output by passing along more detailed information about the options used to generate the mcap reference file.
