### PR TITLE
specification: add ros2idl to MCAP spec appendix

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -39,7 +39,9 @@ words:
   - flatbuffer
   - flatc
   - fwrite
+  - gendeps
   - genpy
+  - gentools
   - golangci
   - jsonschema
   - kaitai

--- a/docs/specification/appendix.md
+++ b/docs/specification/appendix.md
@@ -65,7 +65,7 @@ Schema `encoding` may only be omitted for self-describing message encodings such
 
 ### ros1msg
 
-- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/PointCloud2`. The package resource name does not include the file extension.
+- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/PointCloud2`.
 - `encoding`: `ros1msg`
 - `data`: Delimited concatenated ROS1 .msg files.
 
@@ -76,7 +76,7 @@ the `data` field contains the concatenated `.msg` file content that is sent in t
 The top-level message definition is present first, with no delimiter. All dependent `.msg` definitions are preceded by a two-line delimiter:
 
 - One line containing exactly 80 `=` characters
-- One line containing `MSG: <package resource name>` for that type.
+- One line containing `MSG: <package resource name>` for that type. The space between `MSG:` and the package resource name is mandatory. The package resource name does not include a file extension.
 
 This format can be reproduced using [gendeps --cat](http://wiki.ros.org/roslib/gentools).
 
@@ -101,7 +101,7 @@ The `.msg` definition is stored alongside its dependencies in the same format as
 The IDL definition of the type specified by `name` along with all dependent types are stored together. The IDL definitions can be stored in any order. Every definition is preceded by a two-line delimiter:
 
 - a line containing exactly 80 `=` characters, then
-- A line containing only `IDL: <package resource name>` for that definition. The space between `IDL:` and the package resource name is mandatory.
+- A line containing only `IDL: <package resource name>` for that definition. The space between `IDL:` and the package resource name is mandatory. The package resource name does not include a file extension.
 
 ### jsonschema
 

--- a/docs/specification/appendix.md
+++ b/docs/specification/appendix.md
@@ -65,15 +65,43 @@ Schema `encoding` may only be omitted for self-describing message encodings such
 
 ### ros1msg
 
-- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/PointCloud2`
+- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/PointCloud2`. The package resource name does not include the file extension.
 - `encoding`: `ros1msg`
-- `data`: Concatenated ROS1 .msg files
+- `data`: Delimited concatenated ROS1 .msg files.
+
+#### ros1msg Data Format
+
+the `data` field contains the concatenated `.msg` file content that is sent in the ROS subscription connection header for this message type.
+
+The top-level message definition is present first, with no delimiter. All dependent `.msg` definitions are preceded by a two-line delimiter:
+
+- One line containing exactly 80 `=` characters
+- One line containing `MSG: <package resource name>` for that type.
+
+This format can be reproduced using [gendeps --cat](http://wiki.ros.org/roslib/gentools).
 
 ### ros2msg
 
-- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/msg/PointCloud2`
+- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/msg/PointCloud2`.
 - `encoding`: `ros2msg`
-- `data`: Concatenated ROS2 .msg files
+- `data`: Delimited concatenated ROS2 .msg files
+
+#### ros2msg Data Format
+
+The `.msg` definition is stored alongside its dependencies in the same format as [ros1msg](#ros1msg-data-format).
+
+### ros2idl
+
+- `name`: A valid [package resource name](http://wiki.ros.org/Names#Package_Resource_Names), e.g. `sensor_msgs/msg/PointCloud2`
+- `encoding`: `ros2idl`
+- `data`: Delimited concatenated ROS2 .idl files
+
+#### ros2idl Data Format
+
+The IDL definition of the type specified by `name` along with all dependent types are stored together. The IDL definitions can be stored in any order. Every definition is preceded by a two-line delimiter:
+
+- a line containing exactly 80 `=` characters, then
+- A line containing only `IDL: <package resource name>` for that definition. The space between `IDL:` and the package resource name is mandatory.
 
 ### jsonschema
 
@@ -118,4 +146,4 @@ The `ros2` profile describes how to create MCAP files for [ROS 2](https://docs.r
 
 #### Schema
 
-- `encoding`: MUST contain `ros2msg`
+- `encoding`: MUST contain either `ros2msg` or `ros2idl`

--- a/python/mcap/mcap/mcap0/well_known.py
+++ b/python/mcap/mcap/mcap0/well_known.py
@@ -22,6 +22,7 @@ class SchemaEncoding:
     Flatbuffer = "flatbuffer"
     ROS1 = "ros1msg"
     ROS2 = "ros2msg"
+    ROS2IDL = "ros2idl"
     JSONSchema = "jsonschema"
 
 


### PR DESCRIPTION
**Public-Facing Changes**
Adds `ros2idl` as a well-known schema encoding, as well as a more complete description of the concatenations scheme for `.msg` definitions.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
