### PR TITLE
Remove note about Swift library being experimental

### DIFF
--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -6,8 +6,6 @@ The Python, C++, Go, and TypeScript MCAP libraries are actively developed. This 
 
 **Note**: This does not mean that their APIs are stable.
 
-The Swift MCAP library is experimental, and not actively developed. This means that PRs contributing bug-fixes are welcome, but GitHub Issues regarding it will not be prioritized.
-
 ## Feature Matrix
 
 |  | Python | C++ | Go | TypeScript | Swift | Rust |


### PR DESCRIPTION
The Swift indexed reader is being used in production as of https://github.com/foxglove/studio/pull/4745

We still have this sentence:

> The Python, C++, Go, and TypeScript MCAP libraries are actively developed. This means that Foxglove actively pursues bug fixes and ensures conformance with the MCAP specification.

That also excludes Rust. I'm not sure if this sentence is very valuable or accurate?