### PR TITLE
CLI: Add support for listing channels and schemas

### DIFF
--- a/go/cli/mcap/cmd/channels.go
+++ b/go/cli/mcap/cmd/channels.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+
+	"github.com/foxglove/mcap/go/cli/mcap/utils"
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+func printChannels(w io.Writer, channels []*mcap.Channel) error {
+	tw := tablewriter.NewWriter(w)
+	rows := make([][]string, 0, len(channels))
+	rows = append(rows, []string{
+		"id",
+		"schemaId",
+		"topic",
+		"messageEncoding",
+		"metadata",
+	})
+	for _, channel := range channels {
+		metadata, err := json.Marshal(channel.Metadata)
+		if err != nil {
+			return fmt.Errorf("failed to marshal channel metadata: %v", err)
+		}
+		row := []string{
+			fmt.Sprintf("%d", channel.ID),
+			fmt.Sprintf("%d", channel.SchemaID),
+			channel.Topic,
+			channel.MessageEncoding,
+			string(metadata),
+		}
+		rows = append(rows, row)
+	}
+	tw.SetBorder(false)
+	tw.SetAutoWrapText(false)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetColumnSeparator("")
+	tw.AppendBulk(rows)
+	tw.Render()
+	return nil
+}
+
+// channelsCmd represents the channels command
+var channelsCmd = &cobra.Command{
+	Use:   "channels",
+	Short: "List channels in an mcap file",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		if len(args) != 1 {
+			log.Fatal("Unexpected number of args")
+		}
+		filename := args[0]
+		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+			reader, err := mcap.NewReader(rs)
+			if err != nil {
+				return fmt.Errorf("failed to get reader: %w", err)
+			}
+			info, err := reader.Info()
+			if err != nil {
+				return fmt.Errorf("failed to get info: %w", err)
+			}
+			channels := []*mcap.Channel{}
+			for _, channel := range info.Channels {
+				channels = append(channels, channel)
+			}
+			sort.Slice(channels, func(i, j int) bool {
+				return channels[i].ID < channels[j].ID
+			})
+			return printChannels(os.Stdout, channels)
+		})
+		if err != nil {
+			log.Fatal("Failed to list channels: %w", err)
+		}
+	},
+}
+
+func init() {
+	listCmd.AddCommand(channelsCmd)
+}

--- a/go/cli/mcap/cmd/schemas.go
+++ b/go/cli/mcap/cmd/schemas.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+
+	"github.com/foxglove/mcap/go/cli/mcap/utils"
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+func printSchemas(w io.Writer, schemas []*mcap.Schema) {
+	tw := tablewriter.NewWriter(w)
+	rows := make([][]string, 0, len(schemas))
+	rows = append(rows, []string{
+		"id",
+		"name",
+		"encoding",
+		"data",
+	})
+	for _, schema := range schemas {
+		row := []string{
+			fmt.Sprintf("%d", schema.ID),
+			schema.Name,
+			schema.Encoding,
+			string(schema.Data),
+		}
+		rows = append(rows, row)
+	}
+	tw.SetBorder(false)
+	tw.SetAutoWrapText(false)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetColumnSeparator("")
+	tw.AppendBulk(rows)
+	tw.Render()
+}
+
+// schemasCmd represents the schemas command
+var schemasCmd = &cobra.Command{
+	Use:   "schemas",
+	Short: "List schemas in an mcap file",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		if len(args) != 1 {
+			log.Fatal("Unexpected number of args")
+		}
+		filename := args[0]
+		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+			reader, err := mcap.NewReader(rs)
+			if err != nil {
+				return fmt.Errorf("failed to get reader: %w", err)
+			}
+			info, err := reader.Info()
+			if err != nil {
+				return fmt.Errorf("failed to get info: %w", err)
+			}
+
+			schemas := []*mcap.Schema{}
+			for _, schema := range info.Schemas {
+				schemas = append(schemas, schema)
+			}
+			sort.Slice(schemas, func(i, j int) bool {
+				return schemas[i].ID < schemas[j].ID
+			})
+			printSchemas(os.Stdout, schemas)
+			return nil
+		})
+		if err != nil {
+			log.Fatal("Failed to list schemas: %w", err)
+		}
+	},
+}
+
+func init() {
+	listCmd.AddCommand(schemasCmd)
+}


### PR DESCRIPTION
Adds support for `mcap list schemas` and `mcap list channels`, similar to `mcap list chunks`.