### PR TITLE
Add McapReader seeking, channels(), schemas(), byteRange(), McapWriter dataSink()

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,29 +21,10 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Test mcap",
-      "program": "/Applications/Xcode.app/Contents/Developer/usr/bin/xctest",
-      "args": [".build/debug/mcapPackageTests.xctest"],
-      "cwd": "${workspaceFolder:mcap}",
-      "preLaunchTask": "swift: Build All"
-    },
-    {
-      "type": "lldb",
-      "request": "launch",
-      "name": "Debug conformance",
-      "program": "${workspaceFolder:mcap}/.build/debug/conformance",
+      "name": "C++ unit tests",
+      "program": "${workspaceFolder}/cpp/test/build/Debug/bin/unit-tests",
       "args": [],
-      "cwd": "${workspaceFolder:mcap}",
-      "preLaunchTask": "swift: Build Debug conformance"
-    },
-    {
-      "type": "lldb",
-      "request": "launch",
-      "name": "Release conformance",
-      "program": "${workspaceFolder:mcap}/.build/release/conformance",
-      "args": [],
-      "cwd": "${workspaceFolder:mcap}",
-      "preLaunchTask": "swift: Build Release conformance"
+      "cwd": "${workspaceFolder}"
     }
   ]
 }

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -283,6 +283,24 @@ public:
                                  Timestamp endTime = MaxTime);
 
   /**
+   * @brief Returns starting and ending byte offsets that must be read to
+   * iterate all messges in the given time range. If `readSummary()` has been
+   * successfully called and the recording contains Chunk records, this range
+   * will be narrowed to Chunk records that contain messages in the given time
+   * range. Otherwise, this range will be the entire Data section if the Data
+   * End record has been found or the entire file otherwise.
+   *
+   * This method is automatically used by `readMessages()`, and only needs to be
+   * called directly if the caller is manually constructing an iterator.
+   *
+   * @param startTime Start time in nanoseconds.
+   * @param endTime Optional end time in nanoseconds.
+   * @return Start and end byte offsets.
+   */
+  std::pair<ByteOffset, ByteOffset> byteRange(Timestamp startTime,
+                                              Timestamp endTime = MaxTime) const;
+
+  /**
    * @brief Returns a pointer to the IReadable data source backing this reader.
    * Will return nullptr if the reader is not open.
    */
@@ -302,6 +320,17 @@ public:
   const std::optional<Statistics>& statistics() const;
 
   /**
+   * @brief Returns all of the parsed Channel records. Call `readSummary()`
+   * first to fully populate this data structure.
+   */
+  const std::unordered_map<ChannelId, ChannelPtr> channels() const;
+  /**
+   * @brief Returns all of the parsed Schema records. Call `readSummary()`
+   * first to fully populate this data structure.
+   */
+  const std::unordered_map<SchemaId, SchemaPtr> schemas() const;
+
+  /**
    * @brief Look up a Channel record by channel ID. If the Channel has not been
    * encountered yet or does not exist in the file, this will return nullptr.
    *
@@ -318,6 +347,10 @@ public:
    */
   SchemaPtr schema(SchemaId schemaId) const;
 
+  /**
+   * @brief Returns all of the parsed ChunkIndex records. Call `readSummary()`
+   * first to fully populate this data structure.
+   */
   const std::vector<ChunkIndex>& chunkIndexes() const;
 
   // The following static methods are used internally for parsing MCAP records

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -383,6 +383,12 @@ public:
    */
   const Statistics& statistics() const;
 
+  /**
+   * @brief Returns a pointer to the IWritable data destination backing this
+   * writer. Will return nullptr if the writer is not open.
+   */
+  IWritable* dataSink();
+
   // The following static methods are used for serialization of records and
   // primitives to an output stream. They are not intended to be used directly
   // unless you are implementing a lower level writer or tests

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -649,6 +649,10 @@ const Statistics& McapWriter::statistics() const {
   return statistics_;
 }
 
+IWritable* McapWriter::dataSink() {
+  return output_;
+}
+
 // Private methods /////////////////////////////////////////////////////////////
 
 IWritable& McapWriter::getOutput() {


### PR DESCRIPTION
**Public-Facing Changes**

**C++**

- McapReader.readMessages() will only iterate over the relevant portion of the file if readSummary() has been successfully called and a time range is given
- McapReader.byteRange()
- McapReader.channels()
- McapReader.schemas()
- McapWriter.dataSink()

**Description**

These are the remaining C++ API methods required to finish the rosbag2_storage_mcap implementation
