### PR TITLE
Separate test reader & writer interfaces.

### DIFF
--- a/tests/conformance/scripts/run-tests/runners/CppStreamedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/CppStreamedTestRunner.ts
@@ -3,13 +3,12 @@ import { join } from "path";
 import { promisify } from "util";
 import { TestVariant } from "variants/types";
 
-import { ITestRunner } from ".";
+import { ReadTestRunner } from "./TestRunner";
 
-export default class CppStreamedTestRunner implements ITestRunner {
+export default class CppStreamedTestRunner extends ReadTestRunner {
   name = "cpp-streamed-reader";
-  mode = "read" as const;
 
-  async run(filePath: string): Promise<string> {
+  async runReadTest(filePath: string): Promise<string> {
     const { stdout } = await promisify(exec)(`./streamed-reader-conformance ${filePath}`, {
       cwd: join(__dirname, "../../../../../cpp/test/build/Debug/bin"),
     });

--- a/tests/conformance/scripts/run-tests/runners/GoStreamedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/GoStreamedTestRunner.ts
@@ -3,13 +3,12 @@ import { join } from "path";
 import { promisify } from "util";
 import { TestVariant } from "variants/types";
 
-import { ITestRunner } from ".";
+import { ReadTestRunner } from "./TestRunner";
 
-export default class GoStreamedTestRunner implements ITestRunner {
+export default class GoStreamedTestRunner extends ReadTestRunner {
   name = "go-streamed-reader";
-  mode = "read" as const;
 
-  async run(filePath: string): Promise<string> {
+  async runReadTest(filePath: string): Promise<string> {
     const { stdout } = await promisify(exec)(`./check-conformance ${filePath}`, {
       cwd: join(__dirname, "../../../../../go/conformance"),
     });

--- a/tests/conformance/scripts/run-tests/runners/ITestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/ITestRunner.ts
@@ -1,8 +1,0 @@
-import { TestVariant } from "../../../variants/types";
-
-export default interface ITestRunner {
-  readonly mode: "read" | "write";
-  readonly name: string;
-  supportsVariant(variant: TestVariant): boolean;
-  run(filePath: string, variant: TestVariant): Promise<string>;
-}

--- a/tests/conformance/scripts/run-tests/runners/PythonStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/PythonStreamedReaderTestRunner.ts
@@ -2,13 +2,12 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import { TestVariant } from "variants/types";
 
-import { ITestRunner } from ".";
+import { ReadTestRunner } from "./TestRunner";
 
-export default class PythonStreamedReaderTestRunner implements ITestRunner {
+export default class PythonStreamedReaderTestRunner extends ReadTestRunner {
   name = "py-streamed-reader";
-  mode = "read" as const;
 
-  async run(filePath: string): Promise<string> {
+  async runReadTest(filePath: string): Promise<string> {
     const { stdout } = await promisify(exec)(`python3 tests/run_reader_test.py ${filePath}`, {
       cwd: "../../python",
     });

--- a/tests/conformance/scripts/run-tests/runners/PythonStreamedWriterTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/PythonStreamedWriterTestRunner.ts
@@ -2,17 +2,17 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import { TestVariant } from "variants/types";
 
-import { ITestRunner } from ".";
+import { WriteTestRunner } from "./TestRunner";
 
-export default class PythonStreamedWriterTestRunner implements ITestRunner {
+export default class PythonStreamedWriterTestRunner implements WriteTestRunner {
   name = "py-streamed-writer";
-  mode = "write" as const;
 
-  async run(filePath: string): Promise<string> {
+  async runWriteTest(filePath: string): Promise<Uint8Array> {
     const { stdout } = await promisify(exec)(`python3 tests/run_writer_test.py ${filePath}`, {
       cwd: "../../python",
+      encoding: "binary",
     });
-    return stdout.trim();
+    return stdout as unknown as Uint8Array;
   }
 
   supportsVariant(_variant: TestVariant): boolean {

--- a/tests/conformance/scripts/run-tests/runners/TestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TestRunner.ts
@@ -1,0 +1,13 @@
+import { TestVariant } from "../../../variants/types";
+
+export abstract class ReadTestRunner {
+  abstract readonly name: string;
+  abstract supportsVariant(variant: TestVariant): boolean;
+  abstract runReadTest(filePath: string, variant: TestVariant): Promise<string>;
+}
+
+export abstract class WriteTestRunner {
+  abstract readonly name: string;
+  abstract supportsVariant(variant: TestVariant): boolean;
+  abstract runWriteTest(filePath: string, variant: TestVariant): Promise<Uint8Array>;
+}

--- a/tests/conformance/scripts/run-tests/runners/TypescriptIndexedTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptIndexedTestRunner.ts
@@ -2,14 +2,13 @@ import { Mcap0IndexedReader } from "@foxglove/mcap";
 import fs from "fs/promises";
 import { TestFeatures, TestVariant } from "variants/types";
 
-import ITestRunner from "./ITestRunner";
+import { ReadTestRunner } from "./TestRunner";
 import { stringifyRecords } from "./stringifyRecords";
 
-export default class TypescriptIndexedTestRunner implements ITestRunner {
+export default class TypescriptIndexedTestRunner extends ReadTestRunner {
   name = "ts-indexed";
-  mode = "read" as const;
 
-  async run(filePath: string, variant: TestVariant): Promise<string> {
+  async runReadTest(filePath: string, variant: TestVariant): Promise<string> {
     const handle = await fs.open(filePath, "r");
     try {
       return await this._run(handle, variant);

--- a/tests/conformance/scripts/run-tests/runners/TypescriptStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptStreamedReaderTestRunner.ts
@@ -2,18 +2,17 @@ import { Mcap0StreamReader } from "@foxglove/mcap";
 import fs from "fs/promises";
 import { TestVariant } from "variants/types";
 
-import ITestRunner from "./ITestRunner";
+import { ReadTestRunner } from "./TestRunner";
 import { stringifyRecords } from "./stringifyRecords";
 
-export default class TypescriptStreamedReaderTestRunner implements ITestRunner {
+export default class TypescriptStreamedReaderTestRunner extends ReadTestRunner {
   name = "ts-streamed-reader";
-  mode = "read" as const;
 
   supportsVariant(_variant: TestVariant): boolean {
     return true;
   }
 
-  async run(filePath: string, variant: TestVariant): Promise<string> {
+  async runReadTest(filePath: string, variant: TestVariant): Promise<string> {
     const result = [];
     const reader = new Mcap0StreamReader({ validateCrcs: true });
     reader.append(await fs.readFile(filePath));

--- a/tests/conformance/scripts/run-tests/runners/TypescriptStreamedWriterTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptStreamedWriterTestRunner.ts
@@ -1,22 +1,19 @@
 import fs from "fs/promises";
 import { TestVariant } from "variants/types";
 
-import ITestRunner from "./ITestRunner";
+import { WriteTestRunner } from "./TestRunner";
 
-export default class TypescriptStreamedWriterTestRunner implements ITestRunner {
+export default class TypescriptStreamedWriterTestRunner extends WriteTestRunner {
   name = "ts-streamed-writer";
-  mode = "write" as const;
 
   supportsVariant(_variant: TestVariant): boolean {
     return true;
   }
 
-  async run(filePath: string, _variant: TestVariant): Promise<string> {
+  async runWriteTest(filePath: string, _variant: TestVariant): Promise<Uint8Array> {
     // Passthrough test for now.
     const mcapPath = filePath.replace(/\.[^.]+$/, ".mcap");
     const bytes = await fs.readFile(mcapPath);
-    return Array.from(bytes)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
+    return bytes as Uint8Array;
   }
 }

--- a/tests/conformance/scripts/run-tests/runners/index.ts
+++ b/tests/conformance/scripts/run-tests/runners/index.ts
@@ -1,15 +1,12 @@
 import CppStreamedTestRunner from "./CppStreamedTestRunner";
 import GoStreamedTestRunner from "./GoStreamedTestRunner";
-import ITestRunner from "./ITestRunner";
 import PythonStreamedReaderTestRunner from "./PythonStreamedReaderTestRunner";
 import PythonStreamedWriterTestRunner from "./PythonStreamedWriterTestRunner";
 import TypescriptIndexedTestRunner from "./TypescriptIndexedTestRunner";
 import TypescriptStreamedReaderTestRunner from "./TypescriptStreamedReaderTestRunner";
 import TypescriptStreamedWriterTestRunner from "./TypescriptStreamedWriterTestRunner";
 
-export type { ITestRunner };
-
-const runners: readonly ITestRunner[] = [
+const runners = [
   new CppStreamedTestRunner(),
   new GoStreamedTestRunner(),
   new PythonStreamedReaderTestRunner(),
@@ -17,5 +14,6 @@ const runners: readonly ITestRunner[] = [
   new TypescriptIndexedTestRunner(),
   new TypescriptStreamedReaderTestRunner(),
   new TypescriptStreamedWriterTestRunner(),
-];
+] as const;
+
 export default runners;


### PR DESCRIPTION
**Public-Facing Changes**
This splits the `ITestRunner` interface into two separate reader & writer interfaces.


**Description**
This allows us to return binary from writer tests which is more natural for comparison.


<!-- link relevant GitHub issues -->
