### PR TITLE
Go: miscellaneous documentation improvements

### DIFF
--- a/go/libmcap/crc_writer.go
+++ b/go/libmcap/crc_writer.go
@@ -1,0 +1,32 @@
+package libmcap
+
+import (
+	"hash"
+	"hash/crc32"
+	"io"
+)
+
+type CRCWriter struct {
+	w   io.Writer
+	crc hash.Hash32
+}
+
+func (w *CRCWriter) Write(p []byte) (int, error) {
+	_, _ = w.crc.Write(p)
+	return w.w.Write(p)
+}
+
+func (w *CRCWriter) Checksum() uint32 {
+	return w.crc.Sum32()
+}
+
+func (w *CRCWriter) Reset() {
+	w.crc = crc32.NewIEEE()
+}
+
+func NewCRCWriter(w io.Writer) *CRCWriter {
+	return &CRCWriter{
+		w:   w,
+		crc: crc32.NewIEEE(),
+	}
+}

--- a/go/libmcap/lexer.go
+++ b/go/libmcap/lexer.go
@@ -12,32 +12,51 @@ import (
 	"github.com/pierrec/lz4/v4"
 )
 
-var (
-	ErrNestedChunk = errors.New("detected nested chunk")
-	ErrBadMagic    = errors.New("not an mcap file")
-)
+// ErrNestedChunk indicates the lexer has detected a nested chunk.
+var ErrNestedChunk = errors.New("detected nested chunk")
+
+// ErrBadMagic indicates the lexer has detected invalid magic bytes.
+var ErrBadMagic = errors.New("not an mcap file")
 
 const (
+	// TokenHeader represents a header token.
 	TokenHeader TokenType = iota
+	// TokenFooter represents a footer token.
 	TokenFooter
+	// TokenSchema represents a schema token.
 	TokenSchema
+	// TokenChannel represents a channel token.
 	TokenChannel
+	// TokenMessage represents a message token.
 	TokenMessage
+	// TokenChunk represents a chunk token.
 	TokenChunk
+	// TokenMessageIndex represents a message index token.
 	TokenMessageIndex
+	// TokenChunkIndex represents a chunk index token.
 	TokenChunkIndex
+	// TokenAttachment represents an attachment token.
 	TokenAttachment
+	// TokenAttachmentIndex represents an attachment index token.
 	TokenAttachmentIndex
+	// TokenStatistics represents a statistics token.
 	TokenStatistics
+	// TokenMetadata represents a metadata token.
 	TokenMetadata
+	// TokenSummaryOffset represents a summary offset token.
 	TokenMetadataIndex
+	// TokenDataEnd represents a data end token.
 	TokenSummaryOffset
+	// 	TokenError represents an error token.
 	TokenDataEnd
+	// TokenError represents an error token.
 	TokenError
 )
 
+// TokenType encodes a type of token from the lexer.
 type TokenType int
 
+// String converts a token type to its string representation.
 func (t TokenType) String() string {
 	switch t {
 	case TokenHeader:
@@ -75,12 +94,9 @@ func (t TokenType) String() string {
 	}
 }
 
-type decoders struct {
-	zstd *zstd.Decoder
-	lz4  *lz4.Reader
-	none *bytes.Reader
-}
-
+// Lexer is a low-level reader for mcap files that emits tokenized byte strings
+// without parsing or interpreting them, except in the case of chunks, which may
+// be optionally de-chunked.
 type Lexer struct {
 	basereader io.Reader
 	reader     io.Reader
@@ -90,134 +106,6 @@ type Lexer struct {
 	inChunk     bool
 	buf         []byte
 	validateCRC bool
-}
-
-func validateMagic(r io.Reader) error {
-	magic := make([]byte, len(Magic))
-	if _, err := io.ReadFull(r, magic); err != nil {
-		return ErrBadMagic
-	}
-	if !bytes.Equal(magic, Magic) {
-		return ErrBadMagic
-	}
-	return nil
-}
-
-func (l *Lexer) setNoneDecoder(buf []byte) {
-	if l.decoders.none == nil {
-		l.decoders.none = bytes.NewReader(buf)
-	} else {
-		l.decoders.none.Reset(buf)
-	}
-	l.reader = l.decoders.none
-}
-
-func (l *Lexer) setZSTDDecoder(r io.Reader) error {
-	if l.decoders.zstd == nil {
-		decoder, err := zstd.NewReader(r)
-		if err != nil {
-			return err
-		}
-		l.decoders.zstd = decoder
-	} else {
-		err := l.decoders.zstd.Reset(r)
-		if err != nil {
-			return err
-		}
-	}
-	l.reader = l.decoders.zstd
-	return nil
-}
-
-func (l *Lexer) setLZ4Decoder(r io.Reader) {
-	if l.decoders.lz4 == nil {
-		l.decoders.lz4 = lz4.NewReader(r)
-	} else {
-		l.decoders.lz4.Reset(r)
-	}
-	l.reader = l.decoders.lz4
-}
-
-func loadChunk(l *Lexer) error {
-	if l.inChunk {
-		return ErrNestedChunk
-	}
-	_, err := io.ReadFull(l.reader, l.buf[:8+8+8+4+4])
-	if err != nil {
-		return err
-	}
-
-	// the reader does not care about the start, end, or uncompressed size, or
-	// they would be using emitChunks.
-
-	// Skip the uncompressed size; the lexer will read messages out of the
-	// reader incrementally.
-	_, offset, err := getUint64(l.buf, 0) // start
-	if err != nil {
-		return fmt.Errorf("failed to read start: %w", err)
-	}
-	_, offset, err = getUint64(l.buf, offset) // end
-	if err != nil {
-		return fmt.Errorf("failed to read end: %w", err)
-	}
-	_, offset, err = getUint64(l.buf, offset) // uncompressed size
-	if err != nil {
-		return fmt.Errorf("failed to read uncompressed size: %w", err)
-	}
-	uncompressedCRC, offset, err := getUint32(l.buf, offset)
-	if err != nil {
-		return fmt.Errorf("failed to read uncompressed CRC: %w", err)
-	}
-	compressionLen, _, err := getUint32(l.buf, offset)
-	if err != nil {
-		return fmt.Errorf("failed to read compression length: %w", err)
-	}
-
-	// read compression and records length into buffer
-	_, err = io.ReadFull(l.reader, l.buf[:compressionLen+8])
-	if err != nil {
-		return fmt.Errorf("failed to read compression from chunk: %w", err)
-	}
-	compression := CompressionFormat(l.buf[:compressionLen])
-	recordsLength, _, err := getUint64(l.buf, int(compressionLen))
-	if err != nil {
-		return fmt.Errorf("failed to read records length: %w", err)
-	}
-
-	// remaining bytes in the record are the chunk data
-	lr := io.LimitReader(l.reader, int64(recordsLength))
-	switch compression {
-	case CompressionNone:
-		l.reader = lr
-	case CompressionZSTD:
-		err = l.setZSTDDecoder(lr)
-		if err != nil {
-			return err
-		}
-	case CompressionLZ4:
-		l.setLZ4Decoder(lr)
-	default:
-		return fmt.Errorf("unsupported compression: %s", string(compression))
-	}
-
-	// if we are validating the CRC, we need to fully decompress the chunk right
-	// here, then rewrap the decompressed data in a compatible reader after
-	// validation. If we are not validating CRCs, we can use incremental
-	// decompression for the chunk's data, which may be beneficial to streaming
-	// readers.
-	if l.validateCRC {
-		uncompressed, err := io.ReadAll(l.reader)
-		if err != nil {
-			return err
-		}
-		crc := crc32.ChecksumIEEE(uncompressed)
-		if crc != uncompressedCRC {
-			return fmt.Errorf("invalid CRC: %x != %x", crc, uncompressedCRC)
-		}
-		l.setNoneDecoder(uncompressed)
-	}
-	l.inChunk = true
-	return nil
 }
 
 // Next returns the next token from the lexer as a byte array. The result will
@@ -292,7 +180,7 @@ func (l *Lexer) Next(p []byte) (TokenType, []byte, error) {
 			return TokenMetadataIndex, record, nil
 		case OpSummaryOffset:
 			return TokenSummaryOffset, record, nil
-		case OpInvalidZero:
+		case OpReserved:
 			return TokenError, nil, fmt.Errorf("invalid zero opcode")
 		default:
 			continue // skip unrecognized opcodes
@@ -300,12 +188,146 @@ func (l *Lexer) Next(p []byte) (TokenType, []byte, error) {
 	}
 }
 
-type LexerOptions struct {
-	SkipMagic   bool
-	ValidateCRC bool
-	EmitChunks  bool
+type decoders struct {
+	zstd *zstd.Decoder
+	lz4  *lz4.Reader
+	none *bytes.Reader
 }
 
+func validateMagic(r io.Reader) error {
+	magic := make([]byte, len(Magic))
+	if _, err := io.ReadFull(r, magic); err != nil {
+		return ErrBadMagic
+	}
+	if !bytes.Equal(magic, Magic) {
+		return ErrBadMagic
+	}
+	return nil
+}
+
+func (l *Lexer) setNoneDecoder(buf []byte) {
+	if l.decoders.none == nil {
+		l.decoders.none = bytes.NewReader(buf)
+	} else {
+		l.decoders.none.Reset(buf)
+	}
+	l.reader = l.decoders.none
+}
+
+func (l *Lexer) setZSTDDecoder(r io.Reader) error {
+	if l.decoders.zstd == nil {
+		decoder, err := zstd.NewReader(r)
+		if err != nil {
+			return err
+		}
+		l.decoders.zstd = decoder
+	} else {
+		err := l.decoders.zstd.Reset(r)
+		if err != nil {
+			return err
+		}
+	}
+	l.reader = l.decoders.zstd
+	return nil
+}
+
+func (l *Lexer) setLZ4Decoder(r io.Reader) {
+	if l.decoders.lz4 == nil {
+		l.decoders.lz4 = lz4.NewReader(r)
+	} else {
+		l.decoders.lz4.Reset(r)
+	}
+	l.reader = l.decoders.lz4
+}
+
+func loadChunk(l *Lexer) error {
+	if l.inChunk {
+		return ErrNestedChunk
+	}
+	_, err := io.ReadFull(l.reader, l.buf[:8+8+8+4+4])
+	if err != nil {
+		return err
+	}
+	_, offset, err := getUint64(l.buf, 0) // start
+	if err != nil {
+		return fmt.Errorf("failed to read start: %w", err)
+	}
+	_, offset, err = getUint64(l.buf, offset) // end
+	if err != nil {
+		return fmt.Errorf("failed to read end: %w", err)
+	}
+	_, offset, err = getUint64(l.buf, offset) // uncompressed size
+	if err != nil {
+		return fmt.Errorf("failed to read uncompressed size: %w", err)
+	}
+	uncompressedCRC, offset, err := getUint32(l.buf, offset)
+	if err != nil {
+		return fmt.Errorf("failed to read uncompressed CRC: %w", err)
+	}
+	compressionLen, _, err := getUint32(l.buf, offset)
+	if err != nil {
+		return fmt.Errorf("failed to read compression length: %w", err)
+	}
+
+	// read compression and records length into buffer
+	_, err = io.ReadFull(l.reader, l.buf[:compressionLen+8])
+	if err != nil {
+		return fmt.Errorf("failed to read compression from chunk: %w", err)
+	}
+	compression := CompressionFormat(l.buf[:compressionLen])
+	recordsLength, _, err := getUint64(l.buf, int(compressionLen))
+	if err != nil {
+		return fmt.Errorf("failed to read records length: %w", err)
+	}
+
+	// remaining bytes in the record are the chunk data
+	lr := io.LimitReader(l.reader, int64(recordsLength))
+	switch compression {
+	case CompressionNone:
+		l.reader = lr
+	case CompressionZSTD:
+		err = l.setZSTDDecoder(lr)
+		if err != nil {
+			return err
+		}
+	case CompressionLZ4:
+		l.setLZ4Decoder(lr)
+	default:
+		return fmt.Errorf("unsupported compression: %s", string(compression))
+	}
+
+	// if we are validating the CRC, we need to fully decompress the chunk right
+	// here, then rewrap the decompressed data in a compatible reader after
+	// validation. If we are not validating CRCs, we can use incremental
+	// decompression for the chunk's data, which may be beneficial to streaming
+	// readers.
+	if l.validateCRC {
+		uncompressed, err := io.ReadAll(l.reader)
+		if err != nil {
+			return err
+		}
+		crc := crc32.ChecksumIEEE(uncompressed)
+		if crc != uncompressedCRC {
+			return fmt.Errorf("invalid CRC: %x != %x", crc, uncompressedCRC)
+		}
+		l.setNoneDecoder(uncompressed)
+	}
+	l.inChunk = true
+	return nil
+}
+
+// LexerOptions holds options for the lexer.
+type LexerOptions struct {
+	// SkipMagic instructs the lexer not to perform validation of the leading magic bytes.
+	SkipMagic bool
+	// ValidateCRC instructs the lexer to validate CRC checksums for chunks.
+	ValidateCRC bool
+	// EmitChunks instructs the lexer to emit chunk records without de-chunking.
+	// It is incompatible with ValidateCRC.
+	EmitChunks bool
+}
+
+// NewLexer returns a new lexer for the given reader.
 func NewLexer(r io.Reader, opts ...*LexerOptions) (*Lexer, error) {
 	var validateCRC, emitChunks, skipMagic bool
 	if len(opts) > 0 {

--- a/go/libmcap/mcap.go
+++ b/go/libmcap/mcap.go
@@ -1,167 +1,27 @@
 package libmcap
 
-import (
-	"bytes"
-	"encoding/binary"
-	"hash"
-	"hash/crc32"
-	"io"
-	"time"
-)
-
-var (
-	Magic = []byte{0x89, 'M', 'C', 'A', 'P', 0x30, '\r', '\n'}
-)
+// Magic is the magic number for an MCAP file.
+var Magic = []byte{0x89, 'M', 'C', 'A', 'P', 0x30, '\r', '\n'}
 
 const (
+	// CompressionZSTD represents zstd compression.
 	CompressionZSTD CompressionFormat = "zstd"
-	CompressionLZ4  CompressionFormat = "lz4"
+	// CompressionLZ4 represents lz4 compression.
+	CompressionLZ4 CompressionFormat = "lz4"
+	// CompressionNone represents no compression.
 	CompressionNone CompressionFormat = ""
 )
 
-type BufCloser struct {
-	b *bytes.Buffer
-}
-
-func (b BufCloser) Close() error {
-	return nil
-}
-
-func (b BufCloser) Write(p []byte) (int, error) {
-	return b.b.Write(p)
-}
-
-func (b BufCloser) Reset(w io.Writer) {
-	b.b.Reset()
-}
-
-type ResettableReader interface {
-	io.ReadCloser
-	Reset(io.Reader)
-}
-
-type ResettableWriteCloser interface {
-	io.WriteCloser
-	Reset(io.Writer)
-}
-
-type CRCWriter struct {
-	w   io.Writer
-	crc hash.Hash32
-}
-
-func (w *CRCWriter) Write(p []byte) (int, error) {
-	_, _ = w.crc.Write(p)
-	return w.w.Write(p)
-}
-
-func (w *CRCWriter) Checksum() uint32 {
-	return w.crc.Sum32()
-}
-
-func (w *CRCWriter) Reset() {
-	w.crc = crc32.NewIEEE()
-}
-
-func NewCRCWriter(w io.Writer) *CRCWriter {
-	return &CRCWriter{
-		w:   w,
-		crc: crc32.NewIEEE(),
-	}
-}
-
-type WriteSizer struct {
-	w    *CRCWriter
-	size uint64
-}
-
-func (w *WriteSizer) Write(p []byte) (int, error) {
-	w.size += uint64(len(p))
-	return w.w.Write(p)
-}
-
-func NewWriteSizer(w io.Writer) *WriteSizer {
-	return &WriteSizer{
-		w: NewCRCWriter(w),
-	}
-}
-
-func (w *WriteSizer) Size() uint64 {
-	return w.size
-}
-
-func (w *WriteSizer) Checksum() uint32 {
-	return w.w.Checksum()
-}
-
-func (w *WriteSizer) Reset() {
-	w.w.crc = crc32.NewIEEE()
-}
-
-func putByte(buf []byte, x byte) (int, error) {
-	if len(buf) < 1 {
-		return 0, io.ErrShortBuffer
-	}
-	buf[0] = x
-	return 1, nil
-}
-
-func getUint16(buf []byte, offset int) (x uint16, newoffset int, err error) {
-	if offset > len(buf)-2 {
-		return 0, 0, io.ErrShortBuffer
-	}
-	return binary.LittleEndian.Uint16(buf[offset:]), offset + 2, nil
-}
-
-func getUint32(buf []byte, offset int) (x uint32, newoffset int, err error) {
-	if offset > len(buf)-4 {
-		return 0, 0, io.ErrShortBuffer
-	}
-	return binary.LittleEndian.Uint32(buf[offset:]), offset + 4, nil
-}
-
-func getUint64(buf []byte, offset int) (x uint64, newoffset int, err error) {
-	if offset > len(buf)-8 {
-		return 0, 0, io.ErrShortBuffer
-	}
-	return binary.LittleEndian.Uint64(buf[offset:]), offset + 8, nil
-}
-
-func putUint16(buf []byte, i uint16) int {
-	binary.LittleEndian.PutUint16(buf, i)
-	return 2
-}
-
-func putUint32(buf []byte, i uint32) int {
-	binary.LittleEndian.PutUint32(buf, i)
-	return 4
-}
-
-func putUint64(buf []byte, i uint64) int {
-	binary.LittleEndian.PutUint64(buf, i)
-	return 8
-}
-
-func putPrefixedString(buf []byte, s string) int {
-	offset := putUint32(buf, uint32(len(s)))
-	offset += copy(buf[offset:], s)
-	return offset
-}
-
-func putPrefixedBytes(buf []byte, s []byte) int {
-	offset := putUint32(buf, uint32(len(s)))
-	offset += copy(buf[offset:], s)
-	return offset
-}
-
+// CompressionFormat represents a supported chunk compression format.
 type CompressionFormat string
 
+// String converts a compression format to a string for display.
 func (c CompressionFormat) String() string {
 	return string(c)
 }
 
 const (
-	OpInvalidZero     OpCode = 0x00
+	OpReserved        OpCode = 0x00
 	OpHeader          OpCode = 0x01
 	OpFooter          OpCode = 0x02
 	OpSchema          OpCode = 0x03
@@ -181,19 +41,35 @@ const (
 
 type OpCode byte
 
+// Header is the first record in an MCAP file.
 type Header struct {
 	Profile string
 	Library string
 }
 
-type Message struct {
-	ChannelID   uint16
-	Sequence    uint32
-	LogTime     uint64
-	PublishTime uint64
-	Data        []byte
+// Footer records contain end-of-file information. MCAP files must end with a
+// Footer record.
+type Footer struct {
+	SummaryStart       uint64
+	SummaryOffsetStart uint64
+	SummaryCRC         uint32
 }
 
+// A Schema record defines an individual schema. Schema records are uniquely
+// identified within a file by their schema ID. A Schema record must occur at
+// least once in the file prior to any Channel referring to its ID. Any two
+// schema records sharing a common ID must be identical.
+type Schema struct {
+	ID       uint16
+	Name     string
+	Encoding string
+	Data     []byte
+}
+
+// Channel records define encoded streams of messages on topics. Channel records
+// are uniquely identified within a file by their channel ID. A Channel record
+// must occur at least once in the file prior to any message referring to its
+// channel ID. Any two channel records sharing a common ID must be identical.
 type Channel struct {
 	ID              uint16
 	SchemaID        uint16
@@ -202,131 +78,43 @@ type Channel struct {
 	Metadata        map[string]string
 }
 
-type Attachment struct {
+// Message records encode a single timestamped message on a channel. The message
+// encoding and schema must match that of the Channel record corresponding to
+// the message's channel ID.
+type Message struct {
+	ChannelID   uint16
+	Sequence    uint32
 	LogTime     uint64
-	CreateTime  uint64
-	Name        string
-	ContentType string
+	PublishTime uint64
 	Data        []byte
-	CRC         uint32
 }
 
-type CompressionSummary struct {
-	Algorithm  CompressionFormat
-	ChunkCount uint64
+// Chunk records each contain a batch of Schema, Channel, and Message records.
+// The batch of records contained in a chunk may be compressed or uncompressed.
+// All messages in the chunk must reference channels recorded earlier in the
+// file (in a previous chunk or earlier in the current chunk).
+type Chunk struct {
+	MessageStartTime uint64
+	MessageEndTime   uint64
+	UncompressedSize uint64
+	UncompressedCRC  uint32
+	Compression      string
+	Records          []byte
 }
 
-type TypeSummary struct {
-	SchemaName string
-}
-
-type TopicSummary struct {
-	TopicName    string
-	MessageCount uint64
-	SchemaName   string
-}
-type Summary struct {
-	Duration    time.Duration
-	Start       uint64
-	End         uint64
-	Size        uint64
-	Messages    uint64
-	Compression []CompressionSummary
-	Types       []TypeSummary
-	Topics      []TopicSummary
-}
-
-type AttachmentIndex struct {
-	Offset      uint64
-	Length      uint64
-	LogTime     uint64
-	CreateTime  uint64
-	DataSize    uint64
-	Name        string
-	ContentType string
-}
-
-type Schema struct {
-	ID       uint16
-	Name     string
-	Encoding string
-	Data     []byte
-}
-
-type Footer struct {
-	SummaryStart       uint64
-	SummaryOffsetStart uint64
-	SummaryCRC         uint32
-}
-
-type SummaryOffset struct {
-	GroupOpcode OpCode
-	GroupStart  uint64
-	GroupLength uint64
-}
-
-type Metadata struct {
-	Name     string
-	Metadata map[string]string
-}
-
-type MetadataIndex struct {
-	Offset uint64
-	Length uint64
-	Name   string
-}
-
-type ChunkIndex struct {
-	MessageStartTime    uint64
-	MessageEndTime      uint64
-	ChunkStartOffset    uint64
-	ChunkLength         uint64
-	MessageIndexOffsets map[uint16]uint64
-	MessageIndexLength  uint64
-	Compression         CompressionFormat
-	CompressedSize      uint64
-	UncompressedSize    uint64
-}
-
-type Statistics struct {
-	MessageCount         uint64
-	SchemaCount          uint16
-	ChannelCount         uint32
-	AttachmentCount      uint32
-	MetadataCount        uint32
-	ChunkCount           uint32
-	MessageStartTime     uint64
-	MessageEndTime       uint64
-	ChannelMessageCounts map[uint16]uint64
-}
-
-type Info struct {
-	Statistics   *Statistics
-	Channels     map[uint16]*Channel
-	Schemas      map[uint16]*Schema
-	ChunkIndexes []*ChunkIndex
-}
-
-func (i *Info) ChannelCounts() map[string]uint64 {
-	counts := make(map[string]uint64)
-	for k, v := range i.Statistics.ChannelMessageCounts {
-		channel := i.Channels[k]
-		counts[channel.Topic] = v
-	}
-	return counts
-}
-
-type MessageIndexEntry struct {
-	Timestamp uint64
-	Offset    uint64
-}
-
+// MessageIndex records allow readers to locate individual records within a
+// chunk by timestamp. A sequence of Message Index records occurs immediately
+// after each chunk. Exactly one Message Index record must exist in the sequence
+// for every channel on which a message occurs inside the chunk.
 type MessageIndex struct {
 	ChannelID    uint16
 	Records      []*MessageIndexEntry
 	currentIndex int
 }
 
+// Insort sorts the records of a MessageIndex record by timestamp, using an
+// insertion sort. This can be advantageous as MessageIndex records are often
+// nearly or fully-sorted already.
 func (idx *MessageIndex) Insort() {
 	i := 1
 	for i < len(idx.Entries()) {
@@ -339,14 +127,17 @@ func (idx *MessageIndex) Insort() {
 	}
 }
 
+// Reset resets the MessageIndex to an empty state, to enable reuse.
 func (idx *MessageIndex) Reset() {
 	idx.currentIndex = 0
 }
 
+// Entries lists the entries in the message index.
 func (idx *MessageIndex) Entries() []*MessageIndexEntry {
 	return idx.Records[:idx.currentIndex]
 }
 
+// Add an entry to the message index.
 func (idx *MessageIndex) Add(timestamp uint64, offset uint64) {
 	if idx.currentIndex >= len(idx.Records) {
 		records := make([]*MessageIndexEntry, (len(idx.Records)+20)*2)
@@ -361,15 +152,105 @@ func (idx *MessageIndex) Add(timestamp uint64, offset uint64) {
 	idx.currentIndex++
 }
 
-type Chunk struct {
-	MessageStartTime uint64
-	MessageEndTime   uint64
-	UncompressedSize uint64
-	UncompressedCRC  uint32
-	Compression      string
-	Records          []byte
+// ChunkIndex records contain the location of a Chunk record and its associated
+// MessageIndex records. A ChunkIndex record exists for every Chunk in the file.
+type ChunkIndex struct {
+	MessageStartTime    uint64
+	MessageEndTime      uint64
+	ChunkStartOffset    uint64
+	ChunkLength         uint64
+	MessageIndexOffsets map[uint16]uint64
+	MessageIndexLength  uint64
+	Compression         CompressionFormat
+	CompressedSize      uint64
+	UncompressedSize    uint64
 }
 
+// Attachment records contain auxiliary artifacts such as text, core dumps,
+// calibration data, or other arbitrary data. Attachment records must not appear
+// within a chunk.
+type Attachment struct {
+	LogTime     uint64
+	CreateTime  uint64
+	Name        string
+	ContentType string
+	Data        []byte
+	CRC         uint32
+}
+
+// AttachmentIndex records contain the location of attachments in the file. An
+// AttachmentIndex record exists for every Attachment in the file.
+type AttachmentIndex struct {
+	Offset      uint64
+	Length      uint64
+	LogTime     uint64
+	CreateTime  uint64
+	DataSize    uint64
+	Name        string
+	ContentType string
+}
+
+// Statistics records contain summary information about recorded data. The
+// statistics record is optional, but the file should contain at most one.
+type Statistics struct {
+	MessageCount         uint64
+	SchemaCount          uint16
+	ChannelCount         uint32
+	AttachmentCount      uint32
+	MetadataCount        uint32
+	ChunkCount           uint32
+	MessageStartTime     uint64
+	MessageEndTime       uint64
+	ChannelMessageCounts map[uint16]uint64
+}
+
+// Metadata records contain arbitrary user data in key-value pairs.
+type Metadata struct {
+	Name     string
+	Metadata map[string]string
+}
+
+// MetadataIndex records each contain the location of a metadata record within the file.
+type MetadataIndex struct {
+	Offset uint64
+	Length uint64
+	Name   string
+}
+
+// SummaryOffset records contain the location of records within the summary
+// section. Each SummaryOffset record corresponds to a group of summary records
+// with a common opcode.
+type SummaryOffset struct {
+	GroupOpcode OpCode
+	GroupStart  uint64
+	GroupLength uint64
+}
+
+// DataEnd indicates the end of the data section.
 type DataEnd struct {
 	DataSectionCRC uint32
+}
+
+// Info represents the result of an "info" operation, for gathering information
+// from the summary section of a file.
+type Info struct {
+	Statistics   *Statistics
+	Channels     map[uint16]*Channel
+	Schemas      map[uint16]*Schema
+	ChunkIndexes []*ChunkIndex
+}
+
+// ChannelCounts counts the number of messages on each channel in an Info.
+func (i *Info) ChannelCounts() map[string]uint64 {
+	counts := make(map[string]uint64)
+	for k, v := range i.Statistics.ChannelMessageCounts {
+		channel := i.Channels[k]
+		counts[channel.Topic] = v
+	}
+	return counts
+}
+
+type MessageIndexEntry struct {
+	Timestamp uint64
+	Offset    uint64
 }

--- a/go/libmcap/resettable_write_closer.go
+++ b/go/libmcap/resettable_write_closer.go
@@ -1,0 +1,36 @@
+package libmcap
+
+import (
+	"bytes"
+	"io"
+)
+
+// ResettableWriteCloser is a WriteCloser that supports a Reset method.
+type ResettableWriteCloser interface {
+	io.WriteCloser
+	Reset(io.Writer)
+}
+
+type bufCloser struct {
+	b *bytes.Buffer
+}
+
+func (b bufCloser) Close() error {
+	return nil
+}
+
+func (b bufCloser) Write(p []byte) (int, error) {
+	return b.b.Write(p)
+}
+
+func (b bufCloser) Reset(w io.Writer) {
+	b.b.Reset()
+}
+
+// NewResettableBufCloser returns a ResettableWriteCloser backed by a
+// bytes.Buffer.
+func NewResettableBufCloser(buf *bytes.Buffer) ResettableWriteCloser {
+	return &bufCloser{
+		b: buf,
+	}
+}

--- a/go/libmcap/utils.go
+++ b/go/libmcap/utils.go
@@ -1,0 +1,62 @@
+package libmcap
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+func putByte(buf []byte, x byte) (int, error) {
+	if len(buf) < 1 {
+		return 0, io.ErrShortBuffer
+	}
+	buf[0] = x
+	return 1, nil
+}
+
+func getUint16(buf []byte, offset int) (x uint16, newoffset int, err error) {
+	if offset > len(buf)-2 {
+		return 0, 0, io.ErrShortBuffer
+	}
+	return binary.LittleEndian.Uint16(buf[offset:]), offset + 2, nil
+}
+
+func getUint32(buf []byte, offset int) (x uint32, newoffset int, err error) {
+	if offset > len(buf)-4 {
+		return 0, 0, io.ErrShortBuffer
+	}
+	return binary.LittleEndian.Uint32(buf[offset:]), offset + 4, nil
+}
+
+func getUint64(buf []byte, offset int) (x uint64, newoffset int, err error) {
+	if offset > len(buf)-8 {
+		return 0, 0, io.ErrShortBuffer
+	}
+	return binary.LittleEndian.Uint64(buf[offset:]), offset + 8, nil
+}
+
+func putUint16(buf []byte, i uint16) int {
+	binary.LittleEndian.PutUint16(buf, i)
+	return 2
+}
+
+func putUint32(buf []byte, i uint32) int {
+	binary.LittleEndian.PutUint32(buf, i)
+	return 4
+}
+
+func putUint64(buf []byte, i uint64) int {
+	binary.LittleEndian.PutUint64(buf, i)
+	return 8
+}
+
+func putPrefixedString(buf []byte, s string) int {
+	offset := putUint32(buf, uint32(len(s)))
+	offset += copy(buf[offset:], s)
+	return offset
+}
+
+func putPrefixedBytes(buf []byte, s []byte) int {
+	offset := putUint32(buf, uint32(len(s)))
+	offset += copy(buf[offset:], s)
+	return offset
+}

--- a/go/libmcap/write_sizer.go
+++ b/go/libmcap/write_sizer.go
@@ -1,0 +1,34 @@
+package libmcap
+
+import (
+	"hash/crc32"
+	"io"
+)
+
+type WriteSizer struct {
+	w    *CRCWriter
+	size uint64
+}
+
+func (w *WriteSizer) Write(p []byte) (int, error) {
+	w.size += uint64(len(p))
+	return w.w.Write(p)
+}
+
+func NewWriteSizer(w io.Writer) *WriteSizer {
+	return &WriteSizer{
+		w: NewCRCWriter(w),
+	}
+}
+
+func (w *WriteSizer) Size() uint64 {
+	return w.size
+}
+
+func (w *WriteSizer) Checksum() uint32 {
+	return w.w.Checksum()
+}
+
+func (w *WriteSizer) Reset() {
+	w.w.crc = crc32.NewIEEE()
+}


### PR DESCRIPTION
Improves docstrings for the go public functions in some areas. Also
reorganizes the order of types in mcap.go to match the order in the
spec, removes some unused types, and splits the custom reader/writer
types into their own files.