### PR TITLE
cli: info: don't crash when channel has no schema

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -101,6 +101,8 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		}
 		if schema != nil {
 			row = append(row, fmt.Sprintf(" : %s [%s]", schema.Name, schema.Encoding))
+		} else if channel.SchemaID != 0 {
+			row = append(row, fmt.Sprintf(" : <missing schema %d>", channel.SchemaID))
 		} else {
 			row = append(row, " : <no schema>")
 		}

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -87,10 +87,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 	}
 	for _, chanID := range chanIDs {
 		channel := info.Channels[chanID]
-		var schema *mcap.Schema
-		if channel.SchemaID != 0 {
-			schema = info.Schemas[channel.SchemaID]
-		}
+		schema := info.Schemas[channel.SchemaID]
 		channelMessageCount := info.Statistics.ChannelMessageCounts[chanID]
 		frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
 		row := []string{

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -87,7 +87,10 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 	}
 	for _, chanID := range chanIDs {
 		channel := info.Channels[chanID]
-		schema := info.Schemas[channel.SchemaID]
+		var schema *mcap.Schema
+		if channel.SchemaID != 0 {
+			schema = info.Schemas[channel.SchemaID]
+		}
 		channelMessageCount := info.Statistics.ChannelMessageCounts[chanID]
 		frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
 		row := []string{
@@ -96,7 +99,11 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		if info.Statistics != nil {
 			row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
 		}
-		row = append(row, fmt.Sprintf(" : %s [%s]", schema.Name, schema.Encoding))
+		if schema != nil {
+			row = append(row, fmt.Sprintf(" : %s [%s]", schema.Name, schema.Encoding))
+		} else {
+			row = append(row, " : <no schema>")
+		}
 		rows = append(rows, row)
 	}
 	tw := tablewriter.NewWriter(buf)


### PR DESCRIPTION
**Public-Facing Changes**
Fixed a bug where `mcap info` would crash if a channel had no schema.


**Description**
Fixes https://github.com/foxglove/mcap/issues/579