### PR TITLE
Update hostingBasePath for Swift docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -113,7 +113,7 @@ jobs:
             --output-path __docs__/swift \
             --disable-indexing \
             --transform-for-static-hosting \
-            --hosting-base-path mcap/docs/swift
+            --hosting-base-path docs/swift
 
       # https://github.com/actions/upload-artifact/issues/85
       - run: tar -czf docs-swift.tgz __docs__/swift


### PR DESCRIPTION
Updates `--hosting-base-path` now that we are hosting the site on mcap.dev rather than foxglove.github.io/mcap.