### PR TITLE
Fix byte slice reuse; update bag schema encoding to ros1msg

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -34,7 +34,7 @@ int main() {
   }
 
   // Register a Schema
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", "string data");
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", "string data");
   writer.addSchema(stdMsgsString);
 
   // Register a Channel

--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -28,7 +28,7 @@ static void BM_McapWriterBufferWriterUnchunkedUnindexed(benchmark::State& state)
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -72,7 +72,7 @@ static void BM_McapWriterBufferWriterUnchunked(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -116,7 +116,7 @@ static void BM_McapWriterBufferWriterChunked(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -161,7 +161,7 @@ static void BM_McapWriterBufferWriterChunkedNoCRC(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -206,7 +206,7 @@ static void BM_McapWriterBufferWriterChunkedUnindexed(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -252,7 +252,7 @@ static void BM_McapWriterBufferWriterLZ4(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -298,7 +298,7 @@ static void BM_McapWriterBufferWriterZStd(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -345,7 +345,7 @@ static void BM_McapWriterBufferWriterZStdNoCRC(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -389,7 +389,7 @@ static void BM_McapWriterStreamWriterUnchunked(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record
@@ -434,7 +434,7 @@ static void BM_McapWriterStreamWriterChunked(benchmark::State& state) {
   writer.open(out, options);
 
   // Register a Schema record
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   // Register a Channel record

--- a/cpp/examples/bag2mcap.cpp
+++ b/cpp/examples/bag2mcap.cpp
@@ -22,7 +22,7 @@ int main() {
   std::ofstream out("output.mcap", std::ios::binary);
   writer.open(out, options);
 
-  mcap::Schema stdMsgsString("std_msgs/String", "ros1", StringSchema);
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
   writer.addSchema(stdMsgsString);
 
   mcap::Channel topic("/chatter", "ros1", stdMsgsString.id);

--- a/go/libmcap/writer_test.go
+++ b/go/libmcap/writer_test.go
@@ -81,7 +81,7 @@ func TestOutputDeterminism(t *testing.T) {
 		assert.Nil(t, w.WriteSchema(&Schema{
 			ID:       1,
 			Name:     "foo",
-			Encoding: "ros1",
+			Encoding: "ros1msg",
 			Data:     []byte{},
 		}))
 		for i := 0; i < 3; i++ {

--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -261,11 +261,13 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *libmcap.WriterOptions) error {
 			key := fmt.Sprintf("%s/%s", topic, md5sum)
 			if _, ok := schemas[key]; !ok {
 				schemaID := uint16(len(schemas) + 1)
+				msgdefCopy := make([]byte, len(msgdef))
+				copy(msgdefCopy, msgdef)
 				err := writer.WriteSchema(&libmcap.Schema{
 					ID:       schemaID,
-					Encoding: "msg",
+					Encoding: "ros1msg",
 					Name:     string(typ),
-					Data:     msgdef,
+					Data:     msgdefCopy,
 				})
 				if err != nil {
 					return err


### PR DESCRIPTION
Fixes a byte slice reuse in bag2mcap

Updates Go & C++ to use `ros1msg` for schema encoding as per https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-formats.md