### PR TITLE
swift: reduce exported API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "418378107c87a4b312e29a51f773ce0e4e12e199",
+          "revision": "53a8adc54374f620002a3b6401d39e0feb3c57ae",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
 
     // Use pre-release version for Heap
-    .package(url: "https://github.com/apple/swift-collections", revision: "418378107c87a4b312e29a51f773ce0e4e12e199"),
+    .package(url: "https://github.com/apple/swift-collections", revision: "53a8adc54374f620002a3b6401d39e0feb3c57ae"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,6 @@ let package = Package(
   platforms: [.macOS(.v10_15)], // for async/await
   products: [
     .library(name: "MCAP", targets: ["MCAP"]),
-    .library(name: "CRC", targets: ["CRC", "crc-tests"]),
-    .executable(name: "conformance", targets: ["conformance"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
@@ -22,7 +20,7 @@ let package = Package(
       name: "MCAP",
       dependencies: [
         "CRC",
-        .product(name: "Collections", package: "swift-collections"),
+        .product(name: "HeapModule", package: "swift-collections"),
         .product(name: "Algorithms", package: "swift-algorithms"),
       ],
       path: "swift/mcap"

--- a/swift/mcap/MCAPRandomAccessReader.swift
+++ b/swift/mcap/MCAPRandomAccessReader.swift
@@ -1,7 +1,7 @@
 import Algorithms
-import Collections
 import CRC
 import struct Foundation.Data
+import HeapModule
 
 public protocol IRandomAccessReadable {
   /**


### PR DESCRIPTION
- Don't export CRC and conformance as products visible by others who depend on this package
- only depend on HeapModule from swift-collections to reduce build time