### PR TITLE
Go: address goroutine leak when lexing zstd-compressed mcap

### DIFF
--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -77,6 +77,7 @@ var getAttachmentCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to construct reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to get mcap info: %w", err)

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -192,6 +192,7 @@ var catCmd = &cobra.Command{
 			if err != nil {
 				die("Failed to create reader: %s", err)
 			}
+			defer reader.Close()
 			it, err := reader.Messages(getReadOpts(false)...)
 			if err != nil {
 				die("Failed to read messages: %s", err)
@@ -213,6 +214,7 @@ var catCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to create reader: %w", err)
 			}
+			defer reader.Close()
 			it, err := reader.Messages(getReadOpts(true)...)
 			if err != nil {
 				return fmt.Errorf("failed to read messages: %w", err)

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -32,6 +32,7 @@ func TestCat(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			reader, err := mcap.NewReader(r)
 			assert.Nil(t, err)
+			defer reader.Close()
 			it, err := reader.Messages()
 			assert.Nil(t, err)
 			err = printMessages(ctx, w, it, false)
@@ -64,6 +65,7 @@ func BenchmarkCat(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				reader, err := mcap.NewReader(r)
 				assert.Nil(b, err)
+				defer reader.Close()
 				it, err := reader.Messages()
 				assert.Nil(b, err)
 				err = printMessages(ctx, w, it, c.formatJSON)

--- a/go/cli/mcap/cmd/channels.go
+++ b/go/cli/mcap/cmd/channels.go
@@ -55,6 +55,7 @@ var channelsCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to get info: %w", err)

--- a/go/cli/mcap/cmd/chunks.go
+++ b/go/cli/mcap/cmd/chunks.go
@@ -57,6 +57,7 @@ var chunksCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to get info: %w", err)

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -113,6 +113,7 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 		doctor.error("Failed to make lexer for chunk bytes", err)
 		return
 	}
+	defer lexer.Close()
 
 	var minLogTime uint64 = math.MaxUint64
 	var maxLogTime uint64
@@ -216,6 +217,7 @@ func (doctor *mcapDoctor) Examine() error {
 	if err != nil {
 		doctor.fatal(err)
 	}
+	defer lexer.Close()
 
 	var lastMessageTime uint64
 	var lastToken mcap.TokenType

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -164,6 +164,7 @@ func TestFiltering(t *testing.T) {
 				},
 			})
 			assert.Nil(t, err)
+			defer lexer.Close()
 			messageCounter := map[uint16]int{
 				1: 0,
 				2: 0,
@@ -219,6 +220,7 @@ func TestRecover(t *testing.T) {
 			},
 		})
 		assert.Nil(t, err)
+		defer lexer.Close()
 		for {
 			token, record, err := lexer.Next(nil)
 			if err != nil {

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -148,6 +148,7 @@ var infoCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to get info: %w", err)

--- a/go/cli/mcap/cmd/merge.go
+++ b/go/cli/mcap/cmd/merge.go
@@ -163,6 +163,7 @@ func (m *mcapMerger) mergeInputs(w io.Writer, inputs []io.Reader) error {
 		if err != nil {
 			return err
 		}
+		defer reader.Close()
 		profiles[inputID] = reader.Header().Profile
 		iterator, err := reader.Messages(readopts.UsingIndex(false))
 		if err != nil {

--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -64,6 +64,7 @@ func TestMCAPMerging(t *testing.T) {
 		assert.Equal(t, 100, messages["/foo"])
 		assert.Equal(t, 100, messages["/bar"])
 		assert.Equal(t, 100, messages["/baz"])
+		reader.Close()
 	}
 }
 
@@ -81,6 +82,7 @@ func TestMultiChannelInput(t *testing.T) {
 	assert.Nil(t, merger.mergeInputs(output, []io.Reader{multiChannelInput, buf3}))
 	reader, err := mcap.NewReader(output)
 	assert.Nil(t, err)
+	defer reader.Close()
 	assert.Equal(t, reader.Header().Profile, "testprofile")
 	it, err := reader.Messages(readopts.UsingIndex(false))
 	assert.Nil(t, err)

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -83,6 +83,7 @@ var listMetadataCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to build mcap reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to read info: %w", err)
@@ -154,6 +155,7 @@ var getMetadataCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to build reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to collect mcap info: %w", err)

--- a/go/cli/mcap/cmd/schemas.go
+++ b/go/cli/mcap/cmd/schemas.go
@@ -107,6 +107,7 @@ var schemasCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)
 			}
+			defer reader.Close()
 			info, err := reader.Info()
 			if err != nil {
 				return fmt.Errorf("failed to get info: %w", err)

--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb
 	github.com/foxglove/mcap/go/ros v0.0.0-20220630160308-e6a1f32d08fa
-	github.com/klauspost/compress v1.15.10
+	github.com/klauspost/compress v1.15.12
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pierrec/lz4/v4 v4.1.16

--- a/go/cli/mcap/go.sum
+++ b/go/cli/mcap/go.sum
@@ -301,6 +301,8 @@ github.com/klauspost/compress v1.15.7 h1:7cgTQxJCU/vy+oP/E3B9RGbQTgbiVzIJWIKOLoA
 github.com/klauspost/compress v1.15.7/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.15.10 h1:Ai8UzuomSCDw90e1qNMtb15msBXsNpH6gzkkENQNcJo=
 github.com/klauspost/compress v1.15.10/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -145,6 +145,7 @@ func RewriteMCAP(w io.Writer, r io.ReadSeeker, fns ...func(writer *mcap.Writer) 
 	if err != nil {
 		return fmt.Errorf("failed to open mcap reader: %w", err)
 	}
+	defer reader.Close()
 	info, err := reader.Info()
 	if err != nil {
 		return fmt.Errorf("failed to get mcap info")
@@ -180,6 +181,7 @@ func RewriteMCAP(w io.Writer, r io.ReadSeeker, fns ...func(writer *mcap.Writer) 
 	if err != nil {
 		return fmt.Errorf("failed to construct lexer: %w", err)
 	}
+	defer lexer.Close()
 	buf := make([]byte, 1024)
 	schemas := make(map[uint16]bool)
 	channels := make(map[uint16]bool)

--- a/go/mcap/go.mod
+++ b/go/mcap/go.mod
@@ -3,7 +3,7 @@ module github.com/foxglove/mcap/go/mcap
 go 1.18
 
 require (
-	github.com/klauspost/compress v1.14.1
+	github.com/klauspost/compress v1.15.12
 	github.com/pierrec/lz4/v4 v4.1.12
 	github.com/stretchr/testify v1.7.0
 )

--- a/go/mcap/go.sum
+++ b/go/mcap/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/klauspost/compress v1.14.1 h1:hLQYb23E8/fO+1u53d02A97a8UnsddcvYzq4ERRU4ds=
 github.com/klauspost/compress v1.14.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/pierrec/lz4/v4 v4.1.12 h1:44l88ehTZAUGW4VlO1QC4zkilL99M6Y9MXNwEs0uzP8=
 github.com/pierrec/lz4/v4 v4.1.12/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go/mcap/lexer.go
+++ b/go/mcap/lexer.go
@@ -296,6 +296,13 @@ func (l *Lexer) Next(p []byte) (TokenType, []byte, error) {
 	}
 }
 
+// Close the lexer.
+func (l *Lexer) Close() {
+	if l.decoders.zstd != nil {
+		l.decoders.zstd.Close()
+	}
+}
+
 type decoders struct {
 	zstd *zstd.Decoder
 	lz4  *lz4.Reader

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -147,6 +147,8 @@ func (r *Reader) Header() *Header {
 	return r.header
 }
 
+// Info scans the summary section to form a structure describing characteristics
+// of the underlying mcap file.
 func (r *Reader) Info() (*Info, error) {
 	it := r.indexedMessageIterator(nil, 0, math.MaxUint64, readopts.FileOrder)
 	err := it.parseSummarySection()
@@ -165,6 +167,11 @@ func (r *Reader) Info() (*Info, error) {
 	}, nil
 }
 
+// Close the reader.
+func (r *Reader) Close() {
+	r.l.Close()
+}
+
 func NewReader(r io.Reader) (*Reader, error) {
 	var rs io.ReadSeeker
 	if readseeker, ok := r.(io.ReadSeeker); ok {
@@ -176,6 +183,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer lexer.Close()
 	token, headerData, err := lexer.Next(nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not read MCAP header when opening reader: %w", err)

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -24,6 +24,7 @@ func TestMCAPReadWrite(t *testing.T) {
 		assert.Nil(t, err)
 		lexer, err := NewLexer(buf)
 		assert.Nil(t, err)
+		defer lexer.Close()
 		tokenType, record, err := lexer.Next(nil)
 		assert.Nil(t, err)
 		// body of the header is the profile, followed by the metadata map
@@ -195,6 +196,7 @@ func TestChunkedReadWrite(t *testing.T) {
 			assert.Equal(t, int(w.Offset()), buf.Len())
 			lexer, err := NewLexer(buf)
 			assert.Nil(t, err)
+			defer lexer.Close()
 			for i, expected := range []TokenType{
 				TokenHeader,
 				TokenSchema,
@@ -461,6 +463,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 
 	lexer, err := NewLexer(buf)
 	assert.Nil(t, err)
+	defer lexer.Close()
 	for _, expected := range []TokenType{
 		TokenHeader,
 		TokenSchema,
@@ -506,6 +509,7 @@ func TestLibraryString(t *testing.T) {
 			w.Close()
 			lexer, err := NewLexer(buf)
 			assert.Nil(t, err)
+			defer lexer.Close()
 			tokenType, record, err := lexer.Next(nil)
 			assert.Nil(t, err)
 			assert.Equal(t, tokenType, TokenHeader)

--- a/go/ros/go.mod
+++ b/go/ros/go.mod
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/klauspost/compress v1.14.1 // indirect
+	github.com/klauspost/compress v1.15.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go/ros/go.sum
+++ b/go/ros/go.sum
@@ -4,6 +4,8 @@ github.com/foxglove/mcap/go/mcap v0.0.0-20220316142927-cc81709134cd h1:IG8HSe6kk
 github.com/foxglove/mcap/go/mcap v0.0.0-20220316142927-cc81709134cd/go.mod h1:gQrB8PzccHW69xedSZ0uVDQVgDd3h1qX+otbS6fjSkE=
 github.com/klauspost/compress v1.14.1 h1:hLQYb23E8/fO+1u53d02A97a8UnsddcvYzq4ERRU4ds=
 github.com/klauspost/compress v1.14.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/mattn/go-sqlite3 v1.14.11 h1:gt+cp9c0XGqe9S/wAHTL3n/7MqY+siPWgWJgqdsFrzQ=
 github.com/mattn/go-sqlite3 v1.14.11/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pierrec/lz4/v4 v4.1.12 h1:44l88ehTZAUGW4VlO1QC4zkilL99M6Y9MXNwEs0uzP8=


### PR DESCRIPTION
Adds Close() methods to the Lexer and Reader types. These are required to avoid a goroutine leak when working with zstd-compressed files.

Fixes: https://github.com/foxglove/mcap/issues/748