### PR TITLE
cli: parse fields with tab after name

### DIFF
--- a/go/ros/ros1msg/ros1msg_parser.go
+++ b/go/ros/ros1msg/ros1msg_parser.go
@@ -2,11 +2,16 @@ package ros1msg
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/foxglove/mcap/go/ros"
 )
+
+// Field names are restricted to "an alphabetical character followed by any mixture of alphanumeric and underscores",
+// per http://wiki.ros.org/msg#Fields
+var fieldMatcher = regexp.MustCompile(`([^ ]+) +([a-zA-Z][a-zA-Z0-9_]+)`)
 
 type Type struct {
 	BaseType  string
@@ -44,12 +49,12 @@ func resolveDependentFields(
 		}
 
 		// must be a field
-		parts := strings.FieldsFunc(line, func(c rune) bool { return c == ' ' })
-		if len(parts) < 2 {
+		matches := fieldMatcher.FindStringSubmatch(line)
+		if len(matches) < 3 {
 			return nil, fmt.Errorf("malformed field on line %d: %s", i, line)
 		}
-		fieldType := parts[0]
-		fieldName := parts[1]
+		fieldType := matches[1]
+		fieldName := matches[2]
 
 		var isRecord bool
 		var recordFields []Field

--- a/go/ros/ros1msg/ros1msg_parser_test.go
+++ b/go/ros/ros1msg/ros1msg_parser_test.go
@@ -248,6 +248,19 @@ func TestROS1MSGParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			"uses tabs instead of spaces",
+			"",
+			"string foo\t# no spaces for me",
+			[]Field{
+				{
+					Name: "foo",
+					Type: Type{
+						BaseType: "string",
+					},
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {


### PR DESCRIPTION
Previously the parser assumed that any comment after a field name would
come after a space, like this:

```
Type name # the comment
```

However, there is at least one standard msg definition which breaks this
rule, `ns` in ImageMarker:
https://docs.ros.org/en/noetic/api/visualization_msgs/html/msg/ImageMarker.html

```
string ns\t# namespace, used with id to form a unique id
```

This commit uses the field name description in http://wiki.ros.org/msg#Fields to determine which chars contain the field name.

**Public-Facing Changes**
This slightly changes the behaviour of `mcap cat --json`, which attempts to parse and JSON-encode ROS msg definitions.
<!-- describe any changes to the public interface or APIs, or write "None" -->