### PR TITLE
cpp: remove redundant buffer from FileWriter

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -149,21 +149,19 @@ private:
 
 /**
  * @brief Implements the IWritable interface used by McapWriter by wrapping a
- * FILE* pointer created by fopen() and a write buffer.
+ * FILE* pointer created by fopen().
  */
 class FileWriter final : public IWritable {
 public:
   ~FileWriter() override;
 
-  Status open(std::string_view filename, size_t bufferCapacity = 1024);
+  Status open(std::string_view filename);
 
   void handleWrite(const std::byte* data, uint64_t size) override;
   void end() override;
   uint64_t size() const override;
 
 private:
-  std::vector<std::byte> buffer_;
-  size_t bufferCapacity_;
   std::FILE* file_ = nullptr;
   uint64_t size_ = 0;
 };


### PR DESCRIPTION
**Public-Facing Changes**
Removes the "buffer size" parameter from the FileWriter constructor.

**Description**

From the sweep below, as of right now varying the buffer size in FileWriter makes no difference to throughput.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/18162835/198135854-f21a1e01-ed35-4f29-ab5a-91eff719baa2.png">

`fopen` opens the underlying file in buffered mode, meaning the runtime allocates some buffers and does buffering for us.

Opening the file in unbuffered mode and re-sweeping does show a real drop-off at 8192kb on my M1 mac.
<img width="663" alt="image" src="https://user-images.githubusercontent.com/18162835/198136907-536f8efd-5e0b-496c-bf66-bfabfa85e88c.png">

This PR just removes the internal buffer and lets the runtime handle buffering for us. I could alternatively open the file in unbuffered mode and change the default to 16384 - let me know what you think.
<!-- link relevant GitHub issues -->
