### PR TITLE
rust: Don't force serde on users for our tests

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://mcap.dev/docs/rust/doc/mcap/index.html"
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 
@@ -22,7 +22,6 @@ log = "0.4"
 lz4 = "1.0"
 num_cpus = "1.13"
 paste = "1.0"
-serde = { version = "1", features = ["derive"] }
 thiserror = "1.0"
 zstd = { version = "0.11", features = ["zstdmt"] }
 

--- a/rust/examples/conformance_reader.rs
+++ b/rust/examples/conformance_reader.rs
@@ -1,48 +1,135 @@
 use mcap::records::Record;
 
-use serde_json::{json, Value};
-use std::env;
-use std::process;
+use std::{collections::BTreeMap, env, process};
 
-fn transform_record_field(value: &Value) -> Value {
-    match value {
-        Value::Bool(_) => panic!("did not expect any booleans in record fields"),
-        Value::Null => panic!("did not expect any nulls in record fields"),
-        Value::Number(n) => Value::String(n.to_string()),
-        Value::String(_) => value.to_owned(),
-        Value::Object(map) => Value::Object(
-            map.into_iter()
-                .map(|(k, v)| {
-                    (
-                        k.to_owned(),
-                        match v {
-                            Value::String(_) => v.to_owned(),
-                            _ => Value::String(v.to_string()),
-                        },
-                    )
-                })
-                .collect(),
-        ),
-        Value::Array(items) => {
-            Value::Array(items.iter().map(|x| Value::String(x.to_string())).collect())
+use serde_json::{json, Value};
+
+// We don't want to force Serde on users just for the sake of the conformance tests.
+// (In what context would you want to serialize individual records of a MCAP?)
+// Stamp out and stringify them ourselves:
+
+fn get_type(rec: &Record<'_>) -> &'static str {
+    match rec {
+        Record::Header(_) => "Header",
+        Record::Footer(_) => "Footer",
+        Record::Schema { .. } => "Schema",
+        Record::Channel(_) => "Channel",
+        Record::Message { .. } => "Message",
+        Record::Chunk { .. } => "Chunk",
+        Record::MessageIndex(_) => "MessageIndex",
+        Record::ChunkIndex(_) => "ChunkIndex",
+        Record::Attachment { .. } => "Attachment",
+        Record::AttachmentIndex(_) => "AttachmentIndex",
+        Record::Statistics(_) => "Statistics",
+        Record::Metadata(_) => "Metadata",
+        Record::MetadataIndex(_) => "MetadataIndex",
+        Record::SummaryOffset(_) => "SummaryOffset",
+        Record::DataEnd(_) => "DataEnd",
+        Record::Unknown { opcode, .. } => {
+            panic!("Unknown record in conformance test: (op {opcode})")
+        }
+    }
+}
+
+fn get_fields(rec: &Record<'_>) -> Value {
+    fn b2s(bytes: &[u8]) -> Vec<String> {
+        bytes.iter().map(|b| b.to_string()).collect()
+    }
+    fn m2s(map: &BTreeMap<u16, u64>) -> BTreeMap<String, String> {
+        map.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    match rec {
+        Record::Header(h) => json!([["library", h.library], ["profile", h.profile]]),
+        Record::Footer(f) => json!([
+            ["summary_crc", f.summary_crc.to_string()],
+            ["summary_offset_start", f.summary_offset_start.to_string()],
+            ["summary_start", f.summary_start.to_string()]
+        ]),
+        Record::Schema { header, data } => json!([
+            ["data", b2s(data)],
+            ["encoding", header.encoding],
+            ["id", header.id.to_string()],
+            ["name", header.name]
+        ]),
+        Record::Channel(c) => json!([
+            ["id", c.id.to_string()],
+            ["message_encoding", c.message_encoding],
+            ["metadata", c.metadata],
+            ["schema_id", c.schema_id.to_string()],
+            ["topic", c.topic]
+        ]),
+        Record::Message { header, data } => json!([
+            ["channel_id", header.channel_id.to_string()],
+            ["data", b2s(data)],
+            ["log_time", header.log_time.to_string()],
+            ["publish_time", header.publish_time.to_string()],
+            ["sequence", header.sequence.to_string()]
+        ]),
+        Record::Chunk { .. } => unreachable!("Chunks are flattened"),
+        Record::MessageIndex(_) => unreachable!("MessageIndexes are skipped"),
+        Record::ChunkIndex(i) => json!([
+            ["chunk_length", i.chunk_length.to_string()],
+            ["chunk_start_offset", i.chunk_start_offset.to_string()],
+            ["compressed_size", i.compressed_size.to_string()],
+            ["compression", i.compression],
+            ["message_end_time", i.message_end_time.to_string()],
+            ["message_index_length", i.message_index_length.to_string()],
+            ["message_index_offsets", m2s(&i.message_index_offsets)],
+            ["message_start_time", i.message_start_time.to_string()],
+            ["uncompressed_size", i.uncompressed_size.to_string()]
+        ]),
+        Record::Attachment { header, data } => json!([
+            ["create_time", header.create_time.to_string()],
+            ["data", b2s(data)],
+            ["log_time", header.log_time.to_string()],
+            ["media_type", header.media_type],
+            ["name", header.name]
+        ]),
+        Record::AttachmentIndex(i) => json!([
+            ["create_time", i.create_time.to_string()],
+            ["data_size", i.data_size.to_string()],
+            ["length", i.length.to_string()],
+            ["log_time", i.log_time.to_string()],
+            ["media_type", i.media_type],
+            ["name", i.name],
+            ["offset", i.offset.to_string()]
+        ]),
+        Record::Statistics(s) => json!([
+            ["attachment_count", s.attachment_count.to_string()],
+            ["channel_count", s.channel_count.to_string()],
+            ["channel_message_counts", m2s(&s.channel_message_counts)],
+            ["chunk_count", s.chunk_count.to_string()],
+            ["message_count", s.message_count.to_string()],
+            ["message_end_time", s.message_end_time.to_string()],
+            ["message_start_time", s.message_start_time.to_string()],
+            ["metadata_count", s.metadata_count.to_string()],
+            ["schema_count", s.schema_count.to_string()]
+        ]),
+        Record::Metadata(m) => json!([["metadata", m.metadata], ["name", m.name]]),
+        Record::MetadataIndex(i) => json!([
+            ["length", i.length.to_string()],
+            ["name", i.name],
+            ["offset", i.offset.to_string()]
+        ]),
+        Record::SummaryOffset(s) => json!([
+            ["group_length", s.group_length.to_string()],
+            ["group_opcode", s.group_opcode.to_string()],
+            ["group_start", s.group_start.to_string()]
+        ]),
+        Record::DataEnd(d) => json!([["data_section_crc", d.data_section_crc.to_string()]]),
+        Record::Unknown { opcode, .. } => {
+            panic!("Unknown record in conformance test: (op {opcode})")
         }
     }
 }
 
 fn as_json(view: &Record<'_>) -> Value {
-    let view_value = serde_json::to_value(view).unwrap();
-    let (typename, field_object) = match view_value {
-        serde_json::Value::Object(map) => map.into_iter().next().unwrap(),
-        _ => panic!("expected a map"),
-    };
-    let field_array: Vec<(String, Value)> = match field_object {
-        Value::Object(map) => map
-            .into_iter()
-            .map(|(field_name, field_value)| (field_name, transform_record_field(&field_value)))
-            .collect(),
-        _ => panic!("expected fields to be a map"),
-    };
-    json!({"type": typename, "fields": field_array})
+    let typename = get_type(view);
+    let fields = get_fields(view);
+    json!({"type": typename, "fields": fields})
 }
 
 pub fn main() {
@@ -54,20 +141,11 @@ pub fn main() {
     let file = std::fs::read(&args[1]).expect("file wouldn't open");
     let mut json_records: Vec<Value> = vec![];
     for rec in mcap::read::ChunkFlattener::new(&file).expect("Couldn't read file") {
-        match rec {
-            Ok(rec) => match rec {
-                // Skip message indices
-                Record::MessageIndex(_) => (),
-                _ => {
-                    json_records.push(as_json(&rec));
-                }
-            },
-            Err(err) => {
-                eprintln!("failed to read next record: {}", err);
-                process::exit(1);
-            }
+        let r = rec.expect("failed to read next record");
+        if !matches!(r, Record::MessageIndex(_)) {
+            json_records.push(as_json(&r));
         }
     }
-    let out = json!({ "records": Value::Array(json_records) });
+    let out = json!({ "records": json_records });
     print!("{}", serde_json::to_string_pretty(&out).unwrap());
 }

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -14,7 +14,6 @@ use std::{
 
 use binrw::io::{Read, Seek, Write};
 use binrw::*;
-use serde::{Deserialize, Serialize};
 
 /// Opcodes for MCAP file records.
 ///
@@ -44,30 +43,26 @@ pub mod op {
 /// For records with large slices of binary data (schemas, messages, chunks...),
 /// we use a [`CoW`](std::borrow::Cow) that can either borrow directly from the mapped file,
 /// or hold its own buffer if it was decompressed from a chunk.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub enum Record<'a> {
     Header(Header),
     Footer(Footer),
     Schema {
-        #[serde(flatten)]
         header: SchemaHeader,
         data: Cow<'a, [u8]>,
     },
     Channel(Channel),
     Message {
-        #[serde(flatten)]
         header: MessageHeader,
         data: Cow<'a, [u8]>,
     },
     Chunk {
-        #[serde(flatten)]
         header: ChunkHeader,
         data: Cow<'a, [u8]>,
     },
     MessageIndex(MessageIndex),
     ChunkIndex(ChunkIndex),
     Attachment {
-        #[serde(flatten)]
         header: AttachmentHeader,
         data: Cow<'a, [u8]>,
     },
@@ -171,7 +166,7 @@ fn write_vec<W: binrw::io::Write + binrw::io::Seek, T: binrw::BinWrite<Args = ()
     Ok(())
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct Header {
     #[br(map = |s: McapString| s.inner )]
     #[bw(write_with = write_string)]
@@ -182,14 +177,14 @@ pub struct Header {
     pub library: String,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, BinRead, BinWrite)]
 pub struct Footer {
     pub summary_start: u64,
     pub summary_offset_start: u64,
     pub summary_crc: u32,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct SchemaHeader {
     pub id: u16,
 
@@ -304,7 +299,7 @@ where
     Ok(parsed)
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct Channel {
     pub id: u16,
     pub schema_id: u16,
@@ -332,7 +327,7 @@ pub fn nanos_to_system_time(n: u64) -> SystemTime {
     UNIX_EPOCH + Duration::from_nanos(n)
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct MessageHeader {
     pub channel_id: u16,
     pub sequence: u32,
@@ -342,7 +337,7 @@ pub struct MessageHeader {
     pub publish_time: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct ChunkHeader {
     pub message_start_time: u64,
 
@@ -359,14 +354,14 @@ pub struct ChunkHeader {
     pub compressed_size: u64,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, BinRead, BinWrite)]
 pub struct MessageIndexEntry {
     pub log_time: u64,
 
     pub offset: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct MessageIndex {
     pub channel_id: u16,
 
@@ -375,7 +370,7 @@ pub struct MessageIndex {
     pub records: Vec<MessageIndexEntry>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct ChunkIndex {
     pub message_start_time: u64,
 
@@ -400,7 +395,7 @@ pub struct ChunkIndex {
     pub uncompressed_size: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct AttachmentHeader {
     pub log_time: u64,
 
@@ -415,7 +410,7 @@ pub struct AttachmentHeader {
     pub media_type: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct AttachmentIndex {
     pub offset: u64,
 
@@ -436,7 +431,7 @@ pub struct AttachmentIndex {
     pub media_type: String,
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct Statistics {
     pub message_count: u64,
     pub schema_count: u16,
@@ -454,7 +449,7 @@ pub struct Statistics {
     pub channel_message_counts: BTreeMap<u16, u64>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct Metadata {
     #[br(map = |s: McapString| s.inner )]
     #[bw(write_with = write_string)]
@@ -465,7 +460,7 @@ pub struct Metadata {
     pub metadata: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct MetadataIndex {
     pub offset: u64,
 
@@ -476,14 +471,14 @@ pub struct MetadataIndex {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, BinRead, BinWrite)]
 pub struct SummaryOffset {
     pub group_opcode: u8,
     pub group_start: u64,
     pub group_length: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, BinRead, BinWrite, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, BinRead, BinWrite)]
 pub struct DataEnd {
     pub data_section_crc: u32,
 }


### PR DESCRIPTION
**Public-Facing Changes**

Removes `serde` dependency for Rust crate

**Description**

We don't want to force Serde on users just for the sake of the conformance tests. (In what context would you want to serialize individual records of a MCAP to something else?)

Stamp out and stringify them ourselves.

fixes #656 