### PR TITLE
Go: Only build static binary on linux

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,0 +1,1 @@
+mcap/mcap

--- a/go/mcap/Makefile
+++ b/go/mcap/Makefile
@@ -1,6 +1,15 @@
+# stripe binaries
+FLAGS := -tags sqlite_omit_load_extension -ldflags '-s -w'
+
+# platform-specific settings
+GOOS := $(shell go env GOOS)
+ifeq ($(GOOS),linux)
+	# statically link binaries to support alpine linux
+	FLAGS := -tags sqlite_omit_load_extension,netgo,osusergo -ldflags '-s -w -extldflags "-static"'
+endif
+
 build:
-# cspell:disable-next-line
-	go build -ldflags="-extldflags=-static" -tags sqlite_omit_load_extension,netgo
+	go build $(FLAGS) .
 
 lint:
 	golangci-lint run ./...

--- a/go/mcap/Makefile
+++ b/go/mcap/Makefile
@@ -1,4 +1,4 @@
-# stripe binaries
+# strip binaries
 FLAGS := -tags sqlite_omit_load_extension -ldflags '-s -w'
 
 # platform-specific settings


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Don't build static binaries on macOS (not possible). Debatable whether we need this on linux, but it's nice if we plan to generate binaries that people want to run under busybox/alpine.

Closes #89
Closes #183