### PR TITLE
cpp: release 0.3.0 for MIT license change

### DIFF
--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.6.0", "mcap/0.2.0"
+    requires = "benchmark/1.6.0", "mcap/0.3.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/0.2.0
+conan editable add ./mcap mcap/0.3.0
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/0.2.0
+conan editable add ./mcap mcap/0.3.0
 conan install bench --install-folder bench/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 conan install examples --install-folder examples/build/Release \

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/0.2.0"
+    requires = "mcap/0.3.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = ["mcap/0.2.0", "protobuf/3.21.1", "nlohmann_json/3.10.5"]
+    requires = ["mcap/0.3.0", "protobuf/3.21.1", "nlohmann_json/3.10.5"]
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "0.2.0"
+    version = "0.3.0"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -11,7 +11,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "0.2.0"
+#define MCAP_LIBRARY_VERSION "0.3.0"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/0.2.0", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/0.3.0", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
**Public-Facing Changes**
Bump C++ library version to 0.3.0