### PR TITLE
[typescript] Fix indexed message reading

### DIFF
--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -59,20 +59,15 @@ export class ChunkCursor {
    * and re-sort the cursors.
    */
   compare(other: ChunkCursor): number {
-    const reverse = this.reverse;
     if (this.reverse !== other.reverse) {
       throw new Error("Cannot compare a reversed ChunkCursor to a non-reversed ChunkCursor");
     }
 
-    const diff = Number(this.getSortTime() - other.getSortTime());
+    let diff = Number(this.getSortTime() - other.getSortTime());
+
+    // Break ties by chunk offset in the file
     if (diff === 0) {
-      if (reverse) {
-        // Break ties by chunk offset in the file
-        return Number(other.chunkIndex.chunkStartOffset - this.chunkIndex.chunkStartOffset);
-      } else {
-        // Break ties by chunk offset in the file
-        return Number(this.chunkIndex.chunkStartOffset - other.chunkIndex.chunkStartOffset);
-      }
+      diff = Number(this.chunkIndex.chunkStartOffset - other.chunkIndex.chunkStartOffset);
     }
 
     return this.reverse ? -diff : diff;

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -688,7 +688,7 @@ describe("Mcap0IndexedReader", () => {
     }
   });
 
-  it.only("ensure that chunks are loaded only when needed", async () => {
+  it("ensure that chunks are loaded only when needed", async () => {
     const channelA: TypedMcapRecord = {
       type: "Channel",
       id: 1,

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -549,7 +549,7 @@ describe("Mcap0IndexedReader", () => {
     ]);
   });
 
-  it("correctly reads overlapping chunks", async () => {
+  it("uses stable sort when loading overlapping chunks", async () => {
     const channel1: TypedMcapRecord = {
       type: "Channel",
       id: 1,

--- a/typescript/core/src/v0/Mcap0IndexedReader.test.ts
+++ b/typescript/core/src/v0/Mcap0IndexedReader.test.ts
@@ -16,7 +16,7 @@ import {
   uint16LE,
   uint32PrefixedBytes,
 } from "./testUtils";
-import { TypedMcapRecord, TypedMcapRecords } from "./types";
+import { Channel, TypedMcapRecord, TypedMcapRecords } from "./types";
 
 /**
  * Create an IReadable from a buffer. Simulates small buffer reuse to help test that readers aren't
@@ -549,8 +549,7 @@ describe("Mcap0IndexedReader", () => {
     ]);
   });
 
-  // fixme
-  it.only("reads something", async () => {
+  it("correctly reads overlapping chunks", async () => {
     const channel1: TypedMcapRecord = {
       type: "Channel",
       id: 1,
@@ -629,7 +628,6 @@ describe("Mcap0IndexedReader", () => {
       });
     }
 
-    //writeChunk(chunk1);
     writeChunk(chunk1);
     writeChunk(chunk2);
     writeChunk(chunk3);
@@ -645,12 +643,185 @@ describe("Mcap0IndexedReader", () => {
     builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
     builder.writeMagic();
 
-    const reader = await Mcap0IndexedReader.Initialize({ readable: makeReadable(builder.buffer) });
-    await expect(collect(reader.readMessages())).resolves.toEqual([
-      message3,
-      message4,
-      message5,
-      message6,
-    ]);
+    {
+      const readable = makeReadable(builder.buffer);
+      const reader = await Mcap0IndexedReader.Initialize({ readable });
+      expect(readable.readCalls).toEqual(4);
+
+      const messageIter = reader.readMessages();
+      expect(readable.readCalls).toEqual(4);
+
+      const collected = [];
+
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(6);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(8);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(10);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(10);
+
+      expect(collected).toEqual([message3, message4, message5, message6]);
+    }
+
+    {
+      const readable = makeReadable(builder.buffer);
+      const reader = await Mcap0IndexedReader.Initialize({ readable });
+      expect(readable.readCalls).toEqual(4);
+
+      const messageIter = reader.readMessages({ reverse: true });
+      expect(readable.readCalls).toEqual(4);
+
+      const collected = [];
+
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(6);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(8);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(10);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(10);
+
+      expect(collected).toEqual([message3, message4, message5, message6].reverse());
+    }
+  });
+
+  it.only("ensure that chunks are loaded only when needed", async () => {
+    const channelA: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const channelB: TypedMcapRecord = {
+      type: "Channel",
+      id: 2,
+      schemaId: 0,
+      topic: "b",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (channel: Channel, idx: number): TypedMcapRecords["Message"] => {
+      return {
+        type: "Message",
+        channelId: channel.id,
+        sequence: idx,
+        logTime: BigInt(idx),
+        publishTime: 0n,
+        data: new Uint8Array(),
+      };
+    };
+
+    const messageA1 = makeMessage(channelA, 1);
+    const messageB1 = makeMessage(channelB, 1);
+    const messageB2 = makeMessage(channelB, 2);
+
+    const chunk1 = new ChunkBuilder({ useMessageIndex: true });
+    chunk1.addChannel(channelA);
+    chunk1.addChannel(channelB);
+    chunk1.addMessage(messageA1);
+    chunk1.addMessage(messageB2);
+
+    const chunk2 = new ChunkBuilder({ useMessageIndex: true });
+    chunk2.addChannel(channelB);
+    chunk2.addMessage(messageB1);
+
+    const builder = new Mcap0RecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [];
+    function writeChunk(chunk: ChunkBuilder) {
+      const chunkStartOffset = BigInt(builder.length);
+      const chunkLength = builder.writeChunk({
+        messageStartTime: chunk.messageStartTime,
+        messageEndTime: chunk.messageEndTime,
+        uncompressedSize: BigInt(chunk.buffer.length),
+        uncompressedCrc: 0,
+        compression: "",
+        records: chunk.buffer,
+      });
+
+      const messageIndexStart = BigInt(builder.length);
+      let messageIndexLength = 0n;
+      const chunkMessageIndexOffsets = new Map<number, bigint>();
+      for (const messageIndex of chunk.indices) {
+        chunkMessageIndexOffsets.set(
+          messageIndex.channelId,
+          messageIndexStart + messageIndexLength,
+        );
+        messageIndexLength += builder.writeMessageIndex(messageIndex);
+      }
+
+      chunkIndexes.push({
+        type: "ChunkIndex",
+        messageStartTime: chunk.messageStartTime,
+        messageEndTime: chunk.messageEndTime,
+        chunkStartOffset,
+        chunkLength,
+        messageIndexOffsets: chunkMessageIndexOffsets,
+        messageIndexLength,
+        compression: "",
+        compressedSize: BigInt(chunk.buffer.byteLength),
+        uncompressedSize: BigInt(chunk.buffer.byteLength),
+      });
+    }
+
+    writeChunk(chunk1);
+    writeChunk(chunk2);
+
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+
+    const summaryStart = BigInt(builder.length);
+
+    builder.writeChannel(channelA);
+    builder.writeChannel(channelB);
+
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    {
+      const readable = makeReadable(builder.buffer);
+      const reader = await Mcap0IndexedReader.Initialize({ readable });
+      expect(readable.readCalls).toEqual(4);
+
+      const messageIter = reader.readMessages({ topics: [channelB.topic] });
+      expect(readable.readCalls).toEqual(4);
+
+      const collected = [];
+
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(7);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(8);
+
+      expect(collected).toEqual([messageB1, messageB2]);
+    }
+
+    {
+      const readable = makeReadable(builder.buffer);
+      const reader = await Mcap0IndexedReader.Initialize({ readable });
+      expect(readable.readCalls).toEqual(4);
+
+      const messageIter = reader.readMessages({ topics: [channelB.topic], reverse: true });
+      expect(readable.readCalls).toEqual(4);
+
+      const collected = [];
+
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(6);
+      collected.push((await messageIter.next()).value);
+      expect(readable.readCalls).toEqual(8);
+
+      expect(collected).toEqual([messageB1, messageB2].reverse());
+    }
   });
 });


### PR DESCRIPTION
Under certain situations the Mcap0IndexedReader would produce out of log time order messages from `readMessages`. This change fixes this behavior to produce in order messages.

**Problem Description**

To read data in-order the Mcap0IndexedReader uses a heap of ChunkCursors and reads data from the first cursor in the heap (the "min"). The heap is setup to use the `compare` method exposed on each ChunkCursor instance to compare it to other instances to maintain the properties of a heap and bring the "min" cursor to the "front". The logic within the compare function would try to sort ChunkCursors by which one needed reading next but also which one needed loading next (since the message indexes are read lazily for the cursors). This logic produced an anachronism within the heap which resulted in the front heap element being incorrect and ultimately resulting in producing out of order messages.

Here is how the compare logic failed.

Our file contains 3 chunks, each chunk contains messages denoted here with a number indicating their log time and drawn to show the relative time of each message in the overall time:

```
A: [1       4]
B:   [2]
C:      [3]
```

When the ChunkCursors are inserted into the heap their message indexes are un-initialized and they create an ordering of: [A, B, C] since the start time of A < B < C.

The read loop begins. It looks at the front of the heap and sees chunk cursor A. It sees that this chunk cursor needs initializing, it runs logic to initialize it and re-inserts it into the front of the heap. This causes the heap to re-sort from the front. When comparing to its child (B), B now evaluates before A because B has not been initialized (the compare function considers un-initialized chunk cursors as sorting before initialized ones (In certain situations - this is ultimately the bug).

B is at the front of the heap now. The read loop grabs B, sees that it needs initializing and runs logic to initialize it and re-insert it into the front of the heap. This causes the heap to re-sort from the front. The heap wants to properly sort B down. To do this it finds the "best" child of B by comparing the children of B (A, C) against each other and getting the smallest. When comparing A to C, the cursor compare function returns C as smaller than A because C has not been initialized. It returns C as the "best" child and compares B to C. Unfortunately, the compare function sees that B is completely before C and sorts B before C. Our heap is now: [B, A, C].

The read loop continues, grabs the first element (B), sees it is initialized and reads its first message (2). We've now read message (2) out of order because we never read message (1).

**fix**

The fix is to simplify the cursor compare function so that it no longer produces an anachronism but rather a stable sort. Rather than trying to surface un-loaded chunks before loaded ones in certain situations, the compare function evaluates the "sort time" of the two chunk cursors. For un-initialized chunks the sort time is simply the start time of the chunk and for initialized chunks the sort time is the time of the "read head" within the chunk.

Using the above scenario we now produce a stable sort. As the read loop evaluates the initial front of the heap it finds chunk cursor A. It initializes it and re-inserts it into the heap causing a re-sort. Since cursor A is still before cursor B, it remains at the front. The read loop reads message (1) from it and re-sorts the heap. Cursor A now has a time of (4) and so it sorts after B and C. The read loop sees (B) is un-initialized, initializes it and re-sorts the heap. The heap sort remains stable because A is still at (4), B is at (2), and C at (3): B, C, A. The read loop reads message (2) from B, and moves on to C. The process repeats until C is read and then finally A and we are done.