### PR TITLE
docs: use bold font for markdown h2/h3 headings

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -153,3 +153,7 @@ overrides:
       - subrange
       - unkeyed
       - lowercased
+
+  - filename: "docs/**"
+    words:
+      - plex

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,9 +1,14 @@
 .md-source__fact--version {
-    display: none;
-  }
-  .md-source__fact--stars::before {
-    margin-left: 0 !important;
-  }
-  .md-source__fact::before {
-    vertical-align: bottom;
-  }
+  display: none;
+}
+.md-source__fact--stars::before {
+  margin-left: 0 !important;
+}
+.md-source__fact::before {
+  vertical-align: bottom;
+}
+
+.md-typeset h2,
+.md-typeset h3 {
+  font-weight: 600;
+}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{# Override font weights from the theme default (300,300i,400,400i,700,700i) #}
+{%- block fonts %}
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,300i,400,400i,600,600i%7CIBM+Plex+Mono:400,400i,600,600i&display=fallback">
+<style>:root{--md-text-font:"IBM Plex Sans";--md-code-font:"IBM Plex Mono"}</style>
+{%- endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,9 +24,7 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
       primary: "black"
-  font:
-    text: IBM Plex Sans
-    code: IBM Plex Mono
+  font: false # Fonts are configured in theme/main.html
 
 plugins:
   - social


### PR DESCRIPTION
- Use bold font for markdown h2/h3 headings
- Load 600 weight instead of 700 from google fonts. 700 feels quite heavy for the IBM Plex fonts we use.

**Description**
Preview deploy: https://storage.googleapis.com/foxglove-mcap-dev-preview/2f35fb79ae4aba4dd0a0f097a75c5b9dd134c368/index.html

Before | After
--- | ---
<img width="783" alt="image" src="https://user-images.githubusercontent.com/14237/195914447-bc21fcaa-2d71-4c82-bb95-a31559f0ceac.png"> | <img width="772" alt="image" src="https://user-images.githubusercontent.com/14237/195914476-73afabbb-e343-4b16-9cf2-18260c5523c5.png">
