### PR TITLE
[cli] Replace log.Fatal*() calls with die()

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"os"
 	"strconv"
@@ -100,7 +99,7 @@ func printMessages(
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			log.Fatalf("Failed to read next message: %s", err)
+			die("Failed to read next message: %s", err)
 		}
 		if !formatJSON {
 			if len(message.Data) > 10 {
@@ -183,7 +182,7 @@ var catCmd = &cobra.Command{
 		ctx := context.Background()
 		stat, err := os.Stdin.Stat()
 		if err != nil {
-			log.Fatal(err)
+			die("Failed to stat() stdin: %s", err)
 		}
 		// read stdin if no filename has been provided and data is available on stdin.
 		readingStdin := (stat.Mode()&os.ModeCharDevice == 0 && len(args) == 0)
@@ -191,22 +190,22 @@ var catCmd = &cobra.Command{
 		if readingStdin {
 			reader, err := mcap.NewReader(os.Stdin)
 			if err != nil {
-				log.Fatalf("Failed to create reader: %s", err)
+				die("Failed to create reader: %s", err)
 			}
 			it, err := reader.Messages(getReadOpts(false)...)
 			if err != nil {
-				log.Fatalf("Failed to read messages: %s", err)
+				die("Failed to read messages: %s", err)
 			}
 			err = printMessages(ctx, os.Stdout, it, catFormatJSON)
 			if err != nil {
-				log.Fatalf("Failed to print messages: %s", err)
+				die("Failed to print messages: %s", err)
 			}
 			return
 		}
 
 		// otherwise, could be a remote or local file
 		if len(args) != 1 {
-			log.Fatal("supply a file")
+			die("supply a file")
 		}
 		filename := args[0]
 		err = utils.WithReader(ctx, filename, func(remote bool, rs io.ReadSeeker) error {
@@ -225,7 +224,7 @@ var catCmd = &cobra.Command{
 			return nil
 		})
 		if err != nil {
-			log.Fatalf("Error: %s", err)
+			die("Error: %s", err)
 		}
 	},
 }

--- a/go/cli/mcap/cmd/channels.go
+++ b/go/cli/mcap/cmd/channels.go
@@ -69,7 +69,7 @@ var channelsCmd = &cobra.Command{
 			return printChannels(os.Stdout, channels)
 		})
 		if err != nil {
-			die("Failed to list channels: %w", err)
+			die("Failed to list channels: %s", err)
 		}
 	},
 }

--- a/go/cli/mcap/cmd/channels.go
+++ b/go/cli/mcap/cmd/channels.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"sort"
 
@@ -48,7 +47,7 @@ var channelsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
-			log.Fatal("Unexpected number of args")
+			die("Unexpected number of args")
 		}
 		filename := args[0]
 		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
@@ -70,7 +69,7 @@ var channelsCmd = &cobra.Command{
 			return printChannels(os.Stdout, channels)
 		})
 		if err != nil {
-			log.Fatal("Failed to list channels: %w", err)
+			die("Failed to list channels: %w", err)
 		}
 	},
 }

--- a/go/cli/mcap/cmd/chunks.go
+++ b/go/cli/mcap/cmd/chunks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
@@ -32,7 +31,7 @@ func printChunks(w io.Writer, chunkIndexes []*mcap.ChunkIndex) {
 			fmt.Sprintf("%d", ci.ChunkLength),
 			fmt.Sprintf("%d", ci.MessageStartTime),
 			fmt.Sprintf("%d", ci.MessageEndTime),
-			fmt.Sprintf("%s", ci.Compression),
+			string(ci.Compression),
 			fmt.Sprintf("%d", ci.CompressedSize),
 			fmt.Sprintf("%d", ci.UncompressedSize),
 			fmt.Sprintf("%f", ratio),
@@ -50,7 +49,7 @@ var chunksCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
-			log.Fatal("Unexpected number of args")
+			die("Unexpected number of args")
 		}
 		filename := args[0]
 		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
@@ -66,7 +65,7 @@ var chunksCmd = &cobra.Command{
 			return nil
 		})
 		if err != nil {
-			log.Fatal("Failed to list chunks: %w", err)
+			die("Failed to list chunks: %s", err)
 		}
 	},
 }

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"log"
 	"math"
 	"os"
 
@@ -125,7 +124,7 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			log.Fatal("Failed to read token:", err)
+			die("Failed to read token: %s", err)
 		}
 		if len(data) > len(msg) {
 			msg = data
@@ -231,7 +230,7 @@ func (doctor *mcapDoctor) Examine() error {
 				}
 				break
 			}
-			log.Fatal("Failed to read token:", err)
+			die("Failed to read token: %s", err)
 		}
 		lastToken = tokenType
 		if len(data) > len(msg) {
@@ -454,7 +453,7 @@ func main(cmd *cobra.Command, args []string) {
 		return doctor.Examine()
 	})
 	if err != nil {
-		log.Fatalf("Doctor command failed: %s", err)
+		die("Doctor command failed: %s", err)
 	}
 }
 

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"sort"
 	"time"
@@ -122,7 +121,7 @@ var infoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
-			log.Fatal("Unexpected number of args")
+			die("Unexpected number of args")
 		}
 		// check if it's a remote file
 		filename := args[0]
@@ -142,7 +141,7 @@ var infoCmd = &cobra.Command{
 			return nil
 		})
 		if err != nil {
-			log.Fatalf("Failed to read file %s: %v", filename, err)
+			die("Failed to read file %s: %v", filename, err)
 		}
 	},
 }

--- a/go/cli/mcap/cmd/schemas.go
+++ b/go/cli/mcap/cmd/schemas.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"sort"
 	"strings"
@@ -15,10 +14,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb" // cspell:words descriptorpb
-)
-
-var (
-	protobufSchemaSeparator = "================================================================================\n"
 )
 
 func parseDescriptor(b []byte) (*descriptorpb.FileDescriptorSet, error) {
@@ -74,12 +69,12 @@ func printSchemas(w io.Writer, schemas []*mcap.Schema) {
 		case "protobuf":
 			descriptor, err := parseDescriptor(schema.Data)
 			if err != nil {
-				log.Fatalf("failed to parse descriptor: %v", err)
+				die("failed to parse descriptor: %v", err)
 			}
 			buf := &bytes.Buffer{}
 			err = printDescriptor(buf, descriptor)
 			if err != nil {
-				log.Fatalf("Failed to print descriptor: %v", err)
+				die("Failed to print descriptor: %v", err)
 			}
 			displayString = buf.String()
 		default:
@@ -104,7 +99,7 @@ var schemasCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
-			log.Fatal("Unexpected number of args")
+			die("Unexpected number of args")
 		}
 		filename := args[0]
 		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
@@ -128,7 +123,7 @@ var schemasCmd = &cobra.Command{
 			return nil
 		})
 		if err != nil {
-			log.Fatal("Failed to list schemas: %w", err)
+			die("Failed to list schemas: %s", err)
 		}
 	},
 }


### PR DESCRIPTION
**Public-Facing Changes**
- [cli] Consistent formatting for stderr messages

**Description**
Fixes https://github.com/foxglove/mcap/issues/437
