### PR TITLE
Remove lodash dependency from @mcap/core

### DIFF
--- a/typescript/core/src/pre0/parse.ts
+++ b/typescript/core/src/pre0/parse.ts
@@ -191,12 +191,24 @@ export function parseRecord(
 }
 
 function isChannelInfoEqual(a: ChannelInfo, b: ChannelInfo): boolean {
-  return (
-    a.data.byteLength === b.data.byteLength &&
-    a.encoding === b.encoding &&
-    a.id === b.id &&
-    a.schema === b.schema &&
-    a.schemaName === b.schemaName &&
-    a.topic === b.topic
-  );
+  if (
+    a.data.byteLength !== b.data.byteLength ||
+    a.encoding !== b.encoding ||
+    a.id !== b.id ||
+    a.schema !== b.schema ||
+    a.schemaName !== b.schemaName ||
+    a.topic !== b.topic
+  ) {
+    return false;
+  }
+
+  const aData = new Uint8Array(a.data);
+  const bData = new Uint8Array(b.data);
+  for (let i = 0; i < aData.length; i++) {
+    if (aData[i] !== bData[i]) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/typescript/core/src/pre0/parse.ts
+++ b/typescript/core/src/pre0/parse.ts
@@ -1,5 +1,3 @@
-import { isEqual } from "lodash";
-
 import { getBigUint64 } from "../common/getBigUint64";
 import { MCAP_MAGIC, RecordType } from "./constants";
 import { McapMagic, McapRecord, ChannelInfo } from "./types";
@@ -122,7 +120,7 @@ export function parseRecord(
       channelInfosSeenInThisChunk.add(id);
       const existingInfo = channelInfosById.get(id);
       if (existingInfo) {
-        if (!isEqual(existingInfo, record)) {
+        if (!isChannelInfoEqual(existingInfo, record)) {
           throw new Error(`differing channel infos for ${record.id}`);
         }
         return {
@@ -190,4 +188,15 @@ export function parseRecord(
     case RecordType.CHUNK_INFO:
       throw new Error("Not yet implemented");
   }
+}
+
+function isChannelInfoEqual(a: ChannelInfo, b: ChannelInfo): boolean {
+  return (
+    a.data.byteLength === b.data.byteLength &&
+    a.encoding === b.encoding &&
+    a.id === b.id &&
+    a.schema === b.schema &&
+    a.schemaName === b.schemaName &&
+    a.topic === b.topic
+  );
 }

--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -1,6 +1,7 @@
 import Heap from "heap-js";
 
 import { parseRecord } from "./parse";
+import { sortedIndexBy } from "./sortedIndexBy";
 import { IReadable, TypedMcapRecords } from "./types";
 
 type ChunkCursorParams = {
@@ -233,19 +234,11 @@ export class ChunkCursor {
       let startIndex = 0;
       if (reverse) {
         if (this.endTime != undefined) {
-          startIndex = sortedIndexBy(
-            result.record.records,
-            [this.endTime],
-            ([logTime]) => -logTime!,
-          );
+          startIndex = sortedIndexBy(result.record.records, this.endTime, (logTime) => -logTime);
         }
       } else {
         if (this.startTime != undefined) {
-          startIndex = sortedIndexBy(
-            result.record.records,
-            [this.startTime],
-            ([logTime]) => logTime!,
-          );
+          startIndex = sortedIndexBy(result.record.records, this.startTime, (logTime) => logTime);
         }
       }
 
@@ -290,29 +283,4 @@ export class ChunkCursor {
 
     return cursor.records[cursor.index]![0];
   }
-}
-
-// Binary search based on lodash's sortedIndexBy()
-function sortedIndexBy<T>(array: T[], value: T, iteratee: (value: T) => number | bigint): number {
-  let low = 0;
-  let high = array == null ? 0 : array.length;
-  if (high === 0) {
-    return 0;
-  }
-
-  const valueNumber = iteratee(value);
-  const valIsNaN = valueNumber !== valueNumber;
-
-  while (low < high) {
-    const mid = Math.floor((low + high) / 2);
-    const computed = iteratee(array[mid]!);
-    const othIsReflexive = computed === computed;
-
-    if (valIsNaN ? othIsReflexive : computed < valueNumber) {
-      low = mid + 1;
-    } else {
-      high = mid;
-    }
-  }
-  return high;
 }

--- a/typescript/core/src/v0/ChunkCursor.ts
+++ b/typescript/core/src/v0/ChunkCursor.ts
@@ -1,5 +1,4 @@
 import Heap from "heap-js";
-import { sortedIndexBy } from "lodash";
 
 import { parseRecord } from "./parse";
 import { IReadable, TypedMcapRecords } from "./types";
@@ -245,7 +244,7 @@ export class ChunkCursor {
           startIndex = sortedIndexBy(
             result.record.records,
             [this.startTime],
-            ([logTime]) => logTime,
+            ([logTime]) => logTime!,
           );
         }
       }
@@ -291,4 +290,29 @@ export class ChunkCursor {
 
     return cursor.records[cursor.index]![0];
   }
+}
+
+// Binary search based on lodash's sortedIndexBy()
+function sortedIndexBy<T>(array: T[], value: T, iteratee: (value: T) => number | bigint): number {
+  let low = 0;
+  let high = array == null ? 0 : array.length;
+  if (high === 0) {
+    return 0;
+  }
+
+  const valueNumber = iteratee(value);
+  const valIsNaN = valueNumber !== valueNumber;
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const computed = iteratee(array[mid]!);
+    const othIsReflexive = computed === computed;
+
+    if (valIsNaN ? othIsReflexive : computed < valueNumber) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return high;
 }

--- a/typescript/core/src/v0/sortedIndexBy.test.ts
+++ b/typescript/core/src/v0/sortedIndexBy.test.ts
@@ -1,0 +1,53 @@
+import { sortedIndexBy } from "./sortedIndexBy";
+
+describe("sortedIndexBy", () => {
+  it("handles an empty array", () => {
+    const array: [bigint, bigint][] = [];
+
+    expect(sortedIndexBy(array, 0n, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 42n, (x) => x)).toEqual(0);
+  });
+
+  it("handles a contiguous array", () => {
+    const array: [bigint, bigint][] = [
+      [1n, 42n],
+      [2n, 42n],
+      [3n, 42n],
+    ];
+
+    expect(sortedIndexBy(array, 0n, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 1n, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 2n, (x) => x)).toEqual(1);
+    expect(sortedIndexBy(array, 3n, (x) => x)).toEqual(2);
+    expect(sortedIndexBy(array, 4n, (x) => x)).toEqual(3);
+  });
+
+  it("handles a sparse array", () => {
+    const array: [bigint, bigint][] = [
+      [1n, 42n],
+      [3n, 42n],
+    ];
+
+    expect(sortedIndexBy(array, 0n, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 1n, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 2n, (x) => x)).toEqual(1);
+    expect(sortedIndexBy(array, 3n, (x) => x)).toEqual(1);
+    expect(sortedIndexBy(array, 4n, (x) => x)).toEqual(2);
+  });
+
+  it("handles negation", () => {
+    const array: [bigint, bigint][] = [
+      [1n, 42n],
+      [2n, 42n],
+      [3n, 42n],
+      [4n, 42n],
+    ];
+
+    expect(sortedIndexBy(array, 0n, (x) => -x)).toEqual(4);
+    expect(sortedIndexBy(array, 1n, (x) => -x)).toEqual(4);
+    expect(sortedIndexBy(array, 2n, (x) => -x)).toEqual(4);
+    expect(sortedIndexBy(array, 3n, (x) => -x)).toEqual(0);
+    expect(sortedIndexBy(array, 4n, (x) => -x)).toEqual(0);
+    expect(sortedIndexBy(array, 5n, (x) => -x)).toEqual(0);
+  });
+});

--- a/typescript/core/src/v0/sortedIndexBy.ts
+++ b/typescript/core/src/v0/sortedIndexBy.ts
@@ -1,0 +1,29 @@
+/**
+ * Return the lowest index of `array` where an element can be inserted and maintain its sorted
+ * order. This is a specialization of lodash's sortedIndexBy().
+ */
+export function sortedIndexBy(
+  array: [bigint, bigint][],
+  value: bigint,
+  iteratee: (value: bigint) => bigint,
+): number {
+  let low = 0;
+  let high = array.length;
+  if (high === 0) {
+    return 0;
+  }
+
+  const computedValue = iteratee(value);
+
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    const curComputedValue = iteratee(array[mid]![0]);
+
+    if (curComputedValue < computedValue) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return high;
+}


### PR DESCRIPTION
**Public-Facing Changes**
- TypeScript library `@mcap/core` can be used without manually installing `lodash`

**Description**
lodash was used in a few places but there was no dependency on it in package.json. This replaces the few uses of lodash generic  methods with more optimized functions tuned for the @mcap/core library. In particular, it avoids heap allocation of new string  objects during binary searches.

Fixes #588
