### PR TITLE
Run CI on tags and bump python version again.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches: ["*"]
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap
-version = 0.0.2
+version = 0.0.3
 description = MCAP libraries for Python
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
**Public-Facing Changes**
This runs CI jobs on new tags as well as merges. It also bumps the python library version.
<!-- link relevant GitHub issues -->
