### PR TITLE
TS: fix incorrect error message when magic parsing fails

### DIFF
--- a/typescript/core/src/v0/parse.ts
+++ b/typescript/core/src/v0/parse.ts
@@ -19,7 +19,10 @@ export function parseMagic(
       `Expected MCAP magic '${MCAP0_MAGIC.map((val) => val.toString(16).padStart(2, "0")).join(
         " ",
       )}', found '${Array.from(MCAP0_MAGIC, (_, i) =>
-        view.getUint8(i).toString(16).padStart(2, "0"),
+        view
+          .getUint8(startOffset + i)
+          .toString(16)
+          .padStart(2, "0"),
       ).join(" ")}'`,
     );
   }


### PR DESCRIPTION
**Public-Facing Changes**
TypeScript Mcap0IndexedReader: fixed an incorrect error message when footer magic was invalid.

**Description**
Discovered while testing #535 
The `startOffset` was being correctly used for comparison, but was ignored when producing the friendly error message.