### PR TITLE
cpp: fix LZ4 reading/writing

### DIFF
--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -183,13 +183,15 @@ public:
   uint64_t size() const override;
   Status status() const override;
 
-  LZ4Reader() = default;
+  LZ4Reader();
   LZ4Reader(const LZ4Reader&) = delete;
   LZ4Reader& operator=(const LZ4Reader&) = delete;
   LZ4Reader(LZ4Reader&&) = delete;
   LZ4Reader& operator=(LZ4Reader&&) = delete;
+  ~LZ4Reader();
 
 private:
+  void* decompressionContext_ = nullptr;  // LZ4F_dctx*
   Status status_;
   const std::byte* compressedData_;
   ByteArray uncompressedData_;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -261,7 +261,7 @@ public:
 private:
   std::vector<std::byte> uncompressedBuffer_;
   std::vector<std::byte> compressedBuffer_;
-  int acceleration_ = 1;
+  CompressionLevel compressionLevel_;
 };
 
 /**

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -1,7 +1,8 @@
 #include "crc32.hpp"
 #include <cassert>
 #include <iostream>
-#include <lz4.h>
+#include <lz4frame.h>
+#include <lz4hc.h>
 
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
@@ -154,24 +155,26 @@ const std::byte* BufferWriter::compressedData() const {
 
 namespace internal {
 
-int LZ4AccelerationLevel(CompressionLevel level) {
+int LZ4CompressionLevel(CompressionLevel level) {
   switch (level) {
     case CompressionLevel::Fastest:
-      return 65537;
+      return -1;  // "fast acceleration"
     case CompressionLevel::Fast:
-      return 32768;
-    case CompressionLevel::Default:
-    case CompressionLevel::Slow:
-    case CompressionLevel::Slowest:
     default:
-      return 1;
+      return 0;  // "fast mode"
+    case CompressionLevel::Default:
+      return LZ4HC_CLEVEL_DEFAULT;
+    case CompressionLevel::Slow:
+      return LZ4HC_CLEVEL_OPT_MIN;
+    case CompressionLevel::Slowest:
+      return LZ4HC_CLEVEL_MAX;
   }
 }
 
 }  // namespace internal
 
-LZ4Writer::LZ4Writer(CompressionLevel compressionLevel, uint64_t chunkSize) {
-  acceleration_ = internal::LZ4AccelerationLevel(compressionLevel);
+LZ4Writer::LZ4Writer(CompressionLevel compressionLevel, uint64_t chunkSize)
+    : compressionLevel_(compressionLevel) {
   uncompressedBuffer_.reserve(chunkSize);
 }
 
@@ -180,11 +183,17 @@ void LZ4Writer::handleWrite(const std::byte* data, uint64_t size) {
 }
 
 void LZ4Writer::end() {
-  const auto dstCapacity = LZ4_compressBound(uncompressedBuffer_.size());
+  LZ4F_preferences_t preferences = LZ4F_INIT_PREFERENCES;
+  preferences.compressionLevel = internal::LZ4CompressionLevel(compressionLevel_);
+  const auto dstCapacity = LZ4F_compressFrameBound(uncompressedBuffer_.size(), &preferences);
   compressedBuffer_.resize(dstCapacity);
-  const int dstSize = LZ4_compress_fast(reinterpret_cast<const char*>(uncompressedBuffer_.data()),
-                                        reinterpret_cast<char*>(compressedBuffer_.data()),
-                                        uncompressedBuffer_.size(), dstCapacity, acceleration_);
+  const auto dstSize =
+    LZ4F_compressFrame(compressedBuffer_.data(), dstCapacity, uncompressedBuffer_.data(),
+                       uncompressedBuffer_.size(), &preferences);
+  if (LZ4F_isError(dstSize)) {
+    std::cerr << "LZ4F_compressFrame failed: " << LZ4F_getErrorName(dstSize) << "\n";
+    std::abort();
+  }
   compressedBuffer_.resize(dstSize);
 }
 

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -160,9 +160,9 @@ int LZ4CompressionLevel(CompressionLevel level) {
     case CompressionLevel::Fastest:
       return -1;  // "fast acceleration"
     case CompressionLevel::Fast:
-    default:
       return 0;  // "fast mode"
     case CompressionLevel::Default:
+    default:
       return LZ4HC_CLEVEL_DEFAULT;
     case CompressionLevel::Slow:
       return LZ4HC_CLEVEL_OPT_MIN;

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -84,6 +84,9 @@ overrides:
       - cppstd
       - hdoc
       - nlohmann
+    ignoreRegExpList:
+      - "LZ4F_\\w+"
+      - "LZ4HC_\\w+"
 
   - filename: "**/{*.js,*.ts,*.tsx}"
     ignoreRegExpList:


### PR DESCRIPTION
**Public-Facing Changes**
Fixed LZ4 reading and writing in the C++ library.

**Description**
The C++ reader/writer were using the low-level LZ4 block APIs instead of the common higher-level "frame" APIs.