### PR TITLE
Go: add support for stream handling of attachments

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -105,9 +105,9 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 	uncompressedBytesReader := bytes.NewReader(uncompressedBytes)
 
 	lexer, err := mcap.NewLexer(uncompressedBytesReader, &mcap.LexerOptions{
-		SkipMagic:   true,
-		ValidateCRC: true,
-		EmitChunks:  true,
+		SkipMagic:         true,
+		ValidateChunkCRCs: true,
+		EmitChunks:        true,
 	})
 	if err != nil {
 		doctor.error("Failed to make lexer for chunk bytes", err)
@@ -209,9 +209,9 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 
 func (doctor *mcapDoctor) Examine() error {
 	lexer, err := mcap.NewLexer(doctor.reader, &mcap.LexerOptions{
-		SkipMagic:   false,
-		ValidateCRC: true,
-		EmitChunks:  true,
+		SkipMagic:         false,
+		ValidateChunkCRCs: true,
+		EmitChunks:        true,
 	})
 	if err != nil {
 		doctor.fatal(err)
@@ -334,11 +334,6 @@ func (doctor *mcapDoctor) Examine() error {
 				doctor.error("Multiple chunk indexes found for chunk at offset", chunkIndex.ChunkStartOffset)
 			}
 			doctor.chunkIndexes[chunkIndex.ChunkStartOffset] = chunkIndex
-		case mcap.TokenAttachment:
-			_, err := mcap.ParseAttachment(data)
-			if err != nil {
-				doctor.error("Failed to parse attachment:", err)
-			}
 		case mcap.TokenAttachmentIndex:
 			_, err := mcap.ParseAttachmentIndex(data)
 			if err != nil {

--- a/go/conformance/test-streamed-write-conformance/main.go
+++ b/go/conformance/test-streamed-write-conformance/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -279,13 +280,8 @@ func parseAttachment(fields []InputField) (*mcap.Attachment, error) {
 			if err != nil {
 				return nil, err
 			}
-			attachment.Data = data
-		case "crc":
-			crc, err := parseUint32(field.Value.(string))
-			if err != nil {
-				return nil, err
-			}
-			attachment.CRC = crc
+			attachment.Data = bytes.NewReader(data)
+			attachment.DataSize = uint64(len(data))
 		default:
 			return nil, UnknownField(field.Name)
 		}

--- a/go/mcap/crc_reader.go
+++ b/go/mcap/crc_reader.go
@@ -1,0 +1,33 @@
+package mcap
+
+import (
+	"hash"
+	"hash/crc32"
+	"io"
+)
+
+type crcReader struct {
+	r          io.Reader
+	crc        hash.Hash32
+	computeCRC bool
+}
+
+func (r *crcReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if r.computeCRC {
+		_, _ = r.crc.Write(p[:n])
+	}
+	return n, err
+}
+
+func (r *crcReader) Checksum() uint32 {
+	return r.crc.Sum32()
+}
+
+func newCRCReader(r io.Reader, computeCRC bool) *crcReader {
+	return &crcReader{
+		r:          r,
+		crc:        crc32.NewIEEE(),
+		computeCRC: computeCRC,
+	}
+}

--- a/go/mcap/lexer_test.go
+++ b/go/mcap/lexer_test.go
@@ -20,8 +20,8 @@ func TestLexUnchunkedFile(t *testing.T) {
 		channelInfo(),
 		message(),
 		message(),
-		record(OpAttachment),
-		record(OpAttachment),
+		attachment(),
+		attachment(),
 		channelInfo(),
 		record(OpAttachmentIndex),
 		footer(),
@@ -33,8 +33,6 @@ func TestLexUnchunkedFile(t *testing.T) {
 		TokenChannel,
 		TokenMessage,
 		TokenMessage,
-		TokenAttachment,
-		TokenAttachment,
 		TokenChannel,
 		TokenAttachmentIndex,
 		TokenFooter,
@@ -75,7 +73,7 @@ func TestRejectsTooLargeChunks(t *testing.T) {
 	file := file(header(), bigChunk, footer())
 	lexer, err := NewLexer(bytes.NewReader(file), &LexerOptions{
 		MaxDecompressedChunkSize: 999,
-		ValidateCRC:              true,
+		ValidateChunkCRCs:        true,
 	})
 	assert.Nil(t, err)
 	_, _, err = lexer.Next(nil)
@@ -165,7 +163,7 @@ func TestLexChunkedFile(t *testing.T) {
 						footer(),
 					)
 					lexer, err := NewLexer(bytes.NewReader(file), &LexerOptions{
-						ValidateCRC: validateCRC,
+						ValidateChunkCRCs: validateCRC,
 					})
 					assert.Nil(t, err)
 					expected := []TokenType{
@@ -176,8 +174,6 @@ func TestLexChunkedFile(t *testing.T) {
 						TokenChannel,
 						TokenMessage,
 						TokenMessage,
-						TokenAttachment,
-						TokenAttachment,
 						TokenFooter,
 					}
 					for i, expectedTokenType := range expected {
@@ -224,7 +220,7 @@ func TestChunkCRCValidation(t *testing.T) {
 			footer(),
 		)
 		lexer, err := NewLexer(bytes.NewReader(file), &LexerOptions{
-			ValidateCRC: true,
+			ValidateChunkCRCs: true,
 		})
 		assert.Nil(t, err)
 		expected := []TokenType{
@@ -235,8 +231,6 @@ func TestChunkCRCValidation(t *testing.T) {
 			TokenChannel,
 			TokenMessage,
 			TokenMessage,
-			TokenAttachment,
-			TokenAttachment,
 			TokenFooter,
 		}
 		for i, expectedTokenType := range expected {
@@ -254,7 +248,7 @@ func TestChunkCRCValidation(t *testing.T) {
 			footer(),
 		)
 		lexer, err := NewLexer(bytes.NewReader(file), &LexerOptions{
-			ValidateCRC: true,
+			ValidateChunkCRCs: true,
 		})
 		assert.Nil(t, err)
 		expected := []TokenType{
@@ -265,8 +259,6 @@ func TestChunkCRCValidation(t *testing.T) {
 			TokenChannel,
 			TokenMessage,
 			TokenMessage,
-			TokenAttachment,
-			TokenAttachment,
 			TokenFooter,
 		}
 		for i, expectedTokenType := range expected {
@@ -289,7 +281,7 @@ func TestChunkCRCValidation(t *testing.T) {
 			footer(),
 		)
 		lexer, err := NewLexer(bytes.NewReader(file), &LexerOptions{
-			ValidateCRC: true,
+			ValidateChunkCRCs: true,
 		})
 		assert.Nil(t, err)
 		expected := []TokenType{
@@ -307,6 +299,80 @@ func TestChunkCRCValidation(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.True(t, strings.Contains(err.Error(), "invalid chunk CRC"))
 	})
+}
+
+func TestAttachmentHandling(t *testing.T) {
+	cases := []struct {
+		assertion      string
+		attachmentData []byte
+		attachment     *Attachment
+	}{
+		{
+			"empty attachment",
+			[]byte{},
+			&Attachment{
+				LogTime:    0,
+				CreateTime: 0,
+				Name:       "empty",
+				MediaType:  "mediaType",
+				DataSize:   0,
+			},
+		},
+		{
+			"nonempty attachment",
+			[]byte{0x01, 0x02, 0x03, 0x04},
+			&Attachment{
+				LogTime:    0,
+				CreateTime: 0,
+				Name:       "nonempty",
+				MediaType:  "media",
+				DataSize:   4,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			c.attachment.Data = bytes.NewReader(c.attachmentData)
+			file := &bytes.Buffer{}
+			writer, err := NewWriter(file, &WriterOptions{})
+			assert.Nil(t, err)
+			assert.Nil(t, writer.WriteHeader(&Header{
+				Profile: "",
+				Library: "",
+			}))
+			assert.Nil(t, writer.WriteAttachment(c.attachment))
+			assert.Nil(t, writer.Close())
+
+			var called bool
+			lexer, err := NewLexer(file, &LexerOptions{
+				ComputeAttachmentCRCs: true,
+				AttachmentCallback: func(ar *AttachmentReader) error {
+					assert.Equal(t, c.attachment.LogTime, ar.LogTime)
+					assert.Equal(t, c.attachment.CreateTime, ar.CreateTime)
+					assert.Equal(t, c.attachment.Name, ar.Name)
+					assert.Equal(t, c.attachment.MediaType, ar.MediaType)
+					data, err := io.ReadAll(ar.Data())
+					assert.Nil(t, err)
+					assert.Equal(t, c.attachmentData, data)
+					computedCRC, err := ar.ComputedCRC()
+					assert.Nil(t, err)
+					parsedCRC, err := ar.ParsedCRC()
+					assert.Nil(t, err)
+					assert.Equal(t, computedCRC, parsedCRC)
+					called = true
+					return nil
+				},
+			})
+
+			for !errors.Is(err, io.EOF) {
+				_, _, err = lexer.Next(nil)
+				if !errors.Is(err, io.EOF) {
+					assert.Nil(t, err)
+				}
+			}
+			assert.True(t, called)
+		})
+	}
 }
 
 func TestChunkEmission(t *testing.T) {
@@ -329,16 +395,14 @@ func TestChunkEmission(t *testing.T) {
 						footer(),
 					)
 					lexer, err := NewLexer(bytes.NewReader(file), &LexerOptions{
-						ValidateCRC: validateCRC,
-						EmitChunks:  true,
+						ValidateChunkCRCs: validateCRC,
+						EmitChunks:        true,
 					})
 					assert.Nil(t, err)
 					expected := []TokenType{
 						TokenHeader,
 						TokenChunk,
 						TokenChunk,
-						TokenAttachment,
-						TokenAttachment,
 						TokenFooter,
 					}
 					for i, expectedTokenType := range expected {
@@ -385,7 +449,7 @@ func BenchmarkLexer(b *testing.B) {
 					var tokens, bytecount int64
 					reader.Reset(input)
 					lexer, err := NewLexer(reader, &LexerOptions{
-						ValidateCRC: validateCRC,
+						ValidateChunkCRCs: validateCRC,
 					})
 					assert.Nil(b, err)
 					for {

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -1,8 +1,10 @@
 package mcap
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 )
 
@@ -218,8 +220,60 @@ type Attachment struct {
 	CreateTime uint64
 	Name       string
 	MediaType  string
-	Data       []byte
-	CRC        uint32
+	DataSize   uint64
+	Data       io.Reader
+}
+
+// AttachmentReader represents an attachment for handling in a streaming manner.
+type AttachmentReader struct {
+	LogTime    uint64
+	CreateTime uint64
+	Name       string
+	MediaType  string
+	DataSize   uint64
+
+	data       *io.LimitedReader
+	baseReader io.Reader
+	crcReader  *crcReader
+	crc        *uint32
+}
+
+// ComputedCRC discards any remaining data in the Data portion of the
+// AttachmentReader, then returns the checksum computed from the fields of the
+// attachment up to the CRC. If it is called before the data portion of the
+// reader has been fully consumed, an error will be returned. If the
+// AttachmentReader has been created with a crcReader that is instructed not to
+// compute the CRC, this will return a CRC of zero.
+func (ar *AttachmentReader) ComputedCRC() (uint32, error) {
+	if ar.data.N > 0 {
+		return 0, fmt.Errorf("attachment CRC requested with unhandled data")
+	}
+	return ar.crcReader.Checksum(), nil
+}
+
+// ParsedCRC returns the CRC from the crc field of the record. It must be called
+// after the data field has been handled. If ParsedCRC is called before the data
+// reader is exhausted, an error is returned.
+func (ar *AttachmentReader) ParsedCRC() (uint32, error) {
+	if ar.crc != nil {
+		return *ar.crc, nil
+	}
+	if ar.data.N > 0 {
+		return 0, fmt.Errorf("attachment CRC requested with unhandled data")
+	}
+	buf := make([]byte, 4)
+	_, err := io.ReadFull(ar.baseReader, buf)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read CRC: %w", err)
+	}
+	crc := binary.LittleEndian.Uint32(buf)
+	ar.crc = &crc
+	return crc, nil
+}
+
+// Data returns a reader over the data section of the attachment.
+func (ar *AttachmentReader) Data() io.Reader {
+	return ar.data
 }
 
 // AttachmentIndex records contain the location of attachments in the file. An

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -10,7 +10,7 @@ import (
 	"github.com/foxglove/mcap/go/mcap/readopts"
 )
 
-func readPrefixedString(data []byte, offset int) (s string, newoffset int, err error) {
+func getPrefixedString(data []byte, offset int) (s string, newoffset int, err error) {
 	if len(data[offset:]) < 4 {
 		return "", 0, io.ErrShortBuffer
 	}
@@ -21,7 +21,7 @@ func readPrefixedString(data []byte, offset int) (s string, newoffset int, err e
 	return string(data[offset+4 : offset+length+4]), offset + 4 + length, nil
 }
 
-func readPrefixedBytes(data []byte, offset int) (s []byte, newoffset int, err error) {
+func getPrefixedBytes(data []byte, offset int) (s []byte, newoffset int, err error) {
 	if len(data[offset:]) < 4 {
 		return nil, 0, io.ErrShortBuffer
 	}
@@ -32,7 +32,7 @@ func readPrefixedBytes(data []byte, offset int) (s []byte, newoffset int, err er
 	return data[offset+4 : offset+length+4], offset + 4 + length, nil
 }
 
-func readPrefixedMap(data []byte, offset int) (result map[string]string, newoffset int, err error) {
+func getPrefixedMap(data []byte, offset int) (result map[string]string, newoffset int, err error) {
 	var key, value string
 	var inset int
 	m := make(map[string]string)
@@ -41,11 +41,11 @@ func readPrefixedMap(data []byte, offset int) (result map[string]string, newoffs
 		return nil, 0, fmt.Errorf("failed to read map length: %w", err)
 	}
 	for uint32(offset+inset) < uint32(offset)+maplen {
-		key, inset, err = readPrefixedString(data[offset:], inset)
+		key, inset, err = getPrefixedString(data[offset:], inset)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to read map key: %w", err)
 		}
-		value, inset, err = readPrefixedString(data[offset:], inset)
+		value, inset, err = getPrefixedString(data[offset:], inset)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to read map value: %w", err)
 		}

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -107,7 +107,7 @@ func TestReadPrefixedBytes(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
-			s, off, err := readPrefixedBytes(c.data, 0)
+			s, off, err := getPrefixedBytes(c.data, 0)
 			assert.ErrorIs(t, c.expectedError, err)
 			assert.Equal(t, c.expectedBytes, s)
 			assert.Equal(t, c.expectedOffset, off)
@@ -169,7 +169,7 @@ func TestReadPrefixedMap(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
-			output, offset, err := readPrefixedMap(c.input, 0)
+			output, offset, err := getPrefixedMap(c.input, 0)
 			assert.ErrorIs(t, err, c.err)
 			assert.Equal(t, offset, c.newOffset)
 			assert.Equal(t, output, c.output)
@@ -209,7 +209,7 @@ func TestReadPrefixedString(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
-			s, off, err := readPrefixedString(c.data, 0)
+			s, off, err := getPrefixedString(c.data, 0)
 			assert.ErrorIs(t, c.expectedError, err)
 			assert.Equal(t, c.expectedString, s)
 			assert.Equal(t, c.expectedOffset, off)
@@ -484,6 +484,7 @@ func TestMCAPInfo(t *testing.T) {
 			[]*Attachment{
 				{
 					Name: "my attachment",
+					Data: &bytes.Buffer{},
 				},
 			},
 		},

--- a/go/mcap/testutils.go
+++ b/go/mcap/testutils.go
@@ -142,7 +142,15 @@ func record(op OpCode) []byte {
 }
 
 func attachment() []byte {
-	buf := make([]byte, 9)
+	recordLen := 9 + // opcode + record length
+		8 + // record time
+		8 + // create time
+		4 + // attachment name length
+		4 + // media type length
+		8 + // data size
+		4 // crc length
+	buf := make([]byte, recordLen)
 	buf[0] = byte(OpAttachment)
+	putUint64(buf[1:], uint64(recordLen-9))
 	return buf
 }

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"math"
 	"sort"
@@ -15,6 +14,10 @@ import (
 
 // ErrUnknownSchema is returned when a schema ID is not known to the writer.
 var ErrUnknownSchema = errors.New("unknown schema")
+
+// ErrAttachmentDataSizeIncorrect is returned when the length of a written
+// attachment does not match the length supplied.
+var ErrAttachmentDataSizeIncorrect = errors.New("attachment content length incorrect")
 
 // Writer is a writer for the MCAP format.
 type Writer struct {
@@ -245,27 +248,55 @@ func (w *Writer) WriteMessageIndex(idx *MessageIndex) error {
 // contain auxiliary artifacts such as text, core dumps, calibration data, or
 // other arbitrary data. Attachment records must not appear within a chunk.
 func (w *Writer) WriteAttachment(a *Attachment) error {
-	msglen := 4 + len(a.Name) + 8 + 8 + 4 + len(a.MediaType) + 8 + len(a.Data) + 4
-	w.ensureSized(msglen)
-	offset := putUint64(w.msg, a.LogTime)
-	offset += putUint64(w.msg[offset:], a.CreateTime)
-	offset += putPrefixedString(w.msg[offset:], a.Name)
-	offset += putPrefixedString(w.msg[offset:], a.MediaType)
-	offset += putUint64(w.msg[offset:], uint64(len(a.Data)))
-	offset += copy(w.msg[offset:], a.Data)
-	crc := crc32.ChecksumIEEE(w.msg[:offset])
-	offset += putUint32(w.msg[offset:], crc)
-	attachmentOffset := w.w.Size()
-	c, err := w.writeRecord(w.w, OpAttachment, w.msg[:offset])
+	bufferLen := 1 + // opcode
+		8 + // record length
+		8 + // log time
+		8 + // create time
+		4 + len(a.Name) + // name
+		4 + len(a.MediaType) + // media type
+		8 // content length
+	w.ensureSized(bufferLen)
+
+	offset, err := putByte(w.msg, byte(OpAttachment))
 	if err != nil {
 		return err
 	}
+	offset += putUint64(w.msg[offset:], uint64(bufferLen)+a.DataSize+4-9)
+	offset += putUint64(w.msg[offset:], a.LogTime)
+	offset += putUint64(w.msg[offset:], a.CreateTime)
+	offset += putPrefixedString(w.msg[offset:], a.Name)
+	offset += putPrefixedString(w.msg[offset:], a.MediaType)
+	offset += putUint64(w.msg[offset:], a.DataSize)
+
+	attachmentOffset := w.w.Size()
+	// leading 9 bytes not included in CRC
+	_, err = w.w.Write(w.msg[:9])
+	if err != nil {
+		return err
+	}
+	crcWriter := newCRCWriter(w.w)
+	_, err = crcWriter.Write(w.msg[9:offset])
+	if err != nil {
+		return fmt.Errorf("failed to write attachment metadata: %w", err)
+	}
+	bytesWritten, err := io.Copy(crcWriter, a.Data)
+	if err != nil {
+		return fmt.Errorf("failed to write attachment data: %w", err)
+	}
+	if uint64(bytesWritten) != a.DataSize {
+		return ErrAttachmentDataSizeIncorrect
+	}
+	putUint32(w.msg[:4], crcWriter.Checksum())
+	_, err = w.w.Write(w.msg[:4])
+	if err != nil {
+		return fmt.Errorf("failed to write attachment crc: %w", err)
+	}
 	w.AttachmentIndexes = append(w.AttachmentIndexes, &AttachmentIndex{
 		Offset:     attachmentOffset,
-		Length:     uint64(c),
+		Length:     uint64(bufferLen) + a.DataSize + 4,
 		LogTime:    a.LogTime,
 		CreateTime: a.CreateTime,
-		DataSize:   uint64(len(a.Data)),
+		DataSize:   a.DataSize,
 		Name:       a.Name,
 		MediaType:  a.MediaType,
 	})


### PR DESCRIPTION
Adds support for streaming reads and writes of attachment data. With this change, ParseAttachment is dropped as a public function and replaced with a private function, parseAttachmentReader.

A new type AttachmentReader is exposed, which exposes the Data portion of an attachment as a reader that can be streamed. The Attachment type is modified to include a new ContentLength field, to allow the writer to write the attachment length before stream processing the body.

A new option, AttachmentCallback, is exposed in the Lexer. Rather than emitting attachments, the Lexer now parses an attachment reader and calls the supplied callback (if supplied), and consumes any unconsumed bytes from the attachment record (whether or not a callback is supplied).

This is a breaking change in the Go SDK, and introduces some awkwardness due to the presence of the new ContentLength field in the Attachment record. In the specification, that value is folded into the Data field, however this is not a tenable approach for stream handling. The actual binary format is not affected by this - only the way in which the binary format is described.

This change is required for readers and writers to be able to handle attachments bigger than available RAM. Without it, attaching a sufficiently large attachment will crash the reader/writer with an OOM.

**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->


**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
