### PR TITLE
lexer: expose informative error on truncation

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -204,13 +204,16 @@ func filter(
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
-			if opts.recover && errors.Is(err, io.ErrUnexpectedEOF) {
-				fmt.Println("Input file was truncated.")
-				return nil
-			}
-			if opts.recover && token == mcap.TokenInvalidChunk {
-				fmt.Printf("Invalid chunk encountered, skipping: %s\n", err)
-				continue
+			if opts.recover {
+				var expected *mcap.ErrTruncatedRecord
+				if errors.As(err, &expected) {
+					fmt.Println(expected.Error())
+					return nil
+				}
+				if token == mcap.TokenInvalidChunk {
+					fmt.Printf("Invalid chunk encountered, skipping: %s\n", err)
+					continue
+				}
 			}
 			return err
 		}

--- a/go/mcap/lexer_test.go
+++ b/go/mcap/lexer_test.go
@@ -131,7 +131,7 @@ func TestBadMagic(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			_, err := NewLexer(bytes.NewReader(c.magic))
-			assert.ErrorIs(t, err, ErrBadMagic)
+			assert.IsType(t, &ErrBadMagic{}, err)
 		})
 	}
 }


### PR DESCRIPTION
**Public-Facing Changes**
* Improves error message from `mcap recover`  and `mcap doctor` on truncated MCAP files.

Before:
```
Failed to read token: Unexpected EOF
```
After:
```
Failed to read next token: MCAP truncated in message index (0x7) record content with expected length 51542, data ended after 50343 bytes
```

* Library users inspecting errors by equality will need to update their error handling of the `mcap.Lexer` next method. Previously they would expect an `io.UnexpectedEOF`, but now they get `mcap.ErrTruncatedRecord` when an MCAP is truncated. Note that `mcap.ErrTruncatedRecord` wraps `io.UnexpectedEOF`, so if they use `errors.Is` they don't have to modify their code.


<!-- link relevant GitHub issues -->
fixes #697 