### PR TITLE
cli release: cc maintainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,8 @@ jobs:
             {{formulaName}} ${{ steps.extract-version.outputs.version-number }}
 
             Created by https://github.com/mislav/bump-homebrew-formula-action
+
+            cc @foxglove/mcap-cli-maintainers
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
 


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
cc @foxglove/mcap-cli-maintainers on formula bump PRs.

I think this will require @foxglovebot to be added to the @foxglove org for mentions to work.