### PR TITLE
Add rosbag bz2 support to `mcap convert`

### DIFF
--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -2,6 +2,7 @@ package ros
 
 import (
 	"bytes"
+	"compress/bzip2"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -199,6 +200,12 @@ func processBag(
 			case "lz4":
 				if chunkReader == nil {
 					chunkReader = lz4.NewReader(r)
+				} else {
+					chunkReader.Reset(r)
+				}
+			case "bz2":
+				if chunkReader == nil {
+					chunkReader = bzip2.NewReader(r)
 				} else {
 					chunkReader.Reset(r)
 				}


### PR DESCRIPTION
**Public-Facing Changes**
- `mcap convert` supports rosbag `.bag` files with BZ2 compression

**Description**
Fixes https://github.com/foxglove/mcap/issues/573
