### PR TITLE
remove .lfsconfig

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,6 +1,0 @@
-[lfs]
-    # Specify the server to use when pulling Git LFS assets.
-    # This is here to work around a bug in the Swift Package Manager which prevents
-    # it from installing packages when the source repository uses Git LFS.
-    # https://forums.swift.org/t/swiftpm-with-git-lfs/42396/4
-    url = https://github.com/foxglove/mcap.git/info/lfs


### PR DESCRIPTION

This is messing with users' ability to clone using a pure SSH-based authentication method. The `.lfsconfig` file was originally introduced to fix a SwiftPM issue, but this can be mitigated by using `GIT_LFS_IGNORE_DOWNLOAD_ERRORS=1` during the build process on the client side.


<!-- link relevant GitHub issues -->
Fixes #734 