### PR TITLE
Remove go-centric install instructions

### DIFF
--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -52,12 +52,7 @@
       <h2>Quick start</h2>
       <p>
         Install the <code>mcap</code> CLI tool from
-        <a href="https://github.com/foxglove/mcap/releases">GitHub Releases</a>,
-        or by <a href="https://go.dev/dl/">installing Go</a> on your system and
-        running:
-      </p>
-      <pre><code class="shell-input-line">go install github.com/foxglove/mcap/go/cli/mcap@latest</code></pre>
-      <p>
+        <a href="https://github.com/foxglove/mcap/releases">GitHub Releases</a>.
         Use the <code>mcap</code> CLI tool to examine MCAP files, convert to
         MCAP from a
         <a href="https://wiki.ros.org/Bags">ROS 1 <code>.bag</code></a> or

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -52,7 +52,7 @@
       <h2>Quick start</h2>
       <p>
         Install the
-        <a href="https://github.com/foxglove/mcap/releases">mcap CLI tool</a>
+        <a href="https://github.com/foxglove/mcap/releases"><code>mcap</code> CLI tool</a>
         to examine MCAP files, convert to MCAP from a
         <a href="https://wiki.ros.org/Bags">ROS 1 <code>.bag</code></a> or
         <a

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -51,7 +51,8 @@
 
       <h2>Quick start</h2>
       <p>
-        Install the <a href="https://github.com/foxglove/mcap/releases">mcap CLI tool</a>
+        Install the
+        <a href="https://github.com/foxglove/mcap/releases">mcap CLI tool</a>
         to examine MCAP files, convert to MCAP from a
         <a href="https://wiki.ros.org/Bags">ROS 1 <code>.bag</code></a> or
         <a

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -51,10 +51,8 @@
 
       <h2>Quick start</h2>
       <p>
-        Install the <code>mcap</code> CLI tool from
-        <a href="https://github.com/foxglove/mcap/releases">GitHub Releases</a>.
-        Use the <code>mcap</code> CLI tool to examine MCAP files, convert to
-        MCAP from a
+        Install the <a href="https://github.com/foxglove/mcap/releases">mcap CLI tool</a>
+        to examine MCAP files, convert to MCAP from a
         <a href="https://wiki.ros.org/Bags">ROS 1 <code>.bag</code></a> or
         <a
           href="https://docs.ros.org/en/galactic/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.html"

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -52,7 +52,9 @@
       <h2>Quick start</h2>
       <p>
         Install the
-        <a href="https://github.com/foxglove/mcap/releases"><code>mcap</code> CLI tool</a>
+        <a href="https://github.com/foxglove/mcap/releases"
+          ><code>mcap</code> CLI tool</a
+        >
         to examine MCAP files, convert to MCAP from a
         <a href="https://wiki.ros.org/Bags">ROS 1 <code>.bag</code></a> or
         <a


### PR DESCRIPTION
**Public-Facing Changes**

This removes the only reference to a specific language or toolchain on the mcap.dev landing page.
