### PR TITLE
python: add `iter_and_decode_messages` for decoding messages

### DIFF
--- a/python/mcap/mcap/message_queue.py
+++ b/python/mcap/mcap/message_queue.py
@@ -3,7 +3,9 @@ from typing import Union, Tuple, List, Optional
 
 from .records import Schema, Channel, Message, ChunkIndex
 
-QueueItem = Union[ChunkIndex, Tuple[Tuple[Schema, Channel, Message], int, int]]
+QueueItem = Union[
+    ChunkIndex, Tuple[Tuple[Optional[Schema], Channel, Message], int, int]
+]
 
 
 class _Orderable:

--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -108,7 +108,7 @@ class McapReader(ABC):
         end_time: Optional[int] = None,
         log_time_order: bool = True,
         reverse: bool = False,
-    ) -> Iterator[Tuple[Schema, Channel, Message]]:
+    ) -> Iterator[Tuple[Optional[Schema], Channel, Message]]:
         """iterates through the messages in an MCAP.
 
         :param topics: if not None, only messages from these topics will be returned.
@@ -173,7 +173,7 @@ class SeekingReader(McapReader):
         end_time: Optional[int] = None,
         log_time_order: bool = True,
         reverse: bool = False,
-    ) -> Iterator[Tuple[Schema, Channel, Message]]:
+    ) -> Iterator[Tuple[Optional[Schema], Channel, Message]]:
         """iterates through the messages in an MCAP.
 
         :param topics: if not None, only messages from these topics will be returned.
@@ -216,7 +216,10 @@ class SeekingReader(McapReader):
                             continue
                         if end_time is not None and record.log_time >= end_time:
                             continue
-                        schema = summary.schemas[channel.schema_id]
+                        if channel.schema_id == 0:
+                            schema = None
+                        else:
+                            schema = summary.schemas[channel.schema_id]
                         message_queue.push(
                             (
                                 (schema, channel, record),
@@ -322,7 +325,7 @@ class NonSeekingReader(McapReader):
         end_time: Optional[int] = None,
         log_time_order: bool = True,
         reverse: bool = False,
-    ) -> Iterator[Tuple[Schema, Channel, Message]]:
+    ) -> Iterator[Tuple[Optional[Schema], Channel, Message]]:
         """Iterates through the messages in an MCAP.
 
         :param topics: if not None, only messages from these topics will be returned.
@@ -355,7 +358,7 @@ class NonSeekingReader(McapReader):
         topics: Optional[Iterable[str]] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
-    ) -> Iterator[Tuple[Schema, Channel, Message]]:
+    ) -> Iterator[Tuple[Optional[Schema], Channel, Message]]:
         self._check_spent()
         for record in self._stream_reader.records:
             if isinstance(record, Schema):
@@ -378,7 +381,10 @@ class NonSeekingReader(McapReader):
                     continue
                 if end_time is not None and record.log_time >= end_time:
                     continue
-                schema = self._schemas[channel.schema_id]
+                if channel.schema_id == 0:
+                    schema = None
+                else:
+                    schema = self._schemas[channel.schema_id]
                 yield (schema, channel, record)
 
     def get_summary(self) -> Optional[Summary]:


### PR DESCRIPTION
**Public-Facing Changes**
- Adds `iter_and_decode_messages` to Reader
- makes the `Schema` returned by iter_messages optional, to handle schemaless channels properly

** Description **
Adds a method to the Reader class to iterate through messages and decode them. This is intended as a replacement for the high level reader iterators exposed by support libraries like `mcap-ros1-support`. The advantage of this approach is that it can decode heterogenous MCAPs. Also, it's easier to keep the argument list for `iter_and_decode_messages` matching that of `iter_messages` because it is defined in the same file.

Before:
```python
from mcap_ros1.reader import read_ros1_messages
for view in read_ros1_messages("ros1.mcap"):
    print(type(view.ros_msg))
```

After:
```python
from mcap.reader import make_reader
from mcap.well_known import MessageEncoding
from mcap_ros1.decoder import Decoder as ROS1Decoder
from mcap_ros2.decoder import Decoder as ROS2Decoder

with open("heterogenous.mcap", "rb") as f:
    reader = make_reader(f)
    decoders = {
        MessageEncoding.ROS1: ROS1Decoder().decode,
        MessageEncoding.ROS2: ROS2Decoder().decode,
    }
    for _, _, _, decoded_message in reader.iter_and_decode_messages(decoders):
        print(type(decoded_message))
```

<!-- link relevant GitHub issues -->
