### PR TITLE
cpp: remove cryptopp dependency, add crc32 implementation

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -80,7 +80,6 @@ Output binaries can be found in:
 The C++ implementation of MCAP is maintained as a header-only library with the
 following dependencies:
 
-- [cryptopp](https://cryptopp.com/) (tested with [cryptopp/8.5.0](https://conan.io/center/cryptopp))
 - [fmt](https://github.com/fmtlib/fmt) (tested with [fmt/8.1.1](https://conan.io/center/fmt))
 - [lz4](https://lz4.github.io/lz4/) (tested with [lz4/1.9.3](https://conan.io/center/lz4))
 - [zstd](https://facebook.github.io/zstd/) (tested with [zstd/1.5.2](https://conan.io/center/zstd))

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -11,7 +11,7 @@ class McapConan(ConanFile):
     topics = ("mcap", "serialization", "deserialization", "recording")
 
     settings = ("os", "compiler", "build_type", "arch")
-    requires = ("cryptopp/8.5.0", "fmt/8.1.1", "lz4/1.9.3", "zstd/1.5.2")
+    requires = ("fmt/8.1.1", "lz4/1.9.3", "zstd/1.5.2")
     generators = "cmake"
 
     def validate(self):

--- a/cpp/mcap/include/mcap/crc32.hpp
+++ b/cpp/mcap/include/mcap/crc32.hpp
@@ -1,0 +1,107 @@
+#include <array>
+#include <cstdint>
+
+namespace mcap::internal {
+
+/**
+ * Compute CRC32 lookup tables as described at:
+ * https://github.com/komrad36/CRC#option-6-1-byte-tabular
+ *
+ * An iteration of CRC computation can be performed on 8 bits of input at once. By pre-computing a
+ * table of the values of CRC(?) for all 2^8 = 256 possible byte values, during the final
+ * computation we can replace a loop over 8 bits with a single lookup in the table.
+ *
+ * For further speedup, we can also pre-compute the values of CRC(?0) for all possible bytes when a
+ * zero byte is appended. Then we can process two bytes of input at once by computing CRC(AB) =
+ * CRC(A0) ^ CRC(B), using one lookup in the CRC(?0) table and one lookup in the CRC(?) table.
+ *
+ * The same technique applies for any number of bytes to be processed at once, although the speed
+ * improvements diminish.
+ *
+ * @param Polynomial The binary representation of the polynomial to use (reversed, i.e. most
+ * significant bit represents x^0).
+ * @param NumTables The number of bytes of input that will be processed at once.
+ */
+template <size_t Polynomial, size_t NumTables>
+struct CRC32Table {
+private:
+  std::array<uint32_t, 256 * NumTables> table = {};
+
+public:
+  constexpr CRC32Table() {
+    for (uint32_t i = 0; i < 256; i++) {
+      uint32_t r = i;
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      r = ((r & 1) * Polynomial) ^ (r >> 1);
+      table[i] = r;
+    }
+    for (size_t i = 256; i < table.size(); i++) {
+      uint32_t value = table[i - 256];
+      table[i] = table[value & 0xff] ^ (value >> 8);
+    }
+  }
+
+  constexpr uint32_t operator[](size_t index) const {
+    return table[index];
+  }
+};
+
+inline uint32_t getUint32LE(const std::byte* data) {
+  return (uint32_t(data[0]) << 0) | (uint32_t(data[1]) << 8) | (uint32_t(data[2]) << 16) |
+         (uint32_t(data[3]) << 24);
+}
+
+static constexpr CRC32Table<0xedb88320, 8> CRC32_TABLE;
+
+/**
+ * Initialize a CRC32 to all 1 bits.
+ */
+static constexpr uint32_t CRC32_INIT = 0xffffffff;
+
+/**
+ * Update a streaming CRC32 calculation.
+ *
+ * For performance, this implementation processes the data 8 bytes at a time, using the algorithm
+ * presented at: https://github.com/komrad36/CRC#option-9-8-byte-tabular
+ */
+inline uint32_t crc32Update(const uint32_t prev, const std::byte* const data, const size_t length) {
+  // Process bytes one by one until we reach the proper alignment.
+  uint32_t r = prev;
+  size_t offset = 0;
+  for (; (uintptr_t(data + offset) & alignof(uint32_t)) != 0 && offset < length; offset++) {
+    r = CRC32_TABLE[(r ^ uint8_t(data[offset])) & 0xff] ^ (r >> 8);
+  }
+  if (offset == length) {
+    return r;
+  }
+
+  // Process 8 bytes (2 uint32s) at a time.
+  uint32_t remainingBytes = length - offset;
+  for (; remainingBytes >= 8; offset += 8, remainingBytes -= 8) {
+    r ^= getUint32LE(data + offset);
+    uint32_t r2 = getUint32LE(data + offset + 4);
+    r = CRC32_TABLE[0 * 256 + ((r2 >> 24) & 0xff)] ^ CRC32_TABLE[1 * 256 + ((r2 >> 16) & 0xff)] ^
+        CRC32_TABLE[2 * 256 + ((r2 >> 8) & 0xff)] ^ CRC32_TABLE[3 * 256 + ((r2 >> 0) & 0xff)] ^
+        CRC32_TABLE[4 * 256 + ((r >> 24) & 0xff)] ^ CRC32_TABLE[5 * 256 + ((r >> 16) & 0xff)] ^
+        CRC32_TABLE[6 * 256 + ((r >> 8) & 0xff)] ^ CRC32_TABLE[7 * 256 + ((r >> 0) & 0xff)];
+  }
+
+  // Process any remaining bytes one by one.
+  for (; offset < length; offset++) {
+    r = CRC32_TABLE[(r ^ uint8_t(data[offset])) & 0xff] ^ (r >> 8);
+  }
+  return r;
+}
+
+/** Finalize a CRC32 by inverting the output value. */
+inline uint32_t crc32Final(uint32_t crc) {
+  return crc ^ 0xffffffff;
+}
+
+}  // namespace mcap::internal

--- a/cpp/mcap/include/mcap/crc32.hpp
+++ b/cpp/mcap/include/mcap/crc32.hpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 namespace mcap::internal {

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -9,11 +9,6 @@
 // Forward declaration
 struct ZSTD_CCtx_s;
 
-// Forward declaration
-namespace CryptoPP {
-class CRC32;
-}  // namespace CryptoPP
-
 namespace mcap {
 
 /**
@@ -103,6 +98,7 @@ class IWritable {
 public:
   bool crcEnabled = false;
 
+  IWritable() noexcept;
   virtual ~IWritable() = default;
 
   /**
@@ -136,7 +132,7 @@ protected:
   virtual void handleWrite(const std::byte* data, uint64_t size) = 0;
 
 private:
-  std::unique_ptr<CryptoPP::CRC32> crc_;
+  uint32_t crc_;
 };
 
 class FileWriter final : public IWritable {

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -19,7 +19,6 @@ words:
   - cmake
   - crc
   - crcs
-  - cryptopp
   - deserialization
   - golangci
   - libmcap


### PR DESCRIPTION
**Public-Facing Changes**
Removes `cryptopp` dependency from the C++ library, replacing it with a custom CRC32 implementation. The motivation for this is that compiling cryptopp exposes a bug in intrinsics headers provided with certain GCC versions (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100985).

The multi-byte CRC algorithm was ported directly from https://github.com/foxglove/crc, which was adapted from https://github.com/komrad36/CRC.

**Description**
Benchmark results from my MBP (M1 Pro):
```
-------------------------------------------------------------------------------------------------------------
Benchmark                                                   Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------------
BM_CRC32/1                                               1.56 ns         1.56 ns    421951102 bytes_per_second=610.025M/s
BM_CRC32/10                                              3.29 ns         3.29 ns    215671292 bytes_per_second=2.83468G/s
BM_CRC32/100                                             35.8 ns         35.7 ns     19468618 bytes_per_second=2.60784G/s
BM_CRC32/1000                                             422 ns          422 ns      1645971 bytes_per_second=2.20748G/s
BM_CRC32/10000                                           4314 ns         4312 ns       160681 bytes_per_second=2.15964G/s
BM_CRC32/100000                                         43786 ns        43672 ns        15588 bytes_per_second=2.13253G/s
BM_CRC32/1000000                                       434416 ns       433984 ns         1604 bytes_per_second=2.14598G/s
BM_CRC32/10000000                                     4373861 ns      4372379 ns          161 bytes_per_second=2.13001G/s
BM_CryptoppCRC32/1                                       7.26 ns         7.26 ns     96711799 bytes_per_second=131.332M/s
BM_CryptoppCRC32/10                                      9.67 ns         9.66 ns     72054267 bytes_per_second=986.95M/s
BM_CryptoppCRC32/100                                      153 ns          153 ns      4562133 bytes_per_second=622.029M/s
BM_CryptoppCRC32/1000                                    2189 ns         2189 ns       319037 bytes_per_second=435.733M/s
BM_CryptoppCRC32/10000                                  22531 ns        22528 ns        31029 bytes_per_second=423.335M/s
BM_CryptoppCRC32/100000                                228347 ns       228312 ns         3054 bytes_per_second=417.706M/s
BM_CryptoppCRC32/1000000                              2262966 ns      2262541 ns          307 bytes_per_second=421.506M/s
BM_CryptoppCRC32/10000000                            22762134 ns     22755452 ns           31 bytes_per_second=419.097M/s
```