### PR TITLE
Update links for mcap CLI tool for clarity

### DIFF
--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -52,9 +52,7 @@
       <h2>Quick start</h2>
       <p>
         Install the
-        <a href="https://github.com/foxglove/mcap/releases"
-          >latest release</a
-        >
+        <a href="https://github.com/foxglove/mcap/releases">latest release</a>
         of the
         <a href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap"
           ><code>mcap</code> CLI tool</a

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -53,6 +53,10 @@
       <p>
         Install the
         <a href="https://github.com/foxglove/mcap/releases"
+          >latest release</a
+        >
+        of the
+        <a href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap"
           ><code>mcap</code> CLI tool</a
         >
         to examine MCAP files, convert to MCAP from a


### PR DESCRIPTION
**Public-Facing Changes**
- mcap CLI tool link should go to main docs, not a releases page
