### PR TITLE
ros1msg: fix field parsing to handle short names

### DIFF
--- a/go/ros/ros1msg/ros1msg_parser.go
+++ b/go/ros/ros1msg/ros1msg_parser.go
@@ -11,7 +11,7 @@ import (
 
 // Field names are restricted to "an alphabetical character followed by any mixture of alphanumeric and underscores",
 // per http://wiki.ros.org/msg#Fields
-var fieldMatcher = regexp.MustCompile(`([^ ]+) +([a-zA-Z][a-zA-Z0-9_]+)`)
+var fieldMatcher = regexp.MustCompile(`([^ ]+) +([a-zA-Z][a-zA-Z0-9_]*)`)
 
 type Type struct {
 	BaseType  string

--- a/go/ros/ros1msg/ros1msg_parser_test.go
+++ b/go/ros/ros1msg/ros1msg_parser_test.go
@@ -261,6 +261,19 @@ func TestROS1MSGParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			"very short field name",
+			"",
+			"string f",
+			[]Field{
+				{
+					Name: "f",
+					Type: Type{
+						BaseType: "string",
+					},
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {


### PR DESCRIPTION
**Public-Facing Changes**
ROS 1 message deserialization can handle fields with short names. This is very common, so `main` between this commit and  51106da1d4939dcab6a425c4a2324f9f86bbad19 should be considered as broken in this regard.

**Description**
The ROS1 message definition field parsing regex previously required that any field name had two characters, but this is not the case for many common definitions. This bug originated from my copying the field acceptance regex verbatim from https://wiki.ros.org/msg#field-names, which in retrospect was a mistake.

<!-- link relevant GitHub issues -->
