### PR TITLE
Go: do not fail on zero'd CRCs

### DIFF
--- a/go/mcap/lexer.go
+++ b/go/mcap/lexer.go
@@ -342,7 +342,7 @@ func loadChunk(l *Lexer) error {
 		}
 
 		crc := crc32.ChecksumIEEE(l.uncompressedChunk[:uncompressedSize])
-		if crc != uncompressedCRC {
+		if uncompressedCRC > 0 && crc != uncompressedCRC {
 			return fmt.Errorf("invalid CRC: %x != %x", crc, uncompressedCRC)
 		}
 		l.setNoneDecoder(l.uncompressedChunk[:uncompressedSize])


### PR DESCRIPTION
Prior to this commit, when running with chunk CRC validation enabled the
go lexer was not properly accepting zero-valued CRCs as valid, resulting
in errors on files written by writers that opted out of CRC checks.