### PR TITLE
pin conan version to fix CI

### DIFF
--- a/cpp/ci.Dockerfile
+++ b/cpp/ci.Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$IMAGE" = "ubuntu:focal" ]; then \
   update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-13 100 \
   ; fi
 
-RUN pip --no-cache-dir install conan
+RUN pip --no-cache-dir install conan==1.51.3
 
 WORKDIR /mcap/cpp
 

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -30,6 +30,6 @@ ENV CXX=clang++-13
 
 WORKDIR /src
 
-RUN pip --no-cache-dir install conan
+RUN pip --no-cache-dir install conan==1.51.3
 
 CMD [ "./build.sh" ]


### PR DESCRIPTION
Seems like there was a CI failure (https://github.com/foxglove/mcap/runs/7980820079?check_suite_focus=true) due to a conan version mismatch. Pin the latest version.