### PR TITLE
Don't include padding in attachnent index length.

### DIFF
--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.json
@@ -32,7 +32,7 @@
         ["content_type", "application/octet-stream"],
         ["create_time", "1"],
         ["data_size", "3"],
-        ["length", "81"],
+        ["length", "78"],
         ["log_time", "2"],
         ["name", "myFile"],
         ["offset", "28"]

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b375fd455a3fe067ff621d18e92962ca09cd389859f5f00ea98b390c6307d4a
+oid sha256:cd8484b70f84b41bd84f3b2ac46e1564a99346c171e3a4769e93c7e3baf2f07b
 size 368

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.json
@@ -32,7 +32,7 @@
         ["content_type", "application/octet-stream"],
         ["create_time", "1"],
         ["data_size", "3"],
-        ["length", "81"],
+        ["length", "78"],
         ["log_time", "2"],
         ["name", "myFile"],
         ["offset", "28"]

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-st.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc9fdb10d15a494534f2de99aff2d54887c01cce8a0f0f99c6d3d0b9ecec9dc3
+oid sha256:ed1fe9f3e8de0d0d5f64b28995c6ef8669a5827acb9985aa8da65c3284b863d2
 size 310

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.json
@@ -18,7 +18,7 @@
         ["content_type", "application/octet-stream"],
         ["create_time", "1"],
         ["data_size", "3"],
-        ["length", "81"],
+        ["length", "78"],
         ["log_time", "2"],
         ["name", "myFile"],
         ["offset", "28"]

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad-sum.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2acf011d96a35928d17bb7dc37a554ceb6b6f07ba30c8e8ffb6d0a90b96abeb7
+oid sha256:1a684e9e7f5dfb3e5cc6c5a4c7c9673d66cfb8ccbdeca4885434cc18f5340b28
 size 281

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.json
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.json
@@ -18,7 +18,7 @@
         ["content_type", "application/octet-stream"],
         ["create_time", "1"],
         ["data_size", "3"],
-        ["length", "81"],
+        ["length", "78"],
         ["log_time", "2"],
         ["name", "myFile"],
         ["offset", "28"]

--- a/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.mcap
+++ b/tests/conformance/data/OneAttachment/OneAttachment-ax-pad.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8995c8062f1ebd4352fd1b6f5565b0fe354deaaffcbbd240457123428565e0f4
+oid sha256:2026f76a1a1fe75f7ef58e962b021cbc0467d020d0739837f631ca15adb5fbe2
 size 252

--- a/tests/conformance/scripts/generate-inputs.ts
+++ b/tests/conformance/scripts/generate-inputs.ts
@@ -82,7 +82,7 @@ function generateFile(features: Set<TestFeatures>, records: TestDataRecord[]) {
         if (features.has(TestFeatures.UseAttachmentIndex)) {
           attachmentIndexes.push({
             name: record.name,
-            length,
+            length: length - (features.has(TestFeatures.AddExtraDataToRecords) ? 3n : 0n),
             offset,
             dataSize: BigInt(record.data.byteLength),
             contentType: record.contentType,


### PR DESCRIPTION
**Public-Facing Changes**
This excludes the length of the attachment record's padding from the length in the corresponding `AttachmentIndexField`.

For now this just fixes the logic in the generate-inputs script pending a more comprehensive API for users to pad data themselves.