### PR TITLE
rust: use small mcaps for test source data

### DIFF
--- a/rust/tests/compression.rs
+++ b/rust/tests/compression.rs
@@ -10,7 +10,7 @@ use memmap::Mmap;
 use tempfile::tempfile;
 
 fn round_trip(comp: Option<mcap::Compression>) -> Result<()> {
-    let mapped = map_mcap("../testdata/mcap/demo.mcap")?;
+    let mapped = map_mcap("tests/data/compressed.mcap")?;
 
     let mut tmp = tempfile()?;
     let mut writer = mcap::WriteOptions::new()

--- a/rust/tests/data/compressed.mcap
+++ b/rust/tests/data/compressed.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72af1d472529c4d8e1e74d42af6150c65b23157e61061c39abd795a683f42e14
+size 562088

--- a/rust/tests/data/generate.sh
+++ b/rust/tests/data/generate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Generates rust test fixture mcap files from `demo.mcap`.
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DEMO_MCAP_PATH="$SCRIPT_DIR/../../../testdata/mcap/demo.mcap"
+
+mcap filter "$DEMO_MCAP_PATH" \
+    --include-topic-regex "/diagnostics" \
+    --include-topic-regex "/tf" \
+    --output-compression "zstd" \
+    --chunk-size 4096 \
+    --output "$SCRIPT_DIR/compressed.mcap"
+
+mcap filter "$DEMO_MCAP_PATH" \
+    --include-topic-regex "/diagnostics" \
+    --include-topic-regex "/tf" \
+    --output-compression "none" \
+    --chunk-size 4096 \
+    --output "$SCRIPT_DIR/uncompressed.mcap"

--- a/rust/tests/data/uncompressed.mcap
+++ b/rust/tests/data/uncompressed.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29da7e4d5dcb32ff72edf77999fa3941fc0b08bec7f3ca9d3087274291a12d18
+size 2057946

--- a/rust/tests/flush.rs
+++ b/rust/tests/flush.rs
@@ -11,7 +11,7 @@ use tempfile::tempfile;
 
 #[test]
 fn flush_and_cut_chunks() -> Result<()> {
-    let mapped = map_mcap("../testdata/mcap/demo.mcap")?;
+    let mapped = map_mcap("tests/data/compressed.mcap")?;
 
     let messages = mcap::MessageStream::new(&mapped)?;
 

--- a/rust/tests/round_trip.rs
+++ b/rust/tests/round_trip.rs
@@ -14,7 +14,7 @@ use tempfile::tempfile;
 fn demo_round_trip() -> Result<()> {
     use mcap::records::op;
 
-    let mapped = map_mcap("../testdata/mcap/demo.mcap")?;
+    let mapped = map_mcap("tests/data/compressed.mcap")?;
 
     let messages = mcap::MessageStream::new(&mapped)?;
 
@@ -122,7 +122,7 @@ fn demo_round_trip() -> Result<()> {
 
 #[test]
 fn demo_random_chunk_access() -> Result<()> {
-    let mapped = map_mcap("../testdata/mcap/demo.mcap")?;
+    let mapped = map_mcap("tests/data/compressed.mcap")?;
 
     let summary = mcap::Summary::read(&mapped)?.unwrap();
 


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
Adds a script to create more manageably-sized MCAP files for rust tests, reducing test time significantly.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
Fixes #633 