### PR TITLE
Enable compression by default in python writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
       - run: pip install pipenv
       - run: pipenv install --dev --deploy
       - run: pipenv run black --check --diff --color .
+      - run: pipenv run python -m pytest
       - run: pipenv run pyright mcap tests
       - run: pipenv run python -m build
 

--- a/python/mcap/mcap0/writer.py
+++ b/python/mcap/mcap0/writer.py
@@ -1,10 +1,12 @@
 import struct
 import zlib
-import zstd
 from collections import defaultdict
 from enum import Enum, Flag, auto
-from io import BufferedWriter, BytesIO, RawIOBase
-from typing import Dict, List, OrderedDict, Union
+from io import BufferedWriter, RawIOBase
+from typing import IO, Any, Dict, List, OrderedDict, Union
+
+import lz4.frame  # type: ignore
+import zstd
 
 from .chunk_builder import ChunkBuilder
 from .data_stream import RecordBuilder
@@ -48,9 +50,9 @@ class Writer:
 
     def __init__(
         self,
-        output: Union[str, BytesIO, BufferedWriter],
+        output: Union[str, IO[Any], BufferedWriter],
         chunk_size: int = 1024 * 1024,
-        compression: CompressionType = CompressionType.NONE,
+        compression: CompressionType = CompressionType.ZSTD,
         index_types: IndexType = IndexType.ALL,
         repeat_channels: bool = True,
         repeat_schemas: bool = True,

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap
-version = 0.0.4
+version = 0.0.5
 description = MCAP libraries for Python
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/python/tests/run_writer_test.py
+++ b/python/tests/run_writer_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Set, Type
 
 from mcap.mcap0.records import Attachment, Channel, Header, McapRecord, Message, Schema
-from mcap.mcap0.writer import IndexType, Writer
+from mcap.mcap0.writer import CompressionType, IndexType, Writer
 
 
 def deserialize_value(klass: Type[McapRecord], field: str, value: Any) -> Any:
@@ -45,6 +45,7 @@ def write_file(features: List[str], expected_records: List[Dict[str, Any]]) -> b
     writer = Writer(
         output=output,
         index_types=index_type_from_features(features),
+        compression=CompressionType.NONE,
         repeat_channels="rch" in features,
         repeat_schemas="rsh" in features,
         use_chunking="ch" in features,

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1,0 +1,56 @@
+import contextlib
+import json
+from tempfile import TemporaryFile
+
+from mcap.mcap0.writer import CompressionType, Writer
+
+
+@contextlib.contextmanager
+def generate_sample_data(compression: CompressionType):
+    file = TemporaryFile("w+b")
+    writer = Writer(file, compression=compression)
+    writer.start(profile="x-json", library="test")
+    schema_id = writer.register_schema(
+        name="sample",
+        encoding="jsonschema",
+        data=json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "sample": {
+                        "type": "string",
+                    }
+                },
+            }
+        ).encode(),
+    )
+
+    channel_id = writer.register_channel(
+        schema_id=schema_id,
+        topic="sample_topic",
+        message_encoding="json",
+    )
+
+    writer.add_message(
+        channel_id=channel_id,
+        log_time=0,
+        data=json.dumps({"sample": "test"}).encode("utf-8"),
+        publish_time=0,
+    )
+
+    writer.finish()
+    file.seek(0)
+
+    yield file
+
+
+def test_raw_read():
+    with generate_sample_data(CompressionType.LZ4) as t:
+        data = t.read()
+        assert len(data) == 759
+
+
+def test_decode_read():
+    with generate_sample_data(CompressionType.ZSTD) as t:
+        data = t.read()
+        assert len(data) == 721


### PR DESCRIPTION
**Public-Facing Changes**
This enables zstd compression by default in the python writer.


**Description**
This enables zstd compression by default in the python writer and also adds some simple tests of writing compressed files.


<!-- link relevant GitHub issues -->
