### PR TITLE
Set chunk index start ends before closing chunks

### DIFF
--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -349,6 +349,10 @@ func (w *Writer) WriteDataEnd(e *DataEnd) error {
 }
 
 func (w *Writer) flushActiveChunk() error {
+	if w.compressedWriter.Size() == 0 {
+		return nil
+	}
+
 	err := w.compressedWriter.Close()
 	if err != nil {
 		return err

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -255,10 +255,9 @@ func TestChunkBoundaryIndexing(t *testing.T) {
 	}))
 	assert.Nil(t, w.Close())
 	t.Run("chunk indexes correct", func(t *testing.T) {
-		assert.Equal(t, 3, len(w.ChunkIndexes))
+		assert.Equal(t, 2, len(w.ChunkIndexes))
 		assert.Equal(t, 100, int(w.ChunkIndexes[0].MessageStartTime)) // first message
 		assert.Equal(t, 1, int(w.ChunkIndexes[1].MessageStartTime))   // second message
-		assert.Equal(t, 0, int(w.ChunkIndexes[2].MessageStartTime))   // empty chunk
 	})
 }
 


### PR DESCRIPTION
Prior to this commit, when a chunk received enough messages to warrant
closing, the timestamps of the final message to the chunk were recorded
to the _next_ chunk, rather than the one to be closed.