### PR TITLE
CLI: cat --json works for JSON messages

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -142,8 +142,12 @@ func printMessages(
 			if _, err = msg.Write(bytes); err != nil {
 				return fmt.Errorf("failed to write message bytes: %w", err)
 			}
+		case "jsonschema":
+			if _, err = msg.Write(message.Data); err != nil {
+				return fmt.Errorf("failed to write message bytes: %w", err)
+			}
 		default:
-			return fmt.Errorf("JSON output only supported for ros1msg and protobuf schemas")
+			return fmt.Errorf("JSON output only supported for ros1msg, protobuf, and JSON schemas")
 		}
 		target.Topic = channel.Topic
 		target.Sequence = message.Sequence


### PR DESCRIPTION
**Public-Facing Changes**
`mcap cat --json` can be used on MCAPs with JSON messages.
