### PR TITLE
ros2db3_to_mcap: change encoding to `ros2msg`

### DIFF
--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -176,7 +176,7 @@ func DB3ToMCAP(w io.Writer, db *sql.DB, opts *mcap.WriterOptions, searchdirs []s
 			ID:       schemaID,
 			Data:     schema,
 			Name:     t.typ,
-			Encoding: "msg",
+			Encoding: "ros2msg",
 		})
 		if err != nil {
 			return fmt.Errorf("failed to write schema: %w", err)


### PR DESCRIPTION
To match https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-encodings.md#ros2msg