### PR TITLE
Go: do not write chunk indexes for chunks without messages

### DIFF
--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -384,6 +384,26 @@ func TestStatistics(t *testing.T) {
 	assert.Equal(t, 1, len(w.AttachmentIndexes))
 }
 
+func TestChunkedFileNoMessageMakesNoIndex(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w, err := NewWriter(buf, &WriterOptions{
+		IncludeCRC: true,
+		Chunked:    true,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, w.WriteHeader(&Header{
+		Profile: "ros1",
+	}))
+	assert.Nil(t, w.WriteSchema(&Schema{
+		ID:       1,
+		Name:     "foo",
+		Encoding: "ros1msg",
+		Data:     []byte{},
+	}))
+	assert.Nil(t, w.Close())
+	assert.Equal(t, 0, len(w.ChunkIndexes))
+}
+
 func TestUnchunkedReadWrite(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w, err := NewWriter(buf, &WriterOptions{})


### PR DESCRIPTION
Prior to this commit, if a chunk contained only messages or only
schemas, an index record would still be written. The record would
incorrectly reflect a start time of 0, which resulted in tooling
interpreting the file as starting at zero instead of the time of the
first message contained within.