### PR TITLE
Fix reading messages outside of requested time range

### DIFF
--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -305,6 +305,15 @@ export class ChunkCursor {
       if (startIndex >= result.record.records.length) {
         continue;
       }
+      if (reverse) {
+        if (this.startTime != undefined && result.record.records[startIndex]![0] < this.startTime) {
+          continue;
+        }
+      } else {
+        if (this.endTime != undefined && result.record.records[startIndex]![0] > this.endTime) {
+          continue;
+        }
+      }
 
       this.messageIndexCursors.push({
         index: startIndex,

--- a/typescript/core/src/v0/Mcap0Writer.test.ts
+++ b/typescript/core/src/v0/Mcap0Writer.test.ts
@@ -3,42 +3,11 @@ import { crc32 } from "@foxglove/crc";
 import { Mcap0IndexedReader } from "./Mcap0IndexedReader";
 import Mcap0StreamReader from "./Mcap0StreamReader";
 import { Mcap0Writer } from "./Mcap0Writer";
+import { TempBuffer } from "./TempBuffer";
 import { Opcode } from "./constants";
 import { parseMagic, parseRecord } from "./parse";
 import { collect, keyValues, record, string, uint16LE, uint32LE, uint64LE } from "./testUtils";
 import { TypedMcapRecord } from "./types";
-
-class TempBuffer {
-  private _buffer = new ArrayBuffer(1024);
-  private _size = 0;
-
-  position() {
-    return BigInt(this._size);
-  }
-  async write(data: Uint8Array) {
-    if (this._size + data.byteLength > this._buffer.byteLength) {
-      const newBuffer = new ArrayBuffer(this._size + data.byteLength);
-      new Uint8Array(newBuffer).set(new Uint8Array(this._buffer));
-      this._buffer = newBuffer;
-    }
-    new Uint8Array(this._buffer, this._size).set(data);
-    this._size += data.byteLength;
-  }
-
-  async size() {
-    return BigInt(this._size);
-  }
-  async read(offset: bigint, size: bigint) {
-    if (offset < 0n || offset + size > BigInt(this._buffer.byteLength)) {
-      throw new Error("read out of range");
-    }
-    return new Uint8Array(this._buffer, Number(offset), Number(size));
-  }
-
-  get() {
-    return new Uint8Array(this._buffer, 0, this._size);
-  }
-}
 
 describe("Mcap0Writer", () => {
   it("supports messages with logTime 0", async () => {

--- a/typescript/core/src/v0/TempBuffer.ts
+++ b/typescript/core/src/v0/TempBuffer.ts
@@ -1,0 +1,34 @@
+import { IWritable } from "../common/IWritable";
+import { IReadable } from "./types";
+
+export class TempBuffer implements IReadable, IWritable {
+  private _buffer = new ArrayBuffer(1024);
+  private _size = 0;
+
+  position(): bigint {
+    return BigInt(this._size);
+  }
+  async write(data: Uint8Array): Promise<void> {
+    if (this._size + data.byteLength > this._buffer.byteLength) {
+      const newBuffer = new ArrayBuffer(this._size + data.byteLength);
+      new Uint8Array(newBuffer).set(new Uint8Array(this._buffer));
+      this._buffer = newBuffer;
+    }
+    new Uint8Array(this._buffer, this._size).set(data);
+    this._size += data.byteLength;
+  }
+
+  async size(): Promise<bigint> {
+    return BigInt(this._size);
+  }
+  async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+    if (offset < 0n || offset + size > BigInt(this._buffer.byteLength)) {
+      throw new Error("read out of range");
+    }
+    return new Uint8Array(this._buffer, Number(offset), Number(size));
+  }
+
+  get(): Uint8Array {
+    return new Uint8Array(this._buffer, 0, this._size);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,6 +891,15 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@mcap/core@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@mcap/core/-/core-0.1.1.tgz#4133d8505ea108f650d5bedca1aeb422c3afaea6"
+  integrity sha512-8TiYLkmzHSvWglWqbdIR2lQi3djZt4/SyopeXBGaKewfoG9E8m5lxBvLrXB4GrCNPf/S39275BlXpRlILZBZcQ==
+  dependencies:
+    "@foxglove/crc" "^0.0.3"
+    heap-js "^2.1.6"
+    tslib "^2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3367,6 +3376,13 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -3374,13 +3390,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsdom@^16.6.0:
   version "16.7.0"
@@ -3499,12 +3508,12 @@ jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-kaitai-struct-compiler@^0.9.0:
+kaitai-struct-compiler@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/kaitai-struct-compiler/-/kaitai-struct-compiler-0.9.0.tgz#90ff9cd0f0ea0ec4f8532de2ca1e2439df6999be"
   integrity sha512-KA1rRv6FjUl/J8UfLhpvgtG3UGx6mDh6/Q1uC+/CSr3RsK4ejvDehY59DjQSNF3iNtzHo6kvptoa9XmUD3gIrg==
 
-kaitai-struct@^0.9.0:
+kaitai-struct@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/kaitai-struct/-/kaitai-struct-0.9.0.tgz#07264320f7aa4fa4c9d6b261495f483ab1af569b"
   integrity sha512-mfoBu9+IGqaY3ykG1TyAy9omOAZWtheqESQOvo/HKIQVTz+gRPVCNBnhjbO+8wAQ77RD33wYvLBWmITuXIviQg==


### PR DESCRIPTION
**Public-Facing Changes**
Fixed an issue where `Mcap0IndexedReader` would crash when trying to read messages with a requested time range that ended in the middle of a chunk but before the earliest message on some channel in that chunk.

**Description**
There is logic to avoid _advancing_ the cursor beyond the requested range, but the logic to choose the initial index was assuming that all message indexes within a chunk that overlaps the requested range would have at least one message in the requested range.