### PR TITLE
cli: fix cat reading beyond bounds of data

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -90,7 +90,11 @@ func printMessages(
 			log.Fatalf("Failed to read next message: %s", err)
 		}
 		if !formatJSON {
-			fmt.Fprintf(w, "%d %s [%s] %v...\n", message.LogTime, channel.Topic, schema.Name, message.Data[:10])
+			if len(message.Data) > 10 {
+				fmt.Fprintf(w, "%d %s [%s] %v...\n", message.LogTime, channel.Topic, schema.Name, message.Data[:10])
+			} else {
+				fmt.Fprintf(w, "%d %s [%s] %v\n", message.LogTime, channel.Topic, schema.Name, message.Data)
+			}
 			continue
 		}
 		switch schema.Encoding {

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -12,6 +12,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCat(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		assertion string
+		inputfile string
+		expected  string
+	}{
+		{
+			"OneMessage",
+			"../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap",
+			"2 example [Example] [1 2 3]\n",
+		},
+	}
+	for _, c := range cases {
+		input, err := ioutil.ReadFile(c.inputfile)
+		assert.Nil(t, err)
+		w := new(bytes.Buffer)
+		r := bytes.NewReader(input)
+		t.Run(c.assertion, func(t *testing.T) {
+			reader, err := mcap.NewReader(r)
+			assert.Nil(t, err)
+			it, err := reader.Messages(0, math.MaxInt64, []string{}, true)
+			assert.Nil(t, err)
+			err = printMessages(ctx, w, it, false)
+			assert.Nil(t, err)
+			r.Reset(input)
+			assert.Equal(t, c.expected, w.String())
+		})
+	}
+}
+
 func BenchmarkCat(b *testing.B) {
 	ctx := context.Background()
 	cases := []struct {

--- a/go/conformance/test-streamed-read-conformance/go.mod
+++ b/go/conformance/test-streamed-read-conformance/go.mod
@@ -2,9 +2,7 @@ module github.com/foxglove/mcap/go/conformance/test-streamed-read-conformance
 
 go 1.18
 
-replace github.com/foxglove/mcap/go/mcap => ../../mcap
-
-require github.com/foxglove/mcap/go/mcap v0.0.0-00010101000000-000000000000
+require github.com/foxglove/mcap/go/mcap v0.0.0-20220328132551-ffb9c0b0ebdc
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/go/conformance/test-streamed-write-conformance/go.mod
+++ b/go/conformance/test-streamed-write-conformance/go.mod
@@ -3,7 +3,7 @@ module github.com/foxglove/mcap/go/conformance/test-streamed-write-performance
 go 1.18
 
 require (
-	github.com/foxglove/mcap/go/mcap v0.0.0-00010101000000-000000000000
+	github.com/foxglove/mcap/go/mcap v0.0.0-20220328132551-ffb9c0b0ebdc
 	github.com/stretchr/testify v1.7.0
 )
 
@@ -14,5 +14,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
-
-replace github.com/foxglove/mcap/go/mcap => ../../mcap

--- a/go/go.work
+++ b/go/go.work
@@ -1,0 +1,9 @@
+go 1.18
+
+use (
+	./cli/mcap
+	./conformance/test-streamed-read-conformance
+	./conformance/test-streamed-write-conformance
+	./mcap
+	./ros
+)

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -311,13 +311,13 @@ func TestIndexStructures(t *testing.T) {
 			MessageStartTime: 1,
 			MessageEndTime:   1,
 			ChunkStartOffset: 105,
-			ChunkLength:      144,
+			ChunkLength:      145,
 			MessageIndexOffsets: map[uint16]uint64{
-				1: 249,
+				1: 250,
 			},
 			MessageIndexLength: 31,
 			Compression:        "zstd",
-			CompressedSize:     91,
+			CompressedSize:     92,
 			UncompressedSize:   110,
 		}, chunkIndex)
 	})


### PR DESCRIPTION
**Public-Facing Changes**
Fix a bug where cat would display data beyond the bound of a message record.