### PR TITLE
pages: upload to preview bucket

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -180,6 +180,13 @@ jobs:
           parent: false
           destination: "foxglove-mcap-dev-preview/${{ github.ref }}"
 
-      - name: "Preview: print URL"
+      - name: "Preview: display URL"
         if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
-        run: "echo 'See generated docs at https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html'"
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "Pages Preview"
+          description: "Available in details"
+          state: "success"
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: "https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -182,11 +182,9 @@ jobs:
 
       - name: "Preview: display URL"
         if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
-        uses: Sibz/github-status-action@v1
+        uses: LouisBrunner/checks-action@v1.1.1
         with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "Pages Preview"
-          description: "Available in details"
-          state: "success"
-          sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: "https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html"
+          token: ${{secrets.GITHUB_TOKEN}}
+          name: "Pages Preview"
+          conclusion: "${{ job.status }}"
+          details_url: "https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -124,6 +124,7 @@ jobs:
       - pages-swift
     permissions:
       contents: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -182,9 +183,11 @@ jobs:
 
       - name: "Preview: display URL"
         if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
-        uses: LouisBrunner/checks-action@v1.1.1
+        uses: Sibz/github-status-action@v1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          name: "Pages Preview"
-          conclusion: "${{ job.status }}"
-          details_url: "https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html"
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "Pages Preview"
+          description: "Available in details"
+          state: "success"
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: "https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -161,3 +161,25 @@ jobs:
             git commit -m "Update docs from $GITHUB_REF_NAME (${GITHUB_SHA::7})"
             git push origin gh-pages
           fi
+
+      - name: "Preview: copy to staging dir"
+        if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
+        run: cp -r . /tmp/preview-files && rm -rf /tmp/preview-files/.git
+
+      - name: "Preview: auth to GCS"
+        if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.GCS_PREVIEW_KEY_JSON }}"
+
+      - name: "Preview: push to preview bucket"
+        if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
+        uses: "google-github-actions/upload-cloud-storage@v0"
+        with:
+          path: "/tmp/preview-files"
+          parent: false
+          destination: "foxglove-mcap-dev-preview/${{ github.ref }}"
+
+      - name: "Preview: print URL"
+        if: "!github.event.pull_request.head.repo.fork && github.ref != 'refs/heads/main'"
+        run: "echo 'See generated docs at https://storage.googleapis.com/foxglove-mcap-dev-preview/${{ github.ref }}/index.html'"


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
None
**Description**
This gives us a way to preview changes to `mcap.dev` before merging. Behind the scenes is pretty simple:
* A bucket exists (currently under the James Sandbox project, but can be moved if needed) with a 90 day lifecycle rule
* A service account exists with push access to that bucket only
* A new secret key has been added to this repo to auth with that service account
