### PR TITLE
Add `reverse` option to Mcap0IndexedReader#readMessages

### DIFF
--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -2,7 +2,7 @@ export { default as McapPre0Reader } from "./pre0/McapPre0Reader";
 export { default as McapPre0Writer } from "./pre0/McapPre0Writer";
 export * as McapPre0Types from "./pre0/types";
 
-export { default as Mcap0IndexedReader } from "./v0/Mcap0IndexedReader";
+export { Mcap0IndexedReader } from "./v0/Mcap0IndexedReader";
 export { default as Mcap0StreamReader } from "./v0/Mcap0StreamReader";
 export { Mcap0Writer } from "./v0/Mcap0Writer";
 export type { Mcap0WriterOptions } from "./v0/Mcap0Writer";

--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -60,6 +60,10 @@ export class ChunkCursor {
    */
   compare(other: ChunkCursor): number {
     const reverse = this.reverse;
+    if (this.reverse !== other.reverse) {
+      throw new Error("Cannot compare a reversed ChunkCursor to a non-reversed ChunkCursor");
+    }
+
     if (reverse) {
       // If chunks don't overlap at all, sort later chunk first
       if (this.chunkIndex.messageEndTime < other.chunkIndex.messageStartTime) {

--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -281,7 +281,7 @@ export class ChunkCursor {
 
       let startIndex = 0;
       if (reverse) {
-        if (this.endTime) {
+        if (this.endTime != undefined) {
           startIndex = sortedIndexBy(
             result.record.records,
             [this.endTime],
@@ -289,7 +289,7 @@ export class ChunkCursor {
           );
         }
       } else {
-        if (this.startTime) {
+        if (this.startTime != undefined) {
           startIndex = sortedIndexBy(
             result.record.records,
             [this.startTime],

--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -1,8 +1,8 @@
 import Heap from "heap-js";
 import { sortedIndexBy } from "lodash";
 
-import { parseRecord } from "../parse";
-import { IReadable, TypedMcapRecords } from "../types";
+import { parseRecord } from "./parse";
+import { IReadable, TypedMcapRecords } from "./types";
 
 type ChunkCursorParams = {
   chunkIndex: TypedMcapRecords["ChunkIndex"];

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -245,18 +245,13 @@ describe("Mcap0IndexedReader", () => {
       data: new Uint8Array(),
     };
     it.each([
-      {
-        startTime: undefined,
-        endTime: undefined,
-        expected: [message1, message2, message3],
-      },
+      { startTime: undefined, endTime: undefined, expected: [message1, message2, message3] },
       { startTime: 11n, endTime: 11n, expected: [message2] },
-
       { startTime: 11n, endTime: undefined, expected: [message2, message3] },
       { startTime: undefined, endTime: 11n, expected: [message1, message2] },
       { startTime: 10n, endTime: 12n, expected: [message1, message2, message3] },
     ])(
-      "fetches chunk data and reads requested messages between $startTime and $endTime, reverse: $reverse",
+      "fetches chunk data and reads requested messages between $startTime and $endTime",
       async ({ startTime, endTime, expected }) => {
         const schema = record(Opcode.SCHEMA, [
           ...uint16LE(1), // schema id

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -1,9 +1,9 @@
 import { crc32 } from "@foxglove/crc";
 
-import Mcap0IndexedReader from ".";
-import { ChunkBuilder } from "../ChunkBuilder";
-import { Mcap0RecordBuilder } from "../Mcap0RecordBuilder";
-import { MCAP0_MAGIC, Opcode } from "../constants";
+import { Mcap0IndexedReader } from "./Mcap0IndexedReader";
+import { ChunkBuilder } from "./ChunkBuilder";
+import { Mcap0RecordBuilder } from "./Mcap0RecordBuilder";
+import { MCAP0_MAGIC, Opcode } from "./constants";
 import {
   record,
   uint64LE,
@@ -13,8 +13,8 @@ import {
   collect,
   uint16LE,
   uint32PrefixedBytes,
-} from "../testUtils";
-import { TypedMcapRecord, TypedMcapRecords } from "../types";
+} from "./testUtils";
+import { TypedMcapRecord, TypedMcapRecords } from "./types";
 
 /**
  * Create an IReadable from a buffer. Simulates small buffer reuse to help test that readers aren't

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -244,7 +244,7 @@ describe("Mcap0IndexedReader", () => {
       logTime: 12n,
       data: new Uint8Array(),
     };
-    it.only.each([
+    it.each([
       {
         startTime: undefined,
         endTime: undefined,

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -1,7 +1,7 @@
 import { crc32 } from "@foxglove/crc";
 
-import { Mcap0IndexedReader } from "./Mcap0IndexedReader";
 import { ChunkBuilder } from "./ChunkBuilder";
+import { Mcap0IndexedReader } from "./Mcap0IndexedReader";
 import { Mcap0RecordBuilder } from "./Mcap0RecordBuilder";
 import { MCAP0_MAGIC, Opcode } from "./constants";
 import {

--- a/typescript/core/src/v0/Mcap0IndexedReader.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.ts
@@ -1,10 +1,10 @@
 import { crc32, crc32Final, crc32Init, crc32Update } from "@foxglove/crc";
 import Heap from "heap-js";
 
+import { ChunkCursor } from "./ChunkCursor";
 import { MCAP0_MAGIC } from "./constants";
 import { parseMagic, parseRecord } from "./parse";
 import { DecompressHandlers, IReadable, TypedMcapRecords } from "./types";
-import { ChunkCursor } from "./ChunkCursor";
 
 type Mcap0IndexedReaderArgs = {
   readable: IReadable;
@@ -64,7 +64,6 @@ export class Mcap0IndexedReader {
     return new Error(`${message} [library=${this.header.library}]`);
   }
 
-  // fixme - what is this and when do I call it?
   static async Initialize({
     readable,
     decompressHandlers,

--- a/typescript/core/src/v0/Mcap0IndexedReader.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.ts
@@ -1,12 +1,12 @@
 import { crc32, crc32Final, crc32Init, crc32Update } from "@foxglove/crc";
 import Heap from "heap-js";
 
-import { MCAP0_MAGIC } from "../constants";
-import { parseMagic, parseRecord } from "../parse";
-import { DecompressHandlers, IReadable, TypedMcapRecords } from "../types";
+import { MCAP0_MAGIC } from "./constants";
+import { parseMagic, parseRecord } from "./parse";
+import { DecompressHandlers, IReadable, TypedMcapRecords } from "./types";
 import { ChunkCursor } from "./ChunkCursor";
 
-export default class Mcap0IndexedReader {
+export class Mcap0IndexedReader {
   readonly chunkIndexes: readonly TypedMcapRecords["ChunkIndex"][];
   readonly attachmentIndexes: readonly TypedMcapRecords["AttachmentIndex"][];
   readonly metadataIndexes: readonly TypedMcapRecords["MetadataIndex"][] = [];

--- a/typescript/core/src/v0/Mcap0Writer.test.ts
+++ b/typescript/core/src/v0/Mcap0Writer.test.ts
@@ -1,6 +1,6 @@
 import { crc32 } from "@foxglove/crc";
 
-import Mcap0IndexedReader from "./Mcap0IndexedReader";
+import { Mcap0IndexedReader } from "./Mcap0IndexedReader";
 import Mcap0StreamReader from "./Mcap0StreamReader";
 import { Mcap0Writer } from "./Mcap0Writer";
 import { Opcode } from "./constants";


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
A new `reverse` option for the `readMessages` method of Mcap0IndexedReader. The reverse option emits messages in reverse logTime order (i.e. older messages first).

`startTime` and `endTime` arguments are _not_ reversed when using the `reverse` option. Only the order of the messages produced from the iterator.

**Description**
<!-- describe what has changed, and motivation behind those changes -->
Providing a reverse iterator allows users to lookup the latest messages on a topic. This is useful when building a file player and wanting to find the latest available message on all requested topics when seeking to arbitrary locations in an indexed file.

<!-- link relevant GitHub issues -->
