### PR TITLE
TS writer: add chunkSize param with 1MB default

### DIFF
--- a/typescript/mcap/src/v0/ChunkBuilder.ts
+++ b/typescript/mcap/src/v0/ChunkBuilder.ts
@@ -26,6 +26,10 @@ class ChunkBuilder {
     return this.recordWriter.buffer;
   }
 
+  get byteLength(): number {
+    return this.recordWriter.length;
+  }
+
   get indices(): Iterable<MessageIndex> {
     if (this.messageIndices) {
       return this.messageIndices.values();


### PR DESCRIPTION
**Public-Facing Changes**
The TypeScript `Mcap0Writer` now accepts a `chunkSize` option rather than creating a new chunk every 10 messages.


**Description**
Fixes https://github.com/foxglove/mcap/issues/252