### PR TITLE
Go: break ties in indexed reading on chunk offset

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -262,6 +262,9 @@ func (it *indexedMessageIterator) loadNextChunkset() error {
 		}
 	}
 	sort.Slice(it.messageOffsets, func(i, j int) bool {
+		if it.messageOffsets[i].timestamp == it.messageOffsets[j].timestamp {
+			return it.messageOffsets[i].chunkOffset < it.messageOffsets[j].chunkOffset
+		}
 		return it.messageOffsets[i].timestamp < it.messageOffsets[j].timestamp
 	})
 	it.messageOffsetIdx = 0


### PR DESCRIPTION
Prior to this commit, indexed playback of mcap files with the go library
would not deterministically resolve ties on timestamp. With this change
such ties are broken by the physical offset of the message in the chunk.