### PR TITLE
Add some benchmarks for writer memory consumption

### DIFF
--- a/go/mcap/counting_writer.go
+++ b/go/mcap/counting_writer.go
@@ -18,7 +18,7 @@ func (c *CountingCRCWriter) Reset(w io.Writer) {
 }
 
 func (c *CountingCRCWriter) ResetCRC() {
-	c.crc = crc32.NewIEEE()
+	c.crc.Reset()
 }
 
 func (c *CountingCRCWriter) ResetSize() {

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -154,7 +154,7 @@ type Chunk struct {
 // for every channel on which a message occurs inside the chunk.
 type MessageIndex struct {
 	ChannelID    uint16
-	Records      []*MessageIndexEntry
+	Records      []MessageIndexEntry
 	currentIndex int
 }
 
@@ -179,19 +179,16 @@ func (idx *MessageIndex) Reset() {
 }
 
 // Entries lists the entries in the message index.
-func (idx *MessageIndex) Entries() []*MessageIndexEntry {
+func (idx *MessageIndex) Entries() []MessageIndexEntry {
 	return idx.Records[:idx.currentIndex]
 }
 
 // Add an entry to the message index.
 func (idx *MessageIndex) Add(timestamp uint64, offset uint64) {
 	if idx.currentIndex >= len(idx.Records) {
-		records := make([]*MessageIndexEntry, (len(idx.Records)+20)*2)
+		records := make([]MessageIndexEntry, (len(idx.Records)+20)*2)
 		copy(records, idx.Records)
 		idx.Records = records
-	}
-	if idx.Records[idx.currentIndex] == nil {
-		idx.Records[idx.currentIndex] = &MessageIndexEntry{timestamp, offset}
 	}
 	idx.Records[idx.currentIndex].Timestamp = timestamp
 	idx.Records[idx.currentIndex].Offset = offset

--- a/go/mcap/parse.go
+++ b/go/mcap/parse.go
@@ -176,7 +176,7 @@ func ParseMessageIndex(buf []byte) (*MessageIndex, error) {
 	}
 	var value, stamp uint64
 	var start = offset
-	records := make([]*MessageIndexEntry, 0, (len(buf)-2)/(8+8))
+	records := make([]MessageIndexEntry, 0, (len(buf)-2)/(8+8))
 	for uint32(offset) < uint32(start)+entriesByteLength {
 		stamp, offset, err = getUint64(buf, offset)
 		if err != nil {
@@ -186,7 +186,7 @@ func ParseMessageIndex(buf []byte) (*MessageIndex, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read message index entry value: %w", err)
 		}
-		records = append(records, &MessageIndexEntry{
+		records = append(records, MessageIndexEntry{
 			Timestamp: stamp,
 			Offset:    value,
 		})

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -514,6 +514,12 @@ func BenchmarkWriterAllocs(b *testing.B) {
 			2e6,
 			100,
 		},
+		{
+			"small chunks many messages",
+			8 * 1024,
+			2e6,
+			100,
+		},
 	}
 
 	stringData := "hello, world!"


### PR DESCRIPTION
Adds a benchmark tests with three scenarios for writes - lots of messages with large chunks, lots of messages with small chunks, and lots of messages with lots of channels. Adds a couple trivial performance improvements as well: switch away from pointers for the message index entry structures, and reset the chunk crc instead of replacing it.