### PR TITLE
Go: Expose writer offset

### DIFF
--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -53,6 +53,12 @@ func (w *Writer) WriteHeader(header *Header) error {
 	return err
 }
 
+// Offset returns the current offset of the writer, or the size of the written
+// file if called after Close().
+func (w *Writer) Offset() uint64 {
+	return w.w.Size()
+}
+
 // WriteFooter writes a footer record to the output. A Footer record contains
 // end-of-file information. It must be the last record in the file. Readers
 // using the index to read the file will begin with by reading the footer and

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -182,6 +182,7 @@ func TestChunkedReadWrite(t *testing.T) {
 			assert.Equal(t, uint32(0), w.Statistics.AttachmentCount)
 			assert.Equal(t, uint32(1), w.Statistics.ChannelCount)
 			assert.Equal(t, uint32(1), w.Statistics.ChunkCount)
+			assert.Equal(t, int(w.Offset()), buf.Len())
 			lexer, err := NewLexer(buf)
 			assert.Nil(t, err)
 			for i, expected := range []TokenType{


### PR DESCRIPTION
Adds an Offset() method to the writer's public interface, to allow the
caller to retrieve the size of the written file. This was already
tracked internally and is useful for streaming writers that may wish to
record statistics in a database, similar to the public accumulated index
structures.