### PR TITLE
go: read in log time order with overlapping chunks

### DIFF
--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -13,10 +13,10 @@ The Swift MCAP library is experimental, and not actively developed. This means t
 |  | Python | C++ | Go | Typescript | Swift |
 | --- | --- | --- | --- | --- | --- |
 | Indexed unordered message reading | Yes | Yes | Yes | Yes | No |
-| Timestamp-ordered message reading | Yes | Partial [^2] | Partial [^3] | Yes | No |
-| Indexed metadata reading | Yes | Yes [^1] | Yes [^1] | Yes [^1] | No |
-| Indexed attachment reading | Yes | Yes [^1] | Yes [^1] | Yes [^1] | No |
-| Non-materialized attachment reading | No | Yes [^5] | No | No | No |
+| Timestamp-ordered message reading | Yes | Partial [^1] | Yes | Yes | No |
+| Indexed metadata reading | Yes | Yes [^2] | Yes [^2] | Yes [^2] | No |
+| Indexed attachment reading | Yes | Yes [^2] | Yes [^2] | Yes [^2] | No |
+| Non-materialized attachment reading | No | Yes [^3] | No | No | No |
 | Non-indexed reading | Yes | Yes | Yes | Yes | Yes |
 | CRC validation | No | No | Yes | Yes | No |
 | ROS1 wrapper | Yes | No | No | No | No |
@@ -24,11 +24,10 @@ The Swift MCAP library is experimental, and not actively developed. This means t
 | Protobuf wrapper | Yes | No | No | No | No |
 | Record writing | Yes | Yes | Yes | Yes | Yes |
 | Easy chunked writing | Yes | Yes | Yes | Yes | Yes |
-| Automatic summary writing | Yes [^6] | Yes [^6] | Yes [^6] | Yes [^6] | Yes [^6] |
+| Automatic summary writing | Yes [^5] | Yes [^5] | Yes [^5] | Yes [^5] | Yes [^5] |
 
-[^1]: These readers don’t have a single call to read an attachment or metadata record by name, but do allow you to read the summary, seek to that location, read a record and parse it.
-[^2]: The C++ reader does not assume chunk indices are in order, but assumes all messages in a chunk are in order and chunk time ranges do not overlap.
-[^3]: Go reader does not assume messages or chunks are in order but assumes chunks do not overlap in time.
-[^4]: Using the [MCAP Rosbag2 storage plugin](https://github.com/ros-tooling/rosbag2_storage_mcap).
-[^5]: The C++ reader interface does not preclude one from backing it with a memory-mapped file. This could be used to implement message and attachment parsing without copying data into memory.
-[^6]: All writers currently do not compute a CRC for the DataEnd record.
+[^1]: The C++ reader does not assume chunk indices are in order, but assumes all messages in a chunk are in order and chunk time ranges do not overlap.
+[^2]: These readers don’t have a single call to read an attachment or metadata record by name, but do allow you to read the summary, seek to that location, read a record and parse it.
+[^3]: Using the [MCAP Rosbag2 storage plugin](https://github.com/ros-tooling/rosbag2_storage_mcap).
+[^4]: The C++ reader interface does not preclude one from backing it with a memory-mapped file. This could be used to implement message and attachment parsing without copying data into memory.
+[^5]: All writers currently do not compute a CRC for the DataEnd record.

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -180,7 +180,12 @@ var catCmd = &cobra.Command{
 				log.Fatalf("Failed to create reader: %s", err)
 			}
 			topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
-			it, err := reader.Messages(catStart*1e9, catEnd*1e9, topics, false, false)
+			it, err := reader.Messages(
+				mcap.ReadMessagesAfter(catStart*1e9),
+				mcap.ReadMessagesBefore(catEnd*1e9),
+				mcap.ReadMessagesWithTopics(topics),
+				mcap.ReadMessagesUsingIndex(false),
+			)
 			if err != nil {
 				log.Fatalf("Failed to read messages: %s", err)
 			}
@@ -202,7 +207,11 @@ var catCmd = &cobra.Command{
 				return fmt.Errorf("failed to create reader: %w", err)
 			}
 			topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
-			it, err := reader.Messages(catStart*1e9, catEnd*1e9, topics, true, false)
+			it, err := reader.Messages(
+				mcap.ReadMessagesAfter(catStart*1e9),
+				mcap.ReadMessagesBefore(catEnd*1e9),
+				mcap.ReadMessagesWithTopics(topics),
+			)
 			if err != nil {
 				return fmt.Errorf("failed to read messages: %w", err)
 			}

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -16,6 +16,7 @@ import (
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/cli/mcap/utils/ros"
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/foxglove/mcap/go/mcap/readopts"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -181,10 +182,10 @@ var catCmd = &cobra.Command{
 			}
 			topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
 			it, err := reader.Messages(
-				mcap.ReadMessagesAfter(catStart*1e9),
-				mcap.ReadMessagesBefore(catEnd*1e9),
-				mcap.ReadMessagesWithTopics(topics),
-				mcap.ReadMessagesUsingIndex(false),
+				readopts.After(catStart*1e9),
+				readopts.Before(catEnd*1e9),
+				readopts.WithTopics(topics),
+				readopts.UsingIndex(false),
 			)
 			if err != nil {
 				log.Fatalf("Failed to read messages: %s", err)
@@ -208,9 +209,9 @@ var catCmd = &cobra.Command{
 			}
 			topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
 			it, err := reader.Messages(
-				mcap.ReadMessagesAfter(catStart*1e9),
-				mcap.ReadMessagesBefore(catEnd*1e9),
-				mcap.ReadMessagesWithTopics(topics),
+				readopts.After(catStart*1e9),
+				readopts.Before(catEnd*1e9),
+				readopts.WithTopics(topics),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to read messages: %w", err)

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -180,7 +180,7 @@ var catCmd = &cobra.Command{
 				log.Fatalf("Failed to create reader: %s", err)
 			}
 			topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
-			it, err := reader.Messages(catStart*1e9, catEnd*1e9, topics, false)
+			it, err := reader.Messages(catStart*1e9, catEnd*1e9, topics, false, false)
 			if err != nil {
 				log.Fatalf("Failed to read messages: %s", err)
 			}
@@ -202,7 +202,7 @@ var catCmd = &cobra.Command{
 				return fmt.Errorf("failed to create reader: %w", err)
 			}
 			topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
-			it, err := reader.Messages(catStart*1e9, catEnd*1e9, topics, true)
+			it, err := reader.Messages(catStart*1e9, catEnd*1e9, topics, true, false)
 			if err != nil {
 				return fmt.Errorf("failed to read messages: %w", err)
 			}

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -33,7 +33,7 @@ func TestCat(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			reader, err := mcap.NewReader(r)
 			assert.Nil(t, err)
-			it, err := reader.Messages(0, math.MaxInt64, []string{}, true)
+			it, err := reader.Messages(0, math.MaxInt64, []string{}, true, false)
 			assert.Nil(t, err)
 			err = printMessages(ctx, w, it, false)
 			assert.Nil(t, err)
@@ -65,7 +65,7 @@ func BenchmarkCat(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				reader, err := mcap.NewReader(r)
 				assert.Nil(b, err)
-				it, err := reader.Messages(0, math.MaxInt64, []string{}, true)
+				it, err := reader.Messages(0, math.MaxInt64, []string{}, true, false)
 				assert.Nil(b, err)
 				err = printMessages(ctx, w, it, c.formatJSON)
 				assert.Nil(b, err)

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"math"
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
@@ -33,7 +32,7 @@ func TestCat(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			reader, err := mcap.NewReader(r)
 			assert.Nil(t, err)
-			it, err := reader.Messages(0, math.MaxInt64, []string{}, true, false)
+			it, err := reader.Messages()
 			assert.Nil(t, err)
 			err = printMessages(ctx, w, it, false)
 			assert.Nil(t, err)
@@ -65,7 +64,7 @@ func BenchmarkCat(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				reader, err := mcap.NewReader(r)
 				assert.Nil(b, err)
-				it, err := reader.Messages(0, math.MaxInt64, []string{}, true, false)
+				it, err := reader.Messages()
 				assert.Nil(b, err)
 				err = printMessages(ctx, w, it, c.formatJSON)
 				assert.Nil(b, err)

--- a/go/cli/mcap/cmd/merge.go
+++ b/go/cli/mcap/cmd/merge.go
@@ -130,7 +130,7 @@ func buildIterator(r io.Reader) (mcap.MessageIterator, error) {
 	if err != nil {
 		return nil, err
 	}
-	iterator, err := reader.Messages(0, math.MaxInt64, nil, false)
+	iterator, err := reader.Messages(0, math.MaxInt64, nil, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/cli/mcap/cmd/merge.go
+++ b/go/cli/mcap/cmd/merge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/foxglove/mcap/go/mcap/readopts"
 	"github.com/spf13/cobra"
 )
 
@@ -129,7 +130,7 @@ func buildIterator(r io.Reader) (mcap.MessageIterator, error) {
 	if err != nil {
 		return nil, err
 	}
-	iterator, err := reader.Messages(mcap.ReadMessagesUsingIndex(false))
+	iterator, err := reader.Messages(readopts.UsingIndex(false))
 	if err != nil {
 		return nil, err
 	}

--- a/go/cli/mcap/cmd/merge.go
+++ b/go/cli/mcap/cmd/merge.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
@@ -130,7 +129,7 @@ func buildIterator(r io.Reader) (mcap.MessageIterator, error) {
 	if err != nil {
 		return nil, err
 	}
-	iterator, err := reader.Messages(0, math.MaxInt64, nil, false, false)
+	iterator, err := reader.Messages(mcap.ReadMessagesUsingIndex(false))
 	if err != nil {
 		return nil, err
 	}

--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"math"
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
@@ -51,7 +50,7 @@ func TestMCAPMerging(t *testing.T) {
 		// output should now be a well-formed mcap
 		reader, err := mcap.NewReader(output)
 		assert.Nil(t, err)
-		it, err := reader.Messages(0, math.MaxInt64, nil, false, false)
+		it, err := reader.Messages(mcap.ReadMessagesUsingIndex(false))
 		assert.Nil(t, err)
 
 		messages := make(map[string]int)
@@ -80,7 +79,7 @@ func TestMultiChannelInput(t *testing.T) {
 	assert.Nil(t, merger.mergeInputs(output, []io.Reader{multiChannelInput, buf3}))
 	reader, err := mcap.NewReader(output)
 	assert.Nil(t, err)
-	it, err := reader.Messages(0, math.MaxInt64, nil, false, false)
+	it, err := reader.Messages(mcap.ReadMessagesUsingIndex(false))
 	assert.Nil(t, err)
 	messages := make(map[string]int)
 	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {

--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/foxglove/mcap/go/mcap/readopts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,7 +51,7 @@ func TestMCAPMerging(t *testing.T) {
 		// output should now be a well-formed mcap
 		reader, err := mcap.NewReader(output)
 		assert.Nil(t, err)
-		it, err := reader.Messages(mcap.ReadMessagesUsingIndex(false))
+		it, err := reader.Messages(readopts.UsingIndex(false))
 		assert.Nil(t, err)
 
 		messages := make(map[string]int)
@@ -79,7 +80,7 @@ func TestMultiChannelInput(t *testing.T) {
 	assert.Nil(t, merger.mergeInputs(output, []io.Reader{multiChannelInput, buf3}))
 	reader, err := mcap.NewReader(output)
 	assert.Nil(t, err)
-	it, err := reader.Messages(mcap.ReadMessagesUsingIndex(false))
+	it, err := reader.Messages(readopts.UsingIndex(false))
 	assert.Nil(t, err)
 	messages := make(map[string]int)
 	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {

--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -51,7 +51,7 @@ func TestMCAPMerging(t *testing.T) {
 		// output should now be a well-formed mcap
 		reader, err := mcap.NewReader(output)
 		assert.Nil(t, err)
-		it, err := reader.Messages(0, math.MaxInt64, nil, false)
+		it, err := reader.Messages(0, math.MaxInt64, nil, false, false)
 		assert.Nil(t, err)
 
 		messages := make(map[string]int)
@@ -80,7 +80,7 @@ func TestMultiChannelInput(t *testing.T) {
 	assert.Nil(t, merger.mergeInputs(output, []io.Reader{multiChannelInput, buf3}))
 	reader, err := mcap.NewReader(output)
 	assert.Nil(t, err)
-	it, err := reader.Messages(0, math.MaxInt64, nil, false)
+	it, err := reader.Messages(0, math.MaxInt64, nil, false, false)
 	assert.Nil(t, err)
 	messages := make(map[string]int)
 	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -15,12 +15,11 @@ import (
 // seeking is required). It makes reads in alternation from the index data
 // section, the message index at the end of a chunk, and the chunk's contents.
 type indexedMessageIterator struct {
-	lexer   *Lexer
-	rs      io.ReadSeeker
-	topics  map[string]bool
-	start   uint64
-	end     uint64
-	reverse bool
+	lexer  *Lexer
+	rs     io.ReadSeeker
+	topics map[string]bool
+	start  uint64
+	end    uint64
 
 	channels          map[uint16]*Channel
 	schemas           map[uint16]*Schema
@@ -99,7 +98,6 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 					if (it.end == 0 && it.start == 0) || (idx.MessageStartTime < it.end && idx.MessageEndTime >= it.start) {
 						rangeIndex := rangeIndex{
 							chunkIndex: idx,
-							reverse:    it.reverse,
 						}
 						heap.Push(&it.indexHeap, rangeIndex)
 					}
@@ -184,7 +182,6 @@ func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
 				rangeIndex := rangeIndex{
 					messageIndexEntry: &offset,
 					buf:               chunkData,
-					reverse:           it.reverse,
 				}
 				heap.Push(&it.indexHeap, rangeIndex)
 			}

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -222,18 +222,18 @@ func (it *indexedMessageIterator) Next(p []byte) (*Schema, *Channel, *Message, e
 			if err != nil {
 				return nil, nil, nil, err
 			}
-		} else {
-			chunkOffset := ri.messageIndexEntry.Offset
-			length := binary.LittleEndian.Uint64(ri.buf[chunkOffset+1:])
-			messageData := ri.buf[chunkOffset+1+8 : chunkOffset+1+8+length]
-			message, err := ParseMessage(messageData)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			channel := it.channels[message.ChannelID]
-			schema := it.schemas[channel.SchemaID]
-			return schema, channel, message, nil
+			continue
 		}
+		chunkOffset := ri.messageIndexEntry.Offset
+		length := binary.LittleEndian.Uint64(ri.buf[chunkOffset+1:])
+		messageData := ri.buf[chunkOffset+1+8 : chunkOffset+1+8+length]
+		message, err := ParseMessage(messageData)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		channel := it.channels[message.ChannelID]
+		schema := it.schemas[channel.SchemaID]
+		return schema, channel, message, nil
 	}
 	return nil, nil, nil, io.EOF
 }

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -181,6 +181,7 @@ func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
 			timestamp := messageIndex.Records[i].Timestamp
 			if timestamp >= it.start && timestamp < it.end {
 				heap.Push(&it.indexHeap, rangeIndex{
+					chunkIndex:        chunkIndex,
 					messageIndexEntry: &messageIndex.Records[i],
 					buf:               chunkData,
 				})
@@ -200,7 +201,7 @@ func (it *indexedMessageIterator) Next(p []byte) (*Schema, *Channel, *Message, e
 
 	for it.indexHeap.Len() > 0 {
 		ri := heap.Pop(&it.indexHeap).(rangeIndex)
-		if ri.chunkIndex != nil {
+		if ri.messageIndexEntry == nil {
 			err := it.loadChunk(ri.chunkIndex)
 			if err != nil {
 				return nil, nil, nil, err

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -99,7 +99,9 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 						rangeIndex := rangeIndex{
 							chunkIndex: idx,
 						}
-						heap.Push(&it.indexHeap, rangeIndex)
+						if err := it.indexHeap.HeapPush(rangeIndex); err != nil {
+							return err
+						}
 					}
 					break
 				}
@@ -200,7 +202,10 @@ func (it *indexedMessageIterator) Next(p []byte) (*Schema, *Channel, *Message, e
 	}
 
 	for it.indexHeap.Len() > 0 {
-		ri := heap.Pop(&it.indexHeap).(rangeIndex)
+		ri, err := it.indexHeap.HeapPop()
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		if ri.messageIndexEntry == nil {
 			err := it.loadChunk(ri.chunkIndex)
 			if err != nil {

--- a/go/mcap/range_index_heap.go
+++ b/go/mcap/range_index_heap.go
@@ -1,0 +1,41 @@
+package mcap
+
+type rangeIndex struct {
+	chunkIndex        *ChunkIndex
+	messageIndexEntry *MessageIndexEntry
+	reverse           bool
+	buf               []uint8
+}
+
+func (ri *rangeIndex) logTime() uint64 {
+	if ri.chunkIndex != nil {
+		if ri.reverse {
+			return ri.chunkIndex.MessageEndTime
+		}
+		return ri.chunkIndex.MessageStartTime
+	}
+	return ri.messageIndexEntry.Timestamp
+}
+
+type rangeIndexHeap []rangeIndex
+
+func (h rangeIndexHeap) Len() int      { return len(h) }
+func (h rangeIndexHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *rangeIndexHeap) Push(x interface{}) {
+	*h = append(*h, x.(rangeIndex))
+}
+
+func (h *rangeIndexHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func (h rangeIndexHeap) Less(i, j int) bool {
+	if h[i].reverse {
+		return h[i].logTime() > h[j].logTime()
+	}
+	return h[i].logTime() < h[j].logTime()
+}

--- a/go/mcap/range_index_heap.go
+++ b/go/mcap/range_index_heap.go
@@ -3,6 +3,8 @@ package mcap
 import (
 	"container/heap"
 	"fmt"
+
+	"github.com/foxglove/mcap/go/mcap/readopts"
 )
 
 // rangeIndex refers to either a chunk (via the ChunkIndex, with other fields nil)
@@ -16,7 +18,7 @@ type rangeIndex struct {
 // heap of rangeIndex entries, where the entries are sorted by their log time.
 type rangeIndexHeap struct {
 	indices []rangeIndex
-	order   ReadOrder
+	order   readopts.ReadOrder
 	lastErr error
 }
 
@@ -24,7 +26,7 @@ type rangeIndexHeap struct {
 func (h rangeIndexHeap) timestamp(i int) uint64 {
 	ri := h.indices[i]
 	if ri.messageIndexEntry == nil {
-		if h.order == ReadOrderReverseLogTime {
+		if h.order == readopts.ReverseLogTimeOrder {
 			return ri.chunkIndex.MessageEndTime
 		}
 		return ri.chunkIndex.MessageStartTime
@@ -76,11 +78,11 @@ func (h *rangeIndexHeap) Pop() interface{} {
 // Less is required by `heap.Interface`.
 func (h *rangeIndexHeap) Less(i, j int) bool {
 	switch h.order {
-	case ReadOrderFile:
+	case readopts.FileOrder:
 		return h.filePositionLess(i, j)
-	case ReadOrderLogTime:
+	case readopts.LogTimeOrder:
 		return h.timestamp(i) < h.timestamp(j)
-	case ReadOrderReverseLogTime:
+	case readopts.ReverseLogTimeOrder:
 		return h.timestamp(i) > h.timestamp(j)
 	}
 	h.lastErr = fmt.Errorf("ReadOrder case not handled: %v", h.order)

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -1,0 +1,42 @@
+package mcap
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForwardOrdering(t *testing.T) {
+	h := &rangeIndexHeap{}
+	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 0}})
+	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}})
+	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 3}})
+	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}})
+
+	assert.Equal(t, h.Len(), 4)
+
+	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 0}}, heap.Pop(h))
+	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}}, heap.Pop(h))
+	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}}, heap.Pop(h))
+	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 3}}, heap.Pop(h))
+
+	assert.Equal(t, h.Len(), 0)
+}
+
+func TestReverseOrdering(t *testing.T) {
+	h := &rangeIndexHeap{reverse: true}
+	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 0}})
+	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}})
+	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 3}})
+	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}})
+
+	assert.Equal(t, h.Len(), 4)
+
+	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 3}}, heap.Pop(h))
+	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}}, heap.Pop(h))
+	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}}, heap.Pop(h))
+	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 0}}, heap.Pop(h))
+
+	assert.Equal(t, h.Len(), 0)
+}

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/foxglove/mcap/go/mcap/readopts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,22 +44,22 @@ var rangeIndexHeapTestItems = []rangeIndex{
 func TestMessageOrdering(t *testing.T) {
 	cases := []struct {
 		assertion          string
-		order              ReadOrder
+		order              readopts.ReadOrder
 		expectedIndexOrder []int
 	}{
 		{
 			assertion:          "read time order forwards",
-			order:              ReadOrderLogTime,
+			order:              readopts.LogTimeOrder,
 			expectedIndexOrder: []int{0, 1, 2, 3},
 		},
 		{
 			assertion:          "read time order backwards",
-			order:              ReadOrderReverseLogTime,
+			order:              readopts.ReverseLogTimeOrder,
 			expectedIndexOrder: []int{3, 0, 2, 1},
 		},
 		{
 			assertion:          "read file order",
-			order:              ReadOrderFile,
+			order:              readopts.FileOrder,
 			expectedIndexOrder: []int{0, 2, 1, 3},
 		},
 	}

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -1,42 +1,88 @@
 package mcap
 
 import (
-	"container/heap"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestForwardOrdering(t *testing.T) {
-	h := &rangeIndexHeap{order: ReadOrderLogTime}
-	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 0}})
-	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}})
-	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 3}})
-	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}})
-
-	assert.Equal(t, h.Len(), 4)
-
-	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 0}}, heap.Pop(h))
-	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}}, heap.Pop(h))
-	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}}, heap.Pop(h))
-	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 3}}, heap.Pop(h))
-
-	assert.Equal(t, h.Len(), 0)
+var rangeIndexHeapTestItems = []rangeIndex{
+	{
+		chunkIndex: &ChunkIndex{
+			ChunkStartOffset: 1,
+			MessageStartTime: 100,
+			MessageEndTime:   300,
+		},
+	},
+	{
+		chunkIndex: &ChunkIndex{
+			ChunkStartOffset: 2,
+			MessageStartTime: 200,
+			MessageEndTime:   400,
+		},
+		messageIndexEntry: &MessageIndexEntry{Offset: 3, Timestamp: 200},
+	},
+	{
+		chunkIndex: &ChunkIndex{
+			ChunkStartOffset: 2,
+			MessageStartTime: 200,
+			MessageEndTime:   400,
+		},
+		messageIndexEntry: &MessageIndexEntry{Offset: 2, Timestamp: 250},
+	},
+	{
+		chunkIndex: &ChunkIndex{
+			ChunkStartOffset: 3,
+			MessageStartTime: 300,
+			MessageEndTime:   400,
+		},
+	},
 }
 
-func TestReverseOrdering(t *testing.T) {
-	h := &rangeIndexHeap{order: ReadOrderReverseLogTime}
-	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 0}})
-	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}})
-	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 3}})
-	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}})
-
-	assert.Equal(t, h.Len(), 4)
-
-	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 3}}, heap.Pop(h))
-	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 2}}, heap.Pop(h))
-	assert.Equal(t, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}}, heap.Pop(h))
-	assert.Equal(t, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 0}}, heap.Pop(h))
-
-	assert.Equal(t, h.Len(), 0)
+func TestMessageOrdering(t *testing.T) {
+	cases := []struct {
+		assertion          string
+		order              ReadOrder
+		expectedIndexOrder []int
+	}{
+		{
+			assertion:          "read time order forwards",
+			order:              ReadOrderLogTime,
+			expectedIndexOrder: []int{0, 1, 2, 3},
+		},
+		{
+			assertion:          "read time order backwards",
+			order:              ReadOrderReverseLogTime,
+			expectedIndexOrder: []int{3, 0, 2, 1},
+		},
+		{
+			assertion:          "read file order",
+			order:              ReadOrderFile,
+			expectedIndexOrder: []int{0, 2, 1, 3},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			h := &rangeIndexHeap{order: c.order}
+			for _, item := range rangeIndexHeapTestItems {
+				assert.Nil(t, h.HeapPush(item))
+			}
+			assert.Equal(t, h.Len(), len(rangeIndexHeapTestItems))
+			i := 0
+			for h.Len() > 0 {
+				popped_item, err := h.HeapPop()
+				assert.Nil(t, err)
+				found := false
+				for index, item := range rangeIndexHeapTestItems {
+					if reflect.DeepEqual(item, *popped_item) {
+						assert.Equal(t, c.expectedIndexOrder[i], index)
+						found = true
+					}
+				}
+				assert.True(t, found)
+				i++
+			}
+		})
+	}
 }

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -71,11 +71,11 @@ func TestMessageOrdering(t *testing.T) {
 			assert.Equal(t, h.Len(), len(rangeIndexHeapTestItems))
 			i := 0
 			for h.Len() > 0 {
-				popped_item, err := h.HeapPop()
+				poppedItem, err := h.HeapPop()
 				assert.Nil(t, err)
 				found := false
 				for index, item := range rangeIndexHeapTestItems {
-					if reflect.DeepEqual(item, *popped_item) {
+					if reflect.DeepEqual(item, *poppedItem) {
 						assert.Equal(t, c.expectedIndexOrder[i], index)
 						found = true
 					}

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestForwardOrdering(t *testing.T) {
-	h := &rangeIndexHeap{}
+	h := &rangeIndexHeap{order: ReadOrderLogTime}
 	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 0}})
 	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}})
 	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageStartTime: 3}})
@@ -25,7 +25,7 @@ func TestForwardOrdering(t *testing.T) {
 }
 
 func TestReverseOrdering(t *testing.T) {
-	h := &rangeIndexHeap{reverse: true}
+	h := &rangeIndexHeap{order: ReadOrderReverseLogTime}
 	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 0}})
 	heap.Push(h, rangeIndex{messageIndexEntry: &MessageIndexEntry{Timestamp: 1}})
 	heap.Push(h, rangeIndex{chunkIndex: &ChunkIndex{MessageEndTime: 3}})

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -12,8 +12,8 @@ type ReadOrder int
 
 const (
 	ReadOrderFile           ReadOrder = 0
-	ReadOrderLogTime                  = 1
-	ReadOrderReverseLogTime           = 2
+	ReadOrderLogTime        ReadOrder = 1
+	ReadOrderReverseLogTime ReadOrder = 2
 )
 
 func readPrefixedString(data []byte, offset int) (s string, newoffset int, err error) {

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -107,14 +107,14 @@ func (r *Reader) indexedMessageIterator(
 	}
 	r.l.emitChunks = true
 	return &indexedMessageIterator{
-		lexer:    r.l,
-		rs:       r.rs,
-		channels: make(map[uint16]*Channel),
-		schemas:  make(map[uint16]*Schema),
-		topics:   topicMap,
-		start:    start,
-		end:      end,
-		reverse:  reverse,
+		lexer:     r.l,
+		rs:        r.rs,
+		channels:  make(map[uint16]*Channel),
+		schemas:   make(map[uint16]*Schema),
+		topics:    topicMap,
+		start:     start,
+		end:       end,
+		indexHeap: rangeIndexHeap{reverse: reverse},
 	}
 }
 

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/foxglove/mcap/go/mcap/readopts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,7 +63,7 @@ func TestIndexedReaderBreaksTiesOnChunkOffset(t *testing.T) {
 	reader, err := NewReader(bytes.NewReader(buf.Bytes()))
 	assert.Nil(t, err)
 
-	it, err := reader.Messages(ReadMessagesUsingIndex(true))
+	it, err := reader.Messages(readopts.UsingIndex(true))
 	assert.Nil(t, err)
 	expectedTopics := []string{"/foo", "/bar"}
 	for i := 0; i < 2; i++ {
@@ -272,7 +273,7 @@ func TestMessageReading(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
-						it, err := r.Messages(ReadMessagesUsingIndex(useIndex))
+						it, err := r.Messages(readopts.UsingIndex(useIndex))
 						assert.Nil(t, err)
 						c := 0
 						for {
@@ -295,8 +296,8 @@ func TestMessageReading(t *testing.T) {
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
 						it, err := r.Messages(
-							ReadMessagesWithTopics([]string{"/test1"}),
-							ReadMessagesUsingIndex(useIndex),
+							readopts.WithTopics([]string{"/test1"}),
+							readopts.UsingIndex(useIndex),
 						)
 						assert.Nil(t, err)
 						c := 0
@@ -320,8 +321,8 @@ func TestMessageReading(t *testing.T) {
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
 						it, err := r.Messages(
-							ReadMessagesWithTopics([]string{"/test1", "/test2"}),
-							ReadMessagesUsingIndex(useIndex),
+							readopts.WithTopics([]string{"/test1", "/test2"}),
+							readopts.UsingIndex(useIndex),
 						)
 						assert.Nil(t, err)
 						c := 0
@@ -345,9 +346,9 @@ func TestMessageReading(t *testing.T) {
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
 						it, err := r.Messages(
-							ReadMessagesAfter(100),
-							ReadMessagesBefore(200),
-							ReadMessagesUsingIndex(useIndex),
+							readopts.After(100),
+							readopts.Before(200),
+							readopts.UsingIndex(useIndex),
 						)
 						assert.Nil(t, err)
 						c := 0
@@ -378,7 +379,7 @@ func TestReaderCounting(t *testing.T) {
 			defer f.Close()
 			r, err := NewReader(f)
 			assert.Nil(t, err)
-			it, err := r.Messages(ReadMessagesUsingIndex(indexed))
+			it, err := r.Messages(readopts.UsingIndex(indexed))
 			assert.Nil(t, err)
 			c := 0
 			for {
@@ -427,7 +428,7 @@ func TestReadingDiagnostics(t *testing.T) {
 	assert.Nil(t, err)
 	r, err := NewReader(f)
 	assert.Nil(t, err)
-	it, err := r.Messages(ReadMessagesWithTopics([]string{"/diagnostics"}))
+	it, err := r.Messages(readopts.WithTopics([]string{"/diagnostics"}))
 	assert.Nil(t, err)
 	c := 0
 	for {
@@ -501,8 +502,8 @@ func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
 	assert.Nil(t, err)
 
 	it, err := reader.Messages(
-		ReadMessagesUsingIndex(true),
-		ReadMessagesInOrder(ReadOrderLogTime),
+		readopts.UsingIndex(true),
+		readopts.InOrder(readopts.LogTimeOrder),
 	)
 	assert.Nil(t, err)
 
@@ -522,8 +523,8 @@ func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
 
 	// now try iterating in reverse
 	reverseIt, err := reader.Messages(
-		ReadMessagesUsingIndex(true),
-		ReadMessagesInOrder(ReadOrderReverseLogTime),
+		readopts.UsingIndex(true),
+		readopts.InOrder(readopts.ReverseLogTimeOrder),
 	)
 	assert.Nil(t, err)
 

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -63,7 +63,7 @@ func TestIndexedReaderBreaksTiesOnChunkOffset(t *testing.T) {
 	reader, err := NewReader(bytes.NewReader(buf.Bytes()))
 	assert.Nil(t, err)
 
-	it, err := reader.Messages(0, 100, []string{}, true)
+	it, err := reader.Messages(0, 100, []string{}, true, false)
 	assert.Nil(t, err)
 	expectedTopics := []string{"/foo", "/bar"}
 	for i := 0; i < 2; i++ {
@@ -273,7 +273,7 @@ func TestMessageReading(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
-						it, err := r.Messages(0, 10000, []string{}, useIndex)
+						it, err := r.Messages(0, 10000, []string{}, useIndex, false)
 						assert.Nil(t, err)
 						c := 0
 						for {
@@ -295,7 +295,7 @@ func TestMessageReading(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
-						it, err := r.Messages(0, 10000, []string{"/test1"}, useIndex)
+						it, err := r.Messages(0, 10000, []string{"/test1"}, useIndex, false)
 						assert.Nil(t, err)
 						c := 0
 						for {
@@ -317,7 +317,7 @@ func TestMessageReading(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
-						it, err := r.Messages(0, 10000, []string{"/test1", "/test2"}, useIndex)
+						it, err := r.Messages(0, 10000, []string{"/test1", "/test2"}, useIndex, false)
 						assert.Nil(t, err)
 						c := 0
 						for {
@@ -339,7 +339,7 @@ func TestMessageReading(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
-						it, err := r.Messages(100, 200, []string{}, useIndex)
+						it, err := r.Messages(100, 200, []string{}, useIndex, false)
 						assert.Nil(t, err)
 						c := 0
 						for {
@@ -369,7 +369,7 @@ func TestReaderCounting(t *testing.T) {
 			defer f.Close()
 			r, err := NewReader(f)
 			assert.Nil(t, err)
-			it, err := r.Messages(0, time.Now().UnixNano(), []string{}, indexed)
+			it, err := r.Messages(0, time.Now().UnixNano(), []string{}, indexed, false)
 			assert.Nil(t, err)
 			c := 0
 			for {
@@ -418,7 +418,7 @@ func TestReadingDiagnostics(t *testing.T) {
 	assert.Nil(t, err)
 	r, err := NewReader(f)
 	assert.Nil(t, err)
-	it, err := r.Messages(0, time.Now().UnixNano(), []string{"/diagnostics"}, true)
+	it, err := r.Messages(0, time.Now().UnixNano(), []string{"/diagnostics"}, true, false)
 	assert.Nil(t, err)
 	c := 0
 	for {

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/foxglove/mcap/go/mcap/readopts"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,7 +39,7 @@ func TestDB3MCAPConversion(t *testing.T) {
 	assert.Equal(t, 1, len(info.Channels))
 	assert.Equal(t, "/chatter", info.Channels[1].Topic)
 	messageCount := 0
-	it, err := reader.Messages(mcap.ReadMessagesWithTopics([]string{"/chatter"}))
+	it, err := reader.Messages(readopts.WithTopics([]string{"/chatter"}))
 	assert.Nil(t, err)
 	for {
 		schema, channel, message, err := it.Next(nil)

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"io"
-	"math"
 	"strings"
 	"testing"
 
@@ -39,7 +38,7 @@ func TestDB3MCAPConversion(t *testing.T) {
 	assert.Equal(t, 1, len(info.Channels))
 	assert.Equal(t, "/chatter", info.Channels[1].Topic)
 	messageCount := 0
-	it, err := reader.Messages(0, math.MaxInt64, []string{"/chatter"}, true, false)
+	it, err := reader.Messages(mcap.ReadMessagesWithTopics([]string{"/chatter"}))
 	assert.Nil(t, err)
 	for {
 		schema, channel, message, err := it.Next(nil)

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -39,7 +39,7 @@ func TestDB3MCAPConversion(t *testing.T) {
 	assert.Equal(t, 1, len(info.Channels))
 	assert.Equal(t, "/chatter", info.Channels[1].Topic)
 	messageCount := 0
-	it, err := reader.Messages(0, math.MaxInt64, []string{"/chatter"}, true)
+	it, err := reader.Messages(0, math.MaxInt64, []string{"/chatter"}, true, false)
 	assert.Nil(t, err)
 	for {
 		schema, channel, message, err := it.Next(nil)


### PR DESCRIPTION
**Public-Facing Changes**
Adds a `reverse` argument to McapReader.Messages(), letting a user read in reverse order.

Indexed MCAP reads will now return messages in log time order, even if there are chunks with overlapping time ranges.


# Description
This PR changes the approach to reading messages using the indexed reader. 

## Before
The previous implementation had one active chunk, and all messages were read out of it in ascending log time order before moving on to the next chunk. If two chunks are present in an MCAP with overlapping time ranges, this would cause messages to be read out-of-order.

## After
This PR changes to a scheme where there is one heap containing chunk indexes and message index entries that match the search criteria. 

When a chunk index reaches the top of the heap, the corresponding chunk is decompressed and all of its message index entries are pushed to the heap.

Message index entries in the heap are stored alongside a pointer to the underlying decompressed chunk. There is no "owning" pointer to the decompressed chunk data, so we now rely on the garbage collector to clean up the decompressed chunk once all message index entries are consumed.

Additionally, since it's easy enough, this PR adds a flag to iterate through the MCAP in reverse time order. This can be used to search for the first message on a topic before a given timestamp.
Fixes #533.

# TODO
- [x] Add reader test with overlapping chunks
- [x] Add test to read in reverse order