### PR TITLE
CLI: Ros2 bag converter out of bounds slice access

### DIFF
--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -40,6 +40,9 @@ var rosPrimitives = map[string]bool{
 
 func getSchema(encoding string, rosType string, directories []string) ([]byte, error) {
 	parts := strings.FieldsFunc(rosType, func(c rune) bool { return c == '/' })
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("expected type %s to match <package>/msg/<type>", rosType)
+	}
 	baseType := parts[2]
 	rosPkg := parts[0]
 	for _, dir := range directories {


### PR DESCRIPTION
We expect the types we receive to look like <package>/msg/<type>, but
previously if they did not we would panic.