### PR TITLE
CLI: doctor: warn on schema with empty data and encoding fields

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -261,8 +261,12 @@ func (doctor *mcapDoctor) Examine() error {
 				doctor.error("Failed to parse schema:", err)
 			}
 
-			if schema.Encoding == "" && len(schema.Data) > 0 {
-				doctor.error("Schema.data field should not be set when Schema.encoding is empty")
+			if schema.Encoding == "" {
+				if len(schema.Data) == 0 {
+					doctor.warn("Schema with ID: %d, Name: %d has empty Encoding and Data fields", schema.ID, schema.Name)
+				} else {
+					doctor.error("Schema with ID: %d has empty Encoding but Data contains: %s", schema.ID, string(schema.Data))
+				}
 			}
 
 			if schema.ID == 0 {


### PR DESCRIPTION
**Public-Facing Changes**
Adds a warning to `mcap doctor` when we encounter a schema record with no `data` and no `encoding`.
**Description**
An empty schema is a pretty odd corner case - the data it refers to is not schemaless, but there is no information that can be used to decode it. The only example I can think of for this is where a user has some JSON messages and there is no `jsonschema` to describe them, but still wants to provide some label to help the decoder figure out what to do with it.

In every other case, this is something the user ought to know about.

<!-- link relevant GitHub issues -->
fixes #698 