### PR TITLE
rust: bump version to 0.5.0

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://mcap.dev/docs/rust/doc/mcap/index.html"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Bump version preparing for a release including 136a41777ac064caf0ca6072411c1d8d90f9d73d .
<!-- link relevant GitHub issues -->
