### PR TITLE
Make mcap::Status [[nodiscard]]

### DIFF
--- a/cpp/bench/run.cpp
+++ b/cpp/bench/run.cpp
@@ -34,6 +34,12 @@ static void BM_CRC32(benchmark::State& state) {
   state.SetBytesProcessed(int64_t(state.iterations()) * int64_t(size));
 }
 
+static void assertOk(const mcap::Status& status) {
+  if (!status.ok()) {
+    throw std::runtime_error(status.message);
+  }
+}
+
 static void BM_McapWriterBufferWriterUnchunkedUnindexed(benchmark::State& state) {
   // Create a message payload
   std::array<std::byte, 4 + 13> payload;
@@ -70,7 +76,7 @@ static void BM_McapWriterBufferWriterUnchunkedUnindexed(benchmark::State& state)
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -114,7 +120,7 @@ static void BM_McapWriterBufferWriterUnchunked(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -158,7 +164,7 @@ static void BM_McapWriterBufferWriterChunked(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -203,7 +209,7 @@ static void BM_McapWriterBufferWriterChunkedNoCRC(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -248,7 +254,7 @@ static void BM_McapWriterBufferWriterChunkedUnindexed(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -294,7 +300,7 @@ static void BM_McapWriterBufferWriterLZ4(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -340,7 +346,7 @@ static void BM_McapWriterBufferWriterZStd(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -387,7 +393,7 @@ static void BM_McapWriterBufferWriterZStdNoCRC(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -432,7 +438,7 @@ static void BM_McapWriterStreamWriterUnchunked(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -478,7 +484,7 @@ static void BM_McapWriterStreamWriterChunked(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }
@@ -502,7 +508,7 @@ static void BM_McapWriterFileWriterChunked(benchmark::State& state) {
 
   // Open an output file stream and write the file header
   const std::string filename = TempFilename();
-  writer.open(filename, options);
+  assertOk(writer.open(filename, options));
 
   // Register a Schema record
   mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
@@ -523,7 +529,7 @@ static void BM_McapWriterFileWriterChunked(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (size_t i = 0; i < WriteIterations; i++) {
-      writer.write(msg);
+      (void)writer.write(msg);
       benchmark::ClobberMemory();
     }
   }

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -7,7 +7,7 @@ class McapConan(ConanFile):
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"
-    license = "MIT"
+    license = "Apache-2.0"
     topics = ("mcap", "serialization", "deserialization", "recording")
 
     settings = ("os", "compiler", "build_type", "arch")

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -30,7 +30,7 @@ enum class StatusCode {
 /**
  * @brief Wraps a status code and string message carrying additional context.
  */
-struct Status {
+struct [[nodiscard]] Status {
   StatusCode code;
   std::string message;
 

--- a/cpp/test/streamed-writer-conformance.cpp
+++ b/cpp/test/streamed-writer-conformance.cpp
@@ -215,6 +215,12 @@ private:
   uint64_t size_ = 0;
 };
 
+static void assertOk(const mcap::Status& status) {
+  if (!status.ok()) {
+    throw std::runtime_error(status.message);
+  }
+}
+
 int main(int argc, char** argv) {
   if (argc != 2) {
     std::cerr << "Usage: " << argv[0] << " <input.mcap>\n";
@@ -250,14 +256,14 @@ int main(int argc, char** argv) {
     } else if (recordType == "Message") {
       mcap::ByteArray buffer;
       const auto message = ReadMessage(record, buffer);
-      mcapWriter.write(message);
+      assertOk(mcapWriter.write(message));
     } else if (recordType == "Attachment") {
       mcap::ByteArray buffer;
       auto attachment = ReadAttachment(record, buffer);
-      mcapWriter.write(attachment);
+      assertOk(mcapWriter.write(attachment));
     } else if (recordType == "Metadata") {
       auto metadata = ReadMetadata(record);
-      mcapWriter.write(metadata);
+      assertOk(mcapWriter.write(metadata));
     } else if (recordType == "DataEnd") {
       mcapWriter.close();
       return 0;


### PR DESCRIPTION
**Public-Facing Changes**
The C++ compiler will produce an error when a `mcap::Status` is unintentionally discarded. Use a `(void)status` cast to intentionally discard a status.

**Description**
Also update conanfile license to match this repo's license