### PR TITLE
CLI: Don't require newline terminated message defs in db3 conversion

### DIFF
--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -72,6 +72,13 @@ func getSchemas(encoding string, directories []string, types []string) (map[stri
 		for len(subdefinitions) > 0 {
 			subdefinition := subdefinitions[0]
 			if !first {
+				// if the previous write did not end with a newline, add one now
+				if messageDefinition.Bytes()[messageDefinition.Len()-1] != '\n' {
+					err := messageDefinition.WriteByte('\n')
+					if err != nil {
+						return nil, fmt.Errorf("failed to write newline")
+					}
+				}
 				_, err := messageDefinition.Write(MessageDefinitionSeparator)
 				if err != nil {
 					return nil, fmt.Errorf("failed to write separator: %w", err)

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -57,6 +57,26 @@ func TestDB3MCAPConversion(t *testing.T) {
 	assert.Equal(t, 7, messageCount)
 }
 
+func TestMergesNonNewlineDelimitedSchemas(t *testing.T) {
+	schemas, err := getSchemas(
+		"msg", []string{"./testdata/galactic"},
+		[]string{"package_a/msg/NoNewline"})
+	assert.Nil(t, err)
+	schema := schemas["package_a/msg/NoNewline"]
+	expected := `
+string data
+package_b/NoNewline SpaceMe
+package_b/TypeB FancyType
+================================================================================
+MSG: package_b/NoNewline
+string data
+================================================================================
+MSG: package_b/TypeB
+int32 foo
+`
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(schema)))
+}
+
 func TestSchemaComposition(t *testing.T) {
 	t.Run("schema dependencies are resolved", func(t *testing.T) {
 		schemas, err := getSchemas("msg", []string{"./testdata/galactic"}, []string{"package_a/msg/TypeA"})

--- a/go/ros/testdata/galactic/share/ament_index/resource_index/rosidl_interfaces/package_a
+++ b/go/ros/testdata/galactic/share/ament_index/resource_index/rosidl_interfaces/package_a
@@ -1,1 +1,2 @@
 msg/TypeA.msg
+msg/NoNewline.msg

--- a/go/ros/testdata/galactic/share/ament_index/resource_index/rosidl_interfaces/package_b
+++ b/go/ros/testdata/galactic/share/ament_index/resource_index/rosidl_interfaces/package_b
@@ -1,1 +1,2 @@
 msg/TypeB.msg
+msg/NoNewline.msg

--- a/go/ros/testdata/galactic/share/package_a/msg/NoNewline.msg
+++ b/go/ros/testdata/galactic/share/package_a/msg/NoNewline.msg
@@ -1,0 +1,3 @@
+string data
+package_b/NoNewline SpaceMe
+package_b/TypeB FancyType

--- a/go/ros/testdata/galactic/share/package_b/msg/NoNewline.msg
+++ b/go/ros/testdata/galactic/share/package_b/msg/NoNewline.msg
@@ -1,0 +1,1 @@
+string data


### PR DESCRIPTION
Prior to this commit, we would produce a malformed merged schema in db3
to mcap conversion if a component message definition did not terminate
in a newline. With this change we will insert newlines after message
definitions that do not end in them.