### PR TITLE
Remove instructions for go command

### DIFF
--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -59,14 +59,7 @@
         <a href="https://github.com/foxglove/mcap/releases">
           latest <code>mcap-cli</code> release binary</a
         >
-        for your platform or by running a simple
-        <a
-          href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap#using-go"
-        >
-          <code>go</code> command</a
-        >
-        . With the tool installed, you will be able to examine MCAP files,
-        convert a
+        for your platform. You can now examine MCAP files, convert a
         <a href="https://wiki.ros.org/Bags">ROS 1 <code>.bag</code></a> or
         <a
           href="https://docs.ros.org/en/galactic/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.html"


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
- Remove instructions using go command for installation
- Resolves https://github.com/foxglove/mcap/issues/393 