### PR TITLE
Go: Address ros2 db3 conversion bug for multiple input paths

### DIFF
--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -53,7 +53,10 @@ func collectMessageSchemas(directories []string, types []string) (map[string][]b
 			packageFile := path.Join(dirPath, packageName)
 			packageData, err := os.ReadFile(packageFile)
 			if errors.Is(err, os.ErrNotExist) {
-				break
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to read package file at %s: %w", packageFile, err)
 			}
 			packagePaths := strings.Split(string(packageData), "\n")
 			for _, packagePath := range packagePaths {


### PR DESCRIPTION
Prior to this commit, if the ros2 conversion function failed to find a
package it was looking for, it would break out of a loop immediately and
error on a check that all requested packages were found. This did not
properly account for the possibility of the package existing in a later
path element. The new code continues instead of breaking so that the
schema may be found in another location if available.