### PR TITLE
TS writer: support messages with logTime 0

### DIFF
--- a/typescript/mcap/src/v0/ChunkBuilder.test.ts
+++ b/typescript/mcap/src/v0/ChunkBuilder.test.ts
@@ -1,0 +1,24 @@
+import { ChunkBuilder } from "./ChunkBuilder";
+
+describe("ChunkBuilder", () => {
+  it("generates correct messageStartTime/messageEndTime for messages with logTime 0", () => {
+    const builder = new ChunkBuilder({ useMessageIndex: true });
+
+    builder.addMessage({
+      channelId: 0,
+      data: new Uint8Array(),
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+    });
+    builder.addMessage({
+      channelId: 0,
+      data: new Uint8Array(),
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 1n,
+    });
+    expect(builder.messageStartTime).toBe(0n);
+    expect(builder.messageEndTime).toBe(1n);
+  });
+});

--- a/typescript/mcap/src/v0/ChunkBuilder.ts
+++ b/typescript/mcap/src/v0/ChunkBuilder.ts
@@ -48,10 +48,10 @@ class ChunkBuilder {
   }
 
   addMessage(message: Message): void {
-    if (this.messageStartTime === 0n || message.logTime < this.messageStartTime) {
+    if (this.totalMessageCount === 0 || message.logTime < this.messageStartTime) {
       this.messageStartTime = message.logTime;
     }
-    if (this.messageEndTime === 0n || message.logTime > this.messageEndTime) {
+    if (this.totalMessageCount === 0 || message.logTime > this.messageEndTime) {
       this.messageEndTime = message.logTime;
     }
 

--- a/typescript/mcap/src/v0/Mcap0Writer.test.ts
+++ b/typescript/mcap/src/v0/Mcap0Writer.test.ts
@@ -1,0 +1,104 @@
+import Mcap0IndexedReader from "./Mcap0IndexedReader";
+import { Mcap0Writer } from "./Mcap0Writer";
+import { collect } from "./testUtils";
+
+class TempBuffer {
+  private _buffer = new ArrayBuffer(1024);
+  private _size = 0;
+
+  position() {
+    return BigInt(this._size);
+  }
+  async write(data: Uint8Array) {
+    if (this._size + data.byteLength > this._buffer.byteLength) {
+      const newBuffer = new ArrayBuffer(this._size + data.byteLength);
+      new Uint8Array(newBuffer).set(new Uint8Array(this._buffer));
+      this._buffer = newBuffer;
+    }
+    new Uint8Array(this._buffer, this._size).set(data);
+    this._size += data.byteLength;
+  }
+
+  async size() {
+    return BigInt(this._size);
+  }
+  async read(offset: bigint, size: bigint) {
+    if (offset < 0n || offset + size > BigInt(this._buffer.byteLength)) {
+      throw new Error("read out of range");
+    }
+    return new Uint8Array(this._buffer, Number(offset), Number(size));
+  }
+}
+
+describe("Mcap0Writer", () => {
+  it("supports messages with logTime 0", async () => {
+    const tempBuffer = new TempBuffer();
+    const writer = new Mcap0Writer({ writable: tempBuffer });
+
+    await writer.start({ library: "", profile: "" });
+    const channelId = await writer.registerChannel({
+      topic: "test",
+      schemaId: 0,
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      data: new Uint8Array(),
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+    });
+    await writer.addMessage({
+      channelId,
+      data: new Uint8Array(),
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 1n,
+    });
+    await writer.end();
+
+    const reader = await Mcap0IndexedReader.Initialize({ readable: tempBuffer });
+
+    expect(reader.chunkIndexes).toMatchObject([{ messageStartTime: 0n, messageEndTime: 1n }]);
+
+    await expect(collect(reader.readMessages())).resolves.toEqual([
+      {
+        type: "Message",
+        channelId,
+        data: new Uint8Array(),
+        sequence: 0,
+        logTime: 0n,
+        publishTime: 0n,
+      },
+      {
+        type: "Message",
+        channelId,
+        data: new Uint8Array(),
+        sequence: 1,
+        logTime: 1n,
+        publishTime: 1n,
+      },
+    ]);
+    await expect(collect(reader.readMessages({ endTime: 0n }))).resolves.toEqual([
+      {
+        type: "Message",
+        channelId,
+        data: new Uint8Array(),
+        sequence: 0,
+        logTime: 0n,
+        publishTime: 0n,
+      },
+    ]);
+    await expect(collect(reader.readMessages({ startTime: 1n }))).resolves.toEqual([
+      {
+        type: "Message",
+        channelId,
+        data: new Uint8Array(),
+        sequence: 1,
+        logTime: 1n,
+        publishTime: 1n,
+      },
+    ]);
+  });
+});

--- a/typescript/mcap/src/v0/Mcap0Writer.ts
+++ b/typescript/mcap/src/v0/Mcap0Writer.ts
@@ -321,7 +321,7 @@ export class Mcap0Writer {
         );
       }
 
-      if (!this.writtenSchemaIds.has(channel.schemaId)) {
+      if (channel.schemaId !== 0 && !this.writtenSchemaIds.has(channel.schemaId)) {
         const schema = this.schemas.get(channel.schemaId);
         if (!schema) {
           throw new Error(


### PR DESCRIPTION
**Public-Facing Changes**
Fixed a bug in the TypeScript `Mcap0Writer` where messages with a logTime of 0 could cause chunk index records to be incorrect. Also fixes a bug where channels with a schema id of 0 were rejected by the writer.