### PR TITLE
Adjust CI tag rule.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+    tags: ["releases/**"]
   pull_request:
     branches: ["*"]
 


### PR DESCRIPTION
**Public-Facing Changes**
Adjust the CI tag rule to run on tags starting with `releases`.

<!-- link relevant GitHub issues -->
