### PR TITLE
[C++] Replace inline methods with MCAP_IMPLEMENTATION macro, allow headers to be included in downstream libraries

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -5,6 +5,7 @@
 <!-- cspell: disable -->
 
 ```cpp
+#define MCAP_IMPLEMENTATION  // Define this in exactly one .cpp file
 #include <mcap/writer.hpp>
 
 #include <chrono>
@@ -87,16 +88,9 @@ following dependencies:
 To simplify installation of dependencies, the [Conan](https://conan.io/) package
 manager can be used with the included
 [conanfile.py](https://github.com/foxglove/mcap/blob/main/cpp/mcap/conanfile.py).
-Alternatively, you can link against system libraries. On Ubuntu/Debian systems,
-use the following command to install the dependencies:
-
-<!-- cspell: disable -->
-
-```bash
-sudo apt install libcrypto++-dev libfmt-dev liblz4-dev libzstd-dev
-```
-
-<!-- cspell: enable -->
+If you use an alternative approach, such as CMake's FetchContent or directly
+vendoring the dependencies, make sure you use versions equal or greater than the
+versions listed above.
 
 ## Usage
 

--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -1,3 +1,4 @@
+#define MCAP_IMPLEMENTATION
 #include <mcap/writer.hpp>
 
 #include <benchmark/benchmark.h>

--- a/cpp/examples/bag2mcap.cpp
+++ b/cpp/examples/bag2mcap.cpp
@@ -1,3 +1,4 @@
+#define MCAP_IMPLEMENTATION
 #include <mcap/writer.hpp>
 
 #include <array>

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/0.0.1"
+    requires = ("fmt/8.1.1", "mcap/0.0.1")
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/mcapdump.cpp
+++ b/cpp/examples/mcapdump.cpp
@@ -1,9 +1,17 @@
+#define MCAP_IMPLEMENTATION
 #include <mcap/reader.hpp>
+
+#include <fmt/core.h>
 
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+template <typename... T>
+[[nodiscard]] inline std::string StrFormat(std::string_view msg, T&&... args) {
+  return fmt::format(msg, std::forward<T>(args)...);
+}
 
 std::string ToString(const mcap::KeyValueMap& map) {
   std::stringstream ss;
@@ -20,7 +28,7 @@ std::string ToString(const mcap::KeyValueMap& map) {
 
 std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
   if (map.size() > 8) {
-    return mcap::StrFormat("<{} entries>", map.size());
+    return StrFormat("<{} entries>", map.size());
   }
 
   std::stringstream ss;
@@ -37,7 +45,7 @@ std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
 
 std::string ToString(const std::vector<std::pair<mcap::Timestamp, mcap::ByteOffset>>& pairs) {
   if (pairs.size() > 8) {
-    return mcap::StrFormat("<{} entries>", pairs.size());
+    return StrFormat("<{} entries>", pairs.size());
   }
 
   std::stringstream ss;
@@ -53,33 +61,33 @@ std::string ToString(const std::vector<std::pair<mcap::Timestamp, mcap::ByteOffs
 }
 
 std::string ToString(const mcap::Header& header) {
-  return mcap::StrFormat("[Header] profile={}, library={}", header.profile, header.library);
+  return StrFormat("[Header] profile={}, library={}", header.profile, header.library);
 }
 
 std::string ToString(const mcap::Footer& footer) {
-  return mcap::StrFormat("[Footer] summary_start={}, summary_offset_start={}, summary_crc={}",
-                         footer.summaryStart, footer.summaryOffsetStart, footer.summaryCrc);
+  return StrFormat("[Footer] summary_start={}, summary_offset_start={}, summary_crc={}",
+                   footer.summaryStart, footer.summaryOffsetStart, footer.summaryCrc);
 }
 
 std::string ToString(const mcap::Schema& schema) {
-  return mcap::StrFormat("[Schema] id={}, name={}, encoding={}, data=<{} bytes>", schema.id,
-                         schema.name, schema.encoding, schema.data.size());
+  return StrFormat("[Schema] id={}, name={}, encoding={}, data=<{} bytes>", schema.id, schema.name,
+                   schema.encoding, schema.data.size());
 }
 
 std::string ToString(const mcap::Channel& channel) {
-  return mcap::StrFormat(
-    "[Channel] id={}, schema_id={}, topic={}, message_encoding={}, metadata={}", channel.id,
-    channel.schemaId, channel.topic, channel.messageEncoding, ToString(channel.metadata));
+  return StrFormat("[Channel] id={}, schema_id={}, topic={}, message_encoding={}, metadata={}",
+                   channel.id, channel.schemaId, channel.topic, channel.messageEncoding,
+                   ToString(channel.metadata));
 }
 
 std::string ToString(const mcap::Message& message) {
-  return mcap::StrFormat(
+  return StrFormat(
     "[Message] channel_id={}, sequence={}, publish_time={}, log_time={}, data=<{} bytes>",
     message.channelId, message.sequence, message.publishTime, message.logTime, message.dataSize);
 }
 
 std::string ToString(const mcap::Chunk& chunk) {
-  return mcap::StrFormat(
+  return StrFormat(
     "[Chunk] message_start_time={}, message_end_time={}, uncompressed_size={}, "
     "uncompressed_crc={}, compression={}, data=<{} bytes>",
     chunk.messageStartTime, chunk.messageEndTime, chunk.uncompressedSize, chunk.uncompressedCrc,
@@ -87,12 +95,12 @@ std::string ToString(const mcap::Chunk& chunk) {
 }
 
 std::string ToString(const mcap::MessageIndex& messageIndex) {
-  return mcap::StrFormat("[MessageIndex] channel_id={}, records={}", messageIndex.channelId,
-                         ToString(messageIndex.records));
+  return StrFormat("[MessageIndex] channel_id={}, records={}", messageIndex.channelId,
+                   ToString(messageIndex.records));
 }
 
 std::string ToString(const mcap::ChunkIndex& chunkIndex) {
-  return mcap::StrFormat(
+  return StrFormat(
     "[ChunkIndex] message_start_time={}, message_end_time={}, chunk_start_offset={}, "
     "chunk_length={}, "
     "message_index_offsets={}, message_index_length={}, compression={}, "
@@ -103,14 +111,14 @@ std::string ToString(const mcap::ChunkIndex& chunkIndex) {
 }
 
 std::string ToString(const mcap::Attachment& attachment) {
-  return mcap::StrFormat(
+  return StrFormat(
     "[Attachment] log_time={}, create_time={}, name={}, content_type={}, data=<{} bytes>, crc={}",
     attachment.logTime, attachment.createTime, attachment.name, attachment.contentType,
     attachment.dataSize, attachment.crc);
 }
 
 std::string ToString(const mcap::AttachmentIndex& attachmentIndex) {
-  return mcap::StrFormat(
+  return StrFormat(
     "[AttachmentIndex] offset={}, length={}, log_time={}, create_time={}, data_size={}, name={}, "
     "content_type={}",
     attachmentIndex.offset, attachmentIndex.length, attachmentIndex.logTime,
@@ -119,7 +127,7 @@ std::string ToString(const mcap::AttachmentIndex& attachmentIndex) {
 }
 
 std::string ToString(const mcap::Statistics& statistics) {
-  return mcap::StrFormat(
+  return StrFormat(
     "[Statistics] message_count={}, schema_count={}, channel_count={}, attachment_count={}, "
     "metadata_count={}, chunk_count={}, message_start_time={}, message_end_time={}, "
     "channel_message_counts={}",
@@ -130,34 +138,33 @@ std::string ToString(const mcap::Statistics& statistics) {
 }
 
 std::string ToString(const mcap::Metadata& metadata) {
-  return mcap::StrFormat("[Metadata] name={}, metadata={}", metadata.name,
-                         ToString(metadata.metadata));
+  return StrFormat("[Metadata] name={}, metadata={}", metadata.name, ToString(metadata.metadata));
 }
 
 std::string ToString(const mcap::MetadataIndex& metadataIndex) {
-  return mcap::StrFormat("[MetadataIndex] offset={}, length={}, name={}", metadataIndex.offset,
-                         metadataIndex.length, metadataIndex.name);
+  return StrFormat("[MetadataIndex] offset={}, length={}, name={}", metadataIndex.offset,
+                   metadataIndex.length, metadataIndex.name);
 }
 
 std::string ToString(const mcap::SummaryOffset& summaryOffset) {
-  return mcap::StrFormat(
-    "[SummaryOffset] group_opcode={} (0x{:02x}), group_start={}, group_length={}",
-    mcap::OpCodeString(summaryOffset.groupOpCode), uint8_t(summaryOffset.groupOpCode),
-    summaryOffset.groupStart, summaryOffset.groupLength);
+  return StrFormat("[SummaryOffset] group_opcode={} (0x{:02x}), group_start={}, group_length={}",
+                   mcap::OpCodeString(summaryOffset.groupOpCode),
+                   uint8_t(summaryOffset.groupOpCode), summaryOffset.groupStart,
+                   summaryOffset.groupLength);
 }
 
 std::string ToString(const mcap::DataEnd& dataEnd) {
-  return mcap::StrFormat("[DataEnd] data_section_crc={}", dataEnd.dataSectionCrc);
+  return StrFormat("[DataEnd] data_section_crc={}", dataEnd.dataSectionCrc);
 }
 
 std::string ToString(const mcap::Record& record) {
-  return mcap::StrFormat("[Unknown] opcode=0x{:02x}, data=<{} bytes>", uint8_t(record.opcode),
-                         record.dataSize);
+  return StrFormat("[Unknown] opcode=0x{:02x}, data=<{} bytes>", uint8_t(record.opcode),
+                   record.dataSize);
 }
 
 std::string ToStringRaw(const mcap::Record& record) {
-  return mcap::StrFormat("[{}] opcode=0x{:02x}, data=<{} bytes>", mcap::OpCodeString(record.opcode),
-                         uint8_t(record.opcode), record.dataSize);
+  return StrFormat("[{}] opcode=0x{:02x}, data=<{} bytes>", mcap::OpCodeString(record.opcode),
+                   uint8_t(record.opcode), record.dataSize);
 }
 
 void DumpRaw(mcap::IReadable& dataSource) {

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <fmt/core.h>
-
 #include <string>
 
 namespace mcap {
@@ -94,14 +92,5 @@ struct Status {
     return code == StatusCode::Success;
   }
 };
-
-/**
- * @brief String formatting compatible with std::format(), used to construct
- * Status messages.
- */
-template <typename... T>
-[[nodiscard]] inline std::string StrFormat(std::string_view msg, T&&... args) {
-  return fmt::format(msg, std::forward<T>(args)...);
-}
 
 }  // namespace mcap

--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <fmt/core.h>
+
 #include "types.hpp"
 
 // Do not compile on systems with non-8-bit bytes
@@ -24,6 +26,15 @@ constexpr uint64_t FooterLength = /* opcode */ 1 +
                                   /* summary offset start */ 8 +
                                   /* summary crc */ 4 +
                                   /* magic bytes */ sizeof(Magic);
+
+/**
+ * @brief String formatting compatible with std::format(), used to construct
+ * Status messages.
+ */
+template <typename... T>
+[[nodiscard]] inline std::string StrFormat(std::string_view msg, T&&... args) {
+  return fmt::format(msg, std::forward<T>(args)...);
+}
 
 inline uint32_t KeyValueMapSize(const KeyValueMap& map) {
   uint32_t size = 0;

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -33,7 +33,7 @@ struct McapReaderOptions {
  * @brief An abstract interface for reading MCAP data.
  */
 struct IReadable {
-  virtual inline ~IReadable() = default;
+  virtual ~IReadable() = default;
 
   /**
    * @brief Returns the size of the file in bytes.
@@ -82,7 +82,7 @@ private:
  */
 class ICompressedReader : public IReadable {
 public:
-  virtual inline ~ICompressedReader() = default;
+  virtual ~ICompressedReader() = default;
 
   /**
    * @brief Reset the reader state, clearing any internal buffers and state, and
@@ -462,4 +462,6 @@ private:
 
 }  // namespace mcap
 
+#ifdef MCAP_IMPLEMENTATION
 #include "reader.inl"
+#endif

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -365,4 +365,6 @@ struct MessageView {
 
 }  // namespace mcap
 
+#ifdef MCAP_IMPLEMENTATION
 #include "types.inl"
+#endif

--- a/cpp/mcap/include/mcap/types.inl
+++ b/cpp/mcap/include/mcap/types.inl
@@ -2,7 +2,7 @@
 
 namespace mcap {
 
-inline constexpr std::string_view OpCodeString(OpCode opcode) {
+constexpr std::string_view OpCodeString(OpCode opcode) {
   switch (opcode) {
     case OpCode::Header:
       return "Header";
@@ -39,7 +39,7 @@ inline constexpr std::string_view OpCodeString(OpCode opcode) {
   }
 }
 
-inline MetadataIndex::MetadataIndex(const Metadata& metadata, ByteOffset fileOffset)
+MetadataIndex::MetadataIndex(const Metadata& metadata, ByteOffset fileOffset)
     : offset(fileOffset)
     , length(9 + 4 + metadata.name.size() + 4 + internal::KeyValueMapSize(metadata.metadata))
     , name(metadata.name) {}

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -1,14 +1,18 @@
 #pragma once
 
-#include <cryptopp/crc.h>
-
 #include "types.hpp"
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
-typedef struct ZSTD_CCtx_s ZSTD_CCtx;
+// Forward declaration
+struct ZSTD_CCtx_s;
+
+// Forward declaration
+namespace CryptoPP {
+class CRC32;
+}  // namespace CryptoPP
 
 namespace mcap {
 
@@ -99,7 +103,7 @@ class IWritable {
 public:
   bool crcEnabled = false;
 
-  virtual inline ~IWritable() = default;
+  virtual ~IWritable() = default;
 
   /**
    * @brief Called whenever the writer needs to write data to the output MCAP
@@ -132,7 +136,7 @@ protected:
   virtual void handleWrite(const std::byte* data, uint64_t size) = 0;
 
 private:
-  CryptoPP::CRC32 crc_;
+  std::unique_ptr<CryptoPP::CRC32> crc_;
 };
 
 class FileWriter final : public IWritable {
@@ -176,7 +180,7 @@ private:
  */
 class IChunkWriter : public IWritable {
 public:
-  virtual inline ~IChunkWriter() = default;
+  virtual ~IChunkWriter() = default;
 
   /**
    * @brief Called when the writer wants to close the current output Chunk.
@@ -280,7 +284,7 @@ public:
 private:
   std::vector<std::byte> uncompressedBuffer_;
   std::vector<std::byte> compressedBuffer_;
-  ZSTD_CCtx* zstdContext_ = nullptr;
+  ZSTD_CCtx_s* zstdContext_ = nullptr;
 };
 
 /**
@@ -435,4 +439,6 @@ private:
 
 }  // namespace mcap
 
+#ifdef MCAP_IMPLEMENTATION
 #include "writer.inl"
+#endif

--- a/cpp/test/streamed-reader-conformance.cpp
+++ b/cpp/test/streamed-reader-conformance.cpp
@@ -1,3 +1,4 @@
+#define MCAP_IMPLEMENTATION
 #include <mcap/reader.hpp>
 
 #include <nlohmann/json.hpp>

--- a/cpp/test/streamed-writer-conformance.cpp
+++ b/cpp/test/streamed-writer-conformance.cpp
@@ -1,3 +1,4 @@
+#define MCAP_IMPLEMENTATION
 #include <mcap/writer.hpp>
 
 #include <nlohmann/json.hpp>

--- a/cpp/test/unit-tests.cpp
+++ b/cpp/test/unit-tests.cpp
@@ -1,3 +1,4 @@
+#define MCAP_IMPLEMENTATION
 #include <mcap/mcap.hpp>
 
 #define CATCH_CONFIG_MAIN


### PR DESCRIPTION
Previously, the C++ headers could not be included in a project that was not pulling in the mcap dependencies and directly compiling mcap, since the statically linked dependencies were referenced directly in .hpp files. This refactor leaves only STL includes in mcap/*.hpp files, allowing more flexibility for downstream users such as building mcap as a dynamic or static library that is used in other projects. Build times should also be improved in projects where mcap includes occur in more than once place.

This unblocks progress on https://github.com/ros-tooling/rosbag2_storage_mcap/pull/5
