### PR TITLE
Update bag2mcap

### DIFF
--- a/typescript/examples/bag2mcap/scripts/bag2mcap.ts
+++ b/typescript/examples/bag2mcap/scripts/bag2mcap.ts
@@ -237,11 +237,6 @@ async function convert(filePath: string, options: { indexed: boolean }) {
     library: "mcap typescript bag2proto",
   });
 
-  await mcapFile.addMetadata({
-    name: "original file info",
-    metadata: new Map([["path", mcapFilePath]]),
-  });
-
   const topicToDetailMap = new Map<string, TopicDetail>();
 
   for (const [, connection] of bag.connections) {


### PR DESCRIPTION
Remove original-file-path metadata. It isn't that useful or actionable if you get rid of the original file.