### PR TITLE
Add writer conformance test support.

### DIFF
--- a/python/tests/run_writer_test.py
+++ b/python/tests/run_writer_test.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+
+def main():
+    # Passthrough test for now.
+    mcap_path = sys.argv[1].replace(".json", ".mcap")
+    data = Path(mcap_path).read_bytes()
+    hex = "".join("{:02x}".format(x) for x in data)
+    print(hex)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conformance/package.json
+++ b/tests/conformance/package.json
@@ -15,6 +15,7 @@
     "@types/node": "16.11.9",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "@typescript-eslint/parser": "5.4.0",
+    "colors": "1.4.0",
     "commander": "8.3.0",
     "diff": "^5.0.0",
     "eslint": "7.32.0",

--- a/tests/conformance/scripts/run-tests/runners/CppStreamedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/CppStreamedTestRunner.ts
@@ -7,6 +7,8 @@ import { ITestRunner } from ".";
 
 export default class CppStreamedTestRunner implements ITestRunner {
   name = "cpp-streamed";
+  mode = "read" as const;
+
   async run(filePath: string): Promise<string> {
     const { stdout } = await promisify(exec)(`./streamed-reader-conformance ${filePath}`, {
       cwd: join(__dirname, "../../../../../cpp/test/build/Debug/bin"),

--- a/tests/conformance/scripts/run-tests/runners/ITestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/ITestRunner.ts
@@ -1,6 +1,7 @@
 import { TestVariant } from "../../../variants/types";
 
 export default interface ITestRunner {
+  readonly mode: "read" | "write";
   readonly name: string;
   supportsVariant(variant: TestVariant): boolean;
   run(filePath: string, variant: TestVariant): Promise<string>;

--- a/tests/conformance/scripts/run-tests/runners/PythonStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/PythonStreamedReaderTestRunner.ts
@@ -1,17 +1,16 @@
 import { exec } from "child_process";
-import { join } from "path";
 import { promisify } from "util";
 import { TestVariant } from "variants/types";
 
 import { ITestRunner } from ".";
 
-export default class GoStreamedTestRunner implements ITestRunner {
-  name = "go-streamed";
+export default class PythonStreamedReaderTestRunner implements ITestRunner {
+  name = "py-streamed-reader";
   mode = "read" as const;
 
   async run(filePath: string): Promise<string> {
-    const { stdout } = await promisify(exec)(`./check-conformance ${filePath}`, {
-      cwd: join(__dirname, "../../../../../go/conformance"),
+    const { stdout } = await promisify(exec)(`python3 tests/run_reader_test.py ${filePath}`, {
+      cwd: "../../python",
     });
     return stdout.trim();
   }

--- a/tests/conformance/scripts/run-tests/runners/PythonStreamedWriterTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/PythonStreamedWriterTestRunner.ts
@@ -4,10 +4,12 @@ import { TestVariant } from "variants/types";
 
 import { ITestRunner } from ".";
 
-export default class PythonStreamedTestRunner implements ITestRunner {
-  name = "py-streamed";
+export default class PythonStreamedWriterTestRunner implements ITestRunner {
+  name = "py-streamed-writer";
+  mode = "write" as const;
+
   async run(filePath: string): Promise<string> {
-    const { stdout } = await promisify(exec)(`python3 tests/run_reader_test.py ${filePath}`, {
+    const { stdout } = await promisify(exec)(`python3 tests/run_writer_test.py ${filePath}`, {
       cwd: "../../python",
     });
     return stdout.trim();

--- a/tests/conformance/scripts/run-tests/runners/TypescriptIndexedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptIndexedTestRunner.ts
@@ -7,6 +7,8 @@ import { stringifyRecords } from "./stringifyRecords";
 
 export default class TypescriptIndexedTestRunner implements ITestRunner {
   name = "ts-indexed";
+  mode = "read" as const;
+
   async run(filePath: string, variant: TestVariant): Promise<string> {
     const handle = await fs.open(filePath, "r");
     try {

--- a/tests/conformance/scripts/run-tests/runners/TypescriptStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptStreamedReaderTestRunner.ts
@@ -5,8 +5,9 @@ import { TestVariant } from "variants/types";
 import ITestRunner from "./ITestRunner";
 import { stringifyRecords } from "./stringifyRecords";
 
-export default class TypescriptStreamedTestRunner implements ITestRunner {
-  name = "ts-streamed";
+export default class TypescriptStreamedReaderTestRunner implements ITestRunner {
+  name = "ts-streamed-reader";
+  mode = "read" as const;
 
   supportsVariant(_variant: TestVariant): boolean {
     return true;

--- a/tests/conformance/scripts/run-tests/runners/TypescriptStreamedWriterTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptStreamedWriterTestRunner.ts
@@ -1,0 +1,22 @@
+import fs from "fs/promises";
+import { TestVariant } from "variants/types";
+
+import ITestRunner from "./ITestRunner";
+
+export default class TypescriptStreamedWriterTestRunner implements ITestRunner {
+  name = "ts-streamed-writer";
+  mode = "write" as const;
+
+  supportsVariant(_variant: TestVariant): boolean {
+    return true;
+  }
+
+  async run(filePath: string, _variant: TestVariant): Promise<string> {
+    // Passthrough test for now.
+    const mcapPath = filePath.replace(/\.[^.]+$/, ".mcap");
+    const bytes = await fs.readFile(mcapPath);
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+}

--- a/tests/conformance/scripts/run-tests/runners/index.ts
+++ b/tests/conformance/scripts/run-tests/runners/index.ts
@@ -1,17 +1,21 @@
 import CppStreamedTestRunner from "./CppStreamedTestRunner";
-import ITestRunner from "./ITestRunner";
-import PythonStreamedTestRunner from "./PythonStreamedTestRunner";
-import TypescriptIndexedTestRunner from "./TypescriptIndexedTestRunner";
-import TypescriptStreamedTestRunner from "./TypescriptStreamedTestRunner";
 import GoStreamedTestRunner from "./GoStreamedTestRunner";
+import ITestRunner from "./ITestRunner";
+import PythonStreamedReaderTestRunner from "./PythonStreamedReaderTestRunner";
+import PythonStreamedWriterTestRunner from "./PythonStreamedWriterTestRunner";
+import TypescriptIndexedTestRunner from "./TypescriptIndexedTestRunner";
+import TypescriptStreamedReaderTestRunner from "./TypescriptStreamedReaderTestRunner";
+import TypescriptStreamedWriterTestRunner from "./TypescriptStreamedWriterTestRunner";
 
 export type { ITestRunner };
 
 const runners: readonly ITestRunner[] = [
   new CppStreamedTestRunner(),
-  new PythonStreamedTestRunner(),
-  new TypescriptIndexedTestRunner(),
-  new TypescriptStreamedTestRunner(),
   new GoStreamedTestRunner(),
+  new PythonStreamedReaderTestRunner(),
+  new PythonStreamedWriterTestRunner(),
+  new TypescriptIndexedTestRunner(),
+  new TypescriptStreamedReaderTestRunner(),
+  new TypescriptStreamedWriterTestRunner(),
 ];
 export default runners;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,6 +1557,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colors@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"


### PR DESCRIPTION
**Public-Facing Changes**
This adds basic support for writer conformance tests.


**Description**
For now this just adapts the harness to support reader & writer tests and adds passthrough writer tests for python & typescript. Implementation of the tests will follow in subsequent PRs.

Writer tests should output the mcap they generate as hex encoded strings of the entire file.

<!-- link relevant GitHub issues -->
