### PR TITLE
cpp: read messages in deterministic order, yield message offset in MessageView

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,6 +4,9 @@ default: build
 dev-image:
 	docker build -t mcap_cpp_dev -f dev.Dockerfile .
 
+dev-shell: dev-image
+	docker run --rm -v $(CURDIR):/src -it mcap_cpp_dev /bin/bash
+
 .PHONY: build
 build: dev-image
 	docker run -t --rm -v $(CURDIR):/src mcap_cpp_dev

--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/0.7.0"
+    requires = "benchmark/1.7.0", "mcap/0.8.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/0.7.0
+conan editable add ./mcap mcap/0.8.0
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/0.7.0
+conan editable add ./mcap mcap/0.8.0
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/0.7.0"
+    requires = "mcap/0.8.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/0.7.0",
+        "mcap/0.8.0",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "0.7.0"
+    version = "0.8.0"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -243,15 +243,6 @@ public:
    * `topicFilter` returns true for a given channel, messages from that channel will be included.
    * if not provided, messages from all channels are provided.
    */
-
-  /**
-   * @brief If provided, in forward order, messages with logTime == startTime
-   * will only be included if their offset in the file is after this offset.
-   * When reading in reverse order, messages with logTime == endTime will only be included
-   * if their offset if the file is before this offset.
-   */
-  std::optional<MessageOffset> messageOffsetTiebreaker = std::nullopt;
-
   std::function<bool(std::string_view)> topicFilter;
   enum struct ReadOrder { FileOrder, LogTimeOrder, ReverseLogTimeOrder };
   /**

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -591,7 +591,7 @@ private:
 struct MCAP_PUBLIC IndexedMessageReader {
 public:
   IndexedMessageReader(McapReader& reader, const ReadMessageOptions& options,
-                       const std::function<void(const Message&, MessageOffset)> onMessage);
+                       const std::function<void(const Message&, RecordOffset)> onMessage);
 
   /**
    * @brief reads the next message out of the MCAP.
@@ -623,7 +623,7 @@ private:
   LZ4Reader lz4Reader_;
   ReadMessageOptions options_;
   std::unordered_set<ChannelId> selectedChannels_;
-  std::function<void(const Message&, MessageOffset)> onMessage_;
+  std::function<void(const Message&, RecordOffset)> onMessage_;
   ReadJobQueue queue_;
   std::vector<ChunkSlot> chunkSlots_;
 };
@@ -676,7 +676,7 @@ struct MCAP_PUBLIC LinearMessageView {
       std::optional<MessageView> curMessageView_;
 
     private:
-      void onMessage(const Message& message, MessageOffset offset);
+      void onMessage(const Message& message, RecordOffset offset);
     };
 
     std::unique_ptr<Impl> impl_;

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1889,19 +1889,6 @@ bool IndexedMessageReader::next() {
                 if (timestamp > options_.endTime) {
                   continue;
                 }
-                if (options_.messageOffsetTiebreaker != std::nullopt) {
-                  MessageOffset thisMessageOffset{byteOffset, decompressChunkJob.chunkStartOffset};
-                  if ((timestamp == options_.endTime) &&
-                      (options_.readOrder == ReadMessageOptions::ReadOrder::ReverseLogTimeOrder) &&
-                      (thisMessageOffset >= *options_.messageOffsetTiebreaker)) {
-                    continue;
-                  }
-                  if ((timestamp == options_.startTime) &&
-                      (options_.readOrder != ReadMessageOptions::ReadOrder::ReverseLogTimeOrder) &&
-                      (thisMessageOffset <= *options_.messageOffsetTiebreaker)) {
-                    continue;
-                  }
-                }
                 ReadMessageJob job;
                 job.chunkReaderIndex = chunkReaderIndex;
                 job.offset = byteOffset;

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -349,6 +350,27 @@ struct MCAP_PUBLIC DataEnd {
   uint32_t dataSectionCrc;
 };
 
+struct MCAP_PUBLIC MessageOffset {
+  ByteOffset messageStartOffset;
+  std::optional<ByteOffset> chunkStartOffset;
+
+  bool operator==(const MessageOffset& other) const;
+  bool operator>(const MessageOffset& other) const;
+
+  bool operator!=(const MessageOffset& other) const {
+    return !(*this == other);
+  }
+  bool operator>=(const MessageOffset& other) const {
+    return ((*this == other) || (*this > other));
+  }
+  bool operator<(const MessageOffset& other) const {
+    return !(*this >= other);
+  }
+  bool operator<=(const MessageOffset& other) const {
+    return !(*this > other);
+  }
+};
+
 /**
  * @brief Returned when iterating over Messages in a file, MessageView contains
  * a reference to one Message, a pointer to its Channel, and an optional pointer
@@ -359,11 +381,14 @@ struct MCAP_PUBLIC MessageView {
   const Message& message;
   const ChannelPtr channel;
   const SchemaPtr schema;
+  const MessageOffset messageOffset;
 
-  MessageView(const Message& message, const ChannelPtr channel, const SchemaPtr schema)
+  MessageView(const Message& message, const ChannelPtr channel, const SchemaPtr schema,
+              MessageOffset offset)
       : message(message)
       , channel(channel)
-      , schema(schema) {}
+      , schema(schema)
+      , messageOffset(offset) {}
 };
 
 }  // namespace mcap

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -354,6 +354,13 @@ struct MCAP_PUBLIC RecordOffset {
   ByteOffset offset;
   std::optional<ByteOffset> chunkOffset;
 
+  RecordOffset() = default;
+  explicit RecordOffset(ByteOffset offset_)
+      : offset(offset_){};
+  RecordOffset(ByteOffset offset_, ByteOffset chunkOffset_)
+      : offset(offset_)
+      , chunkOffset(chunkOffset_){};
+
   bool operator==(const RecordOffset& other) const;
   bool operator>(const RecordOffset& other) const;
 

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -350,23 +350,23 @@ struct MCAP_PUBLIC DataEnd {
   uint32_t dataSectionCrc;
 };
 
-struct MCAP_PUBLIC MessageOffset {
-  ByteOffset messageStartOffset;
-  std::optional<ByteOffset> chunkStartOffset;
+struct MCAP_PUBLIC RecordOffset {
+  ByteOffset offset;
+  std::optional<ByteOffset> chunkOffset;
 
-  bool operator==(const MessageOffset& other) const;
-  bool operator>(const MessageOffset& other) const;
+  bool operator==(const RecordOffset& other) const;
+  bool operator>(const RecordOffset& other) const;
 
-  bool operator!=(const MessageOffset& other) const {
+  bool operator!=(const RecordOffset& other) const {
     return !(*this == other);
   }
-  bool operator>=(const MessageOffset& other) const {
+  bool operator>=(const RecordOffset& other) const {
     return ((*this == other) || (*this > other));
   }
-  bool operator<(const MessageOffset& other) const {
+  bool operator<(const RecordOffset& other) const {
     return !(*this >= other);
   }
-  bool operator<=(const MessageOffset& other) const {
+  bool operator<=(const RecordOffset& other) const {
     return !(*this > other);
   }
 };
@@ -381,10 +381,10 @@ struct MCAP_PUBLIC MessageView {
   const Message& message;
   const ChannelPtr channel;
   const SchemaPtr schema;
-  const MessageOffset messageOffset;
+  const RecordOffset messageOffset;
 
   MessageView(const Message& message, const ChannelPtr channel, const SchemaPtr schema,
-              MessageOffset offset)
+              RecordOffset offset)
       : message(message)
       , channel(channel)
       , schema(schema)

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "0.7.0"
+#define MCAP_LIBRARY_VERSION "0.8.0"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/mcap/include/mcap/types.inl
+++ b/cpp/mcap/include/mcap/types.inl
@@ -44,4 +44,43 @@ MetadataIndex::MetadataIndex(const Metadata& metadata, ByteOffset fileOffset)
     , length(9 + 4 + metadata.name.size() + 4 + internal::KeyValueMapSize(metadata.metadata))
     , name(metadata.name) {}
 
+bool MessageOffset::operator==(const MessageOffset& other) const {
+  if (chunkStartOffset != std::nullopt && other.chunkStartOffset != std::nullopt) {
+    if (*chunkStartOffset != *other.chunkStartOffset) {
+      // messages are in separate chunks, cannot be equal.
+      return false;
+    }
+    // messages are in the same chunk, compare chunk-level offsets.
+    return (messageStartOffset == other.messageStartOffset);
+  }
+  if (chunkStartOffset != std::nullopt || other.chunkStartOffset != std::nullopt) {
+    // one message is in a chunk and one is not, cannot be equal.
+    return false;
+  }
+  // neither message is in a chunk, compare file-level offsets.
+  return (messageStartOffset == other.messageStartOffset);
+}
+
+bool MessageOffset::operator>(const MessageOffset& other) const {
+  if (chunkStartOffset != std::nullopt) {
+    if (other.chunkStartOffset != std::nullopt) {
+      if (*chunkStartOffset == *other.chunkStartOffset) {
+        // messages are in the same chunk, compare chunk-level offsets.
+        return (messageStartOffset > other.messageStartOffset);
+      }
+      // messages are in separate chunks, compare file-level offsets
+      return (*chunkStartOffset > *other.chunkStartOffset);
+    } else {
+      // this message is in a chunk, other is not, compare file-level offsets.
+      return (*chunkStartOffset > other.messageStartOffset);
+    }
+  }
+  if (other.chunkStartOffset != std::nullopt) {
+    // other messsage is in a chunk, this is not, compare file-level offsets.
+    return (messageStartOffset > *other.chunkStartOffset);
+  }
+  // neither message is in a chunk, compare file-level offsets.
+  return (messageStartOffset > other.messageStartOffset);
+}
+
 }  // namespace mcap

--- a/cpp/mcap/include/mcap/types.inl
+++ b/cpp/mcap/include/mcap/types.inl
@@ -44,43 +44,43 @@ MetadataIndex::MetadataIndex(const Metadata& metadata, ByteOffset fileOffset)
     , length(9 + 4 + metadata.name.size() + 4 + internal::KeyValueMapSize(metadata.metadata))
     , name(metadata.name) {}
 
-bool MessageOffset::operator==(const MessageOffset& other) const {
-  if (chunkStartOffset != std::nullopt && other.chunkStartOffset != std::nullopt) {
-    if (*chunkStartOffset != *other.chunkStartOffset) {
+bool RecordOffset::operator==(const RecordOffset& other) const {
+  if (chunkOffset != std::nullopt && other.chunkOffset != std::nullopt) {
+    if (*chunkOffset != *other.chunkOffset) {
       // messages are in separate chunks, cannot be equal.
       return false;
     }
     // messages are in the same chunk, compare chunk-level offsets.
-    return (messageStartOffset == other.messageStartOffset);
+    return (offset == other.offset);
   }
-  if (chunkStartOffset != std::nullopt || other.chunkStartOffset != std::nullopt) {
+  if (chunkOffset != std::nullopt || other.chunkOffset != std::nullopt) {
     // one message is in a chunk and one is not, cannot be equal.
     return false;
   }
   // neither message is in a chunk, compare file-level offsets.
-  return (messageStartOffset == other.messageStartOffset);
+  return (offset == other.offset);
 }
 
-bool MessageOffset::operator>(const MessageOffset& other) const {
-  if (chunkStartOffset != std::nullopt) {
-    if (other.chunkStartOffset != std::nullopt) {
-      if (*chunkStartOffset == *other.chunkStartOffset) {
+bool RecordOffset::operator>(const RecordOffset& other) const {
+  if (chunkOffset != std::nullopt) {
+    if (other.chunkOffset != std::nullopt) {
+      if (*chunkOffset == *other.chunkOffset) {
         // messages are in the same chunk, compare chunk-level offsets.
-        return (messageStartOffset > other.messageStartOffset);
+        return (offset > other.offset);
       }
       // messages are in separate chunks, compare file-level offsets
-      return (*chunkStartOffset > *other.chunkStartOffset);
+      return (*chunkOffset > *other.chunkOffset);
     } else {
       // this message is in a chunk, other is not, compare file-level offsets.
-      return (*chunkStartOffset > other.messageStartOffset);
+      return (*chunkOffset > other.offset);
     }
   }
-  if (other.chunkStartOffset != std::nullopt) {
+  if (other.chunkOffset != std::nullopt) {
     // other messsage is in a chunk, this is not, compare file-level offsets.
-    return (messageStartOffset > *other.chunkStartOffset);
+    return (offset > *other.chunkOffset);
   }
   // neither message is in a chunk, compare file-level offsets.
-  return (messageStartOffset > other.messageStartOffset);
+  return (offset > other.offset);
 }
 
 }  // namespace mcap

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/0.7.0", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/0.8.0", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -625,4 +625,59 @@ TEST_CASE("Read Order", "[reader][writer]") {
 
     reader.close();
   }
+  SECTION("total ordering fallback to offset (chunked)") {
+    Buffer buffer;
+
+    mcap::McapWriter writer;
+    mcap::McapWriterOptions opts("test");
+    opts.compression = mcap::Compression::None;
+    writer.open(buffer, opts);
+    mcap::Schema schema("schema", "schemaEncoding", "ab");
+    writer.addSchema(schema);
+    mcap::Channel channel("topic", "messageEncoding", schema.id);
+    writer.addChannel(channel);
+
+    mcap::Message msg;
+    std::vector<std::byte> data = {std::byte(1), std::byte(2), std::byte(3)};
+    WriteMsg(writer, channel.id, 0, 100, 100, data);
+    WriteMsg(writer, channel.id, 1, 100, 100, data);
+    WriteMsg(writer, channel.id, 2, 100, 100, data);
+    WriteMsg(writer, channel.id, 3, 300, 300, data);
+    WriteMsg(writer, channel.id, 4, 300, 300, data);
+    WriteMsg(writer, channel.id, 5, 300, 300, data);
+    WriteMsg(writer, channel.id, 6, 200, 200, data);
+    writer.close();
+
+    mcap::McapReader reader;
+    auto status = reader.open(buffer);
+    requireOk(status);
+
+    const auto onProblem = [](const mcap::Status& status) {
+      FAIL("Status " + std::to_string((int)status.code) + ": " + status.message);
+    };
+    mcap::ReadMessageOptions options;
+    options.startTime = 100;
+    options.endTime = 300;
+    options.messageOffsetTiebreaker = std::nullopt;
+    options.readOrder = mcap::ReadMessageOptions::ReadOrder::LogTimeOrder;
+    // with no tie breaker, messages should start with the first message in the time range.
+    auto firstMessageView = reader.readMessages(onProblem, options).begin();
+    REQUIRE(firstMessageView->message.sequence == 0);
+
+    // setting the tie breaker at the position of the first message, starting iteration again
+    // should yield the second message.
+    options.messageOffsetTiebreaker = firstMessageView->messageOffset;
+    REQUIRE(reader.readMessages(onProblem, options).begin()->message.sequence == 1);
+
+    // going in reverse now - with no tie breaker, messages should start with the last message
+    // in the time range.
+    options.messageOffsetTiebreaker = std::nullopt;
+    options.readOrder = mcap::ReadMessageOptions::ReadOrder::ReverseLogTimeOrder;
+    auto lastMessageView = reader.readMessages(onProblem, options).begin();
+    REQUIRE(lastMessageView->message.sequence == 5);
+    // using last message as tie breaker, iterating in reverse again, should start at the message
+    // before that one.
+    options.messageOffsetTiebreaker = lastMessageView->messageOffset;
+    REQUIRE(reader.readMessages(onProblem, options).begin()->message.sequence == 4);
+  }
 }

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -675,3 +675,143 @@ TEST_CASE("Read Order", "[reader][writer]") {
     REQUIRE(count == reverse_order_expected.size());
   }
 }
+
+TEST_CASE("RecordOffset equality operators", "[reader]") {
+  SECTION("equality") {
+    REQUIRE(mcap::RecordOffset(10) == mcap::RecordOffset(10));
+    REQUIRE(mcap::RecordOffset(10) != mcap::RecordOffset(20));
+
+    // record in chunk vs record not in chunk
+    REQUIRE(mcap::RecordOffset(10, 0) == mcap::RecordOffset(10, 0));
+    REQUIRE(mcap::RecordOffset(10, 0) != mcap::RecordOffset(10));
+    REQUIRE(mcap::RecordOffset(10) != mcap::RecordOffset(10, 0));
+
+    // records in different chunks with same offsets
+    REQUIRE(mcap::RecordOffset(10, 50) == mcap::RecordOffset(10, 50));
+    REQUIRE(mcap::RecordOffset(10, 50) != mcap::RecordOffset(10, 70));
+
+    // a nonexistent chunk offset is not the same as a zero chunk offset
+    REQUIRE(mcap::RecordOffset(10, 0) != mcap::RecordOffset(10));
+
+    // records in the same chunk with different internal offsets
+    REQUIRE(mcap::RecordOffset(10, 50) != mcap::RecordOffset(20, 50));
+  }
+  SECTION("inequality, non-equal records outside chunk") {
+    mcap::RecordOffset a(10);
+    mcap::RecordOffset b(20);
+
+    REQUIRE(a < b);
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(!(b <= a));
+
+    REQUIRE(!(a > b));
+    REQUIRE(b > a);
+
+    REQUIRE(!(a >= b));
+    REQUIRE(b >= a);
+  }
+
+  SECTION("inequality, equal records outside chunk") {
+    mcap::RecordOffset a(10);
+    mcap::RecordOffset b(10);
+
+    REQUIRE(!(a < b));
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(b <= a);
+
+    REQUIRE(!(a > b));
+    REQUIRE(!(b > a));
+
+    REQUIRE(a >= b);
+    REQUIRE(b >= a);
+  }
+
+  SECTION("inequality, non-equal records in same chunk") {
+    mcap::RecordOffset a(10, 30);
+    mcap::RecordOffset b(20, 30);
+
+    REQUIRE(a < b);
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(!(b <= a));
+
+    REQUIRE(!(a > b));
+    REQUIRE(b > a);
+
+    REQUIRE(!(a >= b));
+    REQUIRE(b >= a);
+  }
+
+  SECTION("inequality, equal records inside chunk") {
+    mcap::RecordOffset a(10, 30);
+    mcap::RecordOffset b(10, 30);
+
+    REQUIRE(!(a < b));
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(b <= a);
+
+    REQUIRE(!(a > b));
+    REQUIRE(!(b > a));
+
+    REQUIRE(a >= b);
+    REQUIRE(b >= a);
+  }
+
+  SECTION("inequality, non-equal records in same chunk") {
+    mcap::RecordOffset a(10, 30);
+    mcap::RecordOffset b(20, 30);
+
+    REQUIRE(a < b);
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(!(b <= a));
+
+    REQUIRE(!(a > b));
+    REQUIRE(b > a);
+
+    REQUIRE(!(a >= b));
+    REQUIRE(b >= a);
+  }
+
+  SECTION("inequality, equally-offsetted records in different chunks") {
+    mcap::RecordOffset a(10, 30);
+    mcap::RecordOffset b(10, 40);
+
+    REQUIRE(a < b);
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(!(b <= a));
+
+    REQUIRE(!(a > b));
+    REQUIRE(b > a);
+
+    REQUIRE(!(a >= b));
+    REQUIRE(b >= a);
+  }
+
+  SECTION("inequality, oppositely-offsetted records in different chunks") {
+    mcap::RecordOffset a(20, 30);
+    mcap::RecordOffset b(10, 40);
+
+    REQUIRE(a < b);
+    REQUIRE(!(b < a));
+
+    REQUIRE(a <= b);
+    REQUIRE(!(b <= a));
+
+    REQUIRE(!(a > b));
+    REQUIRE(b > a);
+
+    REQUIRE(!(a >= b));
+    REQUIRE(b >= a);
+  }
+}


### PR DESCRIPTION
This PR contains a few changes required to get the `rosbag2_storage_mcap` plugin to actually behave correctly with respect to message ordering and selecting messages by time range.

* Messages with the same timestamp are returned in the order of their position in the file. This is neccessary to have a well-defined return order from ReadMessages, since log timestamps are not required to be unique.
* `MessageView` includes a new "messageOffset" field, informing the reader of the returned messages' offset within the file. This allows readers to tell if a message returned from one iterator is the same message as returned from a different iterator.

## Testing
- [x] unit test added to test new read message order.
