### PR TITLE
Split AMENT_PREFIX_PATH for ros2 bags on conversion

### DIFF
--- a/go/cli/mcap/cmd/convert.go
+++ b/go/cli/mcap/cmd/convert.go
@@ -112,9 +112,10 @@ var convertCmd = &cobra.Command{
 				die("failed to open sqlite3: %s", err)
 			}
 			dirs := strings.FieldsFunc(directories, func(c rune) bool { return c == ',' })
-			prefix := os.Getenv("AMENT_PREFIX_PATH")
+			prefixPath := os.Getenv("AMENT_PREFIX_PATH")
 			if prefix != "" {
-				dirs = append(dirs, prefix)
+				pathElements := strings.FieldsFunc(prefixPath, func(c rune) bool { return c == ':' })
+				dirs = append(dirs, pathElements...)
 			}
 			err = ros.DB3ToMCAP(w, db, opts, dirs)
 			if err != nil {


### PR DESCRIPTION
Previously the code was expecting this environment variable to be set to
a file path, however it is actually a colon-delimited list of filepaths.