### PR TITLE
Delete unused diagrams

### DIFF
--- a/docs/specification/diagrams/chunked.png
+++ b/docs/specification/diagrams/chunked.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1aaa25c88cb353b3e1dd94ea3a7e981909f80dc1b0a34c9aa933af9bb517317
-size 103140

--- a/docs/specification/diagrams/unchunked.png
+++ b/docs/specification/diagrams/unchunked.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70d721b7fac6f3765b59926fef0fca185c8943fd8ef153b4ca5db1c09acebf35
-size 70137


### PR DESCRIPTION
These diagrams are outdated and the spec now uses ASCII "diagrams" instead.