### PR TITLE
TypeScript: include header.library in parse error messages

### DIFF
--- a/typescript/mcap/src/v0/Mcap0IndexedReader/index.test.ts
+++ b/typescript/mcap/src/v0/Mcap0IndexedReader/index.test.ts
@@ -102,6 +102,27 @@ describe("Mcap0IndexedReader", () => {
     );
   });
 
+  it("includes library in error messages", async () => {
+    const readable = makeReadable(
+      new Uint8Array([
+        ...MCAP0_MAGIC,
+        ...record(Opcode.HEADER, [
+          ...string(""), // profile
+          ...string("lib"), // library
+        ]),
+        ...record(Opcode.FOOTER, [
+          ...uint64LE(0n), // summary offset
+          ...uint64LE(0n), // summary start offset
+          ...uint32LE(0), // summary crc
+        ]),
+        ...MCAP0_MAGIC,
+      ]),
+    );
+    await expect(Mcap0IndexedReader.Initialize({ readable })).rejects.toThrow(
+      "File is not indexed [library=lib]",
+    );
+  });
+
   it("rejects invalid index crc", async () => {
     const data = [
       ...MCAP0_MAGIC,

--- a/typescript/mcap/src/v0/Mcap0StreamReader.test.ts
+++ b/typescript/mcap/src/v0/Mcap0StreamReader.test.ts
@@ -56,6 +56,7 @@ describe("Mcap0StreamReader", () => {
         ...[0, 0, 0, 0, 0, 0, 0, 0],
       ]),
     );
+    expect(reader.nextRecord()).toEqual({ type: "Header", profile: "prof", library: "lib" });
     expect(() => reader.nextRecord()).toThrow(/Expected MCAP magic.+\[library=lib\]/);
   });
 

--- a/typescript/mcap/src/v0/Mcap0StreamReader.ts
+++ b/typescript/mcap/src/v0/Mcap0StreamReader.ts
@@ -127,6 +127,12 @@ export default class Mcap0StreamReader implements McapStreamReader {
       this.buffer.consume(usedBytes);
     }
 
+    let header: TypedMcapRecords["Header"] | undefined;
+
+    function errorWithLibrary(message: string): Error {
+      return new Error(`${message} ${header ? `[library=${header.library}]` : "[no header]"}`);
+    }
+
     for (;;) {
       let record;
       {
@@ -147,6 +153,13 @@ export default class Mcap0StreamReader implements McapStreamReader {
         case "Unknown":
           break;
         case "Header":
+          if (header) {
+            throw new Error(
+              `Duplicate Header record: library=${header.library} profile=${header.profile} vs. library=${record.library} profile=${record.profile}`,
+            );
+          }
+          header = record;
+          break;
         case "Schema":
         case "Channel":
         case "Message":
@@ -170,14 +183,14 @@ export default class Mcap0StreamReader implements McapStreamReader {
           if (record.compression !== "" && buffer.byteLength > 0) {
             const decompress = this.decompressHandlers[record.compression];
             if (!decompress) {
-              throw new Error(`Unsupported compression ${record.compression}`);
+              throw errorWithLibrary(`Unsupported compression ${record.compression}`);
             }
             buffer = decompress(buffer, record.uncompressedSize);
           }
           if (this.validateCrcs && record.uncompressedCrc !== 0) {
             const chunkCrc = crc32(buffer);
             if (chunkCrc !== record.uncompressedCrc) {
-              throw new Error(
+              throw errorWithLibrary(
                 `Incorrect chunk CRC ${chunkCrc} (expected ${record.uncompressedCrc})`,
               );
             }
@@ -209,7 +222,9 @@ export default class Mcap0StreamReader implements McapStreamReader {
               case "MetadataIndex":
               case "SummaryOffset":
               case "DataEnd":
-                throw new Error(`${chunkResult.record.type} record not allowed inside a chunk`);
+                throw errorWithLibrary(
+                  `${chunkResult.record.type} record not allowed inside a chunk`,
+                );
               case "Schema":
               case "Channel":
               case "Message":
@@ -218,20 +233,22 @@ export default class Mcap0StreamReader implements McapStreamReader {
             }
           }
           if (chunkOffset !== buffer.byteLength) {
-            throw new Error(`${buffer.byteLength - chunkOffset} bytes remaining in chunk`);
+            throw errorWithLibrary(`${buffer.byteLength - chunkOffset} bytes remaining in chunk`);
           }
           break;
         }
         case "Footer":
-          {
+          try {
             let magic, usedBytes;
             while ((({ magic, usedBytes } = parseMagic(this.buffer.view, 0)), !magic)) {
               yield;
             }
             this.buffer.consume(usedBytes);
+          } catch (error) {
+            throw errorWithLibrary((error as Error).message);
           }
           if (this.buffer.bytesRemaining() !== 0) {
-            throw new Error(
+            throw errorWithLibrary(
               `${this.buffer.bytesRemaining()} bytes remaining after MCAP footer and trailing magic`,
             );
           }

--- a/typescript/mcap/src/v0/Mcap0StreamReader.ts
+++ b/typescript/mcap/src/v0/Mcap0StreamReader.ts
@@ -159,6 +159,7 @@ export default class Mcap0StreamReader implements McapStreamReader {
             );
           }
           header = record;
+          yield record;
           break;
         case "Schema":
         case "Channel":


### PR DESCRIPTION
**Public-Facing Changes**
Error messages from TypeScript readers now include the header `library` when possible, to aid in debugging.


**Description**
Closes https://github.com/foxglove/mcap/issues/283