### PR TITLE
go: bump to v0.1.1

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v0.1.0"
+var Version = "v0.1.1"


### PR DESCRIPTION
Bumping the version to get the tag right.