### PR TITLE
doctor: report missing DataEnd/Footer

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -223,7 +223,8 @@ func (doctor *mcapDoctor) Examine() {
 			if errors.Is(err, io.EOF) {
 				if dataEnd == nil {
 					doctor.error("File does not contain a DataEnd record (last record was %s)", lastToken.String())
-				} else if footer == nil {
+				}
+				if footer == nil {
 					doctor.error("File does not contain a Footer record (last record was %s)", lastToken.String())
 				}
 				break


### PR DESCRIPTION
**Public-Facing Changes**
`mcap doctor` now reports files missing their DataEnd or Footer records.


**Description**
Fixes #535 
Also updates the TypeScript `validate` script to report extra bytes remaining after parsing.

Ideally doctor would also validate trailing magic. I believe today it does not.