### PR TITLE
[Python] Add context manager support to ros1 writer

### DIFF
--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -79,3 +79,9 @@ class Writer:
             sequence=sequence,
             data=buffer.getvalue(),
         )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_, exc_type_, tb_):
+        self.finish()


### PR DESCRIPTION
**Public-Facing Changes**
- [Python] Add context manager support (`__enter__` and `__exit__` methods) to the ROS1 support library

**Description**
Fixes https://github.com/foxglove/mcap/issues/546
