### PR TITLE
Revert "Go: do not write chunk indexes for chunks without messages (#…

### DIFF
--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -384,26 +384,6 @@ func TestStatistics(t *testing.T) {
 	assert.Equal(t, 1, len(w.AttachmentIndexes))
 }
 
-func TestChunkedFileNoMessageMakesNoIndex(t *testing.T) {
-	buf := &bytes.Buffer{}
-	w, err := NewWriter(buf, &WriterOptions{
-		IncludeCRC: true,
-		Chunked:    true,
-	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.WriteHeader(&Header{
-		Profile: "ros1",
-	}))
-	assert.Nil(t, w.WriteSchema(&Schema{
-		ID:       1,
-		Name:     "foo",
-		Encoding: "ros1msg",
-		Data:     []byte{},
-	}))
-	assert.Nil(t, w.Close())
-	assert.Equal(t, 0, len(w.ChunkIndexes))
-}
-
 func TestUnchunkedReadWrite(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w, err := NewWriter(buf, &WriterOptions{})


### PR DESCRIPTION
…257)"

This reverts commit a7b663816a3528e55c8c238ce2a46f2f03245524.

The spec actually allows for chunk indexes for chunks without messages,
although the concept is not really sensical. I think a change will need
to be made, probably to include the message count in the chunk index
records, but I don't think this approach is was the right one anymore.