### PR TITLE
CLI: Ensure connection data headers are all converted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 testdata/mcap/demo.mcap filter=lfs diff=lfs merge=lfs -text
 testdata/ filter=lfs diff=lfs merge=lfs -text
 tests/conformance/data/** linguist-generated=true
+go/ros/testdata/markers.bag filter=lfs diff=lfs merge=lfs -text

--- a/go/ros/testdata/markers.bag
+++ b/go/ros/testdata/markers.bag
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dde6a4c872a387e31d15bc6ebd0f71c944aab9789f40d744eb526f2d8cfede6
+size 15423


### PR DESCRIPTION
Prior to this commit, only the md5sum connection data header would be
converted to channel metadata in bag to mcap conversion. With this
change, we convert everything except the message definition and data
type, which are already represented in the schema/channel structures.