### PR TITLE
cpp: use correct image for CI, remove --name

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -6,31 +6,32 @@ dev-image:
 
 .PHONY: build
 build: dev-image
-	docker run -t --rm --name mcap_cpp_dev -v $(CURDIR):/src mcap_cpp
+	docker run -t --rm -v $(CURDIR):/src mcap_cpp_dev
 
 .PHONY: build-host
 build-host:
 	./build.sh
 
 clean:
-	docker rm -f mcap_cpp
+	docker rm -f hdoc
 	docker rmi -f mcap_cpp_dev
 	docker rmi -f mcap_cpp_ci
+	docker rmi -f mcap_cpp_ci_jammy
 	rm -rf bench/build
 	rm -rf examples/build
 	rm -rf test/build
 
 .PHONY: format-check
 format-check: dev-image
-	docker run -t --rm --name mcap_cpp_dev -v $(CURDIR):/src mcap_cpp python3 scripts/format.py /src
+	docker run -t --rm -v $(CURDIR):/src mcap_cpp_dev python3 scripts/format.py /src
 
 .PHONY: format-fix
 format-fix: dev-image
-	docker run -t --rm --name mcap_cpp_dev -v $(CURDIR):/src mcap_cpp python3 scripts/format.py --fix /src
+	docker run -t --rm -v $(CURDIR):/src mcap_cpp_dev python3 scripts/format.py --fix /src
 
 .PHONY: bench
 bench: dev-image
-	docker run -t --rm --name mcap_cpp_dev -v $(CURDIR):/src mcap_cpp ./bench/build/Release/bin/bench-tests
+	docker run -t --rm -v $(CURDIR):/src mcap_cpp_dev ./bench/build/Release/bin/bench-tests
 
 .PHONY: bench-host
 bench-host:
@@ -38,7 +39,7 @@ bench-host:
 
 .PHONY: test
 test: dev-image
-	docker run -t --rm --name mcap_cpp_dev -v $(CURDIR):/src mcap_cpp ./test/build/Debug/bin/unit-tests
+	docker run -t --rm -v $(CURDIR):/src mcap_cpp_dev ./test/build/Debug/bin/unit-tests
 
 .PHONY: test-host
 test-host:
@@ -50,7 +51,7 @@ hdoc-build:
 
 .PHONY: run-examples
 run-examples: dev-image
-	docker run -t --rm --name mcap_cpp_dev -v $(CURDIR):/src mcap_cpp ./run_examples.sh
+	docker run -t --rm -v $(CURDIR):/src mcap_cpp_ci ./run_examples.sh
 
 .PHONY: run-examples-host
 run-examples-host:
@@ -62,13 +63,13 @@ ci-image:
 
 .PHONY: ci
 ci: ci-image
-	docker run -t --rm --name mcap_cpp_ci -v $(CURDIR):/mcap/cpp mcap_cpp ./build.sh
+	docker run -t --rm -v $(CURDIR):/mcap/cpp mcap_cpp_ci ./build.sh
 
 .PHONY: ci-docs
 ci-docs: hdoc-build ci-image
-	docker build -t mcap_cpp -f ci.Dockerfile .
-	docker run -t --rm --name mcap_cpp_ci -v $(CURDIR):/mcap/cpp -v $(CURDIR)/../__docs__/cpp:/hdoc-output mcap_cpp ./build-docs.sh
+	docker build -t mcap_cpp_ci_jammy -f ci.Dockerfile .
+	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(CURDIR)/../__docs__/cpp:/hdoc-output mcap_cpp_ci_jammy ./build-docs.sh
 
 .PHONY: ci-format-check
 ci-format-check: hdoc-build ci-image
-	docker run -t --rm --name mcap_cpp_ci -v $(CURDIR):/mcap/cpp mcap_cpp python3 scripts/format.py .
+	docker run -t --rm -v $(CURDIR):/mcap/cpp mcap_cpp_ci python3 scripts/format.py .

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,6 +1,6 @@
 .PHONY: pipenv
 pipenv:
-	pipenv install --dev --deploy
+	SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pipenv install --dev --deploy
 
 .PHONY: build
 build: pipenv


### PR DESCRIPTION
This commit removes the docker image called `mcap_cpp` from the C++
Makefile. This was being built erroneously in the `hdoc-build` target.

We don't have a need for specific names of containers in this process.
Also, the presence of containers with the same name as images caused
confusion and made this bug harder to spot. Therefore, this commit
removes the `--name` arguments from all `docker run` invocations in
the C++ Makefile.

**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->


**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
