### PR TITLE
Get rid from static linking of the zstd in mcap cpp

### DIFF
--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <lz4frame.h>
 
-#define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 #include <zstd_errors.h>
 

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -4,7 +4,6 @@
 #include <lz4frame.h>
 #include <lz4hc.h>
 
-#define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 #include <zstd_errors.h>
 


### PR DESCRIPTION
**Public-Facing Changes**
Get rid from static linking of the zstd in mcap cpp by removing #define ZSTD_STATIC_LINKING_ONLY

**Description**
We need to link zstd dynamically to be able to use zstd_vendor in ROS2


<!-- link relevant GitHub issues -->
