### PR TITLE
c++: fix dangling reference by copying Message into LinearMessageView

### DIFF
--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -435,7 +435,8 @@ struct LinearMessageView {
     Timestamp startTime_;
     Timestamp endTime_;
     const ProblemCallback& onProblem_;
-    std::optional<MessageView> curMessage_;
+    Message curMessage_;
+    std::optional<MessageView> curMessageView_;
 
     Iterator(McapReader& mcapReader, const ProblemCallback& onProblem);
     Iterator(McapReader& mcapReader, ByteOffset dataStart, ByteOffset dataEnd, Timestamp startTime,

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1309,29 +1309,30 @@ LinearMessageView::Iterator::Iterator(McapReader& mcapReader, ByteOffset dataSta
       }
     }
 
-    curMessage_.emplace(message, maybeChannel, maybeSchema);
+    curMessage_ = message;  // copy message, which may be a reference to a temporary
+    curMessageView_.emplace(curMessage_, maybeChannel, maybeSchema);
   };
 
   ++(*this);
 }
 
 LinearMessageView::Iterator::reference LinearMessageView::Iterator::operator*() const {
-  return *curMessage_;
+  return *curMessageView_;
 }
 
 LinearMessageView::Iterator::pointer LinearMessageView::Iterator::operator->() const {
-  return &*curMessage_;
+  return &*curMessageView_;
 }
 
 LinearMessageView::Iterator& LinearMessageView::Iterator::operator++() {
-  curMessage_ = std::nullopt;
+  curMessageView_ = std::nullopt;
 
   if (!recordReader_.has_value()) {
     return *this;
   }
 
   // Keep iterate through records until we find a message with a logTime >= startTime_
-  while (!curMessage_.has_value() || curMessage_->message.logTime < startTime_) {
+  while (!curMessageView_.has_value() || curMessageView_->message.logTime < startTime_) {
     const bool found = recordReader_->next();
 
     // Surface any problem that may have occurred while reading
@@ -1347,7 +1348,7 @@ LinearMessageView::Iterator& LinearMessageView::Iterator::operator++() {
   }
 
   // Check if this message is past the time range of this view
-  if (curMessage_->message.logTime >= endTime_) {
+  if (curMessageView_->message.logTime >= endTime_) {
     recordReader_ = std::nullopt;
   }
   return *this;


### PR DESCRIPTION
**Public-Facing Changes**
Fixed a dangling reference in LinearMessageView (McapReader::readMessages).


**Description**
Fixes #295 