### PR TITLE
CLI: display small byte values with human-readable units

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -25,6 +25,16 @@ func decimalTime(t time.Time) string {
 	return fmt.Sprintf("%d.%09d", seconds, nanoseconds)
 }
 
+func humanBytes(numBytes uint64) string {
+	prefixes := []string{"B", "KiB", "MiB", "GiB"}
+	displayedValue := float64(numBytes)
+	prefixIndex := 0
+	for ; displayedValue > 1024 && prefixIndex < len(prefixes); prefixIndex++ {
+		displayedValue = displayedValue / 1024
+	}
+	return fmt.Sprintf("%.2f %s", displayedValue, prefixes[prefixIndex])
+}
+
 func printInfo(w io.Writer, info *mcap.Info) error {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "library: %s\n", info.Header.Library)
@@ -65,10 +75,10 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		for k, v := range compressionFormatStats {
 			compressionRatio := 100 * (1 - float64(v.compressedSize)/float64(v.uncompressedSize))
 			fmt.Fprintf(buf, "\t%s: [%d/%d chunks] ", k, v.count, chunkCount)
-			fmt.Fprintf(buf, "[%.2d MB/%.2d MB (%.2f%%)] ",
-				(v.uncompressedSize / (1024 * 1024)), (v.compressedSize / (1024 * 1024)), compressionRatio)
+			fmt.Fprintf(buf, "[%s/%s (%.2f%%)] ",
+				humanBytes(v.uncompressedSize), humanBytes(v.compressedSize), compressionRatio)
 			if durationInSeconds > 0 {
-				fmt.Fprintf(buf, "[%.2f MB/sec] ", float64(v.compressedSize/(1024*1024))/durationInSeconds)
+				fmt.Fprintf(buf, "[%s/sec] ", humanBytes(v.compressedSize/uint64(durationInSeconds)))
 			}
 			fmt.Fprintf(buf, "\n")
 		}


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
Instead of only displaying megabytes in info, this PR allows `info` to dynamically determine the byte unit based on the magnitude of the value.

Before:
```
j@192-168-1-108 mcap % mcap info ../../../rosbag2_2022_11_02-17_25_22_0.mcap
library: libmcap 0.2.0
profile: ros2
messages: 1677
duration: 4.276683915s
start: 2022-11-03T11:25:22.944598562+11:00 (1667435122.944598562)
end: 2022-11-03T11:25:27.221282477+11:00 (1667435127.221282477)
compression:
        zstd: [565/565 chunks] [00 MB/00 MB (40.96%)] [0.00 MB/sec] 
channels:
        (1) /parameter_events    0 msgs (0.00 Hz)     : rcl_interfaces/msg/ParameterEvent [ros2msg]  
        (2) /rosout              6 msgs (1.40 Hz)     : rcl_interfaces/msg/Log [ros2msg]             
        (3) /qux               418 msgs (97.74 Hz)    : std_msgs/msg/Bool [ros2msg]                  
        (4) /foobar2           418 msgs (97.74 Hz)    : std_msgs/msg/String [ros2msg]                
        (5) /foobar            835 msgs (195.24 Hz)   : std_msgs/msg/String [ros2msg]                
attachments: 0
metadata: 0
```

after:
```
j@192-168-1-108 mcap % bin/mcap info ../../../rosbag2_2022_11_02-17_25_22_0.mcap
library: libmcap 0.2.0
profile: ros2
messages: 1677
duration: 4.276683915s
start: 2022-11-03T11:25:22.944598562+11:00 (1667435122.944598562)
end: 2022-11-03T11:25:27.221282477+11:00 (1667435127.221282477)
compression:
        zstd: [565/565 chunks] [80.75 KiB/47.68 KiB (40.96%)] [11.92 KiB/sec] 
channels:
        (1) /parameter_events    0 msgs (0.00 Hz)     : rcl_interfaces/msg/ParameterEvent [ros2msg]  
        (2) /rosout              6 msgs (1.40 Hz)     : rcl_interfaces/msg/Log [ros2msg]             
        (3) /qux               418 msgs (97.74 Hz)    : std_msgs/msg/Bool [ros2msg]                  
        (4) /foobar2           418 msgs (97.74 Hz)    : std_msgs/msg/String [ros2msg]                
        (5) /foobar            835 msgs (195.24 Hz)   : std_msgs/msg/String [ros2msg]                
attachments: 0
metadata: 0
```

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
Fixes https://github.com/foxglove/mcap/issues/699