### PR TITLE
cpp: remove fmt dependency

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -80,7 +80,6 @@ Output binaries can be found in:
 The C++ implementation of MCAP is maintained as a header-only library with the
 following dependencies:
 
-- [fmt](https://github.com/fmtlib/fmt) (tested with [fmt/8.1.1](https://conan.io/center/fmt))
 - [lz4](https://lz4.github.io/lz4/) (tested with [lz4/1.9.3](https://conan.io/center/lz4))
 - [zstd](https://facebook.github.io/zstd/) (tested with [zstd/1.5.2](https://conan.io/center/zstd))
 

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = ("fmt/8.1.1", "mcap/0.0.1")
+    requires = "mcap/0.0.1"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/mcapdump.cpp
+++ b/cpp/examples/mcapdump.cpp
@@ -8,20 +8,27 @@
 
 using mcap::ByteOffset;
 
-inline std::string to_string(const std::string& arg) {
+static std::string to_string(const std::string& arg) {
   return arg;
 }
-inline std::string to_string(std::string_view arg) {
+static std::string to_string(std::string_view arg) {
   return std::string(arg);
 }
-inline std::string to_string(const char* arg) {
+static std::string to_string(const char* arg) {
   return std::string(arg);
 }
 template <typename... T>
-[[nodiscard]] inline std::string StrCat(T&&... args) {
+[[nodiscard]] static std::string StrCat(T&&... args) {
   using ::to_string;
   using std::to_string;
   return ("" + ... + to_string(std::forward<T>(args)));
+}
+
+static std::string ToHex(uint8_t byte) {
+  std::string result{2, '\0'};
+  result[0] = "0123456789ABCDEF"[(uint8_t(byte) >> 4) & 0x0F];
+  result[1] = "0123456789ABCDEF"[uint8_t(byte) & 0x0F];
+  return result;
 }
 
 std::string ToString(const mcap::KeyValueMap& map) {
@@ -159,7 +166,7 @@ std::string ToString(const mcap::MetadataIndex& metadataIndex) {
 
 std::string ToString(const mcap::SummaryOffset& summaryOffset) {
   return StrCat("[SummaryOffset] group_opcode=", mcap::OpCodeString(summaryOffset.groupOpCode),
-                " (0x", uint8_t(summaryOffset.groupOpCode),
+                " (0x", ToHex(uint8_t(summaryOffset.groupOpCode)),
                 "), group_start=", summaryOffset.groupStart,
                 ", group_length=", summaryOffset.groupLength);
 }
@@ -169,13 +176,13 @@ std::string ToString(const mcap::DataEnd& dataEnd) {
 }
 
 std::string ToString(const mcap::Record& record) {
-  return StrCat("[Unknown] opcode=0x", uint8_t(record.opcode), ", data=<", record.dataSize,
+  return StrCat("[Unknown] opcode=0x", ToHex(uint8_t(record.opcode)), ", data=<", record.dataSize,
                 " bytes>");
 }
 
 std::string ToStringRaw(const mcap::Record& record) {
-  return StrCat("[", mcap::OpCodeString(record.opcode), "] opcode=0x", uint8_t(record.opcode),
-                ", data=<", record.dataSize, " bytes>");
+  return StrCat("[", mcap::OpCodeString(record.opcode), "] opcode=0x",
+                ToHex(uint8_t(record.opcode)), ", data=<", record.dataSize, " bytes>");
 }
 
 void DumpRaw(mcap::IReadable& dataSource) {

--- a/cpp/examples/mcapdump.cpp
+++ b/cpp/examples/mcapdump.cpp
@@ -1,8 +1,6 @@
 #define MCAP_IMPLEMENTATION
 #include <mcap/reader.hpp>
 
-#include <fmt/core.h>
-
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -10,9 +8,20 @@
 
 using mcap::ByteOffset;
 
+inline std::string to_string(const std::string& arg) {
+  return arg;
+}
+inline std::string to_string(std::string_view arg) {
+  return std::string(arg);
+}
+inline std::string to_string(const char* arg) {
+  return std::string(arg);
+}
 template <typename... T>
-[[nodiscard]] inline std::string StrFormat(std::string_view msg, T&&... args) {
-  return fmt::format(msg, std::forward<T>(args)...);
+[[nodiscard]] inline std::string StrFormat(T&&... args) {
+  using ::to_string;
+  using std::to_string;
+  return ("" + ... + to_string(std::forward<T>(args)));
 }
 
 std::string ToString(const mcap::KeyValueMap& map) {
@@ -30,7 +39,7 @@ std::string ToString(const mcap::KeyValueMap& map) {
 
 std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
   if (map.size() > 8) {
-    return StrFormat("<{} entries>", map.size());
+    return StrFormat("<", map.size(), " entries>");
   }
 
   std::stringstream ss;
@@ -47,7 +56,7 @@ std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
 
 std::string ToString(const std::vector<std::pair<mcap::Timestamp, ByteOffset>>& pairs) {
   if (pairs.size() > 8) {
-    return StrFormat("<{} entries>", pairs.size());
+    return StrFormat("<", pairs.size(), " entries>");
   }
 
   std::stringstream ss;
@@ -63,110 +72,110 @@ std::string ToString(const std::vector<std::pair<mcap::Timestamp, ByteOffset>>& 
 }
 
 std::string ToString(const mcap::Header& header) {
-  return StrFormat("[Header] profile={}, library={}", header.profile, header.library);
+  return StrFormat("[Header] profile=", header.profile, ", library=", header.library);
 }
 
 std::string ToString(const mcap::Footer& footer) {
-  return StrFormat("[Footer] summary_start={}, summary_offset_start={}, summary_crc={}",
-                   footer.summaryStart, footer.summaryOffsetStart, footer.summaryCrc);
+  return StrFormat("[Footer] summary_start=", footer.summaryStart,
+                   ", summary_offset_start=", footer.summaryOffsetStart,
+                   ", summary_crc=", footer.summaryCrc);
 }
 
 std::string ToString(const mcap::Schema& schema) {
-  return StrFormat("[Schema] id={}, name={}, encoding={}, data=<{} bytes>", schema.id, schema.name,
-                   schema.encoding, schema.data.size());
+  return StrFormat("[Schema] id=", schema.id, ", name=", schema.name,
+                   ", encoding=", schema.encoding, ", data=<", schema.data.size(), " bytes>");
 }
 
 std::string ToString(const mcap::Channel& channel) {
-  return StrFormat("[Channel] id={}, schema_id={}, topic={}, message_encoding={}, metadata={}",
-                   channel.id, channel.schemaId, channel.topic, channel.messageEncoding,
-                   ToString(channel.metadata));
+  return StrFormat("[Channel] id=", channel.id, ", schema_id=", channel.schemaId,
+                   ", topic=", channel.topic, ", message_encoding=", channel.messageEncoding,
+                   ", metadata=", ToString(channel.metadata));
 }
 
 std::string ToString(const mcap::Message& message) {
-  return StrFormat(
-    "[Message] channel_id={}, sequence={}, publish_time={}, log_time={}, data=<{} bytes>",
-    message.channelId, message.sequence, message.publishTime, message.logTime, message.dataSize);
+  return StrFormat("[Message] channel_id=", message.channelId, ", sequence=", message.sequence,
+                   ", publish_time=", message.publishTime, ", log_time=", message.logTime,
+                   ", data=<", message.dataSize, " bytes>");
 }
 
 std::string ToString(const mcap::Chunk& chunk) {
   return StrFormat(
-    "[Chunk] message_start_time={}, message_end_time={}, uncompressed_size={}, "
-    "uncompressed_crc={}, compression={}, data=<{} bytes>",
-    chunk.messageStartTime, chunk.messageEndTime, chunk.uncompressedSize, chunk.uncompressedCrc,
-    chunk.compression, chunk.compressedSize);
+    "[Chunk] message_start_time=", chunk.messageStartTime,
+    ", message_end_time=", chunk.messageEndTime, ", uncompressed_size=", chunk.uncompressedSize,
+    ", uncompressed_crc=", chunk.uncompressedCrc, ", compression=", chunk.compression, ", data=<",
+    chunk.compressedSize, " bytes>");
 }
 
 std::string ToString(const mcap::MessageIndex& messageIndex) {
-  return StrFormat("[MessageIndex] channel_id={}, records={}", messageIndex.channelId,
-                   ToString(messageIndex.records));
+  return StrFormat("[MessageIndex] channel_id=", messageIndex.channelId,
+                   ", records=", ToString(messageIndex.records));
 }
 
 std::string ToString(const mcap::ChunkIndex& chunkIndex) {
   return StrFormat(
-    "[ChunkIndex] message_start_time={}, message_end_time={}, chunk_start_offset={}, "
-    "chunk_length={}, "
-    "message_index_offsets={}, message_index_length={}, compression={}, "
-    "compressed_size={}, uncompressed_size={}",
-    chunkIndex.messageStartTime, chunkIndex.messageEndTime, chunkIndex.chunkStartOffset,
-    chunkIndex.chunkLength, ToString(chunkIndex.messageIndexOffsets), chunkIndex.messageIndexLength,
-    chunkIndex.compression, chunkIndex.compressedSize, chunkIndex.uncompressedSize);
+    "[ChunkIndex] message_start_time=", chunkIndex.messageStartTime,
+    ", message_end_time=", chunkIndex.messageEndTime,
+    ", chunk_start_offset=", chunkIndex.chunkStartOffset, ", chunk_length=", chunkIndex.chunkLength,
+    ", message_index_offsets=", ToString(chunkIndex.messageIndexOffsets),
+    ", message_index_length=", chunkIndex.messageIndexLength,
+    ", compression=", chunkIndex.compression, ", compressed_size=", chunkIndex.compressedSize,
+    ", uncompressed_size=", chunkIndex.uncompressedSize);
 }
 
 std::string ToString(const mcap::Attachment& attachment) {
-  return StrFormat(
-    "[Attachment] log_time={}, create_time={}, name={}, content_type={}, data=<{} bytes>, crc={}",
-    attachment.logTime, attachment.createTime, attachment.name, attachment.contentType,
-    attachment.dataSize, attachment.crc);
+  return StrFormat("[Attachment] log_time=", attachment.logTime,
+                   ", create_time=", attachment.createTime, ", name=", attachment.name,
+                   ", content_type=", attachment.contentType, ", data=<", attachment.dataSize,
+                   " bytes>, crc=", attachment.crc);
 }
 
 std::string ToString(const mcap::AttachmentIndex& attachmentIndex) {
-  return StrFormat(
-    "[AttachmentIndex] offset={}, length={}, log_time={}, create_time={}, data_size={}, name={}, "
-    "content_type={}",
-    attachmentIndex.offset, attachmentIndex.length, attachmentIndex.logTime,
-    attachmentIndex.createTime, attachmentIndex.dataSize, attachmentIndex.name,
-    attachmentIndex.contentType);
+  return StrFormat("[AttachmentIndex] offset=", attachmentIndex.offset,
+                   ", length=", attachmentIndex.length, ", log_time=", attachmentIndex.logTime,
+                   ", create_time=", attachmentIndex.createTime,
+                   ", data_size=", attachmentIndex.dataSize, ", name=", attachmentIndex.name,
+                   ", content_type=", attachmentIndex.contentType);
 }
 
 std::string ToString(const mcap::Statistics& statistics) {
   return StrFormat(
-    "[Statistics] message_count={}, schema_count={}, channel_count={}, attachment_count={}, "
-    "metadata_count={}, chunk_count={}, message_start_time={}, message_end_time={}, "
-    "channel_message_counts={}",
-    statistics.messageCount, statistics.schemaCount, statistics.channelCount,
-    statistics.attachmentCount, statistics.metadataCount, statistics.chunkCount,
-    statistics.messageStartTime, statistics.messageEndTime,
-    ToString(statistics.channelMessageCounts));
+    "[Statistics] message_count=", statistics.messageCount,
+    ", schema_count=", statistics.schemaCount, ", channel_count=", statistics.channelCount,
+    ", attachment_count=", statistics.attachmentCount,
+    ", metadata_count=", statistics.metadataCount, ", chunk_count=", statistics.chunkCount,
+    ", message_start_time=", statistics.messageStartTime,
+    ", message_end_time=", statistics.messageEndTime,
+    ", channel_message_counts=", ToString(statistics.channelMessageCounts));
 }
 
 std::string ToString(const mcap::Metadata& metadata) {
-  return StrFormat("[Metadata] name={}, metadata={}", metadata.name, ToString(metadata.metadata));
+  return StrFormat("[Metadata] name=", metadata.name, ", metadata=", ToString(metadata.metadata));
 }
 
 std::string ToString(const mcap::MetadataIndex& metadataIndex) {
-  return StrFormat("[MetadataIndex] offset={}, length={}, name={}", metadataIndex.offset,
-                   metadataIndex.length, metadataIndex.name);
+  return StrFormat("[MetadataIndex] offset=", metadataIndex.offset,
+                   ", length=", metadataIndex.length, ", name=", metadataIndex.name);
 }
 
 std::string ToString(const mcap::SummaryOffset& summaryOffset) {
-  return StrFormat("[SummaryOffset] group_opcode={} (0x{:02x}), group_start={}, group_length={}",
-                   mcap::OpCodeString(summaryOffset.groupOpCode),
-                   uint8_t(summaryOffset.groupOpCode), summaryOffset.groupStart,
-                   summaryOffset.groupLength);
+  return StrFormat("[SummaryOffset] group_opcode=", mcap::OpCodeString(summaryOffset.groupOpCode),
+                   " (0x", uint8_t(summaryOffset.groupOpCode),
+                   "), group_start=", summaryOffset.groupStart,
+                   ", group_length=", summaryOffset.groupLength);
 }
 
 std::string ToString(const mcap::DataEnd& dataEnd) {
-  return StrFormat("[DataEnd] data_section_crc={}", dataEnd.dataSectionCrc);
+  return StrFormat("[DataEnd] data_section_crc=", dataEnd.dataSectionCrc);
 }
 
 std::string ToString(const mcap::Record& record) {
-  return StrFormat("[Unknown] opcode=0x{:02x}, data=<{} bytes>", uint8_t(record.opcode),
-                   record.dataSize);
+  return StrFormat("[Unknown] opcode=0x", uint8_t(record.opcode), ", data=<", record.dataSize,
+                   " bytes>");
 }
 
 std::string ToStringRaw(const mcap::Record& record) {
-  return StrFormat("[{}] opcode=0x{:02x}, data=<{} bytes>", mcap::OpCodeString(record.opcode),
-                   uint8_t(record.opcode), record.dataSize);
+  return StrFormat("[", mcap::OpCodeString(record.opcode), "] opcode=0x", uint8_t(record.opcode),
+                   ", data=<", record.dataSize, " bytes>");
 }
 
 void DumpRaw(mcap::IReadable& dataSource) {

--- a/cpp/examples/mcapdump.cpp
+++ b/cpp/examples/mcapdump.cpp
@@ -18,7 +18,7 @@ inline std::string to_string(const char* arg) {
   return std::string(arg);
 }
 template <typename... T>
-[[nodiscard]] inline std::string StrFormat(T&&... args) {
+[[nodiscard]] inline std::string StrCat(T&&... args) {
   using ::to_string;
   using std::to_string;
   return ("" + ... + to_string(std::forward<T>(args)));
@@ -39,7 +39,7 @@ std::string ToString(const mcap::KeyValueMap& map) {
 
 std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
   if (map.size() > 8) {
-    return StrFormat("<", map.size(), " entries>");
+    return StrCat("<", map.size(), " entries>");
   }
 
   std::stringstream ss;
@@ -56,7 +56,7 @@ std::string ToString(const std::unordered_map<uint16_t, uint64_t>& map) {
 
 std::string ToString(const std::vector<std::pair<mcap::Timestamp, ByteOffset>>& pairs) {
   if (pairs.size() > 8) {
-    return StrFormat("<", pairs.size(), " entries>");
+    return StrCat("<", pairs.size(), " entries>");
   }
 
   std::stringstream ss;
@@ -72,47 +72,47 @@ std::string ToString(const std::vector<std::pair<mcap::Timestamp, ByteOffset>>& 
 }
 
 std::string ToString(const mcap::Header& header) {
-  return StrFormat("[Header] profile=", header.profile, ", library=", header.library);
+  return StrCat("[Header] profile=", header.profile, ", library=", header.library);
 }
 
 std::string ToString(const mcap::Footer& footer) {
-  return StrFormat("[Footer] summary_start=", footer.summaryStart,
-                   ", summary_offset_start=", footer.summaryOffsetStart,
-                   ", summary_crc=", footer.summaryCrc);
+  return StrCat("[Footer] summary_start=", footer.summaryStart,
+                ", summary_offset_start=", footer.summaryOffsetStart,
+                ", summary_crc=", footer.summaryCrc);
 }
 
 std::string ToString(const mcap::Schema& schema) {
-  return StrFormat("[Schema] id=", schema.id, ", name=", schema.name,
-                   ", encoding=", schema.encoding, ", data=<", schema.data.size(), " bytes>");
+  return StrCat("[Schema] id=", schema.id, ", name=", schema.name, ", encoding=", schema.encoding,
+                ", data=<", schema.data.size(), " bytes>");
 }
 
 std::string ToString(const mcap::Channel& channel) {
-  return StrFormat("[Channel] id=", channel.id, ", schema_id=", channel.schemaId,
-                   ", topic=", channel.topic, ", message_encoding=", channel.messageEncoding,
-                   ", metadata=", ToString(channel.metadata));
+  return StrCat("[Channel] id=", channel.id, ", schema_id=", channel.schemaId,
+                ", topic=", channel.topic, ", message_encoding=", channel.messageEncoding,
+                ", metadata=", ToString(channel.metadata));
 }
 
 std::string ToString(const mcap::Message& message) {
-  return StrFormat("[Message] channel_id=", message.channelId, ", sequence=", message.sequence,
-                   ", publish_time=", message.publishTime, ", log_time=", message.logTime,
-                   ", data=<", message.dataSize, " bytes>");
+  return StrCat("[Message] channel_id=", message.channelId, ", sequence=", message.sequence,
+                ", publish_time=", message.publishTime, ", log_time=", message.logTime, ", data=<",
+                message.dataSize, " bytes>");
 }
 
 std::string ToString(const mcap::Chunk& chunk) {
-  return StrFormat(
-    "[Chunk] message_start_time=", chunk.messageStartTime,
-    ", message_end_time=", chunk.messageEndTime, ", uncompressed_size=", chunk.uncompressedSize,
-    ", uncompressed_crc=", chunk.uncompressedCrc, ", compression=", chunk.compression, ", data=<",
-    chunk.compressedSize, " bytes>");
+  return StrCat("[Chunk] message_start_time=", chunk.messageStartTime,
+                ", message_end_time=", chunk.messageEndTime,
+                ", uncompressed_size=", chunk.uncompressedSize,
+                ", uncompressed_crc=", chunk.uncompressedCrc, ", compression=", chunk.compression,
+                ", data=<", chunk.compressedSize, " bytes>");
 }
 
 std::string ToString(const mcap::MessageIndex& messageIndex) {
-  return StrFormat("[MessageIndex] channel_id=", messageIndex.channelId,
-                   ", records=", ToString(messageIndex.records));
+  return StrCat("[MessageIndex] channel_id=", messageIndex.channelId,
+                ", records=", ToString(messageIndex.records));
 }
 
 std::string ToString(const mcap::ChunkIndex& chunkIndex) {
-  return StrFormat(
+  return StrCat(
     "[ChunkIndex] message_start_time=", chunkIndex.messageStartTime,
     ", message_end_time=", chunkIndex.messageEndTime,
     ", chunk_start_offset=", chunkIndex.chunkStartOffset, ", chunk_length=", chunkIndex.chunkLength,
@@ -123,22 +123,22 @@ std::string ToString(const mcap::ChunkIndex& chunkIndex) {
 }
 
 std::string ToString(const mcap::Attachment& attachment) {
-  return StrFormat("[Attachment] log_time=", attachment.logTime,
-                   ", create_time=", attachment.createTime, ", name=", attachment.name,
-                   ", content_type=", attachment.contentType, ", data=<", attachment.dataSize,
-                   " bytes>, crc=", attachment.crc);
+  return StrCat("[Attachment] log_time=", attachment.logTime,
+                ", create_time=", attachment.createTime, ", name=", attachment.name,
+                ", content_type=", attachment.contentType, ", data=<", attachment.dataSize,
+                " bytes>, crc=", attachment.crc);
 }
 
 std::string ToString(const mcap::AttachmentIndex& attachmentIndex) {
-  return StrFormat("[AttachmentIndex] offset=", attachmentIndex.offset,
-                   ", length=", attachmentIndex.length, ", log_time=", attachmentIndex.logTime,
-                   ", create_time=", attachmentIndex.createTime,
-                   ", data_size=", attachmentIndex.dataSize, ", name=", attachmentIndex.name,
-                   ", content_type=", attachmentIndex.contentType);
+  return StrCat("[AttachmentIndex] offset=", attachmentIndex.offset,
+                ", length=", attachmentIndex.length, ", log_time=", attachmentIndex.logTime,
+                ", create_time=", attachmentIndex.createTime,
+                ", data_size=", attachmentIndex.dataSize, ", name=", attachmentIndex.name,
+                ", content_type=", attachmentIndex.contentType);
 }
 
 std::string ToString(const mcap::Statistics& statistics) {
-  return StrFormat(
+  return StrCat(
     "[Statistics] message_count=", statistics.messageCount,
     ", schema_count=", statistics.schemaCount, ", channel_count=", statistics.channelCount,
     ", attachment_count=", statistics.attachmentCount,
@@ -149,33 +149,33 @@ std::string ToString(const mcap::Statistics& statistics) {
 }
 
 std::string ToString(const mcap::Metadata& metadata) {
-  return StrFormat("[Metadata] name=", metadata.name, ", metadata=", ToString(metadata.metadata));
+  return StrCat("[Metadata] name=", metadata.name, ", metadata=", ToString(metadata.metadata));
 }
 
 std::string ToString(const mcap::MetadataIndex& metadataIndex) {
-  return StrFormat("[MetadataIndex] offset=", metadataIndex.offset,
-                   ", length=", metadataIndex.length, ", name=", metadataIndex.name);
+  return StrCat("[MetadataIndex] offset=", metadataIndex.offset, ", length=", metadataIndex.length,
+                ", name=", metadataIndex.name);
 }
 
 std::string ToString(const mcap::SummaryOffset& summaryOffset) {
-  return StrFormat("[SummaryOffset] group_opcode=", mcap::OpCodeString(summaryOffset.groupOpCode),
-                   " (0x", uint8_t(summaryOffset.groupOpCode),
-                   "), group_start=", summaryOffset.groupStart,
-                   ", group_length=", summaryOffset.groupLength);
+  return StrCat("[SummaryOffset] group_opcode=", mcap::OpCodeString(summaryOffset.groupOpCode),
+                " (0x", uint8_t(summaryOffset.groupOpCode),
+                "), group_start=", summaryOffset.groupStart,
+                ", group_length=", summaryOffset.groupLength);
 }
 
 std::string ToString(const mcap::DataEnd& dataEnd) {
-  return StrFormat("[DataEnd] data_section_crc=", dataEnd.dataSectionCrc);
+  return StrCat("[DataEnd] data_section_crc=", dataEnd.dataSectionCrc);
 }
 
 std::string ToString(const mcap::Record& record) {
-  return StrFormat("[Unknown] opcode=0x", uint8_t(record.opcode), ", data=<", record.dataSize,
-                   " bytes>");
+  return StrCat("[Unknown] opcode=0x", uint8_t(record.opcode), ", data=<", record.dataSize,
+                " bytes>");
 }
 
 std::string ToStringRaw(const mcap::Record& record) {
-  return StrFormat("[", mcap::OpCodeString(record.opcode), "] opcode=0x", uint8_t(record.opcode),
-                   ", data=<", record.dataSize, " bytes>");
+  return StrCat("[", mcap::OpCodeString(record.opcode), "] opcode=0x", uint8_t(record.opcode),
+                ", data=<", record.dataSize, " bytes>");
 }
 
 void DumpRaw(mcap::IReadable& dataSource) {

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -11,7 +11,7 @@ class McapConan(ConanFile):
     topics = ("mcap", "serialization", "deserialization", "recording")
 
     settings = ("os", "compiler", "build_type", "arch")
-    requires = ("fmt/8.1.1", "lz4/1.9.3", "zstd/1.5.2")
+    requires = ("lz4/1.9.3", "zstd/1.5.2")
     generators = "cmake"
 
     def validate(self):

--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.hpp"
+#include <cstring>
 #include <type_traits>
 
 // Do not compile on systems with non-8-bit bytes

--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <fmt/core.h>
-
 #include "types.hpp"
+#include <type_traits>
 
 // Do not compile on systems with non-8-bit bytes
 static_assert(std::numeric_limits<unsigned char>::digits == 8);
@@ -10,11 +9,6 @@ static_assert(std::numeric_limits<unsigned char>::digits == 8);
 namespace mcap {
 
 namespace internal {
-
-constexpr std::string_view ErrorMsgInvalidOpcode = "invalid opcode, expected {}: 0x{:02x}";
-constexpr std::string_view ErrorMsgInvalidLength = "invalid {} length: {}";
-constexpr std::string_view ErrorMsgInvalidMagic = "invalid magic bytes in {}: 0x{}";
-constexpr std::string_view ErrorOpenFileFailed = "failed to open \"{}\"";
 
 constexpr uint64_t MinHeaderLength = /* magic bytes */ sizeof(Magic) +
                                      /* opcode */ 1 +
@@ -28,13 +22,30 @@ constexpr uint64_t FooterLength = /* opcode */ 1 +
                                   /* summary crc */ 4 +
                                   /* magic bytes */ sizeof(Magic);
 
-/**
- * @brief String formatting compatible with std::format(), used to construct
- * Status messages.
- */
+inline std::string ToHex(uint8_t byte) {
+  std::string result{2, '\0'};
+  result[0] = "0123456789ABCDEF"[(uint8_t(byte) >> 4) & 0x0F];
+  result[1] = "0123456789ABCDEF"[uint8_t(byte) & 0x0F];
+  return result;
+}
+inline std::string ToHex(std::byte byte) {
+  return ToHex(uint8_t(byte));
+}
+
+inline std::string to_string(const std::string& arg) {
+  return arg;
+}
+inline std::string to_string(std::string_view arg) {
+  return std::string(arg);
+}
+inline std::string to_string(const char* arg) {
+  return std::string(arg);
+}
 template <typename... T>
-[[nodiscard]] inline std::string StrFormat(std::string_view msg, T&&... args) {
-  return fmt::format(msg, std::forward<T>(args)...);
+[[nodiscard]] inline std::string StrFormat(T&&... args) {
+  using mcap::internal::to_string;
+  using std::to_string;
+  return ("" + ... + to_string(std::forward<T>(args)));
 }
 
 inline uint32_t KeyValueMapSize(const KeyValueMap& map) {
@@ -68,7 +79,7 @@ inline uint32_t ParseUint32(const std::byte* data) {
 
 inline Status ParseUint32(const std::byte* data, uint64_t maxSize, uint32_t* output) {
   if (maxSize < 4) {
-    const auto msg = StrFormat("cannot read uint32 from {} bytes", maxSize);
+    const auto msg = StrFormat("cannot read uint32 from ", maxSize, " bytes");
     return Status{StatusCode::InvalidRecord, msg};
   }
   *output = ParseUint32(data);
@@ -83,7 +94,7 @@ inline uint64_t ParseUint64(const std::byte* data) {
 
 inline Status ParseUint64(const std::byte* data, uint64_t maxSize, uint64_t* output) {
   if (maxSize < 8) {
-    const auto msg = StrFormat("cannot read uint64 from {} bytes", maxSize);
+    const auto msg = StrFormat("cannot read uint64 from ", maxSize, " bytes");
     return Status{StatusCode::InvalidRecord, msg};
   }
   *output = ParseUint64(data);
@@ -93,11 +104,11 @@ inline Status ParseUint64(const std::byte* data, uint64_t maxSize, uint64_t* out
 inline Status ParseStringView(const std::byte* data, uint64_t maxSize, std::string_view* output) {
   uint32_t size = 0;
   if (auto status = ParseUint32(data, maxSize, &size); !status.ok()) {
-    const auto msg = StrFormat("cannot read string size: {}", status.message);
+    const auto msg = StrFormat("cannot read string size: ", status.message);
     return Status{StatusCode::InvalidRecord, msg};
   }
   if (uint64_t(size) > (maxSize - 4)) {
-    const auto msg = StrFormat("string size {} exceeds remaining bytes {}", size, (maxSize - 4));
+    const auto msg = StrFormat("string size ", size, " exceeds remaining bytes ", (maxSize - 4));
     return Status(StatusCode::InvalidRecord, msg);
   }
   *output = std::string_view(reinterpret_cast<const char*>(data + 4), size);
@@ -110,7 +121,7 @@ inline Status ParseString(const std::byte* data, uint64_t maxSize, std::string* 
     return status;
   }
   if (uint64_t(size) > (maxSize - 4)) {
-    const auto msg = StrFormat("string size {} exceeds remaining bytes {}", size, (maxSize - 4));
+    const auto msg = StrFormat("string size ", size, " exceeds remaining bytes ", (maxSize - 4));
     return Status(StatusCode::InvalidRecord, msg);
   }
   *output = std::string(reinterpret_cast<const char*>(data + 4), size);
@@ -124,7 +135,7 @@ inline Status ParseByteArray(const std::byte* data, uint64_t maxSize, ByteArray*
   }
   if (uint64_t(size) > (maxSize - 4)) {
     const auto msg =
-      StrFormat("byte array size {} exceeds remaining bytes {}", size, (maxSize - 4));
+      StrFormat("byte array size ", size, " exceeds remaining bytes ", (maxSize - 4));
     return Status(StatusCode::InvalidRecord, msg);
   }
   output->resize(size);
@@ -139,7 +150,7 @@ inline Status ParseKeyValueMap(const std::byte* data, uint64_t maxSize, KeyValue
   }
   if (sizeInBytes > (maxSize - 4)) {
     const auto msg =
-      StrFormat("key-value map size {} exceeds remaining bytes {}", sizeInBytes, (maxSize - 4));
+      StrFormat("key-value map size ", sizeInBytes, " exceeds remaining bytes ", (maxSize - 4));
     return Status(StatusCode::InvalidRecord, msg);
   }
 
@@ -153,14 +164,14 @@ inline Status ParseKeyValueMap(const std::byte* data, uint64_t maxSize, KeyValue
     std::string_view key;
     if (auto status = ParseStringView(data + pos, sizeInBytes - pos, &key); !status.ok()) {
       const auto msg =
-        StrFormat("cannot read key-value map key at pos {}: {}", pos, status.message);
+        StrFormat("cannot read key-value map key at pos ", pos, ": ", status.message);
       return Status{StatusCode::InvalidRecord, msg};
     }
     pos += 4 + key.size();
     std::string_view value;
     if (auto status = ParseStringView(data + pos, sizeInBytes - pos, &value); !status.ok()) {
-      const auto msg = StrFormat("cannot read key-value map value for key \"{}\" at pos {}: {}",
-                                 key, pos, status.message);
+      const auto msg = StrFormat("cannot read key-value map value for key \"", key, "\" at pos ",
+                                 pos, ": ", status.message);
       return Status{StatusCode::InvalidRecord, msg};
     }
     pos += 4 + value.size();
@@ -170,8 +181,9 @@ inline Status ParseKeyValueMap(const std::byte* data, uint64_t maxSize, KeyValue
 }
 
 inline std::string MagicToHex(const std::byte* data) {
-  return StrFormat("{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}", data[0], data[1], data[2],
-                   data[3], data[4], data[5], data[6], data[7]);
+  return internal::ToHex(data[0]) + internal::ToHex(data[1]) + internal::ToHex(data[2]) +
+         internal::ToHex(data[3]) + internal::ToHex(data[4]) + internal::ToHex(data[5]) +
+         internal::ToHex(data[6]) + internal::ToHex(data[7]);
 }
 
 }  // namespace internal

--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -2,7 +2,6 @@
 
 #include "types.hpp"
 #include <cstring>
-#include <type_traits>
 
 // Do not compile on systems with non-8-bit bytes
 static_assert(std::numeric_limits<unsigned char>::digits == 8);

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -135,14 +135,14 @@ void LZ4Reader::reset(const std::byte* data, uint64_t size, uint64_t uncompresse
                                           compressedSize_, uncompressedSize_);
   if (uint64_t(status) != uncompressedSize_) {
     if (status < 0) {
-      const auto msg = internal::StrFormat(
-        "lz4 decompression of {} bytes into {} output bytes failed with error {}", compressedSize_,
-        uncompressedSize_, status);
+      const auto msg =
+        internal::StrFormat("lz4 decompression of ", compressedSize_, " bytes into ",
+                            uncompressedSize_, " output bytes failed with error ", status);
       status_ = Status{StatusCode::DecompressionFailed, msg};
     } else {
-      const auto msg = internal::StrFormat(
-        "lz4 decompression of {} bytes into {} output bytes only produced {} bytes",
-        compressedSize_, uncompressedSize_, status);
+      const auto msg =
+        internal::StrFormat("lz4 decompression of ", compressedSize_, " bytes into ",
+                            uncompressedSize_, " output bytes only produced ", status, " bytes");
       status_ = StatusCode::DecompressionSizeMismatch;
     }
 
@@ -185,13 +185,13 @@ void ZStdReader::reset(const std::byte* data, uint64_t size, uint64_t uncompress
   if (status != uncompressedSize_) {
     if (ZSTD_isError(status)) {
       const auto msg = internal::StrFormat(
-        "zstd decompression of {} bytes into {} output bytes failed with error {}", compressedSize_,
-        uncompressedSize_, ZSTD_getErrorName(status));
+        "zstd decompression of ", compressedSize_, " bytes into ", uncompressedSize_,
+        " output bytes failed with error ", ZSTD_getErrorName(status));
       status_ = Status{StatusCode::DecompressionFailed, msg};
     } else {
-      const auto msg = internal::StrFormat(
-        "zstd decompression of {} bytes into {} output bytes only produced {} bytes",
-        compressedSize_, uncompressedSize_, status);
+      const auto msg =
+        internal::StrFormat("zstd decompression of ", compressedSize_, " bytes into ",
+                            uncompressedSize_, " output bytes only produced ", status, " bytes");
       status_ = StatusCode::DecompressionSizeMismatch;
     }
 
@@ -245,7 +245,7 @@ Status McapReader::open(IReadable& reader) {
   // Check the header magic bytes
   if (std::memcmp(data, Magic, sizeof(Magic)) != 0) {
     const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidMagic, "Header", internal::MagicToHex(data));
+      internal::StrFormat("invalid magic bytes in Header: 0x", internal::MagicToHex(data));
     return Status{StatusCode::MagicMismatch, msg};
   }
 
@@ -255,8 +255,8 @@ Status McapReader::open(IReadable& reader) {
     return status;
   }
   if (record.opcode != OpCode::Header) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidOpcode, "Header", uint8_t(record.opcode));
+    const auto msg = internal::StrFormat("invalid opcode, expected Header: 0x",
+                                         internal::ToHex(uint8_t(record.opcode)));
     return Status{StatusCode::InvalidFile, msg};
   }
   Header header;
@@ -283,7 +283,7 @@ Status McapReader::open(std::string_view filename) {
   }
   file_ = fopen(filename.data(), "rb");
   if (!file_) {
-    const auto msg = internal::StrFormat(internal::ErrorOpenFileFailed, filename);
+    const auto msg = internal::StrFormat("failed to open \"", filename, "\"");
     return Status{StatusCode::OpenFailed, msg};
   }
 
@@ -384,8 +384,8 @@ Status McapReader::readSummarySection_(IReadable& reader) {
     footer.summaryOffsetStart != 0 ? footer.summaryOffsetStart : fileSize - internal::FooterLength;
   // Sanity check the ordering
   if (summaryOffsetStart < summaryStart) {
-    const auto msg = internal::StrFormat("summary_offset_start {} < summary_start {}",
-                                         summaryOffsetStart, summaryStart);
+    const auto msg = internal::StrFormat("summary_offset_start ", summaryOffsetStart,
+                                         " < summary_start ", summaryStart);
     return Status{StatusCode::InvalidFooter, msg};
   }
 
@@ -596,8 +596,8 @@ Status McapReader::ReadRecord(IReadable& reader, uint64_t offset, Record* record
   // Check that we can read at least 9 bytes (opcode + length)
   auto maxSize = reader.size() - offset;
   if (maxSize < 9) {
-    const auto msg =
-      internal::StrFormat("cannot read record at offset {}, {} bytes remaining", offset, maxSize);
+    const auto msg = internal::StrFormat("cannot read record at offset ", offset, ", ", maxSize,
+                                         " bytes remaining");
     return Status{StatusCode::InvalidFile, msg};
   }
 
@@ -615,16 +615,17 @@ Status McapReader::ReadRecord(IReadable& reader, uint64_t offset, Record* record
   // Read payload
   maxSize -= 9;
   if (maxSize < record->dataSize) {
-    const auto msg = internal::StrFormat(
-      "record type 0x{:02x} at offset {} has length {} but only {} bytes remaining",
-      uint8_t(record->opcode), offset, record->dataSize, maxSize);
+    const auto msg = internal::StrFormat("record type 0x", internal::ToHex(uint8_t(record->opcode)),
+                                         " at offset ", offset, " has length ", record->dataSize,
+                                         " but only ", maxSize, " bytes remaining");
     return Status{StatusCode::InvalidRecord, msg};
   }
   bytesRead = reader.read(&record->data, offset + 9, record->dataSize);
   if (bytesRead != record->dataSize) {
-    const auto msg = internal::StrFormat(
-      "attempted to read {} bytes for record type 0x{:02x} at offset {} but only read {} bytes",
-      record->dataSize, uint8_t(record->opcode), offset, bytesRead);
+    const auto msg =
+      internal::StrFormat("attempted to read ", record->dataSize, " bytes for record type 0x",
+                          internal::ToHex(uint8_t(record->opcode)), " at offset ", offset,
+                          " but only read ", bytesRead, " bytes");
     return Status{StatusCode::ReadFailed, msg};
   }
 
@@ -641,13 +642,14 @@ Status McapReader::ReadFooter(IReadable& reader, uint64_t offset, Footer* footer
   // Check the footer magic bytes
   if (std::memcmp(data + internal::FooterLength - sizeof(Magic), Magic, sizeof(Magic)) != 0) {
     const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidMagic, "Footer",
+      internal::StrFormat("invalid magic bytes in Footer: 0x",
                           internal::MagicToHex(data + internal::FooterLength - sizeof(Magic)));
     return Status{StatusCode::MagicMismatch, msg};
   }
 
   if (OpCode(data[0]) != OpCode::Footer) {
-    const auto msg = internal::StrFormat(internal::ErrorMsgInvalidOpcode, "Footer", data[0]);
+    const auto msg =
+      internal::StrFormat("invalid opcode, expected Footer: 0x", internal::ToHex(data[0]));
     return Status{StatusCode::InvalidFile, msg};
   }
 
@@ -655,7 +657,7 @@ Status McapReader::ReadFooter(IReadable& reader, uint64_t offset, Footer* footer
   // fixed length
   const uint64_t length = internal::ParseUint64(data + 1);
   if (length != 8 + 8 + 4) {
-    const auto msg = internal::StrFormat(internal::ErrorMsgInvalidLength, "Footer", length);
+    const auto msg = internal::StrFormat("invalid Footer length: ", length);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -670,8 +672,7 @@ Status McapReader::ParseHeader(const Record& record, Header* header) {
 
   assert(record.opcode == OpCode::Header);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Header", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Header length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -691,8 +692,7 @@ Status McapReader::ParseFooter(const Record& record, Footer* footer) {
 
   assert(record.opcode == OpCode::Footer);
   if (record.dataSize != FooterSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Footer", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Footer length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -708,8 +708,7 @@ Status McapReader::ParseSchema(const Record& record, Schema* schema) {
 
   assert(record.opcode == OpCode::Schema);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Schema", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Schema length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -747,8 +746,7 @@ Status McapReader::ParseChannel(const Record& record, Channel* channel) {
 
   assert(record.opcode == OpCode::Channel);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Channel", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Channel length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -788,8 +786,7 @@ Status McapReader::ParseMessage(const Record& record, Message* message) {
 
   assert(record.opcode == OpCode::Message);
   if (record.dataSize < MessagePreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Message", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Message length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -807,7 +804,7 @@ Status McapReader::ParseChunk(const Record& record, Chunk* chunk) {
 
   assert(record.opcode == OpCode::Chunk);
   if (record.dataSize < ChunkPreambleSize) {
-    const auto msg = internal::StrFormat(internal::ErrorMsgInvalidLength, "Chunk", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Chunk length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -833,8 +830,7 @@ Status McapReader::ParseChunk(const Record& record, Chunk* chunk) {
   }
   offset += 8;
   if (chunk->compressedSize > record.dataSize - offset) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Chunk.records", chunk->compressedSize);
+    const auto msg = internal::StrFormat("invalid Chunk.records length: ", chunk->compressedSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
   // records
@@ -848,8 +844,7 @@ Status McapReader::ParseMessageIndex(const Record& record, MessageIndex* message
 
   assert(record.opcode == OpCode::MessageIndex);
   if (record.dataSize < PreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "MessageIndex", record.dataSize);
+    const auto msg = internal::StrFormat("invalid MessageIndex length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -857,8 +852,7 @@ Status McapReader::ParseMessageIndex(const Record& record, MessageIndex* message
   const uint32_t recordsSize = internal::ParseUint32(record.data + 2);
 
   if (recordsSize % 16 != 0 || recordsSize > record.dataSize - PreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "MessageIndex.records", recordsSize);
+    const auto msg = internal::StrFormat("invalid MessageIndex.records length: ", recordsSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -877,8 +871,7 @@ Status McapReader::ParseChunkIndex(const Record& record, ChunkIndex* chunkIndex)
 
   assert(record.opcode == OpCode::ChunkIndex);
   if (record.dataSize < PreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "ChunkIndex", record.dataSize);
+    const auto msg = internal::StrFormat("invalid ChunkIndex length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -890,8 +883,8 @@ Status McapReader::ParseChunkIndex(const Record& record, ChunkIndex* chunkIndex)
 
   if (messageIndexOffsetsSize % 10 != 0 ||
       messageIndexOffsetsSize > record.dataSize - PreambleSize) {
-    const auto msg = internal::StrFormat(
-      internal::ErrorMsgInvalidLength, "ChunkIndex.message_index_offsets", messageIndexOffsetsSize);
+    const auto msg = internal::StrFormat("invalid ChunkIndex.message_index_offsets length:",
+                                         messageIndexOffsetsSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -945,8 +938,7 @@ Status McapReader::ParseAttachment(const Record& record, Attachment* attachment)
 
   assert(record.opcode == OpCode::Attachment);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Attachment", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Attachment length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -988,8 +980,7 @@ Status McapReader::ParseAttachment(const Record& record, Attachment* attachment)
   offset += 8;
   // data
   if (attachment->dataSize > record.dataSize - offset) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Attachment.data", attachment->dataSize);
+    const auto msg = internal::StrFormat("invalid Attachment.data length: ", attachment->dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
   attachment->data = record.data + offset;
@@ -1009,8 +1000,7 @@ Status McapReader::ParseAttachmentIndex(const Record& record, AttachmentIndex* a
 
   assert(record.opcode == OpCode::AttachmentIndex);
   if (record.dataSize < PreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "AttachmentIndex", record.dataSize);
+    const auto msg = internal::StrFormat("invalid AttachmentIndex length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1044,8 +1034,7 @@ Status McapReader::ParseStatistics(const Record& record, Statistics* statistics)
 
   assert(record.opcode == OpCode::Statistics);
   if (record.dataSize < PreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Statistics", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Statistics length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1062,8 +1051,8 @@ Status McapReader::ParseStatistics(const Record& record, Statistics* statistics)
     internal::ParseUint32(record.data + 8 + 2 + 4 + 4 + 4 + 4 + 8 + 8);
   if (channelMessageCountsSize % 10 != 0 ||
       channelMessageCountsSize > record.dataSize - PreambleSize) {
-    const auto msg = internal::StrFormat(
-      internal::ErrorMsgInvalidLength, "Statistics.channelMessageCounts", channelMessageCountsSize);
+    const auto msg = internal::StrFormat("invalid Statistics.channelMessageCounts length:",
+                                         channelMessageCountsSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1083,8 +1072,7 @@ Status McapReader::ParseMetadata(const Record& record, Metadata* metadata) {
 
   assert(record.opcode == OpCode::Metadata);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "Metadata", record.dataSize);
+    const auto msg = internal::StrFormat("invalid Metadata length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1109,8 +1097,7 @@ Status McapReader::ParseMetadataIndex(const Record& record, MetadataIndex* metad
 
   assert(record.opcode == OpCode::MetadataIndex);
   if (record.dataSize < PreambleSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "MetadataIndex", record.dataSize);
+    const auto msg = internal::StrFormat("invalid MetadataIndex length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1131,8 +1118,7 @@ Status McapReader::ParseSummaryOffset(const Record& record, SummaryOffset* summa
 
   assert(record.opcode == OpCode::SummaryOffset);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "SummaryOffset", record.dataSize);
+    const auto msg = internal::StrFormat("invalid SummaryOffset length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1148,8 +1134,7 @@ Status McapReader::ParseDataEnd(const Record& record, DataEnd* dataEnd) {
 
   assert(record.opcode == OpCode::DataEnd);
   if (record.dataSize < MinSize) {
-    const auto msg =
-      internal::StrFormat(internal::ErrorMsgInvalidLength, "DataEnd", record.dataSize);
+    const auto msg = internal::StrFormat("invalid DataEnd length: ", record.dataSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
 
@@ -1275,7 +1260,7 @@ bool TypedChunkReader::next() {
     case OpCode::DataEnd: {
       // These opcodes should not appear inside chunks
       const auto msg =
-        internal::StrFormat("record type {} cannot appear in Chunk", uint8_t(record.opcode));
+        internal::StrFormat("record type ", uint8_t(record.opcode), " cannot appear in Chunk");
       status_ = Status{StatusCode::InvalidOpCode, msg};
       break;
     }
@@ -1409,7 +1394,7 @@ bool TypedRecordReader::next() {
           const auto maybeCompression = McapReader::ParseCompression(chunk.compression);
           if (!maybeCompression.has_value()) {
             const auto msg =
-              internal::StrFormat("unrecognized compression \"{}\"", chunk.compression);
+              internal::StrFormat("unrecognized compression \"", chunk.compression, "\"");
             status_ = Status{StatusCode::UnrecognizedCompression, msg};
             return true;
           }
@@ -1581,8 +1566,8 @@ LinearMessageView::Iterator::Impl::Impl(McapReader& mcapReader, ByteOffset dataS
     if (!maybeChannel) {
       onProblem_(Status{
         StatusCode::InvalidChannelId,
-        internal::StrFormat("message at log_time {} (seq {}) references missing channel id {}",
-                            message.logTime, message.sequence, message.channelId)});
+        internal::StrFormat("message at log_time ", message.logTime, " (seq ", message.sequence,
+                            ") references missing channel id ", message.channelId)});
       return;
     }
 
@@ -1591,9 +1576,10 @@ LinearMessageView::Iterator::Impl::Impl(McapReader& mcapReader, ByteOffset dataS
     if (channel.schemaId != 0) {
       maybeSchema = mcapReader_.schema(channel.schemaId);
       if (!maybeSchema) {
-        onProblem_(Status{StatusCode::InvalidSchemaId,
-                          internal::StrFormat("channel {} ({}) references missing schema id {}",
-                                              channel.id, channel.topic, channel.schemaId)});
+        onProblem_(
+          Status{StatusCode::InvalidSchemaId,
+                 internal::StrFormat("channel ", channel.id, " (", channel.topic,
+                                     ") references missing schema id ", channel.schemaId)});
         return;
       }
     }

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -43,7 +43,7 @@ Status FileWriter::open(std::string_view filename, size_t bufferCapacity) {
   end();
   file_ = fopen(filename.data(), "wb");
   if (!file_) {
-    const auto msg = internal::StrCat("failed to open file \"{}\" for writing", filename);
+    const auto msg = internal::StrCat("failed to open file \"", filename, "\" for writing");
     return Status(StatusCode::OpenFailed, msg);
   }
   bufferCapacity_ = bufferCapacity;
@@ -498,7 +498,7 @@ Status McapWriter::write(const Message& message) {
   if (channelMessageCounts.find(message.channelId) == channelMessageCounts.end()) {
     const size_t channelIndex = message.channelId - 1;
     if (channelIndex >= channels_.size()) {
-      const auto msg = internal::StrCat("invalid channel id {}", message.channelId);
+      const auto msg = internal::StrCat("invalid channel id ", message.channelId);
       return Status{StatusCode::InvalidChannelId, msg};
     }
 
@@ -508,7 +508,7 @@ Status McapWriter::write(const Message& message) {
     if (writtenSchemas_.find(channel.schemaId) == writtenSchemas_.end()) {
       const size_t schemaIndex = channel.schemaId - 1;
       if (schemaIndex >= schemas_.size()) {
-        const auto msg = internal::StrCat("invalid schema id {}", channel.schemaId);
+        const auto msg = internal::StrCat("invalid schema id ", channel.schemaId);
         return Status{StatusCode::InvalidSchemaId, msg};
       }
 

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -43,7 +43,7 @@ Status FileWriter::open(std::string_view filename, size_t bufferCapacity) {
   end();
   file_ = fopen(filename.data(), "wb");
   if (!file_) {
-    const auto msg = internal::StrFormat("failed to open file \"{}\" for writing", filename);
+    const auto msg = internal::StrCat("failed to open file \"{}\" for writing", filename);
     return Status(StatusCode::OpenFailed, msg);
   }
   bufferCapacity_ = bufferCapacity;
@@ -498,7 +498,7 @@ Status McapWriter::write(const Message& message) {
   if (channelMessageCounts.find(message.channelId) == channelMessageCounts.end()) {
     const size_t channelIndex = message.channelId - 1;
     if (channelIndex >= channels_.size()) {
-      const auto msg = internal::StrFormat("invalid channel id {}", message.channelId);
+      const auto msg = internal::StrCat("invalid channel id {}", message.channelId);
       return Status{StatusCode::InvalidChannelId, msg};
     }
 
@@ -508,7 +508,7 @@ Status McapWriter::write(const Message& message) {
     if (writtenSchemas_.find(channel.schemaId) == writtenSchemas_.end()) {
       const size_t schemaIndex = channel.schemaId - 1;
       if (schemaIndex >= schemas_.size()) {
-        const auto msg = internal::StrFormat("invalid schema id {}", channel.schemaId);
+        const auto msg = internal::StrCat("invalid schema id {}", channel.schemaId);
         return Status{StatusCode::InvalidSchemaId, msg};
       }
 


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Removed `fmt` dependency to help with https://github.com/ros-tooling/rosbag2_storage_mcap integration