### PR TITLE
Document CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ MCAP libraries are provided in the following languages. For guidance on each lan
 | Language              | Readme                 | API docs                                                        | Package name | Version                                                                              |
 | --------------------- | ---------------------- | --------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------ |
 | C++                   | [readme](./cpp)        | [API docs](https://mcap.dev/docs/cpp)                           | `mcap`       | [![](https://shields.io/conan/v/mcap)](https://conan.io/center/mcap)                 |
-| Go                    | [readme](./go)         | [API docs](https://pkg.go.dev/github.com/foxglove/mcap/go/mcap) |              | see [releases](https://github.com/foxglove/mcap/releases)                            |
+| Go                    | [readme](./go/mcap)    | [API docs](https://pkg.go.dev/github.com/foxglove/mcap/go/mcap) |              | see [releases](https://github.com/foxglove/mcap/releases)                            |
 | Python                | [readme](./python)     | [API docs](https://mcap.dev/docs/python)                        | `mcap`       | [![](https://shields.io/pypi/v/mcap)](https://pypi.org/project/mcap/)                |
 | JavaScript/TypeScript | [readme](./typescript) | [API docs](https://mcap.dev/docs/typescript)                    | `@mcap/core` | [![](https://shields.io/npm/v/@mcap/core)](https://www.npmjs.com/package/@mcap/core) |
 | Swift                 | [readme](./swift)      | [API docs](https://mcap.dev/docs/swift/documentation/mcap)      |              | see [releases](https://github.com/foxglove/mcap/releases)                            |
 
 To run the conformance tests, you will need to use [Git LFS](https://git-lfs.github.com/),
 which is used to store the test logs under `tests/conformance/data`.
+
+## CLI tool
+
+A CLI tool for interacting with the format is available [here](./go/cli/mcap).
 
 ## License
 

--- a/go/cli/mcap/README.md
+++ b/go/cli/mcap/README.md
@@ -7,8 +7,25 @@ for details.
 
 ### Installing:
 
-Download the latest release binary from
-[releases](https://github.com/foxglove/mcap/releases) or install using go:
+Either install from [releases
+binaries](https://github.com/foxglove/mcap/releases) or by using go.
+
+#### From release binaries
+
+Download the executable for your platform and mark it executable (if on mac or
+linux). For example,
+
+    wget https://github.com/foxglove/mcap/releases/latest/download/mcap-linux-amd64 -O mcap
+    chmod +x mcap
+
+If desired, move the binary onto your path.
+
+If on windows, download and run the appropriate .exe for your architecture from
+the releases page.
+
+#### Using go
+
+To install from the latest commit, use
 
     go install github.com/foxglove/mcap/go/cli/mcap@latest
 


### PR DESCRIPTION
Adds some notes about installation of the CLI tool from releases and
source. Also adds a note linking the CLI to the main README, and changes
the link for the go library to point at the library instead of the
parent folder.