### PR TITLE
Fix hashFiles() input for C++ CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('~/.conan/data') }}
+          key: ${{ runner.os }}-${{ hashFiles('cpp/**/conanfile.py') }}
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
       - run: cd cpp && make ci
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('~/.conan/data') }}
+          key: ${{ runner.os }}-${{ hashFiles('cpp/**/conanfile.py') }}
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
       - run: make ci-format-check

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -63,12 +63,12 @@ ci-image: hdoc-build
 
 .PHONY: ci
 ci: ci-image
-	docker run -t --rm -v $(CURDIR):/mcap/cpp mcap_cpp_ci ./build.sh
+	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(HOME)/.conan/data:/root/.conan/data mcap_cpp_ci ./build.sh
 
 .PHONY: ci-docs
 ci-docs: ci-image
 	docker build -t mcap_cpp_ci_jammy -f ci.Dockerfile .
-	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(CURDIR)/../__docs__/cpp:/hdoc-output mcap_cpp_ci_jammy ./build-docs.sh
+	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(CURDIR)/../__docs__/cpp:/hdoc-output -v $(HOME)/.conan/data:/root/.conan/data mcap_cpp_ci_jammy ./build-docs.sh
 
 .PHONY: ci-format-check
 ci-format-check: ci-image

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -72,4 +72,4 @@ ci-docs: ci-image
 
 .PHONY: ci-format-check
 ci-format-check: ci-image
-	docker run -t --rm -v $(CURDIR):/mcap/cpp mcap_cpp_ci python3 scripts/format.py .
+	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(HOME)/.conan/data:/root/.conan/data mcap_cpp_ci python3 scripts/format.py .


### PR DESCRIPTION
**Public-Facing Changes**
- None

**Description**
This PR volume mounts `$HOME/.conan/data` to `/root/.conan/data` inside Docker containers specifically for the `ci` Makefile commands, and fixes `hashFiles()` usage in GitHub Actions to ingest conanfile.py inputs rather than the output artifact directory (which does not exist when the hash check is done). The end result is caching of conan build artifacts between CI runs, so the majority of CI time is no longer spent recompiling the protobuf library.

**New CI output:**

```
Packages
    lz4/1.9.3:63c2a85d57849e261f98f935b93ecac31ba71b84 - Cache
    nlohmann_json/3.10.5:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache
    protobuf/3.21.1:2b471b60d03a9d59f138a492b962f734618de80a - Cache
    zlib/1.2.12:63c2a85d57849e261f98f935b93ecac31ba71b84 - Cache
    zstd/1.5.2:54fbb82fadf7dac819625928c5a96d0047e07f77 - Cache
    mcap/0.5.0:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Editable
Installing (downloading, building) binaries...
lz4/1.9.3: Already installed!
nlohmann_json/3.10.5: Already installed!
zlib/1.2.12: Already installed!
zstd/1.5.2: Already installed!
protobuf/3.21.1: Already installed!
```