### PR TITLE
python: mcap_ros1: treat 0 as a valid timestamp

### DIFF
--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -60,11 +60,14 @@ class Writer:
 
         buffer = BytesIO()
         message.serialize(buffer)
-        log_time = log_time or time.time_ns()
+        if log_time is None:
+            log_time = time.time_ns()
+        if publish_time is None:
+            publish_time = log_time
         self.__writer.add_message(
             channel_id=channel_id,
-            log_time=log_time or time.time_ns(),
-            publish_time=publish_time or log_time,
+            log_time=log_time,
+            publish_time=publish_time,
             sequence=sequence,
             data=buffer.getvalue(),
         )

--- a/python/mcap-ros1-support/tests/test_ros_writer.py
+++ b/python/mcap-ros1-support/tests/test_ros_writer.py
@@ -9,11 +9,13 @@ def test_write_messages():
     output = BytesIO()
     ros_writer = Ros1Writer(output=output)
     for i in range(0, 10):
-        ros_writer.write_message("chatter", String(data=f"string message {i}"))
+        ros_writer.write_message("chatter", String(data=f"string message {i}"), i)
     ros_writer.finish()
 
     output.seek(0)
     decoder = Ros1Decoder(source=output)
-    for index, (topic, _record, message) in enumerate(decoder.messages):
+    for index, (topic, record, message) in enumerate(decoder.messages):
         assert topic == "chatter"
         assert message.data == f"string message {index}"
+        assert record.log_time == index
+        assert record.publish_time == index


### PR DESCRIPTION
Previously a log time or publish time of 0 would be interpreted as a `None`, and the ros1 writer would write `time.time_ns()` instead.