### PR TITLE
Clarify summary_crc begins at Footer record if there are no summary records

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -138,7 +138,7 @@ A Footer record contains end-of-file information. It must be the last record in 
 | --- | --- | --- | --- |
 | 8 | summary_start | uint64 | Byte offset of the start of file to the first record in the summary section. If there are no records in the summary section this should be 0. |
 | 8 | summary_offset_start | uint64 | Byte offset from the start of the first record in the summary offset section. If there are no Summary Offset records this value should be 0. |
-| 4 | summary_crc | uint32 | A CRC32 of all bytes from the start of the Summary section up through the end of the previous field in the footer record. A value of 0 indicates the CRC32 is not available. If there are no records in the summary section this should be 0. |
+| 4 | summary_crc | uint32 | A CRC32 of all bytes from the start of the Summary section up through the end of the previous field in the footer record. (If there are no records in the summary section, this range begins at the start of the footer record.) A value of 0 indicates the CRC32 is not available. |
 
 ### Schema (op=0x03)
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -138,7 +138,7 @@ A Footer record contains end-of-file information. It must be the last record in 
 | --- | --- | --- | --- |
 | 8 | summary_start | uint64 | Byte offset of the start of file to the first record in the summary section. If there are no records in the summary section this should be 0. |
 | 8 | summary_offset_start | uint64 | Byte offset from the start of the first record in the summary offset section. If there are no Summary Offset records this value should be 0. |
-| 4 | summary_crc | uint32 | A CRC32 of all bytes from the start of the Summary section up through the end of the previous field in the footer record. (If there are no records in the summary section, this range begins at the start of the footer record.) A value of 0 indicates the CRC32 is not available. |
+| 4 | summary_crc | uint32 | A CRC32 of all bytes from the start of the Summary section up through and including the end of the previous field (summary_offset_start) in the footer record. A value of 0 indicates the CRC32 is not available. |
 
 ### Schema (op=0x03)
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -138,7 +138,7 @@ A Footer record contains end-of-file information. It must be the last record in 
 | --- | --- | --- | --- |
 | 8 | summary_start | uint64 | Byte offset of the start of file to the first record in the summary section. If there are no records in the summary section this should be 0. |
 | 8 | summary_offset_start | uint64 | Byte offset from the start of the first record in the summary offset section. If there are no Summary Offset records this value should be 0. |
-| 4 | summary_crc | uint32 | A CRC32 of all bytes from the start of the Summary section up through the end of the previous field in the footer record. A value of 0 indicates the CRC32 is not available. |
+| 4 | summary_crc | uint32 | A CRC32 of all bytes from the start of the Summary section up through the end of the previous field in the footer record. A value of 0 indicates the CRC32 is not available. If there are no records in the summary section this should be 0. |
 
 ### Schema (op=0x03)
 


### PR DESCRIPTION
Add clarifying wording to the spec to indicate that if there are no summary records, the `summary_crc` is the crc of the first 1+8+8+8 bytes of the footer (which will necessarily be 02 1400000000000000 0000000000000000 0000000000000000).