### PR TITLE
CLI: Show per-channel frequencies in mcap info

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -75,9 +75,10 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		channel := info.Channels[chanID]
 		schema := info.Schemas[channel.SchemaID]
 		channelMessageCount := info.Statistics.ChannelMessageCounts[chanID]
+		frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
 		row := []string{
 			fmt.Sprintf("\t(%d) %s", channel.ID, channel.Topic),
-			fmt.Sprintf("%*d msgs", maxCountWidth, channelMessageCount),
+			fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency),
 			fmt.Sprintf(" : %s [%s]", schema.Name, schema.Encoding),
 		}
 		rows = append(rows, row)


### PR DESCRIPTION
Example:
```
messages: 1606
duration: 7.780758504s
start: 2017-03-21T19:26:20.103843113-07:00
end: 2017-03-21T19:26:27.884601617-07:00
compression:
        zstd: [14/14 chunks] (50.79%)
channels:
        (0) /diagnostics              52 msgs (6.68 Hz)    : diagnostic_msgs/DiagnosticArray [ros1msg]
        (1) /image_color/compressed  234 msgs (30.07 Hz)   : sensor_msgs/CompressedImage [ros1msg]
        (2) /tf                      774 msgs (99.48 Hz)   : tf2_msgs/TFMessage [ros1msg]
        (3) /radar/points            156 msgs (20.05 Hz)   : sensor_msgs/PointCloud2 [ros1msg]
        (4) /radar/range             156 msgs (20.05 Hz)   : sensor_msgs/Range [ros1msg]
        (5) /radar/tracks            156 msgs (20.05 Hz)   : radar_driver/RadarTracks [ros1msg]
        (6) /velodyne_points          78 msgs (10.02 Hz)   : sensor_msgs/PointCloud2 [ros1msg]
attachments: 0
```