### PR TITLE
Fix python and swift CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           cache: yarn
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: "5.6"
+          swift-version: "5.7"
       - run: swift build
       - run: yarn install --frozen-lockfile
       - run: yarn test:conformance:generate-inputs --verify
@@ -466,7 +466,7 @@ jobs:
           lfs: true
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: "5.6"
+          swift-version: "5.7"
       - run: docker run -t --rm -v $(pwd):/work -w /work ghcr.io/realm/swiftlint:0.49.1
       - run: docker run -t --rm -v $(pwd):/work ghcr.io/nicklockwood/swiftformat:0.49.18 --lint /work
       - run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-          cache: pipenv
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
       - run: pip install pipenv==2022.7.24

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-          cache: pipenv
       - name: Install pipenv
         run: pip install pipenv==2022.7.24
 
@@ -83,7 +82,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-          cache: pipenv
 
       - run: pip install pipenv
       - run: make -C python docs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: "5.6"
+          swift-version: "5.7"
 
       - run: mkdir __docs__
       - name: Generate Swift documentation


### PR DESCRIPTION
Two issues with CI as of yesterday:

### Swift actions

Swift actions have been failing because of some failure to fetch or verify GPG keys. Here's an example failure:
https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840
```
/usr/bin/gpg --import /home/runner/work/_temp/35480592-d4e3-464f-8d31-e52c069463d1
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key D441C977412B37AD: public key "Swift Automatic Signing Key #1 <swift-infrastructure@swift.org>" imported
gpg: key 9F[5](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:6)97F4D21A5[6](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:7)D5F: public key "Swift 2.2 Release Signing Key <swift-infrastructure@swift.org>" imported
gpg: key 63BC1CFE91D306C6: public key "Swift 3.x Release Signing Key <swift-infrastructure@swift.org>" imported
gpg: key EF5430F0[7](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:8)1E1B235: public key "Swift 4.x Release Signing Key <swift-infrastructure@swift.org>" imported
gpg: key 763[8](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:9)F1FB2B2B08C4: public key "Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>" imported
gpg: key [9](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:10)25CC1CCED3D1561: public key "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>" imported
gpg: key FAF6989E1BC16FEA: public key "Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>" imported
gpg: key 925CC1CCED3D1561: "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>" 1 new signature
gpg: key F167DF1ACF9CE069: public key "Swift Automatic Signing Key #4 <swift-infrastructure@forums.swift.org>" imported
gpg: Total number processed: 9
gpg:               imported: 8
gpg:         new signatures: 1
/usr/bin/gpg --keyserver hkp://keyserver.ubuntu.com --refresh-keys Swift
gpg: refreshing 8 keys from hkp://keyserver.ubuntu.com
gpg: key F167DF1ACF9CE069: "Swift Automatic Signing Key #4 <swift-infrastructure@forums.swift.org>" not changed
gpg: key FAF6989E1BC16FEA: "Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>" not changed
gpg: key 925CC1CCED3D1561: "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key 7638F1FB2B2B08C4: "Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>" not changed
gpg: key EF5430F071E1B235: "Swift 4.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key 63BC1CFE91D306C6: "Swift 3.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key 9F597F4D21A56D5F: "Swift 2.2 Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key D441C9774[12](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:13)B37AD: "Swift Automatic Signing Key #1 <swift-infrastructure@swift.org>" not changed
gpg: Total number processed: 8
gpg:              unchanged: 8
/usr/bin/gpg --verify /home/runner/work/_temp/928edf92-96c2-49c8-9ba9-4f81dc1bbb9a /home/runner/work/_temp/7e5a[15](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:16)2d-3ff9-404b-9452-9fe6[17](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:18)df[33](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220840#step:3:34)9f
gpg: no valid OpenPGP data found.
gpg: the signature could not be verified.
Please remember that the signature file (.sig or .asc)
should be the first file given on the command line.
```

Someone appears to have reported this issue upstream: https://github.com/swift-actions/setup-swift/issues/419

Bumping the swift version appears to cause CI to run successfully, but it's not clear why running 5.6 should not work.

### Python
Our strategy of with `cache: pipenv` appears to be flawed - here is a CI run failing because the virtualenv cannot be found:
https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.15/x64/bin/pipenv", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.7.[15](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:16)/x64/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/cli/options.py", line 56, in main
    return super().main(*args, **kwargs, windows_expand_args=False)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line [16](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:17)59, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/vendor/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/cli/command.py", line 253, in install
    site_packages=state.site_packages,
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/core.py", line [21](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:22)11, in do_install
    keep_outdated=keep_outdated,
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/core.py", line 1351, in do_init
    pypi_mirror=pypi_mirror,
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/core.py", line 875, in do_install_dependencies
    project, normal_deps, procs, failed_deps_queue, requirements_dir, **install_kwargs
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/core.py", line 734, in batch_install
    dep for dep in deps_to_install if not project.environment.is_satisfied(dep)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/core.py", line 734, in <listcomp>
    dep for dep in deps_to_install if not project.environment.is_satisfied(dep)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/project.py", line 302, in environment
    self._environment = self.get_environment(allow_global=allow_global)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/project.py", line [28](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:29)9, in get_environment
    project=self,
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/environment.py", line 72, in __init__
    self._base_paths = self.get_paths()
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/environment.py", line [39](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:40)4, in get_paths
    c = subprocess_run(command)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/pipenv/utils/processes.py", line 76, in subprocess_run
    args, universal_newlines=text, encoding=encoding, **other_kwargs
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/subprocess.py", line [48](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:49)8, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/subprocess.py", line 15[51](https://github.com/foxglove/mcap/actions/runs/3560853685/jobs/5981220624#step:7:52), in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/.local/share/virtualenvs/python--WAQ1xVa/bin/python': '/home/runner/.local/share/virtualenvs/python--WAQ1xVa/bin/python'
```
It's not obvious to me what's happening here - possibly we're caching some part of pipenv state but not some other part.