### PR TITLE
cpp: add closeLastChunk on McapWriter

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -401,6 +401,12 @@ public:
    */
   IWritable* dataSink();
 
+  /**
+   * @brief finishes the current chunk in progress and writes it to the file, if a chunk
+   * is in progress.
+   */
+  void closeLastChunk();
+
   // The following static methods are used for serialization of records and
   // primitives to an output stream. They are not intended to be used directly
   // unless you are implementing a lower level writer or tests


### PR DESCRIPTION
**Public-Facing Changes**
Adds `McapWriter::closeLastChunk()`, to allow a writer to clear the chunk buffer into the destination file. 

**Description**
This is useful if a user wants to push all data written so far to the underlying storage medium with `fsync` or similar. They can call `closeLastChunk()` to write out the chunk buffer, then flush and fsync the underlying IWritable instance.

<!-- link relevant GitHub issues -->
