### PR TITLE
Proposal for MIME type encoding

### DIFF
--- a/docs/specification/appendix.md
+++ b/docs/specification/appendix.md
@@ -37,6 +37,10 @@ The Channel `message_encoding` field describes the encoding for all messages wit
 
 - `message_encoding`: [`json`](https://www.json.org/json-en.html)
 
+### mime
+
+- `message_encoding`: [`mime`](https://datatracker.ietf.org/doc/html/rfc6838)
+
 ## Well-known schema encodings
 
 The Schema `encoding` field describes the encoding of a Channel's schema. Typically, this is related to the Channel's `message_encoding`, but they are separate concepts (e.g. there are multiple schema languages for `json`).
@@ -80,6 +84,12 @@ Schema `encoding` may only be omitted for self-describing message encodings such
 - `name`: May contain any value
 - `encoding`: `jsonschema`
 - `data`: [JSON Schema](https://json-schema.org)
+
+### mime type
+
+- `name`: [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml), e.g. `text/plain`
+- `encoding`: `mime`
+- `data`: Must be empty (0 bytes)
 
 ## Well-known profiles
 


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->

This PR proposes a new well-known encoding to the spec for MIME types.

**Description**
<!-- describe what has changed, and motivation behind those changes -->

Channels that pass data without a schema may contain content with a known MIME type. This PR proposes `mime` as a supported channel message encoding, with the schema encoding name referencing the MIME type/subtype directly.

There may be other ways to achieve this that are preferred, but this seemed like a good way to start a conversation about it.