### PR TITLE
Use mislav/bump-homebrew-formula-action to bump homebrew formula upon release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,12 +331,12 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/mcap-cli/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v2
+      - uses: mislav/bump-homebrew-formula-action@64410e9c960837db57b7e35627eb716faaaaec51
         with:
           formula-name: mcap
           push-to: foxglove/homebrew-core
         env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
 
   swift:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,19 @@ jobs:
           body_path: ${{ github.workspace }}-CHANGELOG.txt
           draft: false
 
+  update-homebrew-formula:
+    needs:
+      - go-release-cli
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/mcap-cli/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v2
+        with:
+          formula-name: mcap
+          push-to: foxglove/homebrew-core
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+
   swift:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Make a PR to bump homebrew formula when new release tag is made