### PR TITLE
go: add compression level option to writer

### DIFF
--- a/go/cli/mcap/cmd/convert.go
+++ b/go/cli/mcap/cmd/convert.go
@@ -21,11 +21,12 @@ var (
 )
 
 var (
-	convertAmentPrefixPath string
-	convertCompression     string
-	convertChunkSize       int64
-	convertIncludeCRC      bool
-	convertChunked         bool
+	convertAmentPrefixPath  string
+	convertCompression      string
+	convertCompressionLevel string
+	convertChunkSize        int64
+	convertIncludeCRC       bool
+	convertChunked          bool
 )
 
 type FileType string
@@ -95,10 +96,11 @@ var convertCmd = &cobra.Command{
 		}
 
 		opts := &mcap.WriterOptions{
-			IncludeCRC:  convertIncludeCRC,
-			Chunked:     convertChunked,
-			ChunkSize:   convertChunkSize,
-			Compression: compressionFormat,
+			IncludeCRC:       convertIncludeCRC,
+			Chunked:          convertChunked,
+			ChunkSize:        convertChunkSize,
+			Compression:      compressionFormat,
+			CompressionLevel: mcap.CompressionLevelFromString(convertCompressionLevel),
 		}
 
 		switch filetype {
@@ -147,6 +149,13 @@ func init() {
 		"",
 		"zstd",
 		"chunk compression algorithm (supported: zstd, lz4, none)",
+	)
+	convertCmd.PersistentFlags().StringVarP(
+		&convertCompressionLevel,
+		"compression-level",
+		"",
+		"default",
+		"compression level (supported: fastest, fast, default, slow, slowest)",
 	)
 	convertCmd.PersistentFlags().Int64VarP(
 		&convertChunkSize,

--- a/go/mcap/compression_level.go
+++ b/go/mcap/compression_level.go
@@ -1,0 +1,69 @@
+package mcap
+
+import (
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+)
+
+// Compression level to use when compressing. Recommend using only the constant values to avoid
+// breakage when making library updates.
+type CompressionLevel int
+
+const (
+	CompressionFastest CompressionLevel = -20
+	CompressionFast    CompressionLevel = -10
+	CompressionDefault CompressionLevel = 0
+	CompressionSlow    CompressionLevel = 10
+	CompressionSlowest CompressionLevel = 20
+)
+
+func CompressionLevelFromString(level string) CompressionLevel {
+	switch level {
+	case "fastest":
+		return CompressionFastest
+	case "fast":
+		return CompressionFast
+	case "default":
+		return CompressionDefault
+	case "slow":
+		return CompressionSlow
+	case "slowest":
+		return CompressionSlowest
+	default:
+		return CompressionDefault
+	}
+}
+
+func (c CompressionLevel) lz4Level() lz4.CompressionLevel {
+	switch c {
+	case CompressionFastest:
+		return lz4.Fast
+	case CompressionFast:
+		return lz4.Level3
+	case CompressionDefault:
+		return lz4.Level5
+	case CompressionSlow:
+		return lz4.Level7
+	case CompressionSlowest:
+		return lz4.Level9
+	default:
+		return CompressionDefault.lz4Level()
+	}
+}
+
+func (c CompressionLevel) zstdLevel() zstd.EncoderLevel {
+	switch c {
+	case CompressionFastest:
+		return zstd.SpeedFastest
+	case CompressionFast:
+		return zstd.SpeedFastest
+	case CompressionDefault:
+		return zstd.SpeedDefault
+	case CompressionSlow:
+		return zstd.SpeedBetterCompression
+	case CompressionSlowest:
+		return zstd.SpeedBestCompression
+	default:
+		return CompressionDefault.zstdLevel()
+	}
+}

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -327,13 +327,13 @@ func TestIndexStructures(t *testing.T) {
 			MessageStartTime: 1,
 			MessageEndTime:   1,
 			ChunkStartOffset: 105,
-			ChunkLength:      145,
+			ChunkLength:      144,
 			MessageIndexOffsets: map[uint16]uint64{
-				1: 250,
+				1: 249,
 			},
 			MessageIndexLength: 31,
 			Compression:        "zstd",
-			CompressedSize:     92,
+			CompressedSize:     91,
 			UncompressedSize:   110,
 		}, chunkIndex)
 	})


### PR DESCRIPTION
**Public-Facing Changes**
* Adds a CompressionLevel field to `mcap.WriterOptions`, which controls the compression level of the zstd or lz4 compressors.
* Plumbs that through the CLI for all subcommands that write MCAP data.

**Description**
<!-- describe what has changed, and motivation behind those changes -->