### PR TITLE
Go: bag conversion speed improvements

### DIFF
--- a/go/libmcap/parse.go
+++ b/go/libmcap/parse.go
@@ -447,14 +447,14 @@ func ParseDataEnd(buf []byte) (*DataEnd, error) {
 	}, nil
 }
 
-func readMessageIndexEntries(data []byte, offset int) (entries []MessageIndexEntry, newoffset int, err error) {
+func readMessageIndexEntries(data []byte, offset int) (entries []*MessageIndexEntry, newoffset int, err error) {
 	entriesByteLength, offset, err := getUint32(data, offset)
 	if err != nil {
 		return nil, offset, fmt.Errorf("failed to read message index entries byte length: %w", err)
 	}
 	var value, stamp uint64
 	var start = offset
-	entries = make([]MessageIndexEntry, 0, (len(data)-2)/(8+8))
+	entries = make([]*MessageIndexEntry, 0, (len(data)-2)/(8+8))
 	for uint32(offset) < uint32(start)+entriesByteLength {
 		stamp, offset, err = getUint64(data, offset)
 		if err != nil {
@@ -464,7 +464,7 @@ func readMessageIndexEntries(data []byte, offset int) (entries []MessageIndexEnt
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to read message index entry value: %w", err)
 		}
-		entries = append(entries, MessageIndexEntry{
+		entries = append(entries, &MessageIndexEntry{
 			Timestamp: stamp,
 			Offset:    value,
 		})

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -15,7 +15,7 @@ func BenchmarkBag2MCAP(b *testing.B) {
 		IncludeCRC:  true,
 		Chunked:     true,
 		ChunkSize:   4 * 1024 * 1024,
-		Compression: "lz4",
+		Compression: "",
 	}
 	cases := []struct {
 		assertion string
@@ -25,10 +25,6 @@ func BenchmarkBag2MCAP(b *testing.B) {
 			"demo bag",
 			"../../testdata/bags/demo.bag",
 		},
-		// {
-		// 	"cal loop",
-		// 	"~/data/bags/cal_loop.bag",
-		// },
 	}
 	for _, c := range cases {
 		stats, err := os.Stat(c.inputfile)
@@ -36,7 +32,7 @@ func BenchmarkBag2MCAP(b *testing.B) {
 		input, err := os.ReadFile(c.inputfile)
 		assert.Nil(b, err)
 		reader := &bytes.Reader{}
-		writer := &bytes.Buffer{}
+		writer := bytes.NewBuffer(make([]byte, 4*1024*1024*1024))
 		b.ResetTimer()
 		b.Run(c.assertion, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {


### PR DESCRIPTION
Makes a few changes to speed up bag conversion, primarily by reducing
allocations. Includes:
* Switch to an insertion sort for message indexes within chunks, under
  presumption they are mostly ordered.
* Reuse allocated message index structures across chunks