### PR TITLE
TS writer: fix duplicate data when using multiple chunks

### DIFF
--- a/typescript/mcap/src/index.ts
+++ b/typescript/mcap/src/index.ts
@@ -5,6 +5,7 @@ export * as McapPre0Types from "./pre0/types";
 export { default as Mcap0IndexedReader } from "./v0/Mcap0IndexedReader";
 export { default as Mcap0StreamReader } from "./v0/Mcap0StreamReader";
 export { Mcap0Writer } from "./v0/Mcap0Writer";
+export type { Mcap0WriterOptions } from "./v0/Mcap0Writer";
 export { Mcap0RecordBuilder } from "./v0/Mcap0RecordBuilder";
 export { ChunkBuilder as Mcap0ChunkBuilder } from "./v0/ChunkBuilder";
 export * as Mcap0Types from "./v0/types";

--- a/typescript/mcap/src/v0/ChunkBuilder.ts
+++ b/typescript/mcap/src/v0/ChunkBuilder.ts
@@ -80,6 +80,7 @@ class ChunkBuilder {
     this.messageEndTime = 0n;
     this.totalMessageCount = 0;
     this.messageIndices?.clear();
+    this.recordWriter.reset();
   }
 }
 

--- a/typescript/mcap/src/v0/Mcap0Writer.test.ts
+++ b/typescript/mcap/src/v0/Mcap0Writer.test.ts
@@ -1,6 +1,8 @@
 import Mcap0IndexedReader from "./Mcap0IndexedReader";
+import Mcap0StreamReader from "./Mcap0StreamReader";
 import { Mcap0Writer } from "./Mcap0Writer";
 import { collect } from "./testUtils";
+import { TypedMcapRecord } from "./types";
 
 class TempBuffer {
   private _buffer = new ArrayBuffer(1024);
@@ -27,6 +29,10 @@ class TempBuffer {
       throw new Error("read out of range");
     }
     return new Uint8Array(this._buffer, Number(offset), Number(size));
+  }
+
+  get() {
+    return new Uint8Array(this._buffer, 0, this._size);
   }
 }
 
@@ -98,6 +104,155 @@ describe("Mcap0Writer", () => {
         sequence: 1,
         logTime: 1n,
         publishTime: 1n,
+      },
+    ]);
+  });
+
+  it("supports multiple chunks", async () => {
+    const tempBuffer = new TempBuffer();
+    const writer = new Mcap0Writer({ writable: tempBuffer, chunkSize: 0 });
+
+    await writer.start({ library: "", profile: "" });
+    const channelId = await writer.registerChannel({
+      topic: "test",
+      schemaId: 0,
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      data: new Uint8Array(),
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+    });
+    await writer.addMessage({
+      channelId,
+      data: new Uint8Array(),
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 1n,
+    });
+    await writer.end();
+
+    const reader = new Mcap0StreamReader();
+    reader.append(tempBuffer.get());
+    const records: TypedMcapRecord[] = [];
+    for (let record; (record = reader.nextRecord()); ) {
+      records.push(record);
+    }
+
+    expect(records).toEqual([
+      {
+        type: "Header",
+        library: "",
+        profile: "",
+      },
+      {
+        type: "Channel",
+        id: 0,
+        messageEncoding: "json",
+        metadata: new Map(),
+        schemaId: 0,
+        topic: "test",
+      },
+      {
+        type: "Message",
+        channelId: 0,
+        data: new Uint8Array(),
+        logTime: 0n,
+        publishTime: 0n,
+        sequence: 0,
+      },
+      {
+        type: "MessageIndex",
+        channelId: 0,
+        records: [[0n, 33n]],
+      },
+      {
+        type: "Message",
+        channelId: 0,
+        data: new Uint8Array(),
+        logTime: 1n,
+        publishTime: 1n,
+        sequence: 1,
+      },
+      {
+        type: "MessageIndex",
+        channelId: 0,
+        records: [[1n, 0n]],
+      },
+      {
+        type: "DataEnd",
+        dataSectionCrc: 0,
+      },
+      {
+        type: "Channel",
+        id: 0,
+        messageEncoding: "json",
+        metadata: new Map(),
+        schemaId: 0,
+        topic: "test",
+      },
+      {
+        type: "Statistics",
+        attachmentCount: 0,
+        channelCount: 1,
+        channelMessageCounts: new Map([[0, 2n]]),
+        chunkCount: 2,
+        messageCount: 2n,
+        messageEndTime: 1n,
+        messageStartTime: 0n,
+        metadataCount: 0,
+        schemaCount: 0,
+      },
+      {
+        type: "ChunkIndex",
+        chunkLength: 113n,
+        chunkStartOffset: 25n,
+        compressedSize: 64n,
+        compression: "",
+        messageEndTime: 0n,
+        messageIndexLength: 31n,
+        messageIndexOffsets: new Map([[0, 138n]]),
+        messageStartTime: 0n,
+        uncompressedSize: 64n,
+      },
+      {
+        type: "ChunkIndex",
+        chunkLength: 80n,
+        chunkStartOffset: 169n,
+        compressedSize: 31n,
+        compression: "",
+        messageEndTime: 1n,
+        messageIndexLength: 31n,
+        messageIndexOffsets: new Map([[0, 249n]]),
+        messageStartTime: 1n,
+        uncompressedSize: 31n,
+      },
+      {
+        type: "SummaryOffset",
+        groupLength: 33n,
+        groupOpcode: 4,
+        groupStart: 293n,
+      },
+      {
+        type: "SummaryOffset",
+        groupLength: 65n,
+        groupOpcode: 11,
+        groupStart: 326n,
+      },
+      {
+        type: "SummaryOffset",
+        groupLength: 166n,
+        groupOpcode: 8,
+        groupStart: 391n,
+      },
+      {
+        type: "Footer",
+        summaryCrc: 3779440972,
+        summaryOffsetStart: 557n,
+        summaryStart: 293n,
       },
     ]);
   });

--- a/typescript/mcap/src/v0/Mcap0Writer.ts
+++ b/typescript/mcap/src/v0/Mcap0Writer.ts
@@ -20,7 +20,7 @@ import {
   Statistics,
 } from "./types";
 
-type Mcap0WriterOptions = {
+export type Mcap0WriterOptions = {
   writable: IWritable;
   useStatistics?: boolean;
   useSummaryOffsets?: boolean;


### PR DESCRIPTION
**Public-Facing Changes**
Fixed a bug in the TypeScript `Mcap0Writer` where message data would be duplicated between chunks, resulting in quadratic growth.