### PR TITLE
[C++] Summary parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
         working-directory: cpp
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
       - uses: actions/cache@v2
         with:
           path: ~/.conan/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-node_modules
 .DS_Store
+.vscode/c_cpp_properties.json
+node_modules
 yarn-error.log

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -3,7 +3,6 @@ build/
 *.profdata
 *.profraw
 .vs
-.vscode
 CMakeCache.txt
 CMakeFiles/
 CMakeSettings.json

--- a/cpp/examples/mcapdump.cpp
+++ b/cpp/examples/mcapdump.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <string>
 
+using mcap::ByteOffset;
+
 template <typename... T>
 [[nodiscard]] inline std::string StrFormat(std::string_view msg, T&&... args) {
   return fmt::format(msg, std::forward<T>(args)...);
@@ -43,7 +45,7 @@ std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
   return ss.str();
 }
 
-std::string ToString(const std::vector<std::pair<mcap::Timestamp, mcap::ByteOffset>>& pairs) {
+std::string ToString(const std::vector<std::pair<mcap::Timestamp, ByteOffset>>& pairs) {
   if (pairs.size() > 8) {
     return StrFormat("<{} entries>", pairs.size());
   }
@@ -194,56 +196,56 @@ void Dump(mcap::IReadable& dataSource) {
   mcap::TypedRecordReader reader{dataSource, 8};
   bool inChunk = false;
 
-  reader.onHeader = [](const mcap::Header& record) {
+  reader.onHeader = [](const mcap::Header& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onFooter = [](const mcap::Footer& record) {
+  reader.onFooter = [](const mcap::Footer& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onSchema = [&](const mcap::SchemaPtr recordPtr) {
+  reader.onSchema = [&](const mcap::SchemaPtr recordPtr, ByteOffset, std::optional<ByteOffset>) {
     std::cout << (inChunk ? "  " : "") << ToString(*recordPtr) << "\n";
   };
-  reader.onChannel = [&](const mcap::ChannelPtr recordPtr) {
+  reader.onChannel = [&](const mcap::ChannelPtr recordPtr, ByteOffset, std::optional<ByteOffset>) {
     std::cout << (inChunk ? "  " : "") << ToString(*recordPtr) << "\n";
   };
-  reader.onMessage = [&](const mcap::Message& record) {
+  reader.onMessage = [&](const mcap::Message& record, ByteOffset, std::optional<ByteOffset>) {
     std::cout << (inChunk ? "  " : "") << ToString(record) << "\n";
   };
-  reader.onChunk = [&](const mcap::Chunk& record) {
+  reader.onChunk = [&](const mcap::Chunk& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
     inChunk = true;
   };
-  reader.onMessageIndex = [](const mcap::MessageIndex& record) {
+  reader.onMessageIndex = [](const mcap::MessageIndex& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onChunkIndex = [](const mcap::ChunkIndex& record) {
+  reader.onChunkIndex = [](const mcap::ChunkIndex& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onAttachment = [](const mcap::Attachment& record) {
+  reader.onAttachment = [](const mcap::Attachment& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onAttachmentIndex = [](const mcap::AttachmentIndex& record) {
+  reader.onAttachmentIndex = [](const mcap::AttachmentIndex& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onStatistics = [](const mcap::Statistics& record) {
+  reader.onStatistics = [](const mcap::Statistics& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onMetadata = [](const mcap::Metadata& record) {
+  reader.onMetadata = [](const mcap::Metadata& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onMetadataIndex = [](const mcap::MetadataIndex& record) {
+  reader.onMetadataIndex = [](const mcap::MetadataIndex& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onSummaryOffset = [](const mcap::SummaryOffset& record) {
+  reader.onSummaryOffset = [](const mcap::SummaryOffset& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onDataEnd = [](const mcap::DataEnd& record) {
+  reader.onDataEnd = [](const mcap::DataEnd& record, ByteOffset) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onUnknownRecord = [](const mcap::Record& record) {
+  reader.onUnknownRecord = [](const mcap::Record& record, ByteOffset, std::optional<ByteOffset>) {
     std::cout << ToString(record) << "\n";
   };
-  reader.onChunkEnd = [&]() {
+  reader.onChunkEnd = [&](ByteOffset) {
     inChunk = false;
   };
 

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -24,6 +24,7 @@ enum class StatusCode {
   DecompressionSizeMismatch,
   UnrecognizedCompression,
   OpenFailed,
+  MissingStatistics,
 };
 
 /**
@@ -85,6 +86,9 @@ struct Status {
         break;
       case StatusCode::OpenFailed:
         message = "open failed";
+        break;
+      case StatusCode::MissingStatistics:
+        message = "missing statistics";
         break;
       default:
         message = "unknown";

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -18,6 +18,8 @@ enum class StatusCode {
   InvalidFile,
   InvalidRecord,
   InvalidOpCode,
+  InvalidChunkOffset,
+  InvalidFooter,
   DecompressionFailed,
   DecompressionSizeMismatch,
   UnrecognizedCompression,
@@ -65,6 +67,12 @@ struct Status {
         break;
       case StatusCode::InvalidOpCode:
         message = "invalid opcode";
+        break;
+      case StatusCode::InvalidChunkOffset:
+        message = "invalid chunk offset";
+        break;
+      case StatusCode::InvalidFooter:
+        message = "invalid footer";
         break;
       case StatusCode::DecompressionFailed:
         message = "decompression failed";

--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -14,6 +14,7 @@ namespace internal {
 constexpr std::string_view ErrorMsgInvalidOpcode = "invalid opcode, expected {}: 0x{:02x}";
 constexpr std::string_view ErrorMsgInvalidLength = "invalid {} length: {}";
 constexpr std::string_view ErrorMsgInvalidMagic = "invalid magic bytes in {}: 0x{}";
+constexpr std::string_view ErrorOpenFileFailed = "failed to open \"{}\"";
 
 constexpr uint64_t MinHeaderLength = /* magic bytes */ sizeof(Magic) +
                                      /* opcode */ 1 +

--- a/cpp/mcap/include/mcap/intervaltree.hpp
+++ b/cpp/mcap/include/mcap/intervaltree.hpp
@@ -1,0 +1,307 @@
+// Adapted from <https://github.com/ekg/intervaltree/blob/master/IntervalTree.h>
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace mcap {
+
+namespace internal {
+
+template <class Scalar, typename Value>
+class Interval {
+public:
+  Scalar start;
+  Scalar stop;
+  Value value;
+  Interval(const Scalar& s, const Scalar& e, const Value& v)
+      : start(std::min(s, e))
+      , stop(std::max(s, e))
+      , value(v) {}
+};
+
+template <class Scalar, typename Value>
+Value intervalStart(const Interval<Scalar, Value>& i) {
+  return i.start;
+}
+
+template <class Scalar, typename Value>
+Value intervalStop(const Interval<Scalar, Value>& i) {
+  return i.stop;
+}
+
+template <class Scalar, typename Value>
+std::ostream& operator<<(std::ostream& out, const Interval<Scalar, Value>& i) {
+  out << "Interval(" << i.start << ", " << i.stop << "): " << i.value;
+  return out;
+}
+
+template <class Scalar, class Value>
+class IntervalTree {
+public:
+  using interval = Interval<Scalar, Value>;
+  using interval_vector = std::vector<interval>;
+
+  struct IntervalStartCmp {
+    bool operator()(const interval& a, const interval& b) {
+      return a.start < b.start;
+    }
+  };
+
+  struct IntervalStopCmp {
+    bool operator()(const interval& a, const interval& b) {
+      return a.stop < b.stop;
+    }
+  };
+
+  IntervalTree()
+      : left(nullptr)
+      , right(nullptr)
+      , center(Scalar(0)) {}
+
+  ~IntervalTree() = default;
+
+  std::unique_ptr<IntervalTree> clone() const {
+    return std::unique_ptr<IntervalTree>(new IntervalTree(*this));
+  }
+
+  IntervalTree(const IntervalTree& other)
+      : intervals(other.intervals)
+      , left(other.left ? other.left->clone() : nullptr)
+      , right(other.right ? other.right->clone() : nullptr)
+      , center(other.center) {}
+
+  IntervalTree& operator=(IntervalTree&&) = default;
+  IntervalTree(IntervalTree&&) = default;
+
+  IntervalTree& operator=(const IntervalTree& other) {
+    center = other.center;
+    intervals = other.intervals;
+    left = other.left ? other.left->clone() : nullptr;
+    right = other.right ? other.right->clone() : nullptr;
+    return *this;
+  }
+
+  IntervalTree(interval_vector&& ivals, std::size_t depth = 16, std::size_t minbucket = 64,
+               std::size_t maxbucket = 512, Scalar leftextent = 0, Scalar rightextent = 0)
+      : left(nullptr)
+      , right(nullptr) {
+    --depth;
+    const auto minmaxStop = std::minmax_element(ivals.begin(), ivals.end(), IntervalStopCmp());
+    const auto minmaxStart = std::minmax_element(ivals.begin(), ivals.end(), IntervalStartCmp());
+    if (!ivals.empty()) {
+      center = (minmaxStart.first->start + minmaxStop.second->stop) / 2;
+    }
+    if (leftextent == 0 && rightextent == 0) {
+      // sort intervals by start
+      std::sort(ivals.begin(), ivals.end(), IntervalStartCmp());
+    } else {
+      assert(std::is_sorted(ivals.begin(), ivals.end(), IntervalStartCmp()));
+    }
+    if (depth == 0 || (ivals.size() < minbucket && ivals.size() < maxbucket)) {
+      std::sort(ivals.begin(), ivals.end(), IntervalStartCmp());
+      intervals = std::move(ivals);
+      assert(is_valid().first);
+      return;
+    } else {
+      Scalar leftp = 0;
+      Scalar rightp = 0;
+
+      if (leftextent || rightextent) {
+        leftp = leftextent;
+        rightp = rightextent;
+      } else {
+        leftp = ivals.front().start;
+        rightp = std::max_element(ivals.begin(), ivals.end(), IntervalStopCmp())->stop;
+      }
+
+      interval_vector lefts;
+      interval_vector rights;
+
+      for (typename interval_vector::const_iterator i = ivals.begin(); i != ivals.end(); ++i) {
+        const interval& interval = *i;
+        if (interval.stop < center) {
+          lefts.push_back(interval);
+        } else if (interval.start > center) {
+          rights.push_back(interval);
+        } else {
+          assert(interval.start <= center);
+          assert(center <= interval.stop);
+          intervals.push_back(interval);
+        }
+      }
+
+      if (!lefts.empty()) {
+        left.reset(new IntervalTree(std::move(lefts), depth, minbucket, maxbucket, leftp, center));
+      }
+      if (!rights.empty()) {
+        right.reset(
+          new IntervalTree(std::move(rights), depth, minbucket, maxbucket, center, rightp));
+      }
+    }
+    assert(is_valid().first);
+  }
+
+  // Call f on all intervals near the range [start, stop]:
+  template <class UnaryFunction>
+  void visit_near(const Scalar& start, const Scalar& stop, UnaryFunction f) const {
+    if (!intervals.empty() && !(stop < intervals.front().start)) {
+      for (auto& i : intervals) {
+        f(i);
+      }
+    }
+    if (left && start <= center) {
+      left->visit_near(start, stop, f);
+    }
+    if (right && stop >= center) {
+      right->visit_near(start, stop, f);
+    }
+  }
+
+  // Call f on all intervals crossing pos
+  template <class UnaryFunction>
+  void visit_overlapping(const Scalar& pos, UnaryFunction f) const {
+    visit_overlapping(pos, pos, f);
+  }
+
+  // Call f on all intervals overlapping [start, stop]
+  template <class UnaryFunction>
+  void visit_overlapping(const Scalar& start, const Scalar& stop, UnaryFunction f) const {
+    auto filterF = [&](const interval& interval) {
+      if (interval.stop >= start && interval.start <= stop) {
+        // Only apply f if overlapping
+        f(interval);
+      }
+    };
+    visit_near(start, stop, filterF);
+  }
+
+  // Call f on all intervals contained within [start, stop]
+  template <class UnaryFunction>
+  void visit_contained(const Scalar& start, const Scalar& stop, UnaryFunction f) const {
+    auto filterF = [&](const interval& interval) {
+      if (start <= interval.start && interval.stop <= stop) {
+        f(interval);
+      }
+    };
+    visit_near(start, stop, filterF);
+  }
+
+  interval_vector find_overlapping(const Scalar& start, const Scalar& stop) const {
+    interval_vector result;
+    visit_overlapping(start, stop, [&](const interval& interval) {
+      result.emplace_back(interval);
+    });
+    return result;
+  }
+
+  interval_vector find_contained(const Scalar& start, const Scalar& stop) const {
+    interval_vector result;
+    visit_contained(start, stop, [&](const interval& interval) {
+      result.push_back(interval);
+    });
+    return result;
+  }
+
+  bool empty() const {
+    if (left && !left->empty()) {
+      return false;
+    }
+    if (!intervals.empty()) {
+      return false;
+    }
+    if (right && !right->empty()) {
+      return false;
+    }
+    return true;
+  }
+
+  template <class UnaryFunction>
+  void visit_all(UnaryFunction f) const {
+    if (left) {
+      left->visit_all(f);
+    }
+    std::for_each(intervals.begin(), intervals.end(), f);
+    if (right) {
+      right->visit_all(f);
+    }
+  }
+
+  std::pair<Scalar, Scalar> extent() const {
+    struct Extent {
+      std::pair<Scalar, Scalar> x{std::numeric_limits<Scalar>::max(),
+                                  std::numeric_limits<Scalar>::min()};
+      void operator()(const interval& interval) {
+        x.first = std::min(x.first, interval.start);
+        x.second = std::max(x.second, interval.stop);
+      }
+    };
+    Extent extent;
+
+    visit_all([&](const interval& interval) {
+      extent(interval);
+    });
+    return extent.x;
+  }
+
+  // Check all constraints.
+  // If first is false, second is invalid.
+  std::pair<bool, std::pair<Scalar, Scalar>> is_valid() const {
+    const auto minmaxStop =
+      std::minmax_element(intervals.begin(), intervals.end(), IntervalStopCmp());
+    const auto minmaxStart =
+      std::minmax_element(intervals.begin(), intervals.end(), IntervalStartCmp());
+
+    std::pair<bool, std::pair<Scalar, Scalar>> result = {
+      true, {std::numeric_limits<Scalar>::max(), std::numeric_limits<Scalar>::min()}};
+    if (!intervals.empty()) {
+      result.second.first = std::min(result.second.first, minmaxStart.first->start);
+      result.second.second = std::min(result.second.second, minmaxStop.second->stop);
+    }
+    if (left) {
+      auto valid = left->is_valid();
+      result.first &= valid.first;
+      result.second.first = std::min(result.second.first, valid.second.first);
+      result.second.second = std::min(result.second.second, valid.second.second);
+      if (!result.first) {
+        return result;
+      }
+      if (valid.second.second >= center) {
+        result.first = false;
+        return result;
+      }
+    }
+    if (right) {
+      auto valid = right->is_valid();
+      result.first &= valid.first;
+      result.second.first = std::min(result.second.first, valid.second.first);
+      result.second.second = std::min(result.second.second, valid.second.second);
+      if (!result.first) {
+        return result;
+      }
+      if (valid.second.first <= center) {
+        result.first = false;
+        return result;
+      }
+    }
+    if (!std::is_sorted(intervals.begin(), intervals.end(), IntervalStartCmp())) {
+      result.first = false;
+    }
+    return result;
+  }
+
+private:
+  interval_vector intervals;
+  std::unique_ptr<IntervalTree> left;
+  std::unique_ptr<IntervalTree> right;
+  Scalar center;
+};
+
+}  // namespace internal
+
+}  // namespace mcap

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "intervaltree.hpp"
 #include "types.hpp"
 #include <fstream>
 #include <map>
@@ -11,22 +12,25 @@
 
 namespace mcap {
 
-/**
- * @brief Configuration options for McapReader.
- */
-struct McapReaderOptions {
+enum struct ReadSummaryMethod {
   /**
-   * @brief Read the file sequentially from Header to DataEnd, skipping the
-   * Summary section at the end. Seeking requires reading the file up to the
-   * desired seek point.
+   * @brief Parse the Summary section to produce seeking indexes and summary
+   * statistics. If the Summary section is not present or corrupt, a failure
+   * Status is returned and the seeking indexes and summary statistics are not
+   * populated.
    */
-  bool forceScan;
+  NoFallbackScan,
   /**
    * @brief If the Summary section is missing or incomplete, allow falling back
-   * to reading the file sequentially during summary operations or seeking. This
-   * is equivalent to `forceScan = true` when the Summary cannot be read.
+   * to reading the file sequentially to produce seeking indexes and summary
+   * statistics.
    */
-  bool allowFallbackScan;
+  AllowFallbackScan,
+  /**
+   * @brief Read the file sequentially from Header to DataEnd to produce seeking
+   * indexes and summary statistics.
+   */
+  ForceScan,
 };
 
 /**
@@ -175,7 +179,7 @@ public:
    *   returned, the data source is not considered open and McapReader is not
    *   usable until `open()` is called and a success response is returned.
    */
-  Status open(IReadable& reader, const McapReaderOptions& options = {});
+  Status open(IReadable& reader);
   /**
    * @brief Opens an MCAP file for reading from a std::ifstream input file
    * stream.
@@ -186,7 +190,7 @@ public:
    *   returned, the file is not considered open and McapReader is not usable
    *   until `open()` is called and a success response is returned.
    */
-  Status open(std::ifstream& stream, const McapReaderOptions& options = {});
+  Status open(std::ifstream& stream);
 
   /**
    * @brief Closes the MCAP file, clearing any internal data structures and
@@ -202,7 +206,8 @@ public:
    * upon requesting summary data or first seek if Summary section parsing is
    * allowed by the configuration options.
    */
-  Status readSummary();
+  Status readSummary(
+    ReadSummaryMethod method, const ProblemCallback& onProblem = [](const Status&) {});
 
   /**
    * @brief Returns an iterable view with `begin()` and `end()` methods for
@@ -247,6 +252,10 @@ public:
    * @brief Returns the parsed Footer record, if it has been encountered.
    */
   const std::optional<Footer>& footer() const;
+  /**
+   * @brief Returns the parsed Statistics record, if it has been encountered.
+   */
+  const std::optional<Statistics>& statistics() const;
 
   /**
    * @brief Look up a Channel record by channel ID. If the Channel has not been
@@ -294,27 +303,30 @@ public:
   static std::optional<Compression> ParseCompression(const std::string_view compression);
 
 private:
+  using ChunkInterval = internal::Interval<ByteOffset, ChunkIndex>;
   friend LinearMessageView;
 
   IReadable* input_ = nullptr;
-  McapReaderOptions options_{};
   std::unique_ptr<FileStreamReader> fileStreamInput_;
   std::optional<Header> header_;
   std::optional<Footer> footer_;
   std::optional<Statistics> statistics_;
-  std::vector<ChunkIndex> chunkIndexes_;
-  std::vector<AttachmentIndex> attachmentIndexes_;
+  std::vector<ChunkInterval> chunkIndexes_;
+  internal::IntervalTree<ByteOffset, ChunkIndex> chunkRanges_;
+  std::multimap<std::string, AttachmentIndex> attachmentIndexes_;
+  std::multimap<std::string, MetadataIndex> metadataIndexes_;
   std::unordered_map<SchemaId, SchemaPtr> schemas_;
   std::unordered_map<ChannelId, ChannelPtr> channels_;
   // Used for uncompressed messages
   std::unordered_map<ChannelId, std::map<Timestamp, ByteOffset>> messageIndex_;
-  // Used for messages inside compressed chunks
-  std::unordered_map<ChannelId, std::map<Timestamp, ByteOffset>> messageChunkIndex_;
   ByteOffset dataStart_ = 0;
   ByteOffset dataEnd_ = EndOffset;
   Timestamp startTime_ = 0;
   Timestamp endTime_ = 0;
   bool parsedSummary_ = false;
+
+  Status readSummarySection_(IReadable& reader);
+  Status readSummaryFromScan_(IReadable& reader);
 };
 
 /**
@@ -331,7 +343,9 @@ struct RecordReader {
 
   std::optional<Record> next();
 
-  const Status& status();
+  const Status& status() const;
+
+  ByteOffset curRecordOffset() const;
 
 private:
   IReadable* dataSource_ = nullptr;
@@ -340,10 +354,10 @@ private:
 };
 
 struct TypedChunkReader {
-  std::function<void(const SchemaPtr)> onSchema;
-  std::function<void(const ChannelPtr)> onChannel;
-  std::function<void(const Message&)> onMessage;
-  std::function<void(const Record&)> onUnknownRecord;
+  std::function<void(const SchemaPtr, ByteOffset)> onSchema;
+  std::function<void(const ChannelPtr, ByteOffset)> onChannel;
+  std::function<void(const Message&, ByteOffset)> onMessage;
+  std::function<void(const Record&, ByteOffset)> onUnknownRecord;
 
   TypedChunkReader();
 
@@ -368,23 +382,23 @@ private:
  * data source.
  */
 struct TypedRecordReader {
-  std::function<void(const Header&)> onHeader;
-  std::function<void(const Footer&)> onFooter;
-  std::function<void(const SchemaPtr)> onSchema;
-  std::function<void(const ChannelPtr)> onChannel;
-  std::function<void(const Message&)> onMessage;
-  std::function<void(const Chunk&)> onChunk;
-  std::function<void(const MessageIndex&)> onMessageIndex;
-  std::function<void(const ChunkIndex&)> onChunkIndex;
-  std::function<void(const Attachment&)> onAttachment;
-  std::function<void(const AttachmentIndex&)> onAttachmentIndex;
-  std::function<void(const Statistics&)> onStatistics;
-  std::function<void(const Metadata&)> onMetadata;
-  std::function<void(const MetadataIndex&)> onMetadataIndex;
-  std::function<void(const SummaryOffset&)> onSummaryOffset;
-  std::function<void(const DataEnd&)> onDataEnd;
-  std::function<void(const Record&)> onUnknownRecord;
-  std::function<void(void)> onChunkEnd;
+  std::function<void(const Header&, ByteOffset)> onHeader;
+  std::function<void(const Footer&, ByteOffset)> onFooter;
+  std::function<void(const SchemaPtr, ByteOffset, std::optional<ByteOffset>)> onSchema;
+  std::function<void(const ChannelPtr, ByteOffset, std::optional<ByteOffset>)> onChannel;
+  std::function<void(const Message&, ByteOffset, std::optional<ByteOffset>)> onMessage;
+  std::function<void(const Chunk&, ByteOffset)> onChunk;
+  std::function<void(const MessageIndex&, ByteOffset)> onMessageIndex;
+  std::function<void(const ChunkIndex&, ByteOffset)> onChunkIndex;
+  std::function<void(const Attachment&, ByteOffset)> onAttachment;
+  std::function<void(const AttachmentIndex&, ByteOffset)> onAttachmentIndex;
+  std::function<void(const Statistics&, ByteOffset)> onStatistics;
+  std::function<void(const Metadata&, ByteOffset)> onMetadata;
+  std::function<void(const MetadataIndex&, ByteOffset)> onMetadataIndex;
+  std::function<void(const SummaryOffset&, ByteOffset)> onSummaryOffset;
+  std::function<void(const DataEnd&, ByteOffset)> onDataEnd;
+  std::function<void(const Record&, ByteOffset, std::optional<ByteOffset>)> onUnknownRecord;
+  std::function<void(ByteOffset)> onChunkEnd;
 
   TypedRecordReader(IReadable& dataSource, ByteOffset startOffset,
                     ByteOffset endOffset = EndOffset);

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -139,6 +139,10 @@ private:
   std::unique_ptr<CryptoPP::CRC32> crc_;
 };
 
+/**
+ * @brief Implements the IWritable interface used by McapWriter by wrapping a
+ * FILE* pointer created by fopen() and a write buffer.
+ */
 class FileWriter final : public IWritable {
 public:
   ~FileWriter() override;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -377,6 +377,12 @@ public:
    */
   Status write(const Metadata& metdata);
 
+  /**
+   * @brief Current MCAP file-level statistics. This is written as a Statistics
+   * record in the Summary section of the MCAP file.
+   */
+  const Statistics& statistics() const;
+
   // The following static methods are used for serialization of records and
   // primitives to an output stream. They are not intended to be used directly
   // unless you are implementing a lower level writer or tests

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -642,6 +642,10 @@ Status McapWriter::write(const Metadata& metadata) {
   return StatusCode::Success;
 }
 
+const Statistics& McapWriter::statistics() const {
+  return statistics_;
+}
+
 // Private methods /////////////////////////////////////////////////////////////
 
 IWritable& McapWriter::getOutput() {

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -21,3 +21,4 @@ target_link_libraries(streamed-writer-conformance ${CONAN_LIBS})
 
 add_executable(unit-tests unit-tests.cpp)
 target_link_libraries(unit-tests ${CONAN_LIBS})
+target_compile_definitions(unit-tests PRIVATE TEST_DATA_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data/")

--- a/cpp/test/data/001.mcap
+++ b/cpp/test/data/001.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8755b372ca74d8760b7e2c55714f59f1569dd583026e56b032adf84076858cb5
+size 365

--- a/cpp/test/streamed-reader-conformance.cpp
+++ b/cpp/test/streamed-reader-conformance.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 using json = nlohmann::ordered_json;
+using mcap::ByteOffset;
 
 json ToJson(const std::byte* data, uint64_t size) {
   json output = json::array();
@@ -36,7 +37,7 @@ int main(int argc, char** argv) {
   mcap::FileStreamReader dataSource{input};
   mcap::TypedRecordReader reader{dataSource, 8};
 
-  reader.onHeader = [&](const mcap::Header& header) {
+  reader.onHeader = [&](const mcap::Header& header, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "Header"},
       {"fields", json::array({
@@ -46,7 +47,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onFooter = [&](const mcap::Footer& footer) {
+  reader.onFooter = [&](const mcap::Footer& footer, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "Footer"},
       {"fields", json::array({
@@ -57,7 +58,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onSchema = [&](const mcap::SchemaPtr schemaPtr) {
+  reader.onSchema = [&](const mcap::SchemaPtr schemaPtr, ByteOffset, std::optional<ByteOffset>) {
     const auto& schema = *schemaPtr;
     recordsJson.push_back(json::object({
       {"type", "Schema"},
@@ -70,7 +71,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onChannel = [&](const mcap::ChannelPtr channelPtr) {
+  reader.onChannel = [&](const mcap::ChannelPtr channelPtr, ByteOffset, std::optional<ByteOffset>) {
     const auto& channel = *channelPtr;
     recordsJson.push_back(json::object({
       {"type", "Channel"},
@@ -84,7 +85,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onMessage = [&](const mcap::Message& message) {
+  reader.onMessage = [&](const mcap::Message& message, ByteOffset, std::optional<ByteOffset>) {
     recordsJson.push_back(json::object({
       {"type", "Message"},
       {"fields", json::array({
@@ -97,7 +98,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  // reader.onChunk = [&](const mcap::Chunk& chunk) {
+  // reader.onChunk = [&](const mcap::Chunk& chunk, ByteOffset) {
   //   recordsJson.push_back(json::object({
   //     {"type", "Chunk"},
   //     {"fields", json::array({
@@ -111,7 +112,7 @@ int main(int argc, char** argv) {
   //   }));
   // };
 
-  // reader.onMessageIndex = [&](const mcap::MessageIndex& messageIndex) {
+  // reader.onMessageIndex = [&](const mcap::MessageIndex& messageIndex, ByteOffset) {
   //   recordsJson.push_back(json::object({
   //     {"type", "MessageIndex"},
   //     {"fields", json::array({
@@ -121,7 +122,7 @@ int main(int argc, char** argv) {
   //   }));
   // };
 
-  reader.onChunkIndex = [&](const mcap::ChunkIndex& chunkIndex) {
+  reader.onChunkIndex = [&](const mcap::ChunkIndex& chunkIndex, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "ChunkIndex"},
       {"fields", json::array({
@@ -138,7 +139,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onAttachment = [&](const mcap::Attachment& attachment) {
+  reader.onAttachment = [&](const mcap::Attachment& attachment, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "Attachment"},
       {"fields", json::array({
@@ -151,7 +152,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onAttachmentIndex = [&](const mcap::AttachmentIndex& attachmentIndex) {
+  reader.onAttachmentIndex = [&](const mcap::AttachmentIndex& attachmentIndex, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "AttachmentIndex"},
       {"fields", json::array({
@@ -166,7 +167,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onStatistics = [&](const mcap::Statistics& statistics) {
+  reader.onStatistics = [&](const mcap::Statistics& statistics, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "Statistics"},
       {"fields", json::array({
@@ -183,7 +184,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onMetadata = [&](const mcap::Metadata& metadata) {
+  reader.onMetadata = [&](const mcap::Metadata& metadata, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "Metadata"},
       {"fields", json::array({
@@ -193,7 +194,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onMetadataIndex = [&](const mcap::MetadataIndex& metadataIndex) {
+  reader.onMetadataIndex = [&](const mcap::MetadataIndex& metadataIndex, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "MetadataIndex"},
       {"fields", json::array({
@@ -204,7 +205,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onSummaryOffset = [&](const mcap::SummaryOffset& summaryOffset) {
+  reader.onSummaryOffset = [&](const mcap::SummaryOffset& summaryOffset, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "SummaryOffset"},
       {"fields", json::array({
@@ -215,7 +216,7 @@ int main(int argc, char** argv) {
     }));
   };
 
-  reader.onDataEnd = [&](const mcap::DataEnd& dataEnd) {
+  reader.onDataEnd = [&](const mcap::DataEnd& dataEnd, ByteOffset) {
     recordsJson.push_back(json::object({
       {"type", "DataEnd"},
       {"fields", json::array({

--- a/cpp/test/unit-tests.cpp
+++ b/cpp/test/unit-tests.cpp
@@ -40,6 +40,7 @@ void requireOk(const mcap::Status& status) {
   CAPTURE(status.code);
   CAPTURE(status.message);
   REQUIRE(status.ok());
+}
 
 TEST_CASE("internal::crc32", "[writer]") {
   const auto crc32 = [](const uint8_t* data, size_t len) {

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,6 +5,7 @@ ignorePaths:
   - node_modules
   - go.mod
   - go.sum
+  - intervaltree.hpp
   - testdata
   - CMakeLists.txt
   - Makefile


### PR DESCRIPTION
**Public-Facing Changes**

C++
 * TypedRecordReader callbacks now have fileOffset/chunkOffset arguments
 * Removed McapReaderOptions
 * Changed McapReader.readSummary() to take a method enum and problem callback
 * McapWriter.statistics()
 * McapReader.open(filename)
 * FileReader
 * McapReader.chunkIndexes()

**Description**

A handful of changes (several of them API-breaking) to add full summary parsing to McapReader, including an option to fall back to a full scan of the file to reconstruct summary information.

A follow-up PR will add one or more methods for querying the interval tree to enable fast seeking for summarized files.
