### PR TITLE
python: support packages can use indexed reader

### DIFF
--- a/python/examples/protobuf/reader.py
+++ b/python/examples/protobuf/reader.py
@@ -1,14 +1,14 @@
 import sys
 
-from mcap.mcap0.stream_reader import StreamReader
-from mcap_protobuf.decoder import Decoder
+from mcap.mcap0.reader import make_reader
+from mcap_protobuf.decoder import decode_proto_messages
 
 
 def main():
-    reader = StreamReader(sys.argv[1])
-    decoder = Decoder(reader)
-    for topic, message in decoder.messages:
-        print(f"{topic}: {message}")
+    with open(sys.argv[1], "rb") as f:
+        mcap_iterator = make_reader(f).iter_messages()
+        for topic, message, timestamp in decode_proto_messages(mcap_iterator):
+            print(f"{topic} [{timestamp}]: {message}")
 
 
 if __name__ == "__main__":

--- a/python/examples/ros1/reader.py
+++ b/python/examples/ros1/reader.py
@@ -1,8 +1,10 @@
 import sys
 
-from mcap_ros1.decoder import Decoder
+from mcap.mcap0.reader import make_reader
+from mcap_ros1.decoder import decode_ros1_messages
 
 with open(sys.argv[1], "rb") as f:
-    ros_reader = Decoder(f)
-    for topic, underlying_record, message in ros_reader.messages:
-        print(f"{topic}: ({type(message).__name__}): {message.data}")
+    reader = make_reader(f)
+    ros1_messages = decode_ros1_messages(reader.iter_messages())
+    for topic, message, log_time in ros1_messages:
+        print(f"{topic} [log_time] ({type(message).__name__}): {message.data}")

--- a/python/mcap-protobuf-support/mcap_protobuf/decoder.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/decoder.py
@@ -15,7 +15,7 @@ def decode_proto_messages(
     messages using the definitions in the MCAP.
 
     :param message_iterator: an iterator of Schema, Channel, and Message records.
-        `McapReader.iter_messages()` is a convenient way to get this parameter.
+        Use :py:func:`mcap.mcap0.reader.McapReader.iter_messages()` to create this.
     :param ignore_non_protobuf_messages: if True, ignores non-protobuf messages in the MCAP rather
         than raising an exception.
     :returns: an iterator of (topic, protobuf message, log_time) tuples. Timestamps are provided

--- a/python/mcap-protobuf-support/tests/test_decoder.py
+++ b/python/mcap-protobuf-support/tests/test_decoder.py
@@ -1,8 +1,7 @@
-from io import BytesIO, RawIOBase
-from typing import cast
+from io import BytesIO
 
-from mcap.mcap0.stream_reader import StreamReader
-from mcap_protobuf.decoder import Decoder
+from mcap.mcap0.reader import make_reader
+from mcap_protobuf.decoder import decode_proto_messages
 
 from .generate import generate_sample_data
 
@@ -10,7 +9,12 @@ from .generate import generate_sample_data
 def test_protobuf_decoder():
     output = BytesIO()
     generate_sample_data(output)
-    reader = StreamReader(cast(RawIOBase, output))
-    decoder = Decoder(reader)
-    messages = list(decoder.messages)
-    assert len(messages) == 20
+
+    reader = make_reader(output)
+    message_iterator = reader.iter_messages(topics=["/complex_messages"])
+    proto_iterator = decode_proto_messages(message_iterator)
+    for index, (topic, message, timestamp) in enumerate(proto_iterator):
+        assert topic == "/complex_messages"
+        assert message.fieldA.startswith("Field A")
+        assert message.fieldB.startswith("Field B")
+        assert timestamp == index * 1000

--- a/python/mcap-protobuf-support/tests/test_writer.py
+++ b/python/mcap-protobuf-support/tests/test_writer.py
@@ -1,8 +1,8 @@
 from io import BytesIO
 
 from mcap_protobuf.writer import Writer
-from mcap_protobuf.decoder import Decoder
-from mcap.mcap0.stream_reader import StreamReader
+from mcap_protobuf.decoder import decode_proto_messages
+from mcap.mcap0.reader import make_reader
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -12,14 +12,15 @@ from google.protobuf.duration_pb2 import Duration
 def test_write_one():
     io = BytesIO()
     with Writer(io) as writer:
-        writer.write_message("timestamps", Timestamp(seconds=5, nanos=10))
+        writer.write_message("timestamps", Timestamp(seconds=5, nanos=10), log_time=15)
     io.seek(0)
 
-    messages = list(Decoder(StreamReader(io)).messages)
+    messages = list(decode_proto_messages(make_reader(io).iter_messages()))
     assert len(messages) == 1
-    topic, message = messages[0]
+    topic, message, timestamp = messages[0]
     assert message.seconds == 5
     assert message.nanos == 10
+    assert timestamp == 15
     assert topic == "timestamps"
 
 

--- a/python/mcap-ros1-support/README.md
+++ b/python/mcap-ros1-support/README.md
@@ -35,23 +35,15 @@ genpy = "*"
 ## Reading ROS1 Messages
 
 ```python
-# Reading from a stream
-from mcap.mcap0.stream_reader import StreamReader
-from mcap_ros1.decoder import Decoder
+# Reading from a stream of bytes
+from mcap.mcap0.reader import make_reader
+from mcap_ros1.decoder import decode_ros1_messages
 
-reader = StreamReader("my_data.mcap")
-decoder = Decoder(reader)
-for topic, record, message in decoder.messages:
-    print(message)
-```
-
-```python
-# Reading from raw mcap data
-from mcap_ros1.decoder import Decoder
-
-data = open("my_data.mcap", "rb").read()
-for topic, record, message in Decoder(data).messages:
-    print(message)
+with open("my_data.mcap", "rb") as f:
+    reader = make_reader(f)
+    message_iterator = decode_ros1_messages(reader.iter_messages())
+    for topic, message, timestamp in message_iterator:
+        print(message)
 ```
 
 ## Writing ROS1 Messages

--- a/python/mcap-ros1-support/mcap_ros1/decoder.py
+++ b/python/mcap-ros1-support/mcap_ros1/decoder.py
@@ -14,7 +14,7 @@ def decode_ros1_messages(
     messages using the definitions in the MCAP.
 
     :param message_iterator: an iterator of Schema, Channel, and Message records.
-        `McapReader.iter_messages()` is a convenient way to get this parameter.
+        Use :py:func:`mcap.mcap0.reader.McapReader.iter_messages()` to create this.
     :param ignore_non_ros1_messages: if True, ignores non-ros1 messages in the MCAP rather
         than raising an exception.
     :returns: an iterator of (topic, ros1_message, log_time) tuples. Timestamps are provided

--- a/python/mcap-ros1-support/tests/generate.py
+++ b/python/mcap-ros1-support/tests/generate.py
@@ -1,5 +1,4 @@
 import contextlib
-import time
 from io import BytesIO
 from tempfile import TemporaryFile
 
@@ -16,18 +15,18 @@ def generate_sample_data():
         name=String._type, encoding="ros1msg", data=String._full_text.encode()  # type: ignore
     )
     string_channel_id = writer.register_channel(
-        topic="chatter", message_encoding="ros1", schema_id=string_schema_id
+        topic="/chatter", message_encoding="ros1", schema_id=string_schema_id
     )
 
-    for i in range(1, 11):
+    for i in range(10):
         s = String(data=f"string message {i}")
         buff = BytesIO()
         s.serialize(buff)  # type: ignore
         writer.add_message(
             channel_id=string_channel_id,
-            log_time=time.time_ns(),
+            log_time=i * 1000,
             data=buff.getvalue(),
-            publish_time=time.time_ns(),
+            publish_time=i * 1000,
         )
     writer.finish()
     file.seek(0)

--- a/python/mcap-ros1-support/tests/test_ros_decoder.py
+++ b/python/mcap-ros1-support/tests/test_ros_decoder.py
@@ -1,21 +1,17 @@
-from io import RawIOBase
-from typing import cast
-from mcap.mcap0.stream_reader import StreamReader
-from mcap_ros1.decoder import Decoder
+from mcap.mcap0.reader import make_reader
+from mcap_ros1.decoder import decode_ros1_messages
 
 from .generate import generate_sample_data
 
 
-def test_ros_decoder_from_stream():
+def test_ros_decoder():
     with generate_sample_data() as m:
-        stream_reader = StreamReader(cast(RawIOBase, m))
-        ros_reader = Decoder(stream_reader)
-        messages = [m for m in ros_reader.messages]
-        assert len(messages) == 10
-
-
-def test_ros_decoder_from_bytes():
-    with generate_sample_data() as m:
-        data = m.read()
-        messages = [m for m in Decoder(data).messages]
-        assert len(messages) == 10
+        reader = make_reader(m)
+        ros_message_iterator = decode_ros1_messages(reader.iter_messages())
+        count = 0
+        for index, (topic, message, log_time) in enumerate(ros_message_iterator):
+            assert topic == "/chatter"
+            assert message.data == f"string message {index}"
+            assert log_time == index * 1000
+            count += 1
+        assert count == 10

--- a/python/mcap-ros1-support/tests/test_ros_writer.py
+++ b/python/mcap-ros1-support/tests/test_ros_writer.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
-from mcap_ros1.decoder import Decoder as Ros1Decoder
+from mcap_ros1.decoder import decode_ros1_messages
+from mcap.mcap0.reader import make_reader
 from mcap_ros1.writer import Writer as Ros1Writer
 from std_msgs.msg import String  # type: ignore
 
@@ -9,13 +10,13 @@ def test_write_messages():
     output = BytesIO()
     ros_writer = Ros1Writer(output=output)
     for i in range(0, 10):
-        ros_writer.write_message("chatter", String(data=f"string message {i}"), i)
+        ros_writer.write_message("/chatter", String(data=f"string message {i}"), i)
     ros_writer.finish()
 
     output.seek(0)
-    decoder = Ros1Decoder(source=output)
-    for index, (topic, record, message) in enumerate(decoder.messages):
-        assert topic == "chatter"
+    reader = make_reader(output)
+    message_iterator = decode_ros1_messages(reader.iter_messages())
+    for index, (topic, message, timestamp) in enumerate(message_iterator):
+        assert topic == "/chatter"
         assert message.data == f"string message {index}"
-        assert record.log_time == index
-        assert record.publish_time == index
+        assert timestamp == index


### PR DESCRIPTION
**Public-Facing Changes**
Replaces ROS1 and Protobuf support API for decoding messages.

**Description**

The previous support libraries used the StreamReader to decode messages, which does not take advantage of the index to search for messages by topic or timestamp. This PR replaces those decoding classes with an iterator adapter, which consumes the `McapReader.iter_messages()` iterator. This allows them to take advantage of the index as well.

<!-- link relevant GitHub issues -->
Fixes https://github.com/foxglove/private-issues/issues/47