### PR TITLE
Ensure that fd set only includes one of every message type

### DIFF
--- a/cpp/examples/protobuf/writer.cpp
+++ b/cpp/examples/protobuf/writer.cpp
@@ -53,13 +53,13 @@ std::string SerializeFdSet(const google::protobuf::Descriptor* toplevelDescripto
   while (!toAdd.empty()) {
     const google::protobuf::FileDescriptor* next = toAdd.front();
     toAdd.pop();
-    next->CopyTo(fdSet.add_file());
+    if (added.find(next->name()) == added.end()) {
+      next->CopyTo(fdSet.add_file());
+    }
     added.insert(next->name());
     for (int i = 0; i < next->dependency_count(); ++i) {
       const auto& dep = next->dependency(i);
-      if (added.find(dep->name()) == added.end()) {
-        toAdd.push(dep);
-      }
+      toAdd.push(dep);
     }
   }
   return fdSet.SerializeAsString();


### PR DESCRIPTION
**Description**
* Updates the cpp protobuf example to correctly build the file descriptor set of the parent protobuf type
* Ensures that the file descriptor set doesn't include multiple copies of the same types in the same namespace
