### PR TITLE
rust: Provide RawMessageStream of (header, data) tuples

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://mcap.dev/docs/rust/doc/mcap/index.html"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://mcap.dev/docs/rust/doc/mcap/index.html"
 readme = "README.md"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
**Public-Facing Changes**
Adds `read::RawMessageStream`, no changes to existing API

**Description**
We've run into use cases where we don't care about the specifics of each message's Channel, but just want a way to uniquely identify it. Hashing the Channel each time would be sad and slow, and MCAP already gives us a unique ID for the channel. Use that!

Happy to nitpick names, or whether we'd rather return some
```rust
struct RawMessage<'a> {
    header: records::MessageHeader,
    data: Cow<'a, [u8]>
}
```
instead of a tuple, etc.
```