### PR TITLE
Remove outdated comment

### DIFF
--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -153,9 +153,6 @@ func (w *Writer) WriteMessage(m *Message) error {
 	w.Statistics.ChannelMessageCounts[m.ChannelID]++
 	w.Statistics.MessageCount++
 	if w.opts.Chunked {
-		// TODO preallocate or maybe fancy structure. These could be conserved
-		// across chunks too, which might work ok assuming similar numbers of
-		// messages/chan/chunk.
 		idx, ok := w.messageIndexes[m.ChannelID]
 		if !ok {
 			idx = &MessageIndex{


### PR DESCRIPTION
Removes a comment proposing to reuse message index structures across
chunks, which has already been done.