### PR TITLE
move docs to subfolder in pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,17 +82,13 @@ jobs:
       - name: Push updated docs to GitHub Pages
         run: |
           set -x
-          COMMIT_MSG="Update docs from $GITHUB_REF_NAME ($(git rev-parse --short HEAD))"
-          for DIR in typescript python swift cpp; do
-            sudo rm -rf $DIR
-            cp -R __docs__/$DIR .
-            touch $DIR/.nojekyll
-            git add $DIR
-          done
+          sudo rm -rf docs
+          cp -R __docs__ docs
+          git add docs
           git diff --cached --stat
           if git diff --cached --quiet; then
             echo "No changes to publish"
           else
-            git -c user.name=Foxglove -c user.email=contact@foxglove.dev commit -m "$COMMIT_MSG"
+            git -c user.name=Foxglove -c user.email=contact@foxglove.dev commit -m "Update docs from $GITHUB_REF_NAME (${GITHUB_SHA::7})"
             git push origin gh-pages
           fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
             --output-path __docs__/swift \
             --disable-indexing \
             --transform-for-static-hosting \
-            --hosting-base-path mcap/swift
+            --hosting-base-path mcap/docs/swift
 
       # https://github.com/actions/upload-artifact/issues/85
       - run: tar -czf __docs__.tgz __docs__


### PR DESCRIPTION
This will allow us to use a glob in a jekyll config file to include files from the whole docs dir at once.