### PR TITLE
Improve doctor tool to validate ChunkIndex records

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "eslint.options": {
     "reportUnusedDisableDirectives": true
   },
-  "jest.jestCommandLine": "yarn workspace @foxglove/mcap test",
+  "jest.jestCommandLine": "yarn workspace @mcap/core test",
 
   "cSpell.enabled": true,
 
@@ -30,8 +30,5 @@
   "lldb.library": "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB",
   "python.linting.flake8Enabled": true,
   "python.linting.enabled": true,
-  "python.linting.flake8Args": [
-    "--config",
-    "python/.flake8"
-  ]
+  "python.linting.flake8Args": ["--config", "python/.flake8"]
 }

--- a/swift/mcap/MCAPStreamedReader.swift
+++ b/swift/mcap/MCAPStreamedReader.swift
@@ -82,16 +82,15 @@ private class RecordReader {
     try buffer.withUnsafeBytes { buf in
       while offset + 9 < buf.count {
         let op = buf[offset]
-        offset += 1
         var recordLength: UInt64 = 0
         withUnsafeMutableBytes(of: &recordLength) { rawLength in
-          _ = buf.copyBytes(to: rawLength, from: offset ..< offset + 8)
+          _ = buf.copyBytes(to: rawLength, from: offset + 1 ..< offset + 9)
         }
         recordLength = UInt64(littleEndian: recordLength)
-        offset += 8
-        guard offset + Int(recordLength) <= buf.count else {
+        guard offset + 9 + Int(recordLength) <= buf.count else {
           return nil
         }
+        offset += 9
         defer {
           offset += Int(recordLength)
         }


### PR DESCRIPTION
Example output:

> Chunk at offset 127399 has message start time 160401406940, but its chunk index has message start time 137401467398

Also some minor drive-by fixes for TS/Swift.