### PR TITLE
CLI: Add metadata support

### DIFF
--- a/go/cli/mcap/cmd/attachments.go
+++ b/go/cli/mcap/cmd/attachments.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
@@ -48,7 +47,7 @@ var attachmentsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
-			log.Fatal("Unexpected number of args")
+			die("Unexpected number of args")
 		}
 		filename := args[0]
 		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
@@ -64,7 +63,7 @@ var attachmentsCmd = &cobra.Command{
 			return nil
 		})
 		if err != nil {
-			log.Fatal("Failed to list attachments: %w", err)
+			die("Failed to list attachments: %s", err)
 		}
 	},
 }

--- a/go/cli/mcap/cmd/attachments.go
+++ b/go/cli/mcap/cmd/attachments.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
 func printAttachments(w io.Writer, attachmentIndexes []*mcap.AttachmentIndex) {
-	tw := tablewriter.NewWriter(w)
 	rows := make([][]string, 0, len(attachmentIndexes))
 	rows = append(rows, []string{
 		"log time",
@@ -32,13 +30,7 @@ func printAttachments(w io.Writer, attachmentIndexes []*mcap.AttachmentIndex) {
 		}
 		rows = append(rows, row)
 	}
-	tw.SetBorder(false)
-	tw.SetAutoWrapText(false)
-	tw.SetAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetColumnSeparator("")
-	tw.AppendBulk(rows)
-	tw.Render()
+	utils.FormatTable(w, rows)
 }
 
 var attachmentsCmd = &cobra.Command{

--- a/go/cli/mcap/cmd/channels.go
+++ b/go/cli/mcap/cmd/channels.go
@@ -11,12 +11,10 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
 func printChannels(w io.Writer, channels []*mcap.Channel) error {
-	tw := tablewriter.NewWriter(w)
 	rows := make([][]string, 0, len(channels))
 	rows = append(rows, []string{
 		"id",
@@ -39,13 +37,7 @@ func printChannels(w io.Writer, channels []*mcap.Channel) error {
 		}
 		rows = append(rows, row)
 	}
-	tw.SetBorder(false)
-	tw.SetAutoWrapText(false)
-	tw.SetAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetColumnSeparator("")
-	tw.AppendBulk(rows)
-	tw.Render()
+	utils.FormatTable(w, rows)
 	return nil
 }
 

--- a/go/cli/mcap/cmd/chunks.go
+++ b/go/cli/mcap/cmd/chunks.go
@@ -9,12 +9,10 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
 func printChunks(w io.Writer, chunkIndexes []*mcap.ChunkIndex) {
-	tw := tablewriter.NewWriter(w)
 	rows := make([][]string, 0, len(chunkIndexes))
 	rows = append(rows, []string{
 		"offset",
@@ -42,13 +40,7 @@ func printChunks(w io.Writer, chunkIndexes []*mcap.ChunkIndex) {
 		}
 		rows = append(rows, row)
 	}
-	tw.SetBorder(false)
-	tw.SetAutoWrapText(false)
-	tw.SetAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetColumnSeparator("")
-	tw.AppendBulk(rows)
-	tw.Render()
+	utils.FormatTable(w, rows)
 }
 
 // chunksCmd represents the chunks command

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -113,11 +113,13 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 	tw.AppendBulk(rows)
 	tw.Render()
 
-	var attachmentCount uint32
+	var attachmentCount, metadataCount uint32
 	if info.Statistics != nil {
 		attachmentCount = info.Statistics.AttachmentCount
+		metadataCount = info.Statistics.MetadataCount
 	}
 	fmt.Fprintf(buf, "attachments: %d\n", attachmentCount)
+	fmt.Fprintf(buf, "metadata: %d\n", metadataCount)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -105,14 +104,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		}
 		rows = append(rows, row)
 	}
-	tw := tablewriter.NewWriter(buf)
-	tw.SetBorder(false)
-	tw.SetAutoWrapText(false)
-	tw.SetAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetColumnSeparator("")
-	tw.AppendBulk(rows)
-	tw.Render()
-
+	utils.FormatTable(buf, rows)
 	var attachmentCount, metadataCount uint32
 	if info.Statistics != nil {
 		attachmentCount = info.Statistics.AttachmentCount

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -11,12 +11,10 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
 func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
-	tw := tablewriter.NewWriter(w)
 	rows := make([][]string, 0, len(info.MetadataIndexes))
 	rows = append(rows, []string{
 		"name",
@@ -60,13 +58,7 @@ func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 			indented.String(),
 		})
 	}
-	tw.SetBorder(false)
-	tw.SetAutoWrapText(false)
-	tw.SetAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetColumnSeparator("")
-	tw.AppendBulk(rows)
-	tw.Render()
+	utils.FormatTable(w, rows)
 	return nil
 }
 

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+
+	"github.com/foxglove/mcap/go/cli/mcap/utils"
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
+	tw := tablewriter.NewWriter(w)
+	rows := make([][]string, 0, len(info.MetadataIndexes))
+	rows = append(rows, []string{
+		"name",
+		"offset",
+		"length",
+		"metadata",
+	})
+	for _, idx := range info.MetadataIndexes {
+		offset := idx.Offset + 1 + 8
+		if offset > math.MaxInt64 {
+			return fmt.Errorf("metadata offset out of range: %v", offset)
+		}
+		_, err := r.Seek(int64(offset), io.SeekStart)
+		if err != nil {
+			return fmt.Errorf("failed to seek to metadata record: %w", err)
+		}
+		record := make([]byte, idx.Length)
+		_, err = r.Read(record)
+		if err != nil {
+			return fmt.Errorf("failed to read metadata record: %w", err)
+		}
+		metadata, err := mcap.ParseMetadata(record)
+		if err != nil {
+			return fmt.Errorf("failed to parse metadata: %w", err)
+		}
+
+		jsonSerialized, err := json.Marshal(metadata.Metadata)
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata to JSON: %w", err)
+		}
+
+		indented := &bytes.Buffer{}
+		err = json.Indent(indented, jsonSerialized, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to indent JSON: %w", err)
+		}
+		rows = append(rows, []string{
+			idx.Name,
+			fmt.Sprintf("%d", idx.Offset),
+			fmt.Sprintf("%d", idx.Length),
+			indented.String(),
+		})
+	}
+	tw.SetBorder(false)
+	tw.SetAutoWrapText(false)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetColumnSeparator("")
+	tw.AppendBulk(rows)
+	tw.Render()
+	return nil
+}
+
+var listMetadataCmd = &cobra.Command{
+	Use:   "metadata",
+	Short: "List metadata in an mcap file",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		if len(args) != 1 {
+			die("Unexpected number of args")
+		}
+		filename := args[0]
+		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+			reader, err := mcap.NewReader(rs)
+			if err != nil {
+				return fmt.Errorf("failed to build mcap reader: %w", err)
+			}
+			info, err := reader.Info()
+			if err != nil {
+				return fmt.Errorf("failed to read info: %w", err)
+			}
+			return printMetadata(os.Stdout, rs, info)
+		})
+		if err != nil {
+			die("failed to list metadata: %s", err)
+		}
+	},
+}
+
+func init() {
+	listCmd.AddCommand(listMetadataCmd)
+}

--- a/go/cli/mcap/cmd/schemas.go
+++ b/go/cli/mcap/cmd/schemas.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb" // cspell:words descriptorpb
@@ -59,7 +58,6 @@ func printDescriptor(w io.Writer, desc *descriptorpb.FileDescriptorSet) error {
 }
 
 func printSchemas(w io.Writer, schemas []*mcap.Schema) {
-	tw := tablewriter.NewWriter(w)
 	rows := make([][]string, 0, len(schemas))
 	rows = append(rows, []string{
 		"id",
@@ -96,13 +94,7 @@ func printSchemas(w io.Writer, schemas []*mcap.Schema) {
 		}
 		rows = append(rows, row)
 	}
-	tw.SetBorder(false)
-	tw.SetAutoWrapText(false)
-	tw.SetAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	tw.SetColumnSeparator("")
-	tw.AppendBulk(rows)
-	tw.Render()
+	utils.FormatTable(w, rows)
 }
 
 // schemasCmd represents the schemas command

--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -5,12 +5,12 @@ go 1.18
 require (
 	cloud.google.com/go/storage v1.23.0
 	github.com/fatih/color v1.13.0
-	github.com/foxglove/mcap/go/mcap v0.0.0-20220630160308-e6a1f32d08fa
+	github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb
 	github.com/foxglove/mcap/go/ros v0.0.0-20220630160308-e6a1f32d08fa
-	github.com/klauspost/compress v1.15.7
+	github.com/klauspost/compress v1.15.10
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pierrec/lz4/v4 v4.1.15
+	github.com/pierrec/lz4/v4 v4.1.16
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0

--- a/go/cli/mcap/go.sum
+++ b/go/cli/mcap/go.sum
@@ -134,6 +134,8 @@ github.com/foxglove/mcap/go/mcap v0.0.0-20220328132551-ffb9c0b0ebdc h1:v4dm5b/Z4
 github.com/foxglove/mcap/go/mcap v0.0.0-20220328132551-ffb9c0b0ebdc/go.mod h1:gQrB8PzccHW69xedSZ0uVDQVgDd3h1qX+otbS6fjSkE=
 github.com/foxglove/mcap/go/mcap v0.0.0-20220630160308-e6a1f32d08fa h1:i1tnYfkVXzpEsCY8ypT3l2V4cXodYUHmTppcsd8fnkI=
 github.com/foxglove/mcap/go/mcap v0.0.0-20220630160308-e6a1f32d08fa/go.mod h1:gQrB8PzccHW69xedSZ0uVDQVgDd3h1qX+otbS6fjSkE=
+github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb h1:coUPtEVqMoSaoyqf2MkuHgO3OcakVuMhyC1a0RG/fmE=
+github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb/go.mod h1:LMCS7BVPyHRb7xRXqYuKfM7dUq+MSE7H0dvaYsAQXnc=
 github.com/foxglove/mcap/go/ros v0.0.0-20220328132551-ffb9c0b0ebdc h1:1Nct2T544wwXnElBQEq7sN8sy6exMGeeRFrY8ifMnEg=
 github.com/foxglove/mcap/go/ros v0.0.0-20220328132551-ffb9c0b0ebdc/go.mod h1:6cXLmjzfxXCScF9sye1jzpvGtWY86np5HC33JlOT0so=
 github.com/foxglove/mcap/go/ros v0.0.0-20220630160308-e6a1f32d08fa h1:HQouvCv0GPRIgoVvg680+m33yVXPN6n3jA3r8Kq4gok=
@@ -297,6 +299,8 @@ github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.7 h1:7cgTQxJCU/vy+oP/E3B9RGbQTgbiVzIJWIKOLoAsPok=
 github.com/klauspost/compress v1.15.7/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.10 h1:Ai8UzuomSCDw90e1qNMtb15msBXsNpH6gzkkENQNcJo=
+github.com/klauspost/compress v1.15.10/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -365,6 +369,8 @@ github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.16 h1:kQPfno+wyx6C5572ABwV+Uo3pDFzQ7yhyGchSyRda0c=
+github.com/pierrec/lz4/v4 v4.1.16/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"cloud.google.com/go/storage"
+	"github.com/olekukonko/tablewriter"
 )
 
 var (
@@ -97,6 +98,17 @@ func WithReader(ctx context.Context, filename string, f func(remote bool, rs io.
 	}
 	defer rs.Close()
 	return f(remote, rs)
+}
+
+func FormatTable(w io.Writer, rows [][]string) {
+	tw := tablewriter.NewWriter(w)
+	tw.SetBorder(false)
+	tw.SetAutoWrapText(false)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetColumnSeparator("")
+	tw.AppendBulk(rows)
+	tw.Render()
 }
 
 func Keys[T any](m map[string]T) []string {

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -98,3 +98,11 @@ func WithReader(ctx context.Context, filename string, f func(remote bool, rs io.
 	defer rs.Close()
 	return f(remote, rs)
 }
+
+func Keys[T any](m map[string]T) []string {
+	keys := []string{}
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
Adds metadata counts to mcap info output, and adds an mcap list metadata subcommand.