### PR TITLE
cpp: fix readMessages() for empty file

### DIFF
--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -377,7 +377,7 @@ Status McapReader::readSummarySection_(IReadable& reader) {
   }
   footer_ = footer;
 
-  // Get summartStart and summaryOffsetStart, allowing for zeroed values
+  // Get summaryStart and summaryOffsetStart, allowing for zeroed values
   const ByteOffset summaryStart =
     footer.summaryStart != 0 ? footer.summaryStart : fileSize - internal::FooterLength;
   const ByteOffset summaryOffsetStart =
@@ -1544,6 +1544,9 @@ LinearMessageView::Iterator::Iterator(McapReader& mcapReader, ByteOffset dataSta
                                       ByteOffset dataEnd, Timestamp startTime, Timestamp endTime,
                                       const ProblemCallback& onProblem)
     : impl_(std::make_unique<Impl>(mcapReader, dataStart, dataEnd, startTime, endTime, onProblem)) {
+  if (!impl_->has_value()) {
+    impl_ = nullptr;
+  }
 }
 
 LinearMessageView::Iterator::Impl::Impl(McapReader& mcapReader, ByteOffset dataStart,

--- a/cpp/test/unit-tests.cpp
+++ b/cpp/test/unit-tests.cpp
@@ -383,6 +383,29 @@ TEST_CASE("McapReader::byteRange()", "[reader]") {
 }
 
 TEST_CASE("McapReader::readMessages()", "[reader]") {
+  SECTION("Empty file") {
+    Buffer buffer;
+
+    mcap::McapWriter writer;
+    writer.open(buffer, mcap::McapWriterOptions("test"));
+    mcap::Schema schema("schema", "schemaEncoding", "ab");
+    writer.addSchema(schema);
+    mcap::Channel channel("topic", "messageEncoding", schema.id);
+    writer.addChannel(channel);
+    writer.close();
+
+    mcap::McapReader reader;
+    auto status = reader.open(buffer);
+    requireOk(status);
+
+    for (const auto& msg : reader.readMessages()) {
+      FAIL("Shouldn't have gotten a message: topic " + msg.channel->topic + ", schema " +
+           msg.schema->name);
+    }
+
+    reader.close();
+  }
+
   SECTION("MovableIterators") {
     Buffer buffer;
 


### PR DESCRIPTION
**Public-Facing Changes**
Fixed `McapReader::readMessages()` so it doesn't produce an invalid reference when reading an empty file.

**Description**
We do this `if (!impl_->has_value()) impl_ = nullptr` dance after each `LinearMessageView::Iterator::operator++()`, but we forgot to do it at the beginning.