### PR TITLE
Windows dllexport

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -17,6 +17,7 @@ FixNamespaceComments: true
 PointerAlignment: Left
 ReflowComments: true
 SortIncludes: true
+IndentPPDirectives: AfterHash
 
 IncludeCategories:
   - Regex: "^<mcap"

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -3,6 +3,7 @@
 #include "intervaltree.hpp"
 #include "read_job_queue.hpp"
 #include "types.hpp"
+#include "visibility.hpp"
 #include <cstdio>
 #include <fstream>
 #include <map>
@@ -71,7 +72,7 @@ struct IReadable {
  * @brief IReadable implementation wrapping a FILE* pointer created by fopen()
  * and a read buffer.
  */
-class FileReader final : public IReadable {
+class MCAP_EXPORT FileReader final : public IReadable {
 public:
   FileReader(std::FILE* file);
 
@@ -88,7 +89,7 @@ private:
 /**
  * @brief IReadable implementation wrapping a std::ifstream input file stream.
  */
-class FileStreamReader final : public IReadable {
+class MCAP_EXPORT FileStreamReader final : public IReadable {
 public:
   FileStreamReader(std::ifstream& stream);
 
@@ -153,7 +154,7 @@ private:
  * @brief ICompressedReader implementation that decompresses Zstandard
  * (https://facebook.github.io/zstd/) data.
  */
-class ZStdReader final : public ICompressedReader {
+class MCAP_PUBLIC ZStdReader final : public ICompressedReader {
 public:
   void reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) override;
   uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
@@ -187,7 +188,7 @@ private:
  * @brief ICompressedReader implementation that decompresses LZ4
  * (https://lz4.github.io/lz4/) data.
  */
-class LZ4Reader final : public ICompressedReader {
+class MCAP_PUBLIC LZ4Reader final : public ICompressedReader {
 public:
   void reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) override;
   uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
@@ -267,7 +268,7 @@ public:
 /**
  * @brief Provides a read interface to an MCAP file.
  */
-class McapReader final {
+class MCAP_PUBLIC McapReader final {
 public:
   ~McapReader();
 
@@ -629,8 +630,8 @@ private:
 /**
  * @brief An iterable view of Messages in an MCAP file.
  */
-struct LinearMessageView {
-  struct Iterator {
+struct MCAP_PUBLIC LinearMessageView {
+  struct MCAP_PUBLIC Iterator {
     using iterator_category = std::input_iterator_tag;
     using difference_type = int64_t;
     using value_type = MessageView;

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -642,8 +642,8 @@ struct MCAP_PUBLIC LinearMessageView {
     pointer operator->() const;
     Iterator& operator++();
     void operator++(int);
-    friend bool operator==(const Iterator& a, const Iterator& b);
-    friend bool operator!=(const Iterator& a, const Iterator& b);
+    MCAP_PUBLIC friend bool operator==(const Iterator& a, const Iterator& b);
+    friend MCAP_PUBLIC bool operator!=(const Iterator& a, const Iterator& b);
 
   private:
     friend LinearMessageView;

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -40,7 +40,7 @@ enum struct ReadSummaryMethod {
 /**
  * @brief An abstract interface for reading MCAP data.
  */
-struct IReadable {
+struct MCAP_PUBLIC IReadable {
   virtual ~IReadable() = default;
 
   /**
@@ -72,7 +72,7 @@ struct IReadable {
  * @brief IReadable implementation wrapping a FILE* pointer created by fopen()
  * and a read buffer.
  */
-class MCAP_EXPORT FileReader final : public IReadable {
+class MCAP_PUBLIC FileReader final : public IReadable {
 public:
   FileReader(std::FILE* file);
 
@@ -89,7 +89,7 @@ private:
 /**
  * @brief IReadable implementation wrapping a std::ifstream input file stream.
  */
-class MCAP_EXPORT FileStreamReader final : public IReadable {
+class MCAP_PUBLIC FileStreamReader final : public IReadable {
 public:
   FileStreamReader(std::ifstream& stream);
 
@@ -132,7 +132,7 @@ public:
  * @brief A "null" compressed reader that directly passes through uncompressed
  * data. No internal buffers are allocated.
  */
-class BufferReader final : public ICompressedReader {
+class MCAP_PUBLIC BufferReader final : public ICompressedReader {
 public:
   void reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) override;
   uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
@@ -228,7 +228,7 @@ struct LinearMessageView;
 /**
  * @brief Options for reading messages out of an MCAP file.
  */
-struct ReadMessageOptions {
+struct MCAP_PUBLIC ReadMessageOptions {
 public:
   /**
    * @brief Only messages with log timestamps greater or equal to startTime will be included.
@@ -488,7 +488,7 @@ private:
  * @brief A low-level interface for parsing MCAP-style TLV records from a data
  * source.
  */
-struct RecordReader {
+struct MCAP_PUBLIC RecordReader {
   ByteOffset offset;
   ByteOffset endOffset;
 
@@ -508,7 +508,7 @@ private:
   Record curRecord_;
 };
 
-struct TypedChunkReader {
+struct MCAP_PUBLIC TypedChunkReader {
   std::function<void(const SchemaPtr, ByteOffset)> onSchema;
   std::function<void(const ChannelPtr, ByteOffset)> onChannel;
   std::function<void(const Message&, ByteOffset)> onMessage;
@@ -540,7 +540,7 @@ private:
  * @brief A mid-level interface for parsing and validating MCAP records from a
  * data source.
  */
-struct TypedRecordReader {
+struct MCAP_PUBLIC TypedRecordReader {
   std::function<void(const Header&, ByteOffset)> onHeader;
   std::function<void(const Footer&, ByteOffset)> onFooter;
   std::function<void(const SchemaPtr, ByteOffset, std::optional<ByteOffset>)> onSchema;
@@ -588,7 +588,7 @@ private:
  *  - noMessageIndex: false
  *  - noSummary: false
  */
-struct IndexedMessageReader {
+struct MCAP_PUBLIC IndexedMessageReader {
 public:
   IndexedMessageReader(McapReader& reader, const ReadMessageOptions& options,
                        const std::function<void(const Message&)> onMessage);
@@ -643,7 +643,7 @@ struct MCAP_PUBLIC LinearMessageView {
     Iterator& operator++();
     void operator++(int);
     MCAP_PUBLIC friend bool operator==(const Iterator& a, const Iterator& b);
-    friend MCAP_PUBLIC bool operator!=(const Iterator& a, const Iterator& b);
+    MCAP_PUBLIC friend bool operator!=(const Iterator& a, const Iterator& b);
 
   private:
     friend LinearMessageView;

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -706,5 +706,5 @@ private:
 }  // namespace mcap
 
 #ifdef MCAP_IMPLEMENTATION
-#include "reader.inl"
+#  include "reader.inl"
 #endif

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -106,7 +106,7 @@ private:
 /**
  * @brief An abstract interface for compressed readers.
  */
-class ICompressedReader : public IReadable {
+class MCAP_PUBLIC ICompressedReader : public IReadable {
 public:
   virtual ~ICompressedReader() = default;
 

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <cassert>
 #include <lz4frame.h>
-
 #include <zstd.h>
 #include <zstd_errors.h>
 
@@ -1740,11 +1739,13 @@ void LinearMessageView::Iterator::operator++(int) {
   ++*this;
 }
 
-bool operator==(const LinearMessageView::Iterator& a, const LinearMessageView::Iterator& b) {
+bool MCAP_PUBLIC operator==(const LinearMessageView::Iterator& a,
+                            const LinearMessageView::Iterator& b) {
   return a.impl_ == b.impl_;
 }
 
-bool operator!=(const LinearMessageView::Iterator& a, const LinearMessageView::Iterator& b) {
+bool MCAP_PUBLIC operator!=(const LinearMessageView::Iterator& a,
+                            const LinearMessageView::Iterator& b) {
   return !(a == b);
 }
 

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cassert>
 #include <lz4frame.h>
+
 #include <zstd.h>
 #include <zstd_errors.h>
 

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1739,13 +1739,11 @@ void LinearMessageView::Iterator::operator++(int) {
   ++*this;
 }
 
-bool MCAP_PUBLIC operator==(const LinearMessageView::Iterator& a,
-                            const LinearMessageView::Iterator& b) {
+bool operator==(const LinearMessageView::Iterator& a, const LinearMessageView::Iterator& b) {
   return a.impl_ == b.impl_;
 }
 
-bool MCAP_PUBLIC operator!=(const LinearMessageView::Iterator& a,
-                            const LinearMessageView::Iterator& b) {
+bool operator!=(const LinearMessageView::Iterator& a, const LinearMessageView::Iterator& b) {
   return !(a == b);
 }
 

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -75,13 +75,14 @@ enum struct OpCode : uint8_t {
 /**
  * @brief Get the string representation of an OpCode.
  */
+MCAP_PUBLIC
 constexpr std::string_view OpCodeString(OpCode opcode);
 
 /**
  * @brief A generic Type-Length-Value record using a uint8 type and uint64
  * length. This is the generic form of all MCAP records.
  */
-struct Record {
+struct MCAP_PUBLIC Record {
   OpCode opcode;
   uint64_t dataSize;
   std::byte* data;
@@ -97,7 +98,7 @@ struct Record {
  * <https://github.com/foxglove/mcap/tree/main/docs/specification/profiles>) and
  * a string signature of the recording library.
  */
-struct Header {
+struct MCAP_PUBLIC Header {
   std::string profile;
   std::string library;
 };
@@ -109,7 +110,7 @@ struct Header {
  * Summary and Summary Offset sections. A `summaryStart` and
  * `summaryOffsetStart` of zero indicates no Summary section is available.
  */
-struct Footer {
+struct MCAP_PUBLIC Footer {
   ByteOffset summaryStart;
   ByteOffset summaryOffsetStart;
   uint32_t summaryCrc;
@@ -126,7 +127,7 @@ struct Footer {
  * describing the shape of messages. One or more Channel records map to a single
  * Schema.
  */
-struct Schema {
+struct MCAP_PUBLIC Schema {
   SchemaId id;
   std::string name;
   std::string encoding;
@@ -153,7 +154,7 @@ struct Schema {
  * encodings that are not self-describing (e.g. JSON) or when schema information
  * is available (e.g. JSONSchema).
  */
-struct Channel {
+struct MCAP_PUBLIC Channel {
   ChannelId id;
   std::string topic;
   std::string messageEncoding;
@@ -176,7 +177,7 @@ using ChannelPtr = std::shared_ptr<Channel>;
 /**
  * @brief A single Message published to a Channel.
  */
-struct Message {
+struct MCAP_PUBLIC Message {
   ChannelId channelId;
   /**
    * @brief An optional sequence number. If non-zero, sequence numbers should be
@@ -209,7 +210,7 @@ struct Message {
  * @brief An collection of Schemas, Channels, and Messages that supports
  * compression and indexing.
  */
-struct Chunk {
+struct MCAP_PUBLIC Chunk {
   Timestamp messageStartTime;
   Timestamp messageEndTime;
   ByteOffset uncompressedSize;
@@ -223,7 +224,7 @@ struct Chunk {
  * @brief A list of timestamps to byte offsets for a single Channel. This record
  * appears after each Chunk, one per Channel that appeared in that Chunk.
  */
-struct MessageIndex {
+struct MCAP_PUBLIC MessageIndex {
   ChannelId channelId;
   std::vector<std::pair<Timestamp, ByteOffset>> records;
 };
@@ -233,7 +234,7 @@ struct MessageIndex {
  * summary information for a single Chunk and pointing to each Message Index
  * record associated with that Chunk.
  */
-struct ChunkIndex {
+struct MCAP_PUBLIC ChunkIndex {
   Timestamp messageStartTime;
   Timestamp messageEndTime;
   ByteOffset chunkStartOffset;
@@ -250,7 +251,7 @@ struct ChunkIndex {
  * a name, media type, timestamps, and optional CRC. Attachment records are
  * written in the Data section, outside of Chunks.
  */
-struct Attachment {
+struct MCAP_PUBLIC Attachment {
   Timestamp logTime;
   Timestamp createTime;
   std::string name;
@@ -264,7 +265,7 @@ struct Attachment {
  * @brief Attachment Index records are found in the Summary section, providing
  * summary information for a single Attachment.
  */
-struct AttachmentIndex {
+struct MCAP_PUBLIC AttachmentIndex {
   ByteOffset offset;
   ByteOffset length;
   Timestamp logTime;
@@ -294,7 +295,7 @@ struct AttachmentIndex {
  * @brief The Statistics record is found in the Summary section, providing
  * counts and timestamp ranges for the entire file.
  */
-struct Statistics {
+struct MCAP_PUBLIC Statistics {
   uint64_t messageCount;
   uint16_t schemaCount;
   uint32_t channelCount;
@@ -310,7 +311,7 @@ struct Statistics {
  * @brief Holds a named map of key/value strings containing arbitrary user data.
  * Metadata records are found in the Data section, outside of Chunks.
  */
-struct Metadata {
+struct MCAP_PUBLIC Metadata {
   std::string name;
   KeyValueMap metadata;
 };
@@ -319,7 +320,7 @@ struct Metadata {
  * @brief Metdata Index records are found in the Summary section, providing
  * summary information for a single Metadata record.
  */
-struct MetadataIndex {
+struct MCAP_PUBLIC MetadataIndex {
   uint64_t offset;
   uint64_t length;
   std::string name;
@@ -334,7 +335,7 @@ struct MetadataIndex {
  * found in the Summary section, a Summary Offset references the file offset and
  * length where that type of Summary record can be found.
  */
-struct SummaryOffset {
+struct MCAP_PUBLIC SummaryOffset {
   OpCode groupOpCode;
   ByteOffset groupStart;
   ByteOffset groupLength;
@@ -344,7 +345,7 @@ struct SummaryOffset {
  * @brief The final record in the Data section, signaling the end of Data and
  * beginning of Summary. Optionally contains a CRC of the entire Data section.
  */
-struct DataEnd {
+struct MCAP_PUBLIC DataEnd {
   uint32_t dataSectionCrc;
 };
 

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "errors.hpp"
+#include "visibility.hpp"
 #include <cstddef>
 #include <functional>
 #include <limits>
@@ -353,7 +354,7 @@ struct DataEnd {
  * to that Channel's Schema. The Channel pointer is guaranteed to be valid,
  * while the Schema pointer may be null if the Channel references schema_id 0.
  */
-struct MessageView {
+struct MCAP_PUBLIC MessageView {
   const Message& message;
   const ChannelPtr channel;
   const SchemaPtr schema;

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -369,5 +369,5 @@ struct MCAP_PUBLIC MessageView {
 }  // namespace mcap
 
 #ifdef MCAP_IMPLEMENTATION
-#include "types.inl"
+#  include "types.inl"
 #endif

--- a/cpp/mcap/include/mcap/visibility.hpp
+++ b/cpp/mcap/include/mcap/visibility.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define MCAP_EXPORT __attribute__((dllexport))
+#define MCAP_IMPORT __attribute__((dllimport))
+#else
+#define MCAP_EXPORT __declspec(dllexport)
+#define MCAP_IMPORT __declspec(dllimport)
+#endif
+#ifdef MCAP_BUILDING_DLL
+#define MCAP_PUBLIC MCAP_EXPORT
+#else
+#define MCAP_PUBLIC MCAP_IMPORT
+#endif
+#define MCAP_PUBLIC_TYPE MCAP_PUBLIC
+#define MCAP_LOCAL
+#else
+#define MCAP_EXPORT __attribute__((visibility("default")))
+#define MCAP_IMPORT
+#if __GNUC__ >= 4
+#define MCAP_PUBLIC __attribute__((visibility("default")))
+#define MCAP_LOCAL __attribute__((visibility("hidden")))
+#else
+#define MCAP_PUBLIC
+#define MCAP_LOCAL
+#endif
+#define MCAP_PUBLIC_TYPE
+#endif

--- a/cpp/mcap/include/mcap/visibility.hpp
+++ b/cpp/mcap/include/mcap/visibility.hpp
@@ -13,17 +13,12 @@
 #  else
 #    define MCAP_PUBLIC MCAP_IMPORT
 #  endif
-#  define MCAP_PUBLIC_TYPE MCAP_PUBLIC
-#  define MCAP_LOCAL
 #else
 #  define MCAP_EXPORT __attribute__((visibility("default")))
 #  define MCAP_IMPORT
 #  if __GNUC__ >= 4
 #    define MCAP_PUBLIC __attribute__((visibility("default")))
-#    define MCAP_LOCAL __attribute__((visibility("hidden")))
 #  else
 #    define MCAP_PUBLIC
-#    define MCAP_LOCAL
 #  endif
-#  define MCAP_PUBLIC_TYPE
 #endif

--- a/cpp/mcap/include/mcap/visibility.hpp
+++ b/cpp/mcap/include/mcap/visibility.hpp
@@ -8,9 +8,7 @@
 #    define MCAP_EXPORT __declspec(dllexport)
 #    define MCAP_IMPORT __declspec(dllimport)
 #  endif
-// MCAP_BUILDING_DLL to be defined by build process producing a shared library
-// It must be left unset by consumers of the shared library
-#  ifdef MCAP_BUILDING_DLL
+#  ifdef MCAP_IMPLEMENTATION
 #    define MCAP_PUBLIC MCAP_EXPORT
 #  else
 #    define MCAP_PUBLIC MCAP_IMPORT

--- a/cpp/mcap/include/mcap/visibility.hpp
+++ b/cpp/mcap/include/mcap/visibility.hpp
@@ -1,29 +1,31 @@
 #pragma once
 
 #if defined _WIN32 || defined __CYGWIN__
-#ifdef __GNUC__
-#define MCAP_EXPORT __attribute__((dllexport))
-#define MCAP_IMPORT __attribute__((dllimport))
+#  ifdef __GNUC__
+#    define MCAP_EXPORT __attribute__((dllexport))
+#    define MCAP_IMPORT __attribute__((dllimport))
+#  else
+#    define MCAP_EXPORT __declspec(dllexport)
+#    define MCAP_IMPORT __declspec(dllimport)
+#  endif
+// MCAP_BUILDING_DLL to be defined by build process producing a shared library
+// It must be left unset by consumers of the shared library
+#  ifdef MCAP_BUILDING_DLL
+#    define MCAP_PUBLIC MCAP_EXPORT
+#  else
+#    define MCAP_PUBLIC MCAP_IMPORT
+#  endif
+#  define MCAP_PUBLIC_TYPE MCAP_PUBLIC
+#  define MCAP_LOCAL
 #else
-#define MCAP_EXPORT __declspec(dllexport)
-#define MCAP_IMPORT __declspec(dllimport)
-#endif
-#ifdef MCAP_BUILDING_DLL
-#define MCAP_PUBLIC MCAP_EXPORT
-#else
-#define MCAP_PUBLIC MCAP_IMPORT
-#endif
-#define MCAP_PUBLIC_TYPE MCAP_PUBLIC
-#define MCAP_LOCAL
-#else
-#define MCAP_EXPORT __attribute__((visibility("default")))
-#define MCAP_IMPORT
-#if __GNUC__ >= 4
-#define MCAP_PUBLIC __attribute__((visibility("default")))
-#define MCAP_LOCAL __attribute__((visibility("hidden")))
-#else
-#define MCAP_PUBLIC
-#define MCAP_LOCAL
-#endif
-#define MCAP_PUBLIC_TYPE
+#  define MCAP_EXPORT __attribute__((visibility("default")))
+#  define MCAP_IMPORT
+#  if __GNUC__ >= 4
+#    define MCAP_PUBLIC __attribute__((visibility("default")))
+#    define MCAP_LOCAL __attribute__((visibility("hidden")))
+#  else
+#    define MCAP_PUBLIC
+#    define MCAP_LOCAL
+#  endif
+#  define MCAP_PUBLIC_TYPE
 #endif

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.hpp"
+#include "visibility.hpp"
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -151,7 +152,7 @@ private:
  * @brief Implements the IWritable interface used by McapWriter by wrapping a
  * FILE* pointer created by fopen().
  */
-class FileWriter final : public IWritable {
+class MCAP_PUBLIC FileWriter final : public IWritable {
 public:
   ~FileWriter() override;
 
@@ -277,7 +278,7 @@ private:
  * @brief An in-memory IChunkWriter implementation that holds data in a
  * temporary buffer before flushing to an ZStandard-compressed buffer.
  */
-class ZStdWriter final : public IChunkWriter {
+class MCAP_PUBLIC ZStdWriter final : public IChunkWriter {
 public:
   ZStdWriter(CompressionLevel compressionLevel, uint64_t chunkSize);
   ~ZStdWriter() override;
@@ -300,7 +301,7 @@ private:
 /**
  * @brief Provides a write interface to an MCAP file.
  */
-class McapWriter final {
+class MCAP_EXPORT McapWriter final {
 public:
   ~McapWriter();
 

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -16,7 +16,7 @@ namespace mcap {
 /**
  * @brief Configuration options for McapWriter.
  */
-struct McapWriterOptions {
+struct MCAP_PUBLIC McapWriterOptions {
   /**
    * @brief Disable CRC calculations for Chunks.
    */
@@ -107,7 +107,7 @@ struct McapWriterOptions {
 /**
  * @brief An abstract interface for writing MCAP data.
  */
-class IWritable {
+class MCAP_PUBLIC IWritable {
 public:
   bool crcEnabled = false;
 
@@ -171,7 +171,7 @@ private:
  * @brief Implements the IWritable interface used by McapWriter by wrapping a
  * std::ostream stream.
  */
-class StreamWriter final : public IWritable {
+class MCAP_PUBLIC StreamWriter final : public IWritable {
 public:
   StreamWriter(std::ostream& stream);
 
@@ -189,7 +189,7 @@ private:
  * in memory and written to disk as a single record, to support optimal
  * compression and calculating the final Chunk data size.
  */
-class IChunkWriter : public IWritable {
+class MCAP_PUBLIC IChunkWriter : public IWritable {
 public:
   virtual ~IChunkWriter() = default;
 
@@ -236,7 +236,7 @@ protected:
  * @brief An in-memory IChunkWriter implementation backed by a
  * growable buffer.
  */
-class BufferWriter final : public IChunkWriter {
+class MCAP_PUBLIC BufferWriter final : public IChunkWriter {
 public:
   void handleWrite(const std::byte* data, uint64_t size) override;
   void end() override;
@@ -255,7 +255,7 @@ private:
  * @brief An in-memory IChunkWriter implementation that holds data in a
  * temporary buffer before flushing to an LZ4-compressed buffer.
  */
-class LZ4Writer final : public IChunkWriter {
+class MCAP_PUBLIC LZ4Writer final : public IChunkWriter {
 public:
   LZ4Writer(CompressionLevel compressionLevel, uint64_t chunkSize);
 
@@ -301,7 +301,7 @@ private:
 /**
  * @brief Provides a write interface to an MCAP file.
  */
-class MCAP_EXPORT McapWriter final {
+class MCAP_PUBLIC McapWriter final {
 public:
   ~McapWriter();
 

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -469,5 +469,5 @@ private:
 }  // namespace mcap
 
 #ifdef MCAP_IMPLEMENTATION
-#include "writer.inl"
+#  include "writer.inl"
 #endif


### PR DESCRIPTION
**Public-Facing Changes**
`dllexport`s all interfaces from `reader.hpp`, `writer.hpp`, and `types.hpp` for usage as a shared library on Windows.

**Description**
Add `visibility.hpp` to provide platform-dependent macros to allow for `dllexport`/`dllimport` and skipping on non-Windows.

Part of #716 
Part of https://github.com/ros-tooling/rosbag2_storage_mcap/issues/67
