### PR TITLE
change setup-swift version back to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
-      - uses: fwal/setup-swift@v1.17.0
+      - uses: swift-actions/setup-swift@v1
         with:
           swift-version: "5.6"
       - run: swift build
@@ -398,7 +398,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
-      - uses: fwal/setup-swift@v1.17.0
+      - uses: swift-actions/setup-swift@v1
         with:
           swift-version: "5.6"
       - run: curl -LO https://github.com/realm/SwiftLint/releases/download/0.46.5/swiftlint_linux.zip && unzip swiftlint_linux.zip swiftlint

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: fwal/setup-swift@v1.17.0
+      - uses: swift-actions/setup-swift@v1
         with:
           swift-version: "5.6"
 


### PR DESCRIPTION
This can be `v1` again now that https://github.com/swift-actions/setup-swift/issues/471 has been fixed. The action has also been moved to a different org.