### PR TITLE
Go: Add support for metadata indexes to reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
         with:
           lfs: true
       - name: install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
       - run: make lint
       - run: make test
 

--- a/go/mcap/go.mod
+++ b/go/mcap/go.mod
@@ -1,6 +1,6 @@
 module github.com/foxglove/mcap/go/mcap
 
-go 1.17
+go 1.18
 
 require (
 	github.com/klauspost/compress v1.14.1

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -26,6 +26,7 @@ type indexedMessageIterator struct {
 	statistics        *Statistics
 	chunkIndexes      []*ChunkIndex
 	attachmentIndexes []*AttachmentIndex
+	metadataIndexes   []*MetadataIndex
 
 	indexHeap rangeIndexHeap
 
@@ -89,6 +90,12 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 				return fmt.Errorf("failed to parse attachment index: %w", err)
 			}
 			it.attachmentIndexes = append(it.attachmentIndexes, idx)
+		case TokenMetadataIndex:
+			idx, err := ParseMetadataIndex(record)
+			if err != nil {
+				return fmt.Errorf("failed to parse metadata index: %w", err)
+			}
+			it.metadataIndexes = append(it.metadataIndexes, idx)
 		case TokenChunkIndex:
 			idx, err := ParseChunkIndex(record)
 			if err != nil {
@@ -211,7 +218,6 @@ func (it *indexedMessageIterator) Next(p []byte) (*Schema, *Channel, *Message, e
 			return nil, nil, nil, err
 		}
 	}
-
 	for it.indexHeap.Len() > 0 {
 		ri, err := it.indexHeap.HeapPop()
 		if err != nil {

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -291,6 +291,7 @@ type Info struct {
 	Channels          map[uint16]*Channel
 	Schemas           map[uint16]*Schema
 	ChunkIndexes      []*ChunkIndex
+	MetadataIndexes   []*MetadataIndex
 	AttachmentIndexes []*AttachmentIndex
 	Header            *Header
 }

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -178,6 +178,7 @@ func (r *Reader) Info() (*Info, error) {
 		Channels:          it.channels,
 		ChunkIndexes:      it.chunkIndexes,
 		AttachmentIndexes: it.attachmentIndexes,
+		MetadataIndexes:   it.metadataIndexes,
 		Schemas:           it.schemas,
 		Header:            header,
 	}, nil

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -535,7 +535,7 @@ func TestMCAPInfo(t *testing.T) {
 					return channel.ID == message.ChannelID
 				})
 				assert.Nil(t, err)
-				expectedTopicCounts[channel.Topic] = expectedTopicCounts[channel.Topic] + 1
+				expectedTopicCounts[channel.Topic]++
 			}
 			assert.Equal(t, expectedTopicCounts, info.ChannelCounts())
 		})


### PR DESCRIPTION
Gather metadata index information when reading the summary section. Also, bump required go version to 1.18.