### PR TITLE
Add schema_count to Statistics

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -270,7 +270,8 @@ A Statistics record contains summary information about the recorded data. The st
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |
 | 8 | message_count | uint64 | Number of Message records in the file. |
-| 4 | channel_count | uint32 | Number of unique channel ids in the file. |
+| 4 | schema_count | uint16 | Number of unique schema IDs in the file (not including schema ID 0). |
+| 4 | channel_count | uint32 | Number of unique channel IDs in the file. |
 | 4 | attachment_count | uint32 | Number of Attachment records in the file. |
 | 4 | metadata_count | uint32 | Number of Metadata records in the file. |
 | 4 | chunk_count | uint32 | Number of Chunk records in the file. |

--- a/python/mcap/mcap0/records.py
+++ b/python/mcap/mcap0/records.py
@@ -343,10 +343,12 @@ class Statistics(McapRecord):
     chunk_count: int = field(metadata={"value_type": ["int"]})
     message_count: int
     metadata_count: int = field(metadata={"value_type": ["int"]})
+    schema_count: int = field(metadata={"value_type": ["int"]})
 
     @staticmethod
     def read(stream: ReadDataStream):
         message_count = stream.read8()
+        schema_count = stream.read2()
         channel_count = stream.read4()
         attachment_count = stream.read4()
         metadata_count = stream.read4()
@@ -365,6 +367,7 @@ class Statistics(McapRecord):
             chunk_count=chunk_count,
             message_count=message_count,
             metadata_count=metadata_count,
+            schema_count=schema_count,
         )
 
 

--- a/tests/conformance/scripts/generate-inputs.ts
+++ b/tests/conformance/scripts/generate-inputs.ts
@@ -27,6 +27,7 @@ function generateFile(features: Set<TestFeatures>, records: TestDataRecord[]) {
   const chunkIndexes: ChunkIndex[] = [];
 
   let messageCount = 0n;
+  let schemaCount = 0;
   let channelCount = 0;
   let attachmentCount = 0;
   let metadataCount = 0;
@@ -35,6 +36,7 @@ function generateFile(features: Set<TestFeatures>, records: TestDataRecord[]) {
   for (const record of records) {
     switch (record.type) {
       case "Schema":
+        ++schemaCount;
         if (chunk) {
           chunk.addSchema(record);
         } else {
@@ -150,6 +152,7 @@ function generateFile(features: Set<TestFeatures>, records: TestDataRecord[]) {
     builder.writeStatistics({
       messageCount,
       channelCount,
+      schemaCount,
       attachmentCount,
       metadataCount,
       chunkCount,

--- a/typescript/src/v0/Mcap0RecordBuilder.ts
+++ b/typescript/src/v0/Mcap0RecordBuilder.ts
@@ -367,6 +367,7 @@ export class Mcap0RecordBuilder {
     this.bufferBuilder
       .uint64(0n) // placeholder size
       .uint64(statistics.messageCount)
+      .uint16(statistics.schemaCount)
       .uint32(statistics.channelCount)
       .uint32(statistics.attachmentCount)
       .uint32(statistics.metadataCount)

--- a/typescript/src/v0/parse.ts
+++ b/typescript/src/v0/parse.ts
@@ -301,6 +301,7 @@ export function parseRecord({
     }
     case Opcode.STATISTICS: {
       const messageCount = reader.uint64();
+      const schemaCount = reader.uint16();
       const channelCount = reader.uint32();
       const attachmentCount = reader.uint32();
       const metadataCount = reader.uint32();
@@ -314,6 +315,7 @@ export function parseRecord({
         type: "Statistics",
         messageCount,
         channelCount,
+        schemaCount,
         attachmentCount,
         metadataCount,
         chunkCount,

--- a/typescript/src/v0/types.ts
+++ b/typescript/src/v0/types.ts
@@ -70,6 +70,7 @@ export type AttachmentIndex = {
 };
 export type Statistics = {
   messageCount: bigint;
+  schemaCount: number;
   channelCount: number;
   attachmentCount: number;
   metadataCount: number;


### PR DESCRIPTION
Open for discussion. When the Schema record was added we didn't think to add schema_count to Statistics.

Resolves #137