### PR TITLE
[C++] Fixes for linking against system libraries, McapWriter::open(filename, opts)

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -90,9 +90,13 @@ manager can be used with the included
 Alternatively, you can link against system libraries. On Ubuntu/Debian systems,
 use the following command to install the dependencies:
 
+<!-- cspell: disable -->
+
 ```bash
 sudo apt install libcrypto++-dev libfmt-dev liblz4-dev libzstd-dev
 ```
+
+<!-- cspell: enable -->
 
 ## Usage
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <cstring>
-#include <fstream>
 #include <iostream>
 
 // Returns the system time in nanoseconds. std::chrono is used here, but any
@@ -21,15 +20,11 @@ mcap::Timestamp now() {
 }
 
 int main() {
-  // Open an output file stream. Other output interfaces can be used as well,
-  // including providing your own mcap::IWritable implementation
-  std::ofstream out("output.mcap", std::ios::binary);
-
   // Initialize an MCAP writer with the "ros1" profile and write the file header
   mcap::McapWriter writer;
-  auto status = writer.open(out, mcap::McapWriterOptions("ros1"));
+  auto status = writer.open("output.mcap", mcap::McapWriterOptions("ros1"));
   if (!status.ok()) {
-    std::cerr << "Writing failed: " << status.message << "\n";
+    std::cerr << "Failed to open MCAP file for writing: " << status.message << "\n";
     return 1;
   }
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -85,7 +85,14 @@ following dependencies:
 - [zstd](https://facebook.github.io/zstd/) (tested with [zstd/1.5.2](https://conan.io/center/zstd))
 
 To simplify installation of dependencies, the [Conan](https://conan.io/) package
-manager can be used with the included [conanfile.py](https://github.com/foxglove/mcap/blob/main/cpp/mcap/conanfile.py).
+manager can be used with the included
+[conanfile.py](https://github.com/foxglove/mcap/blob/main/cpp/mcap/conanfile.py).
+Alternatively, you can link against system libraries. On Ubuntu/Debian systems,
+use the following command to install the dependencies:
+
+```bash
+sudo apt install libcrypto++-dev libfmt-dev liblz4-dev libzstd-dev
+```
 
 ## Usage
 

--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 
 constexpr char StringSchema[] = "string data";

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 conan config init
 
 conan editable add ./mcap mcap/0.0.1

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -23,6 +23,7 @@ enum class StatusCode {
   DecompressionFailed,
   DecompressionSizeMismatch,
   UnrecognizedCompression,
+  OpenFailed,
 };
 
 /**
@@ -75,6 +76,9 @@ struct Status {
         break;
       case StatusCode::UnrecognizedCompression:
         message = "unrecognized compression";
+        break;
+      case StatusCode::OpenFailed:
+        message = "open failed";
         break;
       default:
         message = "unknown";

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1,8 +1,6 @@
 #include "internal.hpp"
 #include <cassert>
 #include <lz4.h>
-
-#define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 #include <zstd_errors.h>
 

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -111,6 +111,12 @@ struct Footer {
   ByteOffset summaryStart;
   ByteOffset summaryOffsetStart;
   uint32_t summaryCrc;
+
+  Footer() = default;
+  Footer(ByteOffset summaryStart, ByteOffset summaryOffsetStart)
+      : summaryStart(summaryStart)
+      , summaryOffsetStart(summaryOffsetStart)
+      , summaryCrc(0) {}
 };
 
 /**

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <iostream>
 #include <lz4.h>
 #include <zstd.h>


### PR DESCRIPTION
Fixes various compiler warnings, issues encountered when linking against system libraries, and adds the McapWriter::open(filename, opts) API using the new buffered wrapper around fwrite(), `FileWriter`.
