### PR TITLE
Revert "ci.yml: pin pypa release action v1.5 (#764)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - run: make examples
       - run: make build
       - name: Publish mcap to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           user: __token__
@@ -278,7 +278,7 @@ jobs:
           skip_existing: true
 
       - name: Publish mcap-protobuf-support to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           user: __token__
@@ -288,7 +288,7 @@ jobs:
           packages_dir: python/mcap-protobuf-support/dist
 
       - name: Publish mcap-ros1-support to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           user: __token__
@@ -298,7 +298,7 @@ jobs:
           packages_dir: python/mcap-ros1-support/dist
 
       - name: Publish mcap-ros2-support to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           user: __token__
@@ -311,7 +311,7 @@ jobs:
         if: |
           !github.event.pull_request.head.repo.fork &&
           startsWith(github.ref, 'refs/tags/releases/python/mcap/v')
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -321,7 +321,7 @@ jobs:
         if: |
           !github.event.pull_request.head.repo.fork &&
           startsWith(github.ref, 'refs/tags/releases/python/mcap-protobuf-support/v')
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -331,7 +331,7 @@ jobs:
         if: |
           !github.event.pull_request.head.repo.fork &&
           startsWith(github.ref, 'refs/tags/releases/python/mcap-ros1-support/v')
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -341,7 +341,7 @@ jobs:
         if: |
           !github.event.pull_request.head.repo.fork &&
           startsWith(github.ref, 'refs/tags/releases/python/mcap-ros2-support/v')
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This reverts commit c0f67af1b391f75b49947d9e3302bca207b548d0.

https://github.com/pypa/gh-action-pypi-publish/issues/115 that caused this change is now fixed, can revert.
