### PR TITLE
CLI: mcap filter subcommand

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -1,0 +1,317 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"regexp"
+
+	"github.com/foxglove/mcap/go/cli/mcap/utils"
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/spf13/cobra"
+)
+
+var (
+	filterOutput             string
+	filterIncludeTopics      []string
+	filterExcludeTopics      []string
+	filterStart              uint64
+	filterEnd                uint64
+	filterIncludeMetadata    bool
+	filterIncludeAttachments bool
+	filterOutputCompression  string
+)
+
+type filterOpts struct {
+	includeTopics      []regexp.Regexp
+	excludeTopics      []regexp.Regexp
+	start              uint64
+	end                uint64
+	includeMetadata    bool
+	includeAttachments bool
+	compressionFormat  mcap.CompressionFormat
+}
+
+func buildFilterOptions() (*filterOpts, error) {
+	opts := &filterOpts{
+		start:              filterStart,
+		end:                filterEnd,
+		includeMetadata:    filterIncludeMetadata,
+		includeAttachments: filterIncludeAttachments,
+	}
+	if len(filterIncludeTopics) > 0 && len(filterExcludeTopics) > 0 {
+		return nil, errors.New("can only use one of --include-topic-regex and --exclude-topic-regex")
+	}
+	if filterEnd < filterStart {
+		return nil, errors.New("invalid time range query, end-time is before start-time")
+	}
+	opts.compressionFormat = mcap.CompressionNone
+	switch filterOutputCompression {
+	case "zstd":
+		opts.compressionFormat = mcap.CompressionZSTD
+	case "lz4":
+		opts.compressionFormat = mcap.CompressionLZ4
+	case "none":
+		opts.compressionFormat = mcap.CompressionNone
+	default:
+		return nil, fmt.Errorf("unrecognized compression format '%s': valid options are 'lz4', 'zstd', or 'none'", filterOutputCompression)
+	}
+
+	includeTopics, err := compileMatchers(filterIncludeTopics)
+	if err != nil {
+		return nil, err
+	}
+	opts.includeTopics = includeTopics
+
+	excludeTopics, err := compileMatchers(filterExcludeTopics)
+	if err != nil {
+		return nil, err
+	}
+	opts.excludeTopics = excludeTopics
+	return opts, nil
+}
+
+// filterCmd represents the filter command
+var filterCmd = &cobra.Command{
+	Use:   "filter",
+	Short: "copy some filtered MCAP data to a new file",
+	Long: `This subcommand filters an MCAP by topic and time range to a new file.
+When multiple regexes are used, topics that match any regex are included (or excluded).
+
+usage example:
+  mcap filter in.mcap -o out.mcap -y /diagnostics -y /tf -y /camera_(front|back)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		filterOptions, err := buildFilterOptions()
+		if err != nil {
+			die("configuration error: %s", err)
+		}
+		var reader io.Reader
+		if len(args) == 0 {
+			stat, err := os.Stdin.Stat()
+			if err != nil {
+				die("failed to check stdin state: %s", err)
+			}
+			if stat.Mode()&os.ModeCharDevice == 0 {
+				reader = os.Stdin
+			} else {
+				die("supply a file to read")
+			}
+		} else {
+			close, newReader, err := utils.GetReader(context.Background(), args[0])
+			if err != nil {
+				die("failed to open source for reading: %s", err)
+			}
+			defer func() {
+				if closeErr := close(); closeErr != nil {
+					die("error closing read source: %s", closeErr)
+				}
+			}()
+			reader = newReader
+		}
+
+		var writer io.Writer
+		if filterOutput == "" {
+			if !utils.StdoutRedirected() {
+				die("Binary output can screw up your terminal. Supply -o or redirect to a file or pipe")
+			}
+			writer = os.Stdin
+		} else {
+			newWriter, err := os.Create(filterOutput)
+			if err != nil {
+				die("failed to open %s for writing: %s", filterOutput, err)
+			}
+			writer = newWriter
+		}
+
+		err = filter(reader, writer, filterOptions)
+		if err != nil {
+			die(error.Error(err))
+		}
+	},
+}
+
+func compileMatchers(regexStrings []string) ([]regexp.Regexp, error) {
+	var matchers []regexp.Regexp
+
+	for _, regexString := range regexStrings {
+		// auto-surround with ^$ if not specified.
+		if regexString[:1] != "^" {
+			regexString = "^" + regexString
+		}
+		if regexString[len(regexString)-1:] != "$" {
+			regexString = regexString + "$"
+		}
+		regex, err := regexp.Compile(regexString)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, *regex)
+	}
+	return matchers, nil
+}
+
+type markableSchema struct {
+	*mcap.Schema
+	written bool
+}
+type markableChannel struct {
+	*mcap.Channel
+	written bool
+}
+
+func filter(
+	r io.Reader,
+	w io.Writer,
+	opts *filterOpts,
+) error {
+	lexer, err := mcap.NewLexer(r)
+	if err != nil {
+		return err
+	}
+	mcapWriter, err := mcap.NewWriter(w, &mcap.WriterOptions{
+		Compression: opts.compressionFormat,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = mcapWriter.Close()
+	}()
+
+	buf := make([]byte, 1024)
+	schemas := make(map[uint16]markableSchema)
+	channels := make(map[uint16]markableChannel)
+
+	for {
+		token, data, err := lexer.Next(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+		}
+		if len(data) > len(buf) {
+			buf = data
+		}
+		switch token {
+		case mcap.TokenHeader:
+			header, err := mcap.ParseHeader(data)
+			if err != nil {
+				return err
+			}
+			if err = mcapWriter.WriteHeader(header); err != nil {
+				return err
+			}
+		case mcap.TokenSchema:
+			schema, err := mcap.ParseSchema(data)
+			if err != nil {
+				return err
+			}
+			schemas[schema.ID] = markableSchema{schema, false}
+		case mcap.TokenChannel:
+			channel, err := mcap.ParseChannel(data)
+			if err != nil {
+				return err
+			}
+			if len(opts.includeTopics) > 0 {
+				for _, matcher := range opts.includeTopics {
+					if matcher.MatchString(channel.Topic) {
+						channels[channel.ID] = markableChannel{channel, false}
+					}
+				}
+			} else if len(opts.excludeTopics) > 0 {
+				for _, matcher := range opts.excludeTopics {
+					if !matcher.MatchString(channel.Topic) {
+						channels[channel.ID] = markableChannel{channel, false}
+					}
+				}
+			} else {
+				channels[channel.ID] = markableChannel{channel, false}
+			}
+		case mcap.TokenMessage:
+			message, err := mcap.ParseMessage(data)
+			if err != nil {
+				return err
+			}
+			if message.LogTime < opts.start {
+				continue
+			}
+			if message.LogTime >= opts.end {
+				continue
+			}
+			channel, ok := channels[message.ChannelID]
+			if !ok {
+				continue
+			}
+			if !channel.written {
+				schema, ok := schemas[channel.SchemaID]
+				if !ok {
+					return fmt.Errorf("encountered channel with topic %s with unknown schema ID %d", channel.Topic, channel.SchemaID)
+				}
+				if !schema.written {
+					if err = mcapWriter.WriteSchema(schema.Schema); err != nil {
+						return err
+					}
+					schema.written = true
+				}
+				if err = mcapWriter.WriteChannel(channel.Channel); err != nil {
+					return err
+				}
+				channel.written = true
+			}
+			if err = mcapWriter.WriteMessage(message); err != nil {
+				return err
+			}
+		case mcap.TokenAttachment:
+			if !opts.includeAttachments {
+				continue
+			}
+			attachment, err := mcap.ParseAttachment(data)
+			if err != nil {
+				return err
+			}
+			if attachment.LogTime < opts.start {
+				continue
+			}
+			if attachment.LogTime >= opts.end {
+				continue
+			}
+			if err = mcapWriter.WriteAttachment(attachment); err != nil {
+				return err
+			}
+		case mcap.TokenMetadata:
+			if !opts.includeMetadata {
+				continue
+			}
+			metadata, err := mcap.ParseMetadata(data)
+			if err != nil {
+				return err
+			}
+			if err = mcapWriter.WriteMetadata(metadata); err != nil {
+				return err
+			}
+		case mcap.TokenDataEnd, mcap.TokenFooter:
+			// data section is over, either because the file is over or the summary section starts.
+			return nil
+		case mcap.TokenChunk:
+			return errors.New("expected lexer to remove chunk records from input stream")
+		case mcap.TokenError:
+			return errors.New("received error token but lexer did not return error on Next")
+		}
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(filterCmd)
+
+	filterCmd.PersistentFlags().StringVarP(&filterOutput, "output", "o", "", "output filename")
+	filterCmd.PersistentFlags().StringArrayVarP(&filterIncludeTopics, "include-topic-regex", "y", []string{}, "messages with topic names matching this regex will be included")
+	filterCmd.PersistentFlags().StringArrayVarP(&filterExcludeTopics, "exclude-topic-regex", "n", []string{}, "messages with topic names matching this regex will be included")
+	filterCmd.PersistentFlags().Uint64VarP(&filterStart, "start-time-ns", "s", 0, "messages with log times after or equal to this timestamp will be included.")
+	filterCmd.PersistentFlags().Uint64VarP(&filterEnd, "end-time-ns", "e", math.MaxUint64, "messages with log times before timestamp will be included.")
+	filterCmd.PersistentFlags().BoolVar(&filterIncludeMetadata, "include-metadata", true, "whether to include metadata in the output bag")
+	filterCmd.PersistentFlags().BoolVar(&filterIncludeAttachments, "include-attachments", true, "whether to include attachments in the output mcap")
+	filterCmd.PersistentFlags().StringVar(&filterOutputCompression, "output-compression", "zstd", "compression algorithm to use on output file")
+}

--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -311,7 +311,7 @@ func init() {
 	filterCmd.PersistentFlags().StringArrayVarP(&filterExcludeTopics, "exclude-topic-regex", "n", []string{}, "messages with topic names matching this regex will be included")
 	filterCmd.PersistentFlags().Uint64VarP(&filterStart, "start-time-ns", "s", 0, "messages with log times after or equal to this timestamp will be included.")
 	filterCmd.PersistentFlags().Uint64VarP(&filterEnd, "end-time-ns", "e", math.MaxUint64, "messages with log times before timestamp will be included.")
-	filterCmd.PersistentFlags().BoolVar(&filterIncludeMetadata, "include-metadata", true, "whether to include metadata in the output bag")
-	filterCmd.PersistentFlags().BoolVar(&filterIncludeAttachments, "include-attachments", true, "whether to include attachments in the output mcap")
+	filterCmd.PersistentFlags().BoolVar(&filterIncludeMetadata, "include-metadata", false, "whether to include metadata in the output bag")
+	filterCmd.PersistentFlags().BoolVar(&filterIncludeAttachments, "include-attachments", false, "whether to include attachments in the output mcap")
 	filterCmd.PersistentFlags().StringVar(&filterOutputCompression, "output-compression", "zstd", "compression algorithm to use on output file")
 }

--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -187,7 +187,9 @@ func filter(
 		return err
 	}
 	defer func() {
-		err = mcapWriter.Close()
+		if err := mcapWriter.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "failed to close mcap writer: %w", err)
+		}
 	}()
 
 	buf := make([]byte, 1024)

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"testing"
+
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/stretchr/testify/assert"
+)
+
+func writeFilterTestInput(t *testing.T, w io.Writer) {
+	writer, err := mcap.NewWriter(w, &mcap.WriterOptions{
+		Chunked: true,
+	})
+	assert.Nil(t, err)
+
+	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
+	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+		ID: 1,
+	}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:       1,
+		SchemaID: 1,
+		Topic:    "camera_a",
+	}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:       2,
+		SchemaID: 1,
+		Topic:    "camera_b",
+	}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:       3,
+		SchemaID: 1,
+		Topic:    "radar_a",
+	}))
+	for i := 0; i < 100; i++ {
+		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+			ChannelID: 1,
+			LogTime:   uint64(i),
+		}))
+		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+			ChannelID: 2,
+			LogTime:   uint64(i),
+		}))
+		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+			ChannelID: 3,
+			LogTime:   uint64(i),
+		}))
+	}
+	assert.Nil(t, writer.WriteAttachment(&mcap.Attachment{
+		LogTime: 50,
+		Name:    "attachment",
+	}))
+	assert.Nil(t, writer.WriteMetadata(&mcap.Metadata{
+		Name: "metadata",
+	}))
+	assert.Nil(t, writer.Close())
+}
+func TestFiltering(t *testing.T) {
+	cases := []struct {
+		name                    string
+		opts                    *filterOpts
+		expectedMessageCount    map[uint16]int
+		expectedAttachmentCount int
+		expectedMetadataCount   int
+	}{
+		{
+			name: "inclusive topic filtering",
+			opts: &filterOpts{
+				compressionFormat: mcap.CompressionLZ4,
+				start:             0,
+				end:               1000,
+				includeTopics:     []regexp.Regexp{*regexp.MustCompile("camera.*")},
+			},
+			expectedMessageCount: map[uint16]int{
+				1: 100,
+				2: 100,
+				3: 0,
+			},
+		},
+		{
+			name: "exclusive filtering and including attachments",
+			opts: &filterOpts{
+				compressionFormat:  mcap.CompressionLZ4,
+				start:              0,
+				end:                1000,
+				excludeTopics:      []regexp.Regexp{*regexp.MustCompile("camera.*")},
+				includeAttachments: true,
+			},
+			expectedMessageCount: map[uint16]int{
+				1: 0,
+				2: 0,
+				3: 100,
+			},
+			expectedAttachmentCount: 1,
+		},
+		{
+			name: "time range filtering (including attachments)",
+			opts: &filterOpts{
+				compressionFormat:  mcap.CompressionLZ4,
+				start:              0,
+				end:                49,
+				includeAttachments: true,
+			},
+			expectedMessageCount: map[uint16]int{
+				1: 49,
+				2: 49,
+				3: 49,
+			},
+			expectedAttachmentCount: 0,
+		},
+		{
+			name: "including metadata",
+			opts: &filterOpts{
+				compressionFormat: mcap.CompressionLZ4,
+				start:             0,
+				end:               1000,
+				includeMetadata:   true,
+			},
+			expectedMessageCount: map[uint16]int{
+				1: 100,
+				2: 100,
+				3: 100,
+			},
+			expectedAttachmentCount: 0,
+			expectedMetadataCount:   1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			writeBuf := bytes.Buffer{}
+			readBuf := bytes.Buffer{}
+
+			writeFilterTestInput(t, &readBuf)
+			assert.Nil(t, filter(&readBuf, &writeBuf, c.opts))
+
+			lexer, err := mcap.NewLexer(&writeBuf)
+			assert.Nil(t, err)
+			messageCounter := map[uint16]int{
+				1: 0,
+				2: 0,
+				3: 0,
+			}
+			attachmentCounter := 0
+			metadataCounter := 0
+			for {
+				token, record, err := lexer.Next(nil)
+				if err != nil {
+					assert.ErrorIs(t, err, io.EOF)
+					break
+				}
+				switch token {
+				case mcap.TokenMessage:
+					message, err := mcap.ParseMessage(record)
+					assert.Nil(t, err)
+					messageCounter[message.ChannelID]++
+				case mcap.TokenAttachment:
+					attachmentCounter++
+				case mcap.TokenMetadata:
+					metadataCounter++
+				}
+			}
+			assert.Equal(t, c.expectedAttachmentCount, attachmentCounter)
+			assert.Equal(t, c.expectedMetadataCount, metadataCounter)
+			assert.InDeltaMapValues(t, c.expectedMessageCount, messageCounter, 0.0)
+		})
+	}
+}

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -284,7 +284,7 @@ func (w *Writer) WriteAttachmentIndex(idx *AttachmentIndex) error {
 	if w.opts.SkipAttachmentIndex {
 		return nil
 	}
-	msglen := 8 + 8 + 8 + 8 + 4 + len(idx.Name) + 4 + len(idx.ContentType)
+	msglen := 8 + 8 + 8 + 8 + 8 + 4 + len(idx.Name) + 4 + len(idx.ContentType)
 	w.ensureSized(msglen)
 	offset := putUint64(w.msg, idx.Offset)
 	offset += putUint64(w.msg[offset:], idx.Length)

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -434,6 +434,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 
 	assert.Equal(t, 0, len(w.ChunkIndexes))
 	assert.Equal(t, 1, len(w.AttachmentIndexes))
+	assert.Equal(t, "image/jpeg", w.AttachmentIndexes[0].ContentType)
 	assert.Equal(t, uint64(1), w.Statistics.MessageCount)
 	assert.Equal(t, uint32(1), w.Statistics.AttachmentCount)
 	assert.Equal(t, uint32(1), w.Statistics.ChannelCount)


### PR DESCRIPTION
**Public-Facing Changes**
* New `mcap filter` subcommand added, which you can use to filter MCAPs by topic and time range.
* Bug fixed in the go MCAP library when writing attachment indexes, which would cause the attachment
  content type to be malformed.

**Description**
This PR adds a new subcommand to the MCAP CLI tool that allows people to quickly filter topics into and out-of an MCAP file.