### PR TITLE
doctor: check statistics start/end time

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -230,7 +230,7 @@ func (doctor *mcapDoctor) Examine() {
 			}
 
 			if header.Library == "" {
-				doctor.warn("Header.library field should be non-empty. Its good to include a library field for reference.")
+				doctor.warn("Header.library field should be non-empty. The library field should be set to a value that identifies the software which produced the file.")
 			}
 
 			var customProfile = strings.HasPrefix(header.Profile, "x-")

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -332,6 +332,9 @@ func (doctor *mcapDoctor) Examine() {
 			if err != nil {
 				doctor.error("Failed to parse statistics:", err)
 			}
+			if doctor.statistics != nil {
+				doctor.error("File contains multiple Statistics records")
+			}
 			doctor.statistics = statistics
 		case mcap.TokenMetadata:
 			_, err := mcap.ParseMetadata(data)


### PR DESCRIPTION
**Public-Facing Changes**
Updated `mcap doctor` to check the correctness of Statistics message_start_time/message_end_time.

**Description**
Fixes #501.

Reports new errors on the file from #501:
```
Examining /Users/jacob/Downloads/whattimeisit.mcap
Statistics has message start time 1659409665222474798, but the minimum chunk start time is 0
Statistics has message end time 9900000000, but the maximum chunk end time is 1659409665222474798
```