### PR TITLE
cpp: fix windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,7 @@ jobs:
         with:
           python-version: 3.7
       - run: pip install conan==1.53.0
-      - run: conan config init
-      - run: conan editable add ./mcap mcap/0.6.0
-      - run: conan install test --install-folder test/build/Debug -s compiler.cppstd=17 -s build_type=Debug --build missing
-      - run: conan build test --build-folder test/build/Debug
+      - run: bash build.sh --build-tests-only
       - run: ./test/build/Debug/bin/unit-tests
 
   typescript:

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -5,13 +5,16 @@ set -e
 conan config init
 
 conan editable add ./mcap mcap/0.7.0
-conan install bench --install-folder bench/build/Release \
-  -s compiler.cppstd=17 -s build_type=Release --build missing
-conan install examples --install-folder examples/build/Release \
-  -s compiler.cppstd=17 -s build_type=Release --build missing
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 
-conan build examples --build-folder examples/build/Release
-conan build bench --build-folder bench/build/Release
+if [ "$1" != "--build-tests-only" ]; then
+  conan install bench --install-folder bench/build/Release \
+    -s compiler.cppstd=17 -s build_type=Release --build missing
+  conan install examples --install-folder examples/build/Release \
+    -s compiler.cppstd=17 -s build_type=Release --build missing
+  conan build examples --build-folder examples/build/Release
+  conan build bench --build-folder bench/build/Release
+fi
+
 conan build test --build-folder test/build/Debug


### PR DESCRIPTION
Windows CI specifies the version of the MCAP library in a hardcoded string, which changed recently and is now wrong.

This PR changes windows CI to use the `cpp/build.sh` script where the version string is specified for other build steps.