### PR TITLE
[cli] Add --version / -v support

### DIFF
--- a/go/cli/mcap/cmd/root.go
+++ b/go/cli/mcap/cmd/root.go
@@ -29,7 +29,7 @@ func die(s string, args ...any) {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file (default is $HOME/.mcap.yaml)")
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.InitDefaultVersionFlag()
 }
 
 func initConfig() {


### PR DESCRIPTION
**Public-Facing Changes**
- [cli] `--version` or `-v` shows the mcap version

**Description**
Fixes https://github.com/foxglove/mcap/issues/590. Also removed `--toggle` detritus
