### PR TITLE
Don't run PyPi CI steps on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,8 @@ jobs:
       - run: yarn workspace @mcap/core test
 
       - name: Publish to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
+        if:
+          ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
         run: yarn workspace @mcap/core publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -225,6 +226,7 @@ jobs:
       - run: pipenv run python -m build
 
       - name: Publish to TestPyPI
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
@@ -234,7 +236,8 @@ jobs:
           skip_existing: true
 
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/python/v') }}
+        if: |
+          ${{ !github.event.pull_request.head.repo.fork && startsWith(github.ref, 'refs/tags/releases/python/v') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
@@ -254,7 +257,8 @@ jobs:
         with:
           lfs: true
       - name: install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+        run:
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
       - run: make lint
       - run: make test
 
@@ -264,7 +268,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - go
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/mcap-cli/v')
+    if:
+      github.event_name == 'push' && startsWith(github.ref,
+      'refs/tags/releases/mcap-cli/v')
     defaults:
       run:
         working-directory: go/cli/mcap
@@ -315,8 +321,14 @@ jobs:
       - uses: fwal/setup-swift@v1
         with:
           swift-version: "5.6"
-      - run: curl -LO https://github.com/realm/SwiftLint/releases/download/0.46.5/swiftlint_linux.zip && unzip swiftlint_linux.zip swiftlint
-      - run: curl -LO https://github.com/nicklockwood/SwiftFormat/releases/download/0.49.5/swiftformat_linux.zip && unzip swiftformat_linux.zip && chmod +x swiftformat_linux
+      - run:
+          curl -LO
+          https://github.com/realm/SwiftLint/releases/download/0.46.5/swiftlint_linux.zip
+          && unzip swiftlint_linux.zip swiftlint
+      - run:
+          curl -LO
+          https://github.com/nicklockwood/SwiftFormat/releases/download/0.49.5/swiftformat_linux.zip
+          && unzip swiftformat_linux.zip && chmod +x swiftformat_linux
       - run: ./swiftlint
       - run: ./swiftformat_linux --lint .
       - run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,7 @@ jobs:
       - run: yarn workspace @mcap/core test
 
       - name: Publish to NPM
-        if:
-          ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
         run: yarn workspace @mcap/core publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -226,8 +225,8 @@ jobs:
       - run: pipenv run python -m build
 
       - name: Publish to TestPyPI
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN }}
@@ -236,8 +235,7 @@ jobs:
           skip_existing: true
 
       - name: Publish to PyPI
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork && startsWith(github.ref, 'refs/tags/releases/python/v') }}
+        if: ${{ !github.event.pull_request.head.repo.fork && startsWith(github.ref, 'refs/tags/releases/python/v') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
@@ -257,8 +255,7 @@ jobs:
         with:
           lfs: true
       - name: install golangci-lint
-        run:
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
       - run: make lint
       - run: make test
 
@@ -268,9 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - go
-    if:
-      github.event_name == 'push' && startsWith(github.ref,
-      'refs/tags/releases/mcap-cli/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/mcap-cli/v')
     defaults:
       run:
         working-directory: go/cli/mcap
@@ -321,14 +316,8 @@ jobs:
       - uses: fwal/setup-swift@v1
         with:
           swift-version: "5.6"
-      - run:
-          curl -LO
-          https://github.com/realm/SwiftLint/releases/download/0.46.5/swiftlint_linux.zip
-          && unzip swiftlint_linux.zip swiftlint
-      - run:
-          curl -LO
-          https://github.com/nicklockwood/SwiftFormat/releases/download/0.49.5/swiftformat_linux.zip
-          && unzip swiftformat_linux.zip && chmod +x swiftformat_linux
+      - run: curl -LO https://github.com/realm/SwiftLint/releases/download/0.46.5/swiftlint_linux.zip && unzip swiftlint_linux.zip swiftlint
+      - run: curl -LO https://github.com/nicklockwood/SwiftFormat/releases/download/0.49.5/swiftformat_linux.zip && unzip swiftformat_linux.zip && chmod +x swiftformat_linux
       - run: ./swiftlint
       - run: ./swiftformat_linux --lint .
       - run: swift build


### PR DESCRIPTION
**Public-Facing Changes**
This skips the TestPyPi and PyPi CI steps for forks


**Description**
This skips the PyPI related Python CI steps for forks so that the publishing secrets are not necessary for CI to succeed for forks.


<!-- link relevant GitHub issues -->
