### PR TITLE
Go ROS utilities: Skip action topics in db3 conversion

### DIFF
--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/foxglove/mcap/go/mcap v0.0.0-20220316142927-cc81709134cd
 	github.com/foxglove/mcap/go/ros v0.0.0-20220316142927-cc81709134cd
-	github.com/golang/protobuf v1.5.2
 	github.com/klauspost/compress v1.14.1
 	github.com/mattn/go-sqlite3 v1.14.11
 	github.com/olekukonko/tablewriter v0.0.5
@@ -23,6 +22,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -8,9 +8,14 @@ import (
 	"io"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/foxglove/mcap/go/mcap"
+)
+
+var (
+	messageTopicRegex = regexp.MustCompile(`\w+/msg/.*`)
 )
 
 func getSchema(encoding string, rosType string, directories []string) ([]byte, error) {
@@ -180,7 +185,9 @@ func getTopics(db *sql.DB) ([]topicsRecord, error) {
 		if err != nil {
 			return nil, err
 		}
-		topics = append(topics, record)
+		if messageTopicRegex.MatchString(record.typ) {
+			topics = append(topics, record)
+		}
 	}
 	return topics, nil
 }

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -73,3 +73,32 @@ int32 foo
 		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
 	})
 }
+
+func TestMessageTopicRegex(t *testing.T) {
+	cases := []struct {
+		assertion string
+		input     string
+		match     bool
+	}{
+		{
+			"message topic",
+			"turtlesim/msg/Pose",
+			true,
+		},
+		{
+			"message topic",
+			"action_msgs/msg/GoalStatusArray",
+			true,
+		},
+		{
+			"action topic",
+			"action_msgs/action/GoalStatusArray",
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			assert.Equal(t, c.match, messageTopicRegex.MatchString(c.input))
+		})
+	}
+}


### PR DESCRIPTION
Restricts db3 conversion to message topics only. Topics in rosbag2 db3
files can also correspond to actions, and we need to ensure that these
are correctly handled before we support them.