### PR TITLE
Make zstd optional in Rust library

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,7 +23,11 @@ lz4 = "1.0"
 num_cpus = "1.13"
 paste = "1.0"
 thiserror = "1.0"
-zstd = { version = "0.11", features = ["zstdmt"] }
+zstd = { version = "0.11", features = ["zstdmt"], optional = true }
+
+[features]
+default = ["zstd"]
+zstd = ["dep:zstd"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,7 +1,8 @@
 # Rust MCAP library
 
-A library for reading and writing [Foxglove MCAP](https://github.com/foxglove/mcap) files.
-See the [crate documentation](https://docs.rs/mcap) for examples.
+A library for reading and writing
+[Foxglove MCAP](https://github.com/foxglove/mcap) files. See the
+[crate documentation](https://docs.rs/mcap) for examples.
 
 ## Design goals
 
@@ -9,10 +10,19 @@ See the [crate documentation](https://docs.rs/mcap) for examples.
   automatically linked to its channel, and that channel linked to its schema.
   Users shouldn't have to manually track channel and schema IDs.
 
-- **Performance:** Writers shouldn't hold large buffers (e.g., the current chunk)
-  in memory. Readers should support memory-mapped files to avoid needless copies
-  and to let the OS do what it does best: loading and caching large files based
-  on how you're actually reading them.
+- **Performance:** Writers shouldn't hold large buffers (e.g., the current
+  chunk) in memory. Readers should support memory-mapped files to avoid needless
+  copies and to let the OS do what it does best: loading and caching large files
+  based on how you're actually reading them.
 
 - **Resilience:** Like MCAP itself, the library should let you recover every
   valid message from an incomplete file or chunk.
+
+## Building
+
+By default this package will build with zstd compression support enabled. To
+build without the zstd dependency pass the `--no-default-features` flag:
+
+```
+cargo build --no-default-features
+```

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -135,9 +135,9 @@ pub type McapResult<T> = Result<T, McapError>;
 pub const MAGIC: &[u8] = &[0x89, b'M', b'C', b'A', b'P', 0x30, b'\r', b'\n'];
 
 /// Compression options for chunks of channels, schemas, and messages in an MCAP file
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone)]
 pub enum Compression {
-    #[default]
+    #[cfg(feature = "zstd")]
     Zstd,
     Lz4,
 }

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -13,8 +13,8 @@ pub fn map_mcap<P: AsRef<Utf8Path>>(p: P) -> Result<Mmap> {
 #[allow(dead_code)]
 pub fn mcap_test_file() -> Result<Mmap> {
     if cfg!(feature = "zstd") {
-        return map_mcap("tests/data/compressed.mcap");
+        map_mcap("tests/data/compressed.mcap")
     } else {
-        return map_mcap("tests/data/uncompressed.mcap");
+        map_mcap("tests/data/uncompressed.mcap")
     }
 }

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -9,3 +9,12 @@ pub fn map_mcap<P: AsRef<Utf8Path>>(p: P) -> Result<Mmap> {
     let fd = fs::File::open(p).with_context(|| format!("Couldn't open {p}"))?;
     unsafe { Mmap::map(&fd) }.with_context(|| format!("Couldn't map {p}"))
 }
+
+#[allow(dead_code)]
+pub fn mcap_test_file() -> Result<Mmap> {
+    if cfg!(feature = "zstd") {
+        return map_mcap("tests/data/compressed.mcap");
+    } else {
+        return map_mcap("tests/data/uncompressed.mcap");
+    }
+}

--- a/rust/tests/compression.rs
+++ b/rust/tests/compression.rs
@@ -10,7 +10,7 @@ use memmap::Mmap;
 use tempfile::tempfile;
 
 fn round_trip(comp: Option<mcap::Compression>) -> Result<()> {
-    let mapped = map_mcap("tests/data/compressed.mcap")?;
+    let mapped = mcap_test_file()?;
 
     let mut tmp = tempfile()?;
     let mut writer = mcap::WriteOptions::new()
@@ -43,6 +43,7 @@ fn uncompressed_round_trip() -> Result<()> {
     round_trip(None)
 }
 
+#[cfg(feature = "zstd")]
 #[test]
 fn zstd_round_trip() -> Result<()> {
     round_trip(Some(mcap::Compression::Zstd))

--- a/rust/tests/flush.rs
+++ b/rust/tests/flush.rs
@@ -11,7 +11,7 @@ use tempfile::tempfile;
 
 #[test]
 fn flush_and_cut_chunks() -> Result<()> {
-    let mapped = map_mcap("tests/data/compressed.mcap")?;
+    let mapped = mcap_test_file()?;
 
     let messages = mcap::MessageStream::new(&mapped)?;
 

--- a/rust/tests/round_trip.rs
+++ b/rust/tests/round_trip.rs
@@ -14,7 +14,7 @@ use tempfile::tempfile;
 fn demo_round_trip() -> Result<()> {
     use mcap::records::op;
 
-    let mapped = map_mcap("tests/data/compressed.mcap")?;
+    let mapped = mcap_test_file()?;
 
     let messages = mcap::MessageStream::new(&mapped)?;
 
@@ -122,7 +122,7 @@ fn demo_round_trip() -> Result<()> {
 
 #[test]
 fn demo_random_chunk_access() -> Result<()> {
-    let mapped = map_mcap("tests/data/compressed.mcap")?;
+    let mapped = mcap_test_file()?;
 
     let summary = mcap::Summary::read(&mapped)?.unwrap();
 

--- a/testdata/mcap/demo-uncompressed.mcap
+++ b/testdata/mcap/demo-uncompressed.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fadb659b48f080d4eaec1b54bf3d41a982b7a4f76d564c61588093be46ddd24c
+size 124929087

--- a/testdata/mcap/demo-uncompressed.mcap
+++ b/testdata/mcap/demo-uncompressed.mcap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fadb659b48f080d4eaec1b54bf3d41a982b7a4f76d564c61588093be46ddd24c
-size 124929087


### PR DESCRIPTION
**Public-Facing Changes**
Makes zstd an optional dependency for the Rust library.

**Description**
This makes it possible to build the Rust library without built-in zstd compression support. The default build will still include it.

Note this also required adding an uncompressed version of the demo.mcap test data because when the Rust code is compiled without zstd it is unable to read the existing demo.mcap for test purposes.

<!-- link relevant GitHub issues -->
Fixes #648 