### PR TITLE
remove debug output from rust docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -133,7 +133,8 @@ jobs:
 
       - run: mkdir __docs__
       - name: Generate Rust documentation
-        run: cd rust && cargo doc --no-deps --target-dir ../__docs__/rust
+        run: cd rust && cargo doc --no-deps
+      - run: cp -r rust/target/doc __docs__/rust
 
       - run: tar -czf docs-rust.tgz __docs__/rust
       - uses: actions/upload-artifact@v3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ nav:
       - TypeScript: docs/typescript/index.html
       - Go: https://pkg.go.dev/github.com/foxglove/mcap/go/mcap
       - Swift: docs/swift/documentation/mcap/
-      - Rust: docs/rust/doc/mcap/index.html
+      - Rust: docs/rust/mcap/index.html
 
   - More Resources:
       - GitHub: "https://github.com/foxglove/mcap"


### PR DESCRIPTION
CI pages is failing because we're uploading lots of debug build cache data to our GCS preview bucket unneccessarily.

<!-- link relevant GitHub issues -->
