### PR TITLE
Swift: rename MCAP0_MAGIC to mcapMagic

### DIFF
--- a/swift/mcap/MCAPRandomAccessReader.swift
+++ b/swift/mcap/MCAPRandomAccessReader.swift
@@ -198,16 +198,16 @@ public class MCAPRandomAccessReader {
     do {
       let magicAndHeader = try readable.checkedRead(
         offset: 0,
-        length: UInt64(MCAP0_MAGIC.count) + 1 /* header opcode */ + 8 /* header record length */
+        length: UInt64(mcapMagic.count) + 1 /* header opcode */ + 8 /* header record length */
       )
-      let magic = magicAndHeader.prefix(MCAP0_MAGIC.count)
-      if !magic.elementsEqual(MCAP0_MAGIC) {
+      let magic = magicAndHeader.prefix(mcapMagic.count)
+      if !magic.elementsEqual(mcapMagic) {
         throw MCAPReadError.invalidMagic(actual: Array(magic))
       }
-      if magicAndHeader[MCAP0_MAGIC.count] != Opcode.header.rawValue {
-        throw MCAPReadError.missingHeader(actualOpcode: magicAndHeader[MCAP0_MAGIC.count])
+      if magicAndHeader[mcapMagic.count] != Opcode.header.rawValue {
+        throw MCAPReadError.missingHeader(actualOpcode: magicAndHeader[mcapMagic.count])
       }
-      var offset = MCAP0_MAGIC.count + 1
+      var offset = mcapMagic.count + 1
       let headerLength = try magicAndHeader.withUnsafeBytes {
         try $0.read(littleEndian: UInt64.self, from: &offset)
       }
@@ -223,7 +223,7 @@ public class MCAPRandomAccessReader {
     let footerAndMagic: Data
     let footerOffset: UInt64
     do {
-      let footerAndMagicLength = UInt64(recordPrefixLength + footerLength + MCAP0_MAGIC.count)
+      let footerAndMagicLength = UInt64(recordPrefixLength + footerLength + mcapMagic.count)
       if readableSize < magicAndHeaderLength + footerAndMagicLength {
         throw MCAPReadError.readBeyondBounds(offset: magicAndHeaderLength, length: footerAndMagicLength)
       }
@@ -233,8 +233,8 @@ public class MCAPRandomAccessReader {
         offset: footerOffset,
         length: footerAndMagicLength
       )
-      let magic = footerAndMagic.suffix(MCAP0_MAGIC.count)
-      if !magic.elementsEqual(MCAP0_MAGIC) {
+      let magic = footerAndMagic.suffix(mcapMagic.count)
+      if !magic.elementsEqual(mcapMagic) {
         throw MCAPReadError.invalidMagic(actual: Array(magic))
       }
 

--- a/swift/mcap/MCAPWriter.swift
+++ b/swift/mcap/MCAPWriter.swift
@@ -107,7 +107,7 @@ public final class MCAPWriter {
   }
 
   public func start(library: String, profile: String) async {
-    buffer.append(MCAP0_MAGIC)
+    buffer.append(mcapMagic)
     Header(profile: profile, library: library).serialize(to: &buffer)
   }
 
@@ -329,7 +329,7 @@ public final class MCAPWriter {
     )
     footer.summaryCRC = runningCRC.final
     footer.serialize(to: &buffer)
-    buffer.append(MCAP0_MAGIC)
+    buffer.append(mcapMagic)
     await _flush()
   }
 }

--- a/swift/mcap/RecordReader.swift
+++ b/swift/mcap/RecordReader.swift
@@ -29,7 +29,7 @@ class RecordReader {
   public func readMagic() throws -> Bool {
     if offset + 8 < buffer.count {
       let prefix = buffer[offset ..< offset + 8]
-      if !MCAP0_MAGIC.elementsEqual(prefix) {
+      if !mcapMagic.elementsEqual(prefix) {
         throw MCAPReadError.invalidMagic(actual: Array(prefix))
       }
       offset += 8

--- a/swift/mcap/Records.swift
+++ b/swift/mcap/Records.swift
@@ -5,8 +5,8 @@ public typealias SchemaID = UInt16
 public typealias ChannelID = UInt16
 public typealias Timestamp = UInt64
 
-// swiftlint:disable:next identifier_name
-public let MCAP0_MAGIC = Data([137, 77, 67, 65, 80, 48, 13, 10])
+/// Magic bytes that appear at the beginning and end of every valid MCAP file: `"\u{89}MCAP0\r\n"`.
+public let mcapMagic = Data([137, 77, 67, 65, 80, 48, 13, 10])
 
 public enum MCAPReadError: Error, Equatable {
   case invalidMagic(actual: [UInt8])

--- a/swift/test/MCAPTests.swift
+++ b/swift/test/MCAPTests.swift
@@ -16,7 +16,7 @@ final class MCAPTests: XCTestCase {
 
   func testValidatesChunkCRC() async throws {
     var buffer = Data()
-    buffer.append(MCAP0_MAGIC)
+    buffer.append(mcapMagic)
     Header(profile: "", library: "").serialize(to: &buffer)
     Chunk(
       messageStartTime: 0,


### PR DESCRIPTION
**Public-Facing Changes**
Renamed variable `MCAP0_MAGIC` to `mcapMagic`.

**Description**
Follows guidance from https://www.swift.org/documentation/api-design-guidelines/ and https://google.github.io/swift/#global-constants.