### PR TITLE
Add conformance tests with one metadata record

### DIFF
--- a/cpp/test/streamed-writer-conformance.cpp
+++ b/cpp/test/streamed-writer-conformance.cpp
@@ -187,6 +187,17 @@ mcap::Attachment ReadAttachment(const json& attachmentJson, mcap::ByteArray& buf
   return attachment;
 }
 
+mcap::Metadata ReadMetadata(const json& metadataJson) {
+  // {
+  //   "type": "Metadata",
+  //   "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+  // },
+  mcap::Metadata metadata;
+  metadata.metadata = metadataJson["fields"][0][1];
+  metadata.name = metadataJson["fields"][1][1];
+  return metadata;
+}
+
 class StdoutWriter final : public mcap::IWritable {
 public:
   void handleWrite(const std::byte* data, uint64_t size) override {
@@ -244,6 +255,9 @@ int main(int argc, char** argv) {
       mcap::ByteArray buffer;
       auto attachment = ReadAttachment(record, buffer);
       mcapWriter.write(attachment);
+    } else if (recordType == "Metadata") {
+      auto metadata = ReadMetadata(record);
+      mcapWriter.write(metadata);
     } else if (recordType == "DataEnd") {
       mcapWriter.close();
       return 0;

--- a/python/mcap/mcap0/stream_reader.py
+++ b/python/mcap/mcap0/stream_reader.py
@@ -19,6 +19,7 @@ from .records import (
     McapRecord,
     Message,
     MessageIndex,
+    Metadata,
     MetadataIndex,
     Schema,
     Statistics,
@@ -130,6 +131,8 @@ class StreamReader:
             return Message.read(self.__stream, length)
         if opcode == Opcode.MESSAGE_INDEX:
             return MessageIndex.read(self.__stream)
+        if opcode == Opcode.METADATA:
+            return Metadata.read(self.__stream)
         if opcode == Opcode.METADATA_INDEX:
             return MetadataIndex.read(self.__stream)
         if opcode == Opcode.SCHEMA:

--- a/python/tests/run_writer_test.py
+++ b/python/tests/run_writer_test.py
@@ -4,7 +4,15 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Set, Type
 
-from mcap.mcap0.records import Attachment, Channel, Header, McapRecord, Message, Schema
+from mcap.mcap0.records import (
+    Attachment,
+    Channel,
+    Header,
+    McapRecord,
+    Message,
+    Metadata,
+    Schema,
+)
 from mcap.mcap0.writer import CompressionType, IndexType, Writer
 
 
@@ -35,6 +43,8 @@ def index_type_from_features(features: List[str]) -> IndexType:
         type |= IndexType.CHUNK
     if "mx" in features:
         type |= IndexType.MESSAGE
+    if "mdx" in features:
+        type |= IndexType.METADATA
     return type
 
 
@@ -88,6 +98,8 @@ def write_file(features: List[str], expected_records: List[Dict[str, Any]]) -> b
                     name=record.name, encoding=record.encoding, data=record.data
                 )
             seen_schemas.add(record.name)
+        if isinstance(record, Metadata):
+            writer.add_metadata(record.name, record.metadata)
     writer.finish()
     return output.getvalue()
 

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -47,10 +47,10 @@ def generate_sample_data(compression: CompressionType):
 def test_raw_read():
     with generate_sample_data(CompressionType.LZ4) as t:
         data = t.read()
-        assert len(data) == 759
+        assert len(data) == 785
 
 
 def test_decode_read():
     with generate_sample_data(CompressionType.ZSTD) as t:
         data = t.read()
-        assert len(data) == 721
+        assert len(data) == 747

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st-sum.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st-sum.json
@@ -1,0 +1,53 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "44"], ["name", "myMetadata"], ["offset", "28"]]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "58"],
+        ["group_opcode", "11"],
+        ["group_start", "88"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "42"],
+        ["group_opcode", "13"],
+        ["group_start", "146"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "1149090039"],
+        ["summary_offset_start", "188"],
+        ["summary_start", "88"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "mdx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st-sum.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st-sum.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afda94e21bc22a217f651d46895dfc12d1ac465d2ac8043cc9aa8312d16d95ca
+size 283

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st.json
@@ -1,0 +1,37 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "44"], ["name", "myMetadata"], ["offset", "28"]]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "3080615778"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "88"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "mdx", "pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-st.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e808c2a99fe5aa99abe5aac3f8816e556b302ae2232b6215b81968f9baa91ef2
+size 225

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-sum.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-sum.json
@@ -1,0 +1,31 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "44"], ["name", "myMetadata"], ["offset", "28"]]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "42"],
+        ["group_opcode", "13"],
+        ["group_start", "88"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "2257852717"],
+        ["summary_offset_start", "130"],
+        ["summary_start", "88"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mdx", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-sum.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad-sum.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8953cfd0fd236aee616e25837a3c5e470e17ad36c9cdd30c0749ae41ab8585b1
+size 196

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad.json
@@ -1,0 +1,23 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "44"], ["name", "myMetadata"], ["offset", "28"]]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "3895734819"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "88"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mdx", "pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-pad.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3103870628a97b280af4c2c69eb79a7852f3457bcb68ddd1190b786d07f1fd0d
+size 167

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-st-sum.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-st-sum.json
@@ -1,0 +1,53 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "41"], ["name", "myMetadata"], ["offset", "25"]]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "55"],
+        ["group_opcode", "11"],
+        ["group_start", "79"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "39"],
+        ["group_opcode", "13"],
+        ["group_start", "134"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "1977374533"],
+        ["summary_offset_start", "173"],
+        ["summary_start", "79"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "mdx", "sum"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-st-sum.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-st-sum.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6ab1d4a7aee739d477c9c8f494e8b42f875bd76092eda7ac984a1d8c3ed2872
+size 262

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-st.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-st.json
@@ -1,0 +1,37 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "41"], ["name", "myMetadata"], ["offset", "25"]]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "82366086"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "79"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "mdx"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-st.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-st.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2a311fac26646aed316861c7e9e45d0223e3a4417f10d7b47350f398a27d05e
+size 210

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-sum.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-sum.json
@@ -1,0 +1,31 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "41"], ["name", "myMetadata"], ["offset", "25"]]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "39"],
+        ["group_opcode", "13"],
+        ["group_start", "79"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "1175336642"],
+        ["summary_offset_start", "118"],
+        ["summary_start", "79"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mdx", "sum"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx-sum.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx-sum.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17309e6dcf9a02fa455f4a1df6c67a48ec2925334557eab229cc3d3a34aa9726
+size 181

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx.json
@@ -1,0 +1,23 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "MetadataIndex",
+      "fields": [["length", "41"], ["name", "myMetadata"], ["offset", "25"]]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "1882959022"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "79"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["mdx"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-mdx.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-mdx.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:332b8c03a8ab9de43769d271f5a44a8a81c073ad045f9a3c451f9867c7da33ba
+size 155

--- a/tests/conformance/data/OneMetadata/OneMetadata-pad-st-sum.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-pad-st-sum.json
@@ -1,0 +1,41 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "58"],
+        ["group_opcode", "11"],
+        ["group_start", "88"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "79787231"],
+        ["summary_offset_start", "146"],
+        ["summary_start", "88"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum", "pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-pad-st-sum.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-pad-st-sum.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e55da1261fe718aa05571663621b7b4f6395fc90136e1d07fb1af0c8625156e5
+size 212

--- a/tests/conformance/data/OneMetadata/OneMetadata-pad-st.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-pad-st.json
@@ -1,0 +1,33 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "856565915"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "88"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-pad-st.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-pad-st.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bb3ada750347f60860078e3cd38ac72fc52ddad757e2891d6cf8f0f5f398f91
+size 183

--- a/tests/conformance/data/OneMetadata/OneMetadata-pad.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-pad.json
@@ -1,0 +1,19 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "1875167664"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["pad"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-pad.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-pad.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8ac81e242585bd94babc53110918e86342260144ff9a0a9ee1c258af41589e
+size 125

--- a/tests/conformance/data/OneMetadata/OneMetadata-st-sum.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-st-sum.json
@@ -1,0 +1,41 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "SummaryOffset",
+      "fields": [
+        ["group_length", "55"],
+        ["group_opcode", "11"],
+        ["group_start", "79"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "757763527"],
+        ["summary_offset_start", "134"],
+        ["summary_start", "79"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st", "sum"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-st-sum.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-st-sum.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bf77d567622e60d13d8d31f1b7c59ad24ff5dc02a51435f398c4fe75b4dc65e
+size 197

--- a/tests/conformance/data/OneMetadata/OneMetadata-st.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata-st.json
@@ -1,0 +1,33 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Statistics",
+      "fields": [
+        ["attachment_count", "0"],
+        ["channel_count", "0"],
+        ["channel_message_counts", {}],
+        ["chunk_count", "0"],
+        ["message_count", "0"],
+        ["message_end_time", "0"],
+        ["message_start_time", "0"],
+        ["metadata_count", "1"],
+        ["schema_count", "0"]
+      ]
+    },
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "2339164687"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "79"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": ["st"]}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata-st.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata-st.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73f66ffc186c703ee979a6495b51c20d4e19cfc5b05dc08a72ae79b59c939577
+size 171

--- a/tests/conformance/data/OneMetadata/OneMetadata.json
+++ b/tests/conformance/data/OneMetadata/OneMetadata.json
@@ -1,0 +1,19 @@
+{
+  "records": [
+    {"type": "Header", "fields": [["library", ""], ["profile", ""]]},
+    {
+      "type": "Metadata",
+      "fields": [["metadata", {"foo": "bar"}], ["name", "myMetadata"]]
+    },
+    {"type": "DataEnd", "fields": [["data_section_crc", "0"]]},
+    {
+      "type": "Footer",
+      "fields": [
+        ["summary_crc", "1875167664"],
+        ["summary_offset_start", "0"],
+        ["summary_start", "0"]
+      ]
+    }
+  ],
+  "meta": {"variant": {"features": []}}
+}

--- a/tests/conformance/data/OneMetadata/OneMetadata.mcap
+++ b/tests/conformance/data/OneMetadata/OneMetadata.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e254aad93777c23e224c2f800295f7573607e7841a4883916695d0a292786302
+size 116

--- a/tests/conformance/scripts/generate-inputs.ts
+++ b/tests/conformance/scripts/generate-inputs.ts
@@ -218,18 +218,18 @@ function generateFile(features: Set<TestFeatures>, records: TestDataRecord[]) {
         groupLength: repeatedChannelInfosLength,
       });
     }
-    if (metadataIndexLength !== 0n) {
-      builder.writeSummaryOffset({
-        groupOpcode: Mcap0Constants.Opcode.METADATA_INDEX,
-        groupStart: metadataIndexStart,
-        groupLength: metadataIndexLength,
-      });
-    }
     if (statisticsLength !== 0n) {
       builder.writeSummaryOffset({
         groupOpcode: Mcap0Constants.Opcode.STATISTICS,
         groupStart: statisticsStart,
         groupLength: statisticsLength,
+      });
+    }
+    if (metadataIndexLength !== 0n) {
+      builder.writeSummaryOffset({
+        groupOpcode: Mcap0Constants.Opcode.METADATA_INDEX,
+        groupStart: metadataIndexStart,
+        groupLength: metadataIndexLength,
       });
     }
     if (attachmentIndexLength !== 0n) {

--- a/tests/conformance/variants/inputs.ts
+++ b/tests/conformance/variants/inputs.ts
@@ -43,6 +43,10 @@ const inputs: TestInput[] = [
       },
     ],
   },
+  {
+    baseName: "OneMetadata",
+    records: [{ type: "Metadata", name: "myMetadata", metadata: new Map([["foo", "bar"]]) }],
+  },
 ];
 
 export default inputs;


### PR DESCRIPTION
**Public-Facing Changes**
Fixed metadata index and statistics calculations when writing Metadata records in Go & TypeScript writers. Add support for Metadata in Python reader/writer.


**Description**
Closes #291 