### PR TITLE
Fix range check in unit test Buffer::read

### DIFF
--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -21,4 +21,3 @@ target_link_libraries(streamed-writer-conformance ${CONAN_LIBS})
 
 add_executable(unit-tests unit-tests.cpp)
 target_link_libraries(unit-tests ${CONAN_LIBS})
-target_compile_definitions(unit-tests PRIVATE TEST_DATA_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data/")

--- a/cpp/test/data/001.mcap
+++ b/cpp/test/data/001.mcap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8755b372ca74d8760b7e2c55714f59f1569dd583026e56b032adf84076858cb5
-size 365


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Fixed an incorrect `>=` check in `Buffer`. Updated tests to generate data using Buffer instead of a fixture file, thus exercising the fixed code.
 
Found when writing test code for https://github.com/conan-io/conan-center-index/pull/9848