### PR TITLE
CLI: filtering with multiple exclude matchers works

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -240,16 +240,25 @@ func filter(
 			if err != nil {
 				return err
 			}
+			// if any topics match an includeTopic, add it.
 			for _, matcher := range opts.includeTopics {
 				if matcher.MatchString(channel.Topic) {
 					channels[channel.ID] = markableChannel{channel, false}
 				}
 			}
-			for _, matcher := range opts.excludeTopics {
-				if !matcher.MatchString(channel.Topic) {
+			// if a topic does not match any excludeTopic, add it.
+			if len(opts.excludeTopics) != 0 {
+				shouldInclude := true
+				for _, matcher := range opts.excludeTopics {
+					if matcher.MatchString(channel.Topic) {
+						shouldInclude = false
+					}
+				}
+				if shouldInclude {
 					channels[channel.ID] = markableChannel{channel, false}
 				}
 			}
+			// if neither exclude or include topics are specified, add all channels.
 			if len(opts.includeTopics) == 0 && len(opts.excludeTopics) == 0 {
 				channels[channel.ID] = markableChannel{channel, false}
 			}

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -83,6 +83,23 @@ func TestFiltering(t *testing.T) {
 			},
 		},
 		{
+			name: "double exclusive topic filtering",
+			opts: &filterOpts{
+				compressionFormat: mcap.CompressionLZ4,
+				start:             0,
+				end:               1000,
+				excludeTopics: []regexp.Regexp{
+					*regexp.MustCompile("camera_a"),
+					*regexp.MustCompile("camera_b"),
+				},
+			},
+			expectedMessageCount: map[uint16]int{
+				1: 0,
+				2: 0,
+				3: 100,
+			},
+		},
+		{
 			name: "exclusive filtering and including attachments",
 			opts: &filterOpts{
 				compressionFormat:  mcap.CompressionLZ4,


### PR DESCRIPTION
**Public-Facing Changes**
users can now use multiple exclude patterns with `mcap filter` and it will work.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
Fixes #724 