### PR TITLE
docs tweaks

### DIFF
--- a/docs/website/favicon144.png
+++ b/docs/website/favicon144.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0778e4e9fcd81c0424eebee8c74f8d709a019e78689cce9cfff6e379d96cb9dc
+size 26236

--- a/docs/website/favicon32.png
+++ b/docs/website/favicon32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:657b8c80070f5f5a8408af52733173b1e593b8ec21fe75354caf17b3106ddc22
+size 3509

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="./dist/bundle.css" rel="stylesheet" />
+    <link rel="icon" href="favicon32.png" sizes="32x32" />
+    <link rel="apple-touch-icon" href="favicon144.png" sizes="144x144" />
     <title>
       MCAP: a serialization-agnostic container file format for pub/sub
     </title>
@@ -18,18 +20,30 @@
   <body>
     <div class="max-w-3xl mx-auto">
       <nav class="nav-links links">
-        <a href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap"
-          ><code>mcap</code> CLI</a
+        <span
+          ><a href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap"
+            ><code>mcap</code> CLI</a
+          ></span
         >
-        <a href="https://mcap.dev/docs/cpp/">For C++</a>
-        <a href="https://mcap.dev/docs/python/">For Python</a>
-        <a href="https://mcap.dev/docs/typescript/">For TypeScript</a>
-        <a href="https://pkg.go.dev/github.com/foxglove/mcap/go/mcap">For Go</a>
-        <a href="https://mcap.dev/docs/swift/documentation/mcap/">For Swift</a>
+        <span><a href="https://mcap.dev/docs/cpp/">C++ API</a></span>
+        <span><a href="https://mcap.dev/docs/python/">Python API</a></span>
+        <span
+          ><a href="https://mcap.dev/docs/typescript/">TypeScript API</a></span
+        >
+        <span
+          ><a href="https://pkg.go.dev/github.com/foxglove/mcap/go/mcap"
+            >Go API</a
+          ></span
+        >
+        <span
+          ><a href="https://mcap.dev/docs/swift/documentation/mcap/"
+            >Swift API</a
+          ></span
+        >
       </nav>
 
       <h1 class="mt-8 mb-4 text-center font-bold text-4xl md:text-5xl">
-        <img src="mcap.png" alt="" class="inline-block h-16" />
+        <img src="mcap.png" alt="MCAP logo" class="header-logo" />
         <a href="https://github.com/foxglove/mcap">MCAP</a>
       </h1>
 
@@ -49,7 +63,7 @@
         durability requirements.
       </p>
 
-      <dl class="features">
+      <div class="features">
         <div class="row">
           <div class="col">
             <svg
@@ -147,112 +161,108 @@
             </ul>
           </div>
         </div>
-      </dl>
+      </div>
 
-      <dl class="quick-start">
-        <h2>Quick start</h2>
-        <p>
-          Install the
-          <a href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap"
-            ><code>mcap</code> CLI tool</a
-          >
-          to accomplish any of the following tasks and more:
-        </p>
+      <h2>Quick start</h2>
+      <p>
+        Install the
+        <a href="https://github.com/foxglove/mcap/tree/main/go/cli/mcap"
+          ><code>mcap</code> CLI tool</a
+        >
+        to accomplish any of the following tasks and more:
+      </p>
+      <ul>
+        <li>Examine and get summary information about MCAP files</li>
+        <li>Validate MCAP files</li>
+        <li>Dump an MCAP file’s contents to <code>stdout</code></li>
+        <li>
+          Convert a ROS 1 <code>.bag</code> or ROS 2 <code>.db3</code> file into
+          an MCAP file
+        </li>
+      </ul>
+
+      <p>
+        You can also use the MCAP libraries below to read and write your own
+        MCAP files:
+      </p>
+      <nav class="links space-x-4">
+        <a href="https://mcap.dev/docs/cpp/">C++</a>
+        <a href="https://mcap.dev/docs/python/">Python</a>
+        <a href="https://mcap.dev/docs/typescript/">TypeScript</a>
+        <a href="https://pkg.go.dev/github.com/foxglove/mcap/go/mcap">Go</a>
+        <a href="https://mcap.dev/docs/swift/documentation/mcap/">Swift</a>
+      </nav>
+
+      <h2>Additional resources</h2>
+      <p>MCAP organizes its data via the following concepts:</p>
+      <dl class="glossary">
+        <div>
+          <dt>Message</dt>
+          <dd>
+            The unit of communication between nodes in the pub/sub system.
+          </dd>
+        </div>
+        <div>
+          <dt>Channel</dt>
+          <dd>
+            A stream of messages which have the same type, or schema. Often
+            corresponds to a connection between a publisher and a subscriber.
+          </dd>
+        </div>
+        <div>
+          <dt>Schema</dt>
+          <dd>
+            A description of the structure and contents of messages on a
+            channel, e.g. a
+            <a
+              href="https://developers.google.com/protocol-buffers/docs/techniques#self-description"
+              >Protobuf <code>FileDescriptorSet</code></a
+            >
+            or <a href="https://json-schema.org">JSON Schema</a>.
+          </dd>
+        </div>
+      </dl>
+      <p>Check out the resources below to learn more about MCAP:</p>
+      <nav>
         <ul>
-          <li>Examine and get summary information about MCAP files</li>
-          <li>Validate MCAP files</li>
-          <li>Dump an MCAP file’s contents to <code>stdout</code></li>
           <li>
-            Convert a ROS 1 <code>.bag</code> or ROS 2 <code>.db3</code> file
-            into an MCAP file
+            <a
+              href="https://github.com/foxglove/mcap/blob/main/docs/motivation/evaluation-of-robotics-data-recording-file-formats.md"
+              >Motivation for MCAP: Evaluation of robotics data recording file
+              formats</a
+            >
+          </li>
+          <li>
+            <a href="https://github.com/foxglove/mcap"
+              >MCAP implementations on GitHub</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/foxglove/mcap/tree/main/docs/specification"
+              >File format specification</a
+            >
+          </li>
+
+          <li>
+            <a
+              href="https://github.com/foxglove/mcap/tree/main/tests/conformance"
+              >Conformance tests</a
+            >
+          </li>
+          <li>
+            <a href="https://github.com/ros-tooling/rosbag2_storage_mcap"
+              >ROS 2 storage plugin</a
+            >
           </li>
         </ul>
+      </nav>
 
-        <p>
-          You can also use the MCAP libraries below to read and write your own
-          MCAP files:
-        </p>
-        <nav class="links">
-          <a href="https://mcap.dev/docs/cpp/">C++</a>
-          <a href="https://mcap.dev/docs/python/">Python</a>
-          <a href="https://mcap.dev/docs/typescript/">TypeScript</a>
-          <a href="https://pkg.go.dev/github.com/foxglove/mcap/go/mcap">Go</a>
-          <a href="https://mcap.dev/docs/swift/documentation/mcap/">Swift</a>
-        </nav>
-      </dl>
-
-      <dl class="resources">
-        <h2>Additional resources</h2>
-        <p>MCAP organizes its data via the following concepts:</p>
-        <dl class="glossary">
-          <div>
-            <dt>Message</dt>
-            <dd>
-              The unit of communication between nodes in the pub/sub system.
-            </dd>
-          </div>
-          <div>
-            <dt>Channel</dt>
-            <dd>
-              A stream of messages which have the same type, or schema. Often
-              corresponds to a connection between a publisher and a subscriber.
-            </dd>
-          </div>
-          <div>
-            <dt>Schema</dt>
-            <dd>
-              A description of the structure and contents of messages on a
-              channel, e.g. a
-              <a
-                href="https://developers.google.com/protocol-buffers/docs/techniques#self-description"
-                >Protobuf <code>FileDescriptorSet</code></a
-              >
-              or <a href="https://json-schema.org">JSON Schema</a>.
-            </dd>
-          </div>
-        </dl>
-        <p>Check out the resources below to learn more about MCAP:</p>
-        <nav>
-          <ul>
-            <li>
-              <a
-                href="https://github.com/foxglove/mcap/blob/main/docs/motivation/evaluation-of-robotics-data-recording-file-formats.md"
-                >Motivation for MCAP: Evaluation of robotics data recording file
-                formats</a
-              >
-            </li>
-            <li>
-              <a href="https://github.com/foxglove/mcap"
-                >MCAP implementations on GitHub</a
-              >
-            </li>
-            <li>
-              <a
-                href="https://github.com/foxglove/mcap/tree/main/docs/specification"
-                >File format specification</a
-              >
-            </li>
-
-            <li>
-              <a
-                href="https://github.com/foxglove/mcap/tree/main/tests/conformance"
-                >Conformance tests</a
-              >
-            </li>
-            <li>
-              <a href="https://github.com/ros-tooling/rosbag2_storage_mcap"
-                >ROS 2 storage plugin</a
-              >
-            </li>
-          </ul>
-        </nav>
-
-        <p>
-          Join the
-          <a href="https://foxglove.dev/slack">Foxglove Slack community</a> to
-          ask questions and give feedback.
-        </p>
-      </dl>
+      <p>
+        Join the
+        <a href="https://foxglove.dev/slack">Foxglove Slack community</a> to ask
+        questions and give feedback.
+      </p>
     </div>
   </body>
 </html>

--- a/docs/website/style.css
+++ b/docs/website/style.css
@@ -76,9 +76,8 @@
   }
 
   .features .col {
-    @apply flex flex-col items-center flex-1 p-4 border border-zinc-400 dark:border-zinc-600;
+    @apply flex flex-col items-center flex-1 p-4 border rounded border-zinc-400 dark:border-zinc-600;
     min-width: 180px;
-    border-radius: 5px;
   }
 
   .features .header {

--- a/docs/website/style.css
+++ b/docs/website/style.css
@@ -57,25 +57,27 @@
     @apply table-cell pb-2;
   }
 
+  .header-logo {
+    @apply inline-block align-bottom;
+    height: 1em;
+  }
+
   .nav-links {
-    display: flex;
-    justify-content: space-around;
-    margin-bottom: 2em;
+    @apply flex flex-wrap justify-around gap-x-4;
   }
 
   .features {
-    @apply pt-4 flex flex-col flex-wrap;
+    @apply pt-4 flex flex-col flex-wrap gap-4;
     font-size: 15px;
   }
 
   .features .row {
-    @apply flex flex-wrap flex-1;
+    @apply flex flex-wrap flex-1 gap-4;
   }
 
   .features .col {
-    @apply flex flex-col items-center flex-1 m-2 p-4;
+    @apply flex flex-col items-center flex-1 p-4 border border-zinc-400 dark:border-zinc-600;
     min-width: 180px;
-    border: 1px solid gray;
     border-radius: 5px;
   }
 
@@ -91,16 +93,14 @@
     @apply mt-0;
   }
 
-  .features ul,
-  .quick-start ul,
-  .resources ul {
+  ul {
     list-style: unset;
     margin: revert;
     padding: revert;
   }
 
   .links {
-    @apply mx-8 space-x-4;
+    @apply mx-8;
   }
   .links a {
     @apply border-sky-400 border-b text-black dark:text-gray-100 no-underline;


### PR DESCRIPTION
**Public-Facing Changes**
Minor tweaks to docs page


**Description**
- Change header link wording from "For C++" to "C++ API"
- Fix styling on header links so the container doesn't get taller on hover
- Remove misplaced `<dl>` wrapper elements
- Add favicon
- Tweak card borders