### PR TITLE
Fix chunk start & end time calculation

### DIFF
--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -164,11 +164,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
-                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+                "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b",
+                "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==3.9.2"
         },
         "idna": {
             "hashes": [
@@ -203,11 +203,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
-                "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
+                "sha256:a2f09a92f358b96b5f6ca6ecb4502669c4acb55d8733bbb2b2c9c4af5564c605",
+                "sha256:da424924c069a4013730d8dd010cbecac7e7bb752be388db3741688bffb48dc6"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.0"
         },
         "m2r2": {
             "hashes": [
@@ -323,11 +323,11 @@
         },
         "pipenv": {
             "hashes": [
-                "sha256:3b80b4512934b9d8e8ce12c988394642ff96bb697680e5b092e59af503178327",
-                "sha256:f84d7119239b22ab2ac2b8fbc7d619d83cf41135206d72a17c4f151cda529fd0"
+                "sha256:08ac2ebe788eb30ee1e0bfdff8c758e0cf4893fc118250e372fd2e29a79b66a5",
+                "sha256:800198d430e724f899e6db319cc640d5fd6da2acdbc301ceb1a1f967e990428b"
             ],
             "index": "pypi",
-            "version": "==2022.1.8"
+            "version": "==2022.3.24"
         },
         "platformdirs": {
             "hashes": [
@@ -355,19 +355,19 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
+                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.8.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.7.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
-                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
+                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.0"
+            "version": "==2.3.1"
         },
         "pygments": {
             "hashes": [
@@ -387,11 +387,11 @@
         },
         "pyright": {
             "hashes": [
-                "sha256:1884300bc1d22b7828bc33c345822ca9625ecc7463d4cda4ae4be19880afd7de",
-                "sha256:f72068677ad4b249a066a3c4a2bb17d5f7a80a2dae80020bee2dd1a39c870794"
+                "sha256:08d893a3404abce5efcaf78824c6a40df6f008b90b6c576d39dd79664736f0e1",
+                "sha256:2c79e532815f89e8d4fa931b105840c1f2838431bfad457c5b3d34b1ad3cba47"
             ],
             "index": "pypi",
-            "version": "==1.1.231"
+            "version": "==1.1.232"
         },
         "pytest": {
             "hashes": [
@@ -502,6 +502,36 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e",
+                "sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344",
+                "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266",
+                "sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a",
+                "sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd",
+                "sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d",
+                "sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837",
+                "sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098",
+                "sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e",
+                "sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27",
+                "sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b",
+                "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596",
+                "sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76",
+                "sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30",
+                "sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4",
+                "sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78",
+                "sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca",
+                "sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985",
+                "sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb",
+                "sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88",
+                "sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7",
+                "sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5",
+                "sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e",
+                "sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7"
+            ],
+            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
+            "version": "==1.5.2"
         },
         "typing-extensions": {
             "hashes": [

--- a/python/mcap/mcap0/chunk_builder.py
+++ b/python/mcap/mcap0/chunk_builder.py
@@ -29,7 +29,9 @@ class ChunkBuilder:
     def add_message(self, message: Message):
         if self.num_messages == 0:
             self.message_start_time = message.log_time
-        self.message_end_time = message.log_time
+        else:
+            self.message_start_time = min(self.message_start_time, message.log_time)
+        self.message_end_time = max(self.message_end_time, message.log_time)
 
         if not self.message_indices.get(message.channel_id):
             self.message_indices[message.channel_id] = MessageIndex(

--- a/python/mcap/mcap0/chunk_builder.py
+++ b/python/mcap/mcap0/chunk_builder.py
@@ -27,7 +27,7 @@ class ChunkBuilder:
         schema.write(self.record_writer)
 
     def add_message(self, message: Message):
-        if self.message_start_time == 0:
+        if self.num_messages == 0:
             self.message_start_time = message.log_time
         self.message_end_time = message.log_time
 

--- a/python/mcap/mcap0/stream_reader.py
+++ b/python/mcap/mcap0/stream_reader.py
@@ -97,16 +97,16 @@ class StreamReader:
                 self.__footer = record
                 read_magic(self.__stream)
 
-    def __init__(self, input: Union[str, RawIOBase, BufferedReader]):
+    def __init__(self, input: Union[str, BytesIO, RawIOBase, BufferedReader]):
         """
         input: The input stream from which to read records.
         """
-        if isinstance(input, BufferedReader):
-            self.__stream = ReadDataStream(input)
-        elif isinstance(input, str):
+        if isinstance(input, str):
             self.__stream = ReadDataStream(open(input, "rb"))
-        else:
+        elif isinstance(input, RawIOBase):
             self.__stream = ReadDataStream(BufferedReader(input))
+        else:
+            self.__stream = ReadDataStream(input)
         self.__footer: Optional[Footer] = None
         self.__magic = False
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap
-version = 0.0.7
+version = 0.0.8
 description = MCAP libraries for Python
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/python/tests/test_chunk_log_time.py
+++ b/python/tests/test_chunk_log_time.py
@@ -1,0 +1,64 @@
+import json
+from io import BytesIO
+
+from mcap.mcap0.records import ChunkIndex
+from mcap.mcap0.stream_reader import StreamReader
+from mcap.mcap0.writer import Writer
+
+
+def test_json_schema():
+    output = BytesIO()
+    writer = Writer(output)
+
+    writer.start(profile="x-custom", library="my-writer-v1")
+
+    schema_id = writer.register_schema(
+        name="foxglove.FrameTransform",
+        encoding="jsonschema",
+        data=json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "string",
+                    },
+                },
+            }
+        ).encode(),
+    )
+
+    channel_id = writer.register_channel(
+        schema_id=schema_id,
+        topic="/test",
+        message_encoding="json",
+    )
+
+    writer.add_message(
+        channel_id=channel_id,
+        log_time=0,
+        data=json.dumps(
+            {
+                "data": "testA",
+            }
+        ).encode("utf-8"),
+        publish_time=0,
+    )
+
+    writer.add_message(
+        channel_id=channel_id,
+        log_time=1000000000,
+        data=json.dumps(
+            {
+                "data": "testB",
+            }
+        ).encode("utf-8"),
+        publish_time=1000000000,
+    )
+
+    writer.finish()
+
+    output.seek(0)
+    reader = StreamReader(output)
+    chunk_index = [r for r in reader.records if isinstance(r, ChunkIndex)][0]
+
+    assert chunk_index.message_start_time == 0


### PR DESCRIPTION
**Public-Facing Changes**
This fixes an error in the message start and end time calculation for chunks.

**Description**
The existing logic would overwrite a message start time of zero if any subsequent messages had a later start time. The new logic is to set the chunk start time and end time to the minimum and maximum times of all received messages.

Fixes https://github.com/foxglove/studio/issues/3073