### PR TITLE
mcap info to display the file size

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -61,29 +61,17 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 			compressionFormatStats[ci.Compression] = stats
 		}
 		fmt.Fprintf(buf, "compression:\n")
-		totalCompressedSize := uint64(0)
-		totalUncompressedSize := uint64(0)
 		chunkCount := len(info.ChunkIndexes)
 		for k, v := range compressionFormatStats {
 			compressionRatio := 100 * (1 - float64(v.compressedSize)/float64(v.uncompressedSize))
-			fmt.Fprintf(buf, "\t%s: [%d/%d chunks] (%.2f%%) \n", k, v.count, chunkCount, compressionRatio)
-			totalCompressedSize += v.compressedSize
-			totalUncompressedSize += v.uncompressedSize
+			fmt.Fprintf(buf, "\t%s: [%d/%d chunks] ", k, v.count, chunkCount)
+			fmt.Fprintf(buf, "[%.2d MB/%.2d MB (%.2f%%)] ",
+				(v.uncompressedSize / (1024 * 1024)), (v.compressedSize / (1024 * 1024)), compressionRatio)
+			if durationInSeconds > 0 {
+				fmt.Fprintf(buf, "[%.2f MB/sec] ", float64(v.compressedSize/(1024*1024))/durationInSeconds)
+			}
+			fmt.Fprintf(buf, "\n")
 		}
-
-		fmt.Fprintf(buf, "uncompressed: %.2d MB", totalUncompressedSize/(1024*1024))
-		if durationInSeconds > 0 {
-			fmt.Fprintf(buf, " @ %.2f MB/sec", float64(totalUncompressedSize/(1024*1024))/durationInSeconds)
-		}
-		fmt.Fprintf(buf, "\n")
-
-		fmt.Fprintf(buf, "compressed: %.2d MB", totalCompressedSize/(1024*1024))
-		if durationInSeconds > 0 {
-			fmt.Fprintf(buf, " @ %.2f MB/sec", float64(totalCompressedSize/(1024*1024))/durationInSeconds)
-		}
-
-		totalCompressionRatio := 100 * (1 - float64(totalCompressedSize)/float64(totalUncompressedSize))
-		fmt.Fprintf(buf, " (%.2f%%) \n", totalCompressionRatio)
 	}
 	fmt.Fprintf(buf, "channels:\n")
 	chanIDs := []uint16{}


### PR DESCRIPTION
**Public-Facing Changes**

Adds uncompressed/compressed size details to `mcap info` (in the compression section):

```
compression:
	zstd: [248/248 chunks] [2610 MB/635 MB (75.66%)] [12.85 MB/sec] 
```

**Description**

Note that this UX might not be what the ticket was looking for; we could just as easily leave the per-compression-format statistics untouched and add two separate lines for the uncompressed/compressed details.

An alternative output could be:

```
compression:
	zstd: [248/248 chunks] (75.66%) 
uncompressed: 2610 MB @ 52.83 MB/sec
compressed: 635 MB @ 12.85 MB/sec (75.66%) 
```

Open for a debate :)

**GitHub issues**

Resolves: https://github.com/foxglove/mcap/issues/439
