### PR TITLE
CLI: Make release notes grep case insensitive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
           OUTPUT: mcap-${{ matrix.os }}-${{ matrix.arch }}
       - name: Make release notes
         run: |
-          git log --oneline --no-merges --first-parent --grep CLI --decorate-refs=refs $(git describe --tags $(git rev-list --tags=releases/mcap-cli --max-count=1))..HEAD > ${{ github.workspace }}-CHANGELOG.txt
+          git log --oneline --no-merges --first-parent --grep CLI -i --decorate-refs=refs $(git describe --tags $(git rev-list --tags=releases/mcap-cli --max-count=1))..HEAD > ${{ github.workspace }}-CHANGELOG.txt
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Changes the release script to use a case-insensitive filter for "CLI"
when compiling commit summaries for the GH release notes.