### PR TITLE
Add py.typed stub file

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap
-version = 0.0.5
+version = 0.0.6
 description = MCAP libraries for Python
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -11,8 +11,12 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
+include_package_data = True
 install_requires = 
     lz4
     zstd
 packages = find:
 python_requires = >=3.8
+
+[options.package_data]
+mcap = py.typed


### PR DESCRIPTION
**Public-Facing Changes**
Add a py.typed file to indicate the python mcap module includes type information

**Description**
This just adds a an empty py.typed file so that other tools recognize the mcap module as typed.

<!-- link relevant GitHub issues -->
