### PR TITLE
CLI: merge preserves profile from inputs

### DIFF
--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -16,7 +16,7 @@ func prepInput(t *testing.T, w io.Writer, schemaID uint16, channelID uint16, top
 	})
 	assert.Nil(t, err)
 
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
+	assert.Nil(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
 	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
 		ID: schemaID,
 	}))
@@ -51,6 +51,7 @@ func TestMCAPMerging(t *testing.T) {
 		// output should now be a well-formed mcap
 		reader, err := mcap.NewReader(output)
 		assert.Nil(t, err)
+		assert.Equal(t, reader.Header().Profile, "testprofile")
 		it, err := reader.Messages(readopts.UsingIndex(false))
 		assert.Nil(t, err)
 
@@ -80,6 +81,7 @@ func TestMultiChannelInput(t *testing.T) {
 	assert.Nil(t, merger.mergeInputs(output, []io.Reader{multiChannelInput, buf3}))
 	reader, err := mcap.NewReader(output)
 	assert.Nil(t, err)
+	assert.Equal(t, reader.Header().Profile, "testprofile")
 	it, err := reader.Messages(readopts.UsingIndex(false))
 	assert.Nil(t, err)
 	messages := make(map[string]int)

--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v0.1.2"
+var Version = "v0.2.0"


### PR DESCRIPTION
**Public-Facing Changes**
* Removes the `--profile` argument from `mcap merge`.
* converts `mcap.Reader.readHeader` into a public method `Header()`.  This works on seeking readers always, and non-seeking readers if no other records have been read from the file.

**Description**
Reads the profile from each input before merging messages, if they're all the same that's the profile for the new MCAP.

Fixes #684 

