### PR TITLE
Bump TS package version

### DIFF
--- a/typescript/core/.yarnrc
+++ b/typescript/core/.yarnrc
@@ -1,0 +1,2 @@
+version-tag-prefix "releases/typescript/v"
+version-git-message "TypeScript v%s"

--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCAP file support in TypeScript",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
**Public-Facing Changes**
`@mcap/core` JS/TS package is published at v0.1.1.
