### PR TITLE
rust: set default chunk size to a sane value

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -118,7 +118,7 @@ impl Default for WriteOptions {
             #[cfg(not(feature = "zstd"))]
             compression: None,
             profile: String::new(),
-            chunk_size: None,
+            chunk_size: Some(1024 * 768),
         }
     }
 }
@@ -147,7 +147,7 @@ impl WriteOptions {
     /// specifies the target uncompressed size of each chunk.
     ///
     /// Messages will be written to chunks until the uncompressed chunk is larger than the
-    /// target chunk size, at which point th  chunk will be closed and a new one started.
+    /// target chunk size, at which point the chunk will be closed and a new one started.
     /// If `None`, chunks will not be automatically closed and the user must call `flush()` to
     /// begin a new chunk.
     pub fn chunk_size(self, chunk_size: Option<u64>) -> Self {


### PR DESCRIPTION
**Public-Facing Changes**
Changes the default chunking behavior of the Rust writer to break chunks at a finite value. The current default behavior is a footgun and can lead to a situation where a user loses all of their MCAP data if they never break chunks.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
