### PR TITLE
Python: add JSONSchema encoding tutorial

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -26,17 +26,21 @@ words:
   - conanfile
   - crc
   - crcs
+  - datetime
   - deserialization
   - flatbuffer
   - flatc
   - fwrite
   - golangci
+  - jsonschema
   - kaitai
   - libmcap
   - mcap
   - nsec
   - nsecs
   - pipenv
+  - pointcloud
+  - pointclouds
   - proto
   - protobuf
   - protoc
@@ -101,6 +105,7 @@ overrides:
       - apidoc
       - genindex
       - modindex
+      - literalinclude
 
   - filename: "**/*.py"
     words:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -40,7 +40,6 @@ words:
   - nsecs
   - pipenv
   - pointcloud
-  - pointclouds
   - proto
   - protobuf
   - protoc

--- a/python/docs/index.rst
+++ b/python/docs/index.rst
@@ -5,6 +5,7 @@
    :caption: Contents:
 
    apidoc/index
+   jsonschema_tutorial
 
 Indices and tables
 ==================

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -35,7 +35,7 @@ it knows how to display. These are available for a variety of serializations
 JSON ``PointCloud`` instance, using the provided 
 `schema <https://github.com/foxglove/schemas/blob/main/schemas/jsonschema/PointCloud.json>`_.
 
-Lets start with encoding the point data. The schema expects a single ``base64``-encoded buffer
+Let's start with encoding the point data. The schema expects a single ``base64``-encoded buffer
 containing all point data, and some metadata describing how to decode it:
 
 .. code-block:: json

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -9,8 +9,8 @@ In this tutorial we'll take a publicly available dataset and demonstrate how to 
 CSV format to an MCAP file. We'll use Python and `JSON Schema <https://json-schema.org/>`_ to
 quickly create messages without requiring extra serialization libraries or generated code.
 
-You can run all the code in this tutorial, or reference it
- `in the MCAP repo <https://github.com/foxglove/mcap/tree/main/python/examples/jsonschema/pointcloud_csv_to_mcap.py>`_.
+You can run all the code in this tutorial or reference it
+`in the MCAP repo <https://github.com/foxglove/mcap/tree/main/python/examples/jsonschema/pointcloud_csv_to_mcap.py>`_.
 
 Decoding the data source
 ------------------------
@@ -143,5 +143,5 @@ check this with the `MCAP CLI tool <https://github.com/foxglove/mcap/tree/main/g
     Examining output.mcap
 
 View your point cloud in `Foxglove Studio <https://studio.foxglove.dev>`_ by
-dragging the MCAP file into the window. Add a 3D Panel and enable the **/pointcloud** topic to
-see the result!
+dragging the MCAP file into the window. Add a `3D Panel <https://foxglove.dev/docs/studio/panels/3d>`_
+and enable the **/pointcloud** topic to see the result!

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -174,4 +174,4 @@ check this with the `MCAP CLI tool <https://github.com/foxglove/mcap/tree/main/g
 
 View your point cloud in `Foxglove Studio <https://studio.foxglove.dev>`_ by
 dragging the MCAP file into the window. Add a 3D Panel and enable the **/pointcloud** topic to
-see the result.
+see the result!

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -1,0 +1,161 @@
+********************************
+Tutorial: Converting CSV to MCAP
+********************************
+
+Introduction
+------------
+
+In this tutorial we'll take a publically-available dataset and demonstrate a simple case
+of converting CSV data to MCAP for viewing in Foxglove Studio. All of the code from this tutorial
+is runnable, and can be found
+`in the MCAP repo <https://github.com/foxglove/mcap/tree/main/python/examples/jsonschema/pointcloud_csv_to_mcap.py>`_.
+
+Decoding the Data Source
+------------------------
+
+This tutorial uses the public CSV dataset "Sydney Urban Objects Dataset",
+released by the Australian Centre for Field Robotics at the University of Sydney, NSW, Australia.
+The original dataset can be downloaded from
+`their website <https://www.acfr.usyd.edu.au/papers/SydneyUrbanObjectsDataset.shtml>`_. This is a
+collection of CSV files containing pointclouds collected from objects on the street.
+Decoding the data is pretty simple, thanks to Python's built-in ``csv`` and ``datetime`` libraries:
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-csv-decode-start
+    :end-before: # tutorial-csv-decode-end
+
+Creating a ``foxglove.Pointcloud``
+----------------------------------
+
+In order to view this pointcloud, we need encode these points in a way that Foxglove Studio
+understands. To facilitate this, Foxglove Studio provides a collection of schemas for messages that
+it knows how to display. These are available for a variety of serializations 
+`on GitHub <https://github.com/foxglove/schemas>`_. For this tutorial, we'll focus on building a
+``PointCloud`` instance with JSON encoding. 
+
+To get started, take a look at the schema
+`here <https://github.com/foxglove/schemas/blob/main/schemas/jsonschema/PointCloud.json>`_.
+
+Lets start with encoding the point data. The schema expects a single ``base64``-encoded buffer
+containing all point data, and some metadata describing how to decode it:
+
+.. code-block:: json
+
+    "point_stride": { "type": "integer", "minimum": 0, "description": "Number of bytes between points in the `data`" },
+    "fields": {
+      "type": "array",
+      "items": {
+        "$comment": "Generated from PackedElementField by @foxglove/schemas",
+        "title": "PackedElementField",
+        "description": "A field present within each element in a byte array of packed elements.",
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "description": "Name of the field" },
+          "offset": { "type": "integer", "minimum": 0, "description": "Byte offset from start of data buffer" },
+          "type": {
+            "title": "NumericType: Numeric type",
+            "description": "Type of data in the field. Integers are stored using little-endian byte order.",
+            "oneOf": [
+              { "title": "UNKNOWN", "const": 0 },
+              { "title": "UINT8", "const": 1 },
+              { "title": "INT8", "const": 2 },
+              { "title": "UINT16", "const": 3 },
+              { "title": "INT16", "const": 4 },
+              { "title": "UINT32", "const": 5 },
+              { "title": "INT32", "const": 6 },
+              { "title": "FLOAT32", "const": 7 },
+              { "title": "FLOAT64", "const": 8 }
+            ]
+          }
+        }
+      },
+      "description": "Fields in the `data`"
+    },
+    "data": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "description": "Point data, interpreted using `fields`"
+    }
+
+From the CSV data we have one timestamp and four floating-point data fields per point.
+``foxglove.PointCloud`` uses one timestamp for the whole pointcloud, so we'll just use the first
+point for that. We'll pack each field as a four byte single-precision little-endian float.
+
+We start by describing our data layout in the ``foxglove.PointCloud`` message:
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-point-layout-start
+    :end-before: # tutorial-point-layout-end
+
+And pack the points using the Python built-in ``struct`` and ``base64`` libraries.
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-pack-points-start
+    :end-before: # tutorial-pack-points-end
+
+To set the pointcloud timestamp, the ``foxglove.PointCloud`` schema expects a pair of seconds
+and nanoseconds:
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-timestamp-start
+    :end-before: # tutorial-timestamp-end
+
+And finally we set an arbitrary pose and ``frame_id``.
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-pose-frame-id-start
+    :end-before: # tutorial-pose-frame-id-end
+
+Writing the MCAP
+----------------
+
+Now that the pointcloud is built, we can write it into an MCAP. We'll start with some imports from
+the python MCAP library:
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-mcap-imports-start
+    :end-before: # tutorial-mcap-imports-end
+
+Then we'll open a file for writing and write a header. Note that we can chose whatever name we
+want for both ``profile`` and ``library``, but the profile must start with ``x-``.
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-write-header-start
+    :end-before: # tutorial-write-header-end
+
+After writing a header, we can create a "channel" of messages to contain our pointcloud. The schema
+name and content informs Foxglove Studio that it can parse and display this message as a pointcloud.
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-write-channel-start
+    :end-before: # tutorial-write-channel-end
+
+Finally, we can write our message and ``finish()`` the MCAP writer. ``finish()`` writes the summary
+and footer to the MCAP file.
+
+.. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
+    :start-after: # tutorial-write-message-start
+    :end-before: # tutorial-write-message-end
+
+That's it! Once this is done, we have a valid MCAP file containing a pointcloud message. We can
+check this with the MCAP CLI tool:
+
+.. code-block:: bash
+
+    $ mcap info output.mcap 
+    library: my-excellent-library
+    profile: x-jsonschema
+    messages: 1
+    duration: 0s
+    start: 2011-11-04T01:32:10.881030912+11:00 (1320330730.881030912)
+    end: 2011-11-04T01:32:10.881030912+11:00 (1320330730.881030912)
+    compression:
+            zstd: [1/1 chunks] (40.38%) 
+    channels:
+            (1) /pointcloud  1 msgs (+Inf Hz)   : foxglove.PointCloud [jsonschema]  
+    attachments: 0
+    $ mcap doctor output.mcap
+    Examining output.mcap
+
+We can view the result in Foxglove Studio by navigating to `<https://studio.foxglove.dev>`_
+and dragging the MCAP file into the window.

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -10,7 +10,7 @@ data to MCAP. We'll use Python and `JSON Schema <https://json-schema.org/>`_ to 
 quickly. All of the code from this tutorial is runnable, and can be found
 `in the MCAP repo <https://github.com/foxglove/mcap/tree/main/python/examples/jsonschema/pointcloud_csv_to_mcap.py>`_.
 
-Decoding the Data Source
+Decoding the data source
 ------------------------
 
 This tutorial uses the public CSV dataset "Sydney Urban Objects Dataset",

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -137,7 +137,7 @@ cloud.
     :dedent:
 
 Next, we write our messages. If we only wrote one message, our MCAP file would have an infinitely
-short duration. To address that, we write our point cloud message a few times with increasing
+short duration. To address that, let's write our point cloud message a few times with successive
 timestamps.
 
 .. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -14,7 +14,7 @@ Decoding the Data Source
 ------------------------
 
 This tutorial uses the public CSV dataset "Sydney Urban Objects Dataset",
-released by the **Australian Centre for Field Robotics** at the University of Sydney, NSW, Australia.
+released by the **Australian Centre for Field Robotics** at the University of Sydney.
 The original dataset can be downloaded from
 `their website <https://www.acfr.usyd.edu.au/papers/SydneyUrbanObjectsDataset.shtml>`_. This is a
 collection of CSV files containing point clouds collected from objects on the street.

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -116,13 +116,16 @@ from the `Python MCAP library <https://github.com/foxglove/mcap/tree/main/python
     :dedent:
 
 Let's open a file where we'll write our output MCAP data. First, we'll need to write our header.
-Note that we can chose whatever name we want for both ``profile`` and ``library``, but the profile
-must start with ``x-``.
 
 .. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
     :start-after: # tutorial-write-header-start
     :end-before: # tutorial-write-header-end
     :dedent:
+
+.. note::
+  We can choose whatever name we want for ``library``. We're not using one of the
+  `MCAP well-known profiles <https://github.com/foxglove/mcap/blob/main/docs/specification/appendix.md#well-known-profiles>`_,
+  so we use our own custom profile name. Custom profile names must begin with ``x-``.
 
 Next, create a "channel" of messages to contain our point cloud. The schema
 name and content informs Foxglove Studio that it can parse and display this message as a point

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -29,8 +29,8 @@ Decoding the data is pretty simple, thanks to Python's built-in ``csv`` and ``da
 Creating a ``foxglove.PointCloud``
 ----------------------------------
 
-In order to view this point cloud, we need encode these points in a way that Foxglove Studio
-understands. To facilitate this, Foxglove Studio provides a collection of schemas for messages that
+To view this point cloud, we must encode these points in a way that Foxglove Studio
+understands. To facilitate this, Foxglove Studio provides a collection of message schemas that
 it knows how to display. These are available for a variety of serializations
 `on GitHub <https://github.com/foxglove/schemas>`_. For this tutorial, we'll focus on building a
 JSON ``PointCloud`` instance, using the provided 
@@ -58,11 +58,11 @@ And pack the points using Python's built-in ``struct`` and ``base64`` libraries.
     :dedent:
 
 In Foxglove Studio, each 3D object exists in its own coordinate frame. A point cloud's ``frame_id``
-identifies which coordinate frame it belongs in, and its ``pose`` determines it's relative position
-from the center of that coordinate frame.
+identifies which coordinate frame it belongs in, and its ``pose`` determines its relative position
+from that coordinate frame's center.
 
 Since we will only have one coordinate frame in our MCAP file, we can choose any string as our
-``frame_id``, and use the identity pose to place our point cloud in the center of it.
+``frame_id``, and use the identity pose to place our point cloud in its center.
 
 .. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py
     :start-after: # tutorial-pose-frame-id-start
@@ -92,7 +92,7 @@ Let's open a file where we'll write our output MCAP data. First, we'll need to w
 .. note::
   We can choose whatever name we want for ``library``. We're not using one of the
   `MCAP well-known profiles <https://github.com/foxglove/mcap/blob/main/docs/specification/appendix.md#well-known-profiles>`_,
-  so we use our own custom profile name. Custom profile names must begin with ``x-``.
+  so we use our own custom profile name.
 
 Next, create a "channel" of messages to contain our point cloud. The schema
 name and content informs Foxglove Studio that it can parse and display this message as a point
@@ -103,8 +103,8 @@ cloud.
     :end-before: # tutorial-write-channel-end
     :dedent:
 
-Next, we write our messages. If we only wrote one message, our MCAP file would have an infinitely
-short duration. To address that, let's write our point cloud message a few times with successive
+Next, we write our messages. If we only wrote one message, our MCAP file would be zero duration.
+To address that, let's write our point cloud message a few times with successive
 timestamps.
 
 .. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -76,7 +76,7 @@ containing all point data, and some metadata describing how to decode it:
       "description": "Point data, interpreted using `fields`"
     }
 
-From the CSV data we have one timestamp and four floating-point data fields per point.
+The CSV data contains one timestamp and four floating-point data fields per point.
 ``foxglove.PointCloud`` uses one timestamp for the whole point cloud, so we'll just use the first
 point for that. We'll pack each field as a four byte single-precision little-endian float.
 

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -145,7 +145,7 @@ timestamps.
     :end-before: # tutorial-write-message-end
     :dedent:
 
-Finally we can invoke ``finish()`` on the MCAP writer. This will include the summary and footer
+Finally, we invoke ``finish()`` on the MCAP writer to include the summary and footer
 in the output file.
 
 .. literalinclude:: ../examples/jsonschema/pointcloud_csv_to_mcap.py

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -5,7 +5,7 @@ Tutorial: Converting CSV to MCAP
 Introduction
 ------------
 
-In this tutorial we'll take a publically-available dataset and demonstrate a simple case
+In this tutorial we'll take a publicly-available dataset and demonstrate a simple case
 of converting CSV data to MCAP for viewing in Foxglove Studio. All of the code from this tutorial
 is runnable, and can be found
 `in the MCAP repo <https://github.com/foxglove/mcap/tree/main/python/examples/jsonschema/pointcloud_csv_to_mcap.py>`_.

--- a/python/docs/jsonschema_tutorial.rst
+++ b/python/docs/jsonschema_tutorial.rst
@@ -77,7 +77,7 @@ containing all point data, and some metadata describing how to decode it:
     }
 
 The CSV data contains one timestamp and four floating-point data fields per point.
-``foxglove.PointCloud`` uses one timestamp for the whole point cloud, so we'll just use the first
+``foxglove.PointCloud`` uses one timestamp for the whole point cloud, so we'll use the first
 point for that. We'll pack each field as a four byte single-precision little-endian float.
 
 We start by describing our data layout in the ``foxglove.PointCloud`` message:

--- a/python/examples/jsonschema/PointCloud.json
+++ b/python/examples/jsonschema/PointCloud.json
@@ -1,0 +1,153 @@
+{
+  "$comment": "Generated from PointCloud by @foxglove/schemas",
+  "title": "PointCloud",
+  "description": "A collection of N-dimensional points, which may contain additional fields with information like normals, intensity, etc.",
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "type": "object",
+      "title": "time",
+      "properties": {
+        "sec": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nsec": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 999999999
+        }
+      },
+      "description": "Timestamp of point cloud"
+    },
+    "frame_id": {
+      "type": "string",
+      "description": "Frame of reference"
+    },
+    "pose": {
+      "$comment": "Generated from Pose by @foxglove/schemas",
+      "title": "Pose",
+      "description": "The origin of the point cloud relative to the frame of reference",
+      "type": "object",
+      "properties": {
+        "position": {
+          "$comment": "Generated from Vector3 by @foxglove/schemas",
+          "title": "Vector3",
+          "description": "Point denoting position in 3D space",
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number",
+              "description": "x coordinate length"
+            },
+            "y": {
+              "type": "number",
+              "description": "y coordinate length"
+            },
+            "z": {
+              "type": "number",
+              "description": "z coordinate length"
+            }
+          }
+        },
+        "orientation": {
+          "$comment": "Generated from Quaternion by @foxglove/schemas",
+          "title": "Quaternion",
+          "description": "Quaternion denoting orientation in 3D space",
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number",
+              "description": "x value"
+            },
+            "y": {
+              "type": "number",
+              "description": "y value"
+            },
+            "z": {
+              "type": "number",
+              "description": "z value"
+            },
+            "w": {
+              "type": "number",
+              "description": "w value"
+            }
+          }
+        }
+      }
+    },
+    "point_stride": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of bytes between points in the `data`"
+    },
+    "fields": {
+      "type": "array",
+      "items": {
+        "$comment": "Generated from PackedElementField by @foxglove/schemas",
+        "title": "PackedElementField",
+        "description": "A field present within each element in a byte array of packed elements.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the field"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Byte offset from start of data buffer"
+          },
+          "type": {
+            "title": "NumericType: Numeric type",
+            "description": "Type of data in the field. Integers are stored using little-endian byte order.",
+            "oneOf": [
+              {
+                "title": "UNKNOWN",
+                "const": 0
+              },
+              {
+                "title": "UINT8",
+                "const": 1
+              },
+              {
+                "title": "INT8",
+                "const": 2
+              },
+              {
+                "title": "UINT16",
+                "const": 3
+              },
+              {
+                "title": "INT16",
+                "const": 4
+              },
+              {
+                "title": "UINT32",
+                "const": 5
+              },
+              {
+                "title": "INT32",
+                "const": 6
+              },
+              {
+                "title": "FLOAT32",
+                "const": 7
+              },
+              {
+                "title": "FLOAT64",
+                "const": 8
+              }
+            ]
+          }
+        }
+      },
+      "description": "Fields in the `data`"
+    },
+    "data": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "description": "Point data, interpreted using `fields`"
+    }
+  }
+}

--- a/python/examples/jsonschema/pointcloud_csv_to_mcap.py
+++ b/python/examples/jsonschema/pointcloud_csv_to_mcap.py
@@ -1,0 +1,119 @@
+""" Example script for converting pointcloud CSV data to an MCAP viewable in Foxglove Studio.
+
+This script uses the public CSV dataset "Sydney Urban Objects Dataset",
+released by the Australian Centre for Field Robotics at the University of Sydney, NSW, Australia.
+The original dataset can be downloaded from here:
+https://www.acfr.usyd.edu.au/papers/SydneyUrbanObjectsDataset.shtml
+
+usage:
+    mkdir -p dataset
+    curl https://www.acfr.usyd.edu.au/papers/data/sydney-urban-objects-dataset.tar.gz | tar -x
+    pip install mcap jsonschema
+    python3 pointcloud_csv_to_mcap.py sydney-urban-objects-dataset/objects/4wd.0.2299.csv -o 4wd.mcap
+"""
+import argparse
+import base64
+import csv
+import json
+import typing
+import struct
+from pathlib import Path
+from datetime import datetime, timedelta
+
+import jsonschema
+from mcap.mcap0.writer import Writer
+
+
+def load_schema() -> typing.Dict[typing.Any, typing.Any]:
+    """Load the foxglove pointcloud schema as a JSON object.
+    The schema is a copy of the original at
+    https://github.com/foxglove/schemas/blob/main/schemas/jsonschema/PointCloud.json
+    """
+    with open(Path(__file__).parent / "PointCloud.json", "r") as f:
+        return json.load(f)
+
+
+def point_reader(csv_path: typing.Union[str, Path]):
+    with open(csv_path, "r") as f:
+        for timestamp, intensity, _, x, y, z, _, _, _ in csv.reader(f):
+            yield (timestamp, intensity, x, y, z)
+
+
+def parse_timestamp(csv_timestamp: str) -> datetime:
+    return datetime.strptime(csv_timestamp, "%Y%m%dT%H%M%S.%f")
+
+
+def main():
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("csv", help="The input CSV to read")
+    parser.add_argument(
+        "--output", "-o", default="out.mcap", help="The MCAP output path to write"
+    )
+    args = parser.parse_args()
+
+    # read the fields we need out of the input CSV.
+    # Note that here we're packing each point as four 32-bit floats.
+    points = bytearray([])
+    base_timestamp = None
+    for point_timestamp, intensity, x, y, z in point_reader(args.csv):
+        if base_timestamp is None:
+            base_timestamp = parse_timestamp(point_timestamp)
+        points.extend(
+            struct.pack("<ffff", float(x), float(y), float(z), float(intensity))
+        )
+    assert base_timestamp is not None, "found no points in input csv"
+
+    schema = load_schema()
+
+    # time to write the MCAP!
+    with open(args.output, "wb") as f:
+        writer = Writer(f)
+        # "jsonschema" is a well-known message encoding per the MCAP spec.
+        writer.start("jsonschema", library="my-excellent-library")
+        schema_id = writer.register_schema(
+            name="foxglove.PointCloud",
+            encoding="jsonschema",
+            data=json.dumps(schema).encode("utf-8"),
+        )
+        channel_id = writer.register_channel(
+            topic="/pointcloud", message_encoding="json", schema_id=schema_id
+        )
+
+        for n in range(10):
+            timestamp = base_timestamp + timedelta(seconds=n)
+            timestamp_nanoseconds = int(timestamp.timestamp() * 1e9)
+
+            # build the pointcloud object as specified in the included schema.
+            pointcloud = {
+                "timestamp": {
+                    "sec": int(timestamp.timestamp()),
+                    "nsec": timestamp.microsecond * 1000,
+                },
+                "frame_id": "lidar",
+                "pose": {
+                    "position": {"x": 0, "y": 0, "z": 0},
+                    "orientation": {"x": 0, "y": 0, "z": 0, "w": 1},
+                },
+                "point_stride": (4 + 4 + 4 + 4),
+                "fields": [
+                    {"name": "x", "offset": 0, "type": 7},
+                    {"name": "y", "offset": 4, "type": 7},
+                    {"name": "z", "offset": 8, "type": 7},
+                    {"name": "i", "offset": 12, "type": 7},
+                ],
+                "data": str(base64.b64encode(points)),
+            }
+
+            jsonschema.validate(pointcloud, schema)
+
+            writer.add_message(
+                channel_id,
+                log_time=timestamp_nanoseconds,
+                data=json.dumps(pointcloud).encode("utf-8"),
+                publish_time=timestamp_nanoseconds,
+            )
+        writer.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/jsonschema/pointcloud_csv_to_mcap.py
+++ b/python/examples/jsonschema/pointcloud_csv_to_mcap.py
@@ -57,7 +57,7 @@ def main():
     # tutorial-point-layout-end
 
     # tutorial-pack-points-start
-    points = bytearray([])
+    points = bytearray()
     base_timestamp = None
     for point_timestamp, intensity, x, y, z in point_reader(args.csv):
         if base_timestamp is None:
@@ -90,7 +90,7 @@ def main():
             data=schema,
         )
         channel_id = writer.register_channel(
-            topic="/pointcloud",
+            topic="pointcloud",
             message_encoding=MessageEncoding.JSON,
             schema_id=schema_id,
         )

--- a/python/examples/jsonschema/pointcloud_csv_to_mcap.py
+++ b/python/examples/jsonschema/pointcloud_csv_to_mcap.py
@@ -69,7 +69,7 @@ def main():
     with open(args.output, "wb") as f:
         writer = Writer(f)
         # "jsonschema" is a well-known message encoding per the MCAP spec.
-        writer.start("jsonschema", library="my-excellent-library")
+        writer.start("x-jsonschema", library="my-excellent-library")
         schema_id = writer.register_schema(
             name="foxglove.PointCloud",
             encoding="jsonschema",

--- a/python/mcap/mcap0/well_known.py
+++ b/python/mcap/mcap0/well_known.py
@@ -1,0 +1,36 @@
+"""Enums listing the sets of well-known profiles, schema encodings and message encodings
+available in the MCAP Specification:
+https://github.com/foxglove/mcap/blob/main/docs/specification/appendix.md
+
+NOTE: you don't need to use these profiles or encodings to use MCAP! custom profiles and
+encodings are allowed with the `x-` prefix.
+"""
+
+
+class Profile:
+    """Well-known MCAP profiles."""
+
+    ROS1 = "ros1"
+    ROS2 = "ros2"
+
+
+class SchemaEncoding:
+    """well-known encodings for schema records."""
+
+    SelfDescribing = ""  # used for self-describing content, such as arbitrary JSON.
+    Protobuf = "protobuf"
+    Flatbuffer = "flatbuffer"
+    ROS1 = "ros1msg"
+    ROS2 = "ros2msg"
+    JSONSchema = "jsonschema"
+
+
+class MessageEncoding:
+    """well-known message encodings for message records"""
+
+    ROS1 = "ros1"
+    CDR = "cdr"
+    Protobuf = "protobuf"
+    Flatbuffer = "flatbuffer"
+    CBOR = "cbor"
+    JSON = "json"

--- a/python/mcap/mcap0/well_known.py
+++ b/python/mcap/mcap0/well_known.py
@@ -15,7 +15,7 @@ class Profile:
 
 
 class SchemaEncoding:
-    """well-known encodings for schema records."""
+    """Well-known encodings for schema records."""
 
     SelfDescribing = ""  # used for self-describing content, such as arbitrary JSON.
     Protobuf = "protobuf"
@@ -26,7 +26,7 @@ class SchemaEncoding:
 
 
 class MessageEncoding:
-    """well-known message encodings for message records"""
+    """Well-known message encodings for message records"""
 
     ROS1 = "ros1"
     CDR = "cdr"


### PR DESCRIPTION
**Public-Facing Changes**
None.

**Description**
Adds a tutorial for encoding CSV data into a `foxglove.PointCloud` in an MCAP.

<!-- link relevant GitHub issues -->