### PR TITLE
CLI: Add library and profile to "info" output.

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -22,6 +22,8 @@ var (
 
 func printInfo(w io.Writer, info *mcap.Info) error {
 	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "library: %s\n", info.Header.Library)
+	fmt.Fprintf(buf, "profile: %s\n", info.Header.Profile)
 	fmt.Fprintf(buf, "messages: %d\n", info.Statistics.MessageCount)
 	start := info.Statistics.MessageStartTime
 	end := info.Statistics.MessageEndTime

--- a/go/conformance/test-streamed-write-conformance/main.go
+++ b/go/conformance/test-streamed-write-conformance/main.go
@@ -36,6 +36,7 @@ func parseOptions(features []string) (*mcap.WriterOptions, error) {
 		SkipMetadataIndex:        true,
 		SkipChunkIndex:           true,
 		SkipSummaryOffsets:       true,
+		OverrideLibrary:          true,
 	}
 	for _, feature := range features {
 		switch feature {

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -3,6 +3,7 @@ package mcap
 import (
 	"errors"
 	"math"
+	"runtime/debug"
 )
 
 // Magic is the magic number for an MCAP file.
@@ -25,6 +26,14 @@ type CompressionFormat string
 // String converts a compression format to a string for display.
 func (c CompressionFormat) String() string {
 	return string(c)
+}
+
+func Version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	return info.Main.Version
 }
 
 const (
@@ -282,6 +291,7 @@ type Info struct {
 	Schemas           map[uint16]*Schema
 	ChunkIndexes      []*ChunkIndex
 	AttachmentIndexes []*AttachmentIndex
+	Header            *Header
 }
 
 // ChannelCounts counts the number of messages on each channel in an Info.

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -30,7 +30,7 @@ func TestMCAPReadWrite(t *testing.T) {
 		assert.Equal(t, "ros1", profile)
 		library, _, err := readPrefixedString(record, offset)
 		assert.Nil(t, err)
-		assert.Equal(t, "", library)
+		assert.Equal(t, "mcap go #unknown", library)
 		assert.Equal(t, TokenHeader, tokenType)
 	})
 	t.Run("zero-valued schema IDs permitted", func(t *testing.T) {
@@ -310,10 +310,10 @@ func TestIndexStructures(t *testing.T) {
 		assert.Equal(t, &ChunkIndex{
 			MessageStartTime: 1,
 			MessageEndTime:   1,
-			ChunkStartOffset: 96,
+			ChunkStartOffset: 112,
 			ChunkLength:      144,
 			MessageIndexOffsets: map[uint16]uint64{
-				1: 240,
+				1: 256,
 			},
 			MessageIndexLength: 31,
 			Compression:        "zstd",
@@ -325,7 +325,7 @@ func TestIndexStructures(t *testing.T) {
 		assert.Equal(t, 1, len(w.AttachmentIndexes))
 		attachmentIndex := w.AttachmentIndexes[0]
 		assert.Equal(t, &AttachmentIndex{
-			Offset:      29,
+			Offset:      45,
 			Length:      67,
 			LogTime:     100,
 			CreateTime:  99,

--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -228,7 +228,6 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions) error {
 
 	err = writer.WriteHeader(&mcap.Header{
 		Profile: "ros1",
-		Library: "golang-mcap-v0",
 	})
 	if err != nil {
 		return err

--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -217,7 +217,6 @@ func DB3ToMCAP(w io.Writer, db *sql.DB, opts *mcap.WriterOptions, searchdirs []s
 	defer writer.Close()
 	err = writer.WriteHeader(&mcap.Header{
 		Profile: "ros2",
-		Library: "golang-db3-mcap",
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds library and profile to the info output. Also switches the writer to
deriving the library version from runtime build info. A Library provided
to WriteHeader will be appended to the derived one with a semicolon
separator.