### PR TITLE
Update KSY definition to allow navigation via footer and summary

### DIFF
--- a/docs/specification/mcap.ksy
+++ b/docs/specification/mcap.ksy
@@ -122,6 +122,7 @@ types:
       summary_offset_section:
         io: _root._io
         pos: summary_offset_start
+        size: "_root._io.size - 8 - 20 - 9 - summary_offset_start"
         type: records
         if: summary_offset_start != 0
 

--- a/docs/specification/mcap.ksy
+++ b/docs/specification/mcap.ksy
@@ -113,13 +113,13 @@ types:
       - { id: summary_offset_start, type: u8 }
       - { id: summary_crc, type: u4 }
     instances:
-      summary_records:
+      summary_section:
         io: _root._io
         pos: summary_start
-        size: "(summary_offset_start != 0 ? summary_offset_start : _root._io.size) - summary_start"
+        size: "(summary_offset_start != 0 ? summary_offset_start : _root._io.size - 8 - 20 - 9) - summary_start"
         type: records
         if: summary_start != 0
-      summary_offset_records:
+      summary_offset_section:
         io: _root._io
         pos: summary_offset_start
         type: records

--- a/docs/specification/mcap.ksy
+++ b/docs/specification/mcap.ksy
@@ -26,6 +26,12 @@ seq:
   - id: footer_magic
     contents: [0x89, "MCAP0\r\n"]
 
+instances:
+  footer:
+    pos: _io.size - 8 - 20 - 9
+    size-eos: true
+    type: record
+
 enums:
   opcode:
     0x01: header
@@ -64,6 +70,13 @@ types:
       - { id: len, type: u4 }
       - { id: entry, size: len, type: entries }
 
+  records:
+    seq:
+      - id: records
+        type: record
+        repeat: until
+        repeat-until: "_io.pos + 8 >= _io.size"
+
   record:
     seq:
       - { id: op, type: u1, enum: opcode }
@@ -99,6 +112,18 @@ types:
       - { id: summary_start, type: u8 }
       - { id: summary_offset_start, type: u8 }
       - { id: summary_crc, type: u4 }
+    instances:
+      summary_records:
+        io: _root._io
+        pos: summary_start
+        size: "(summary_offset_start != 0 ? summary_offset_start : _root._io.size) - summary_start"
+        type: records
+        if: summary_start != 0
+      summary_offset_records:
+        io: _root._io
+        pos: summary_offset_start
+        type: records
+        if: summary_offset_start != 0
 
   schema:
     seq:
@@ -259,10 +284,6 @@ types:
       - { id: group_opcode, type: u1, enum: opcode }
       - { id: group_start, type: u8 }
       - { id: group_length, type: u8 }
-    types:
-      records:
-        seq:
-          - { id: records, type: record, repeat: eos }
     instances:
       group:
         io: _root._io


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Adding `instances` for the file footer and summary sections enables navigating the file using the footer:

<img width="691" alt="image" src="https://user-images.githubusercontent.com/14237/159053304-e4c7a607-1b3f-4286-9c9b-d1537f4f0771.png">