### PR TITLE
CLI: cat: do not read from stdin if filename provided

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -172,7 +172,8 @@ var catCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		readingStdin := stat.Mode()&os.ModeCharDevice == 0
+		// read stdin if no filename has been provided and data is available on stdin.
+		readingStdin := (stat.Mode()&os.ModeCharDevice == 0 && len(args) == 0)
 		// stdin is a special case, since we can't seek
 		if readingStdin {
 			reader, err := mcap.NewReader(os.Stdin)


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
`mcap cat` no longer attempts to read stdin if a filename has been provided.

```
$ echo "hello, i am not an mcap" | mcap cat a.mcap
... mcap records...
```

<!-- link relevant GitHub issues -->
Fixes: #373 