### PR TITLE
(POC) optimize subcommand for preloading

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,6 +1,0 @@
-[lfs]
-    # Specify the server to use when pulling Git LFS assets.
-    # This is here to work around a bug in the Swift Package Manager which prevents
-    # it from installing packages when the source repository uses Git LFS.
-    # https://forums.swift.org/t/swiftpm-with-git-lfs/42396/4
-    url = https://github.com/foxglove/mcap.git/info/lfs

--- a/go/cli/mcap/cmd/optimize.go
+++ b/go/cli/mcap/cmd/optimize.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/spf13/cobra"
+)
+
+var (
+	optimizeMode   string
+	optimizeTopics []string
+)
+
+func optimize(r io.Reader, w io.Writer, topics map[string]bool) error {
+	lexer, err := mcap.NewLexer(r, &mcap.LexerOptions{
+		SkipMagic:   false,
+		ValidateCRC: false,
+		EmitChunks:  false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct lexer: %w", err)
+	}
+	writer, err := mcap.NewWriter(w, &mcap.WriterOptions{
+		IncludeCRC:  true,
+		Chunked:     true,
+		ChunkSize:   4 * 1024 * 1024,
+		Compression: "zstd",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create writer: %w", err)
+	}
+	attachmentBuffer := bytes.Buffer{}
+	attachmentWriter, err := mcap.NewWriter(&attachmentBuffer, &mcap.WriterOptions{
+		IncludeCRC:  true,
+		Chunked:     true,
+		ChunkSize:   4 * 1024 * 1024,
+		Compression: "zstd",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create attachment writer: %w", err)
+	}
+	schemas := make(map[uint16]*mcap.Schema)
+	channels := make(map[uint16]*mcap.Channel)
+	buf := make([]byte, 1024)
+	for {
+		tokenType, token, err := lexer.Next(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed to pull next record: %w", err)
+		}
+		if len(token) > len(buf) {
+			buf = token
+		}
+		switch tokenType {
+
+		case mcap.TokenHeader:
+			record, err := mcap.ParseHeader(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse header: %w", err)
+			}
+			err = writer.WriteHeader(record)
+			if err != nil {
+				return fmt.Errorf("failed to write header to optimized mcap: %w", err)
+			}
+			err = attachmentWriter.WriteHeader(record)
+			if err != nil {
+				return fmt.Errorf("failed to write header to preload attachment: %w", err)
+			}
+		case mcap.TokenSchema:
+			record, err := mcap.ParseSchema(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse schema: %w", err)
+			}
+			if _, ok := schemas[record.ID]; !ok {
+				err := writer.WriteSchema(record)
+				if err != nil {
+					return fmt.Errorf("failed to write schema: %w", err)
+				}
+				schemas[record.ID] = record
+			}
+		case mcap.TokenChannel:
+			record, err := mcap.ParseChannel(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse channel: %w", err)
+			}
+			if _, ok := channels[record.ID]; !ok {
+				err := writer.WriteChannel(record)
+				if err != nil {
+					return fmt.Errorf("failed to write channel: %w", err)
+				}
+				channels[record.ID] = record
+
+				if topics[record.Topic] {
+					err := attachmentWriter.WriteSchema(schemas[record.SchemaID])
+					if err != nil {
+						return fmt.Errorf("failed to write schema to attachment: %w", err)
+					}
+					err = attachmentWriter.WriteChannel(record)
+					if err != nil {
+						return fmt.Errorf("failed to write channel to attachment record", err)
+					}
+				}
+			}
+		case mcap.TokenMessage:
+			record, err := mcap.ParseMessage(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse message: %w", err)
+			}
+			err = writer.WriteMessage(record)
+			if err != nil {
+				return fmt.Errorf("failed to write message: %w", err)
+			}
+
+			if topics[channels[record.ChannelID].Topic] {
+				err := attachmentWriter.WriteMessage(record)
+				if err != nil {
+					return fmt.Errorf("failed to write message to preload attachment: %w", err)
+				}
+			}
+		case mcap.TokenMetadata:
+			record, err := mcap.ParseMetadata(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse metadata: %w", err)
+			}
+			err = writer.WriteMetadata(record)
+			if err != nil {
+				return fmt.Errorf("failed to write metadata: %w", err)
+			}
+		case mcap.TokenAttachment:
+			record, err := mcap.ParseAttachment(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse metadata: %w", err)
+			}
+			err = writer.WriteAttachment(record)
+			if err != nil {
+				return fmt.Errorf("failed to write metadata: %w", err)
+			}
+		default:
+			continue
+		}
+	}
+	err = attachmentWriter.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close attachment writer: %w", err)
+	}
+	err = writer.WriteAttachment(&mcap.Attachment{
+		LogTime:    0,
+		CreateTime: 0,
+		Name:       "preload_topics",
+		Data:       attachmentBuffer.Bytes(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write preload_topics attachment: %w", err)
+	}
+	err = writer.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close optimized mcap: %w", err)
+	}
+	return nil
+}
+
+var optimizeCmd = &cobra.Command{
+	Use:   "optimize [file]",
+	Short: "optimize the mcap file for pre-loading",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			die("supply a file")
+		}
+		filename := args[0]
+		f, err := os.Open(filename)
+		if err != nil {
+			die("failed to open file: %s", err)
+		}
+
+		topics := make(map[string]bool)
+		for _, topic := range optimizeTopics {
+			topics[topic] = true
+		}
+
+		err = optimize(f, os.Stdout, topics)
+		if err != nil {
+			die("failed to optimize mcap: %s", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(optimizeCmd)
+	optimizeCmd.PersistentFlags().StringSliceVarP(&optimizeTopics, "topic", "t", []string{}, "topics to optimize for preloading")
+}


### PR DESCRIPTION
This PR is for POC/discussion only.

Implements an "optimize" subcommand that accepts an mcap file and a list
of topics, aggregates the chosen topics from the input mcap file into a
second, in-memory mcap file, and attaches the second file to the end of
the first.

The idea of this is to enable efficient preloading of small topics for
display, regardless of the original size of the mcap. To exhibit the
functionality, select a large mcap file. For example, I have
cal_loop.mcap which is converted from cal_loop.bag. The file is 1.5 GB.

To simulate the current best performance for mcap preloading, run this
command with a selection of small topics:

    $ time mcap cat cal_loop.mcap --topics /diagnostics > /dev/null

    real    0m2.382s
    user    0m2.769s
    sys     0m0.408s

To "optimize" the file, run this command:

    $ time mcap optimize cal_loop.mcap -t /diagnostics > cal_loop.optimized.mcap

Now to simulate the optimized preloading performance, run this:

    $ time mcap get attachment cal_loop.optimized.mcap --name preload_topics | mcap cat > /dev/null

    real    0m0.010s
    user    0m0.017s
    sys     0m0.003s

Performance is 238x improved. Change the cat redirect to `--json` to
play the messages to stdout. Multiple topics may be supplied with
multiple -t flags.