### PR TITLE
cpp: make read_job_queue internal

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -106,3 +106,15 @@ for full details. The high-level interfaces for reading and writing are
    - Update [`all/conandata.yml`](https://github.com/conan-io/conan-center-index/blob/master/recipes/mcap/all/conandata.yml) to add an entry pointing at the tarball from the new release tag. <!-- cspell: word conandata -->
    - Follow the instructions for [developing recipes locally](https://github.com/conan-io/conan-center-index/blob/master/docs/developing_recipes_locally.md) to test the recipe.
    - Examples of previous changes to the mcap recipe: https://github.com/conan-io/conan-center-index/commits/master/recipes/mcap
+
+## Changes to APIs
+
+This project uses a [semantic version](https://semver.org) number to notify users of changes to public APIs.
+This semantic version can be read from `types.hpp`, defined as `MCAP_LIBRARY_VERSION`.
+
+The public API includes names that can be included from the `.hpp` files in `include/mcap`, excluding anything namespaced under `mcap::internal`.
+
+This API version does not cover the compiled ABI of the library. Projects including `mcap` are expected
+to compile it from source as part of their build process.
+
+Build rules in CMake or `conanfile.py` files are not covered as part of this public API.

--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/0.8.1"
+    requires = "benchmark/1.7.0", "mcap/0.9.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/0.8.1
+conan editable add ./mcap mcap/0.9.0
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/0.8.1
+conan editable add ./mcap mcap/0.9.0
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/0.8.1"
+    requires = "mcap/0.9.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/0.8.1",
+        "mcap/0.9.0",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "0.8.1"
+    version = "0.9.0"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/intervaltree.hpp
+++ b/cpp/mcap/include/mcap/intervaltree.hpp
@@ -9,9 +9,7 @@
 #include <memory>
 #include <vector>
 
-namespace mcap {
-
-namespace internal {
+namespace mcap::internal {
 
 template <class Scalar, typename Value>
 class Interval {
@@ -302,6 +300,4 @@ private:
   Scalar center;
 };
 
-}  // namespace internal
-
-}  // namespace mcap
+}  // namespace mcap::internal

--- a/cpp/mcap/include/mcap/read_job_queue.hpp
+++ b/cpp/mcap/include/mcap/read_job_queue.hpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <variant>
 
-namespace mcap {
+namespace mcap::internal {
 
 // Helper for writing compile-time exhaustive variant visitors.
 template <class>
@@ -144,4 +144,4 @@ public:
   }
 };
 
-}  // namespace mcap
+}  // namespace mcap::internal

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -624,7 +624,7 @@ private:
   ReadMessageOptions options_;
   std::unordered_set<ChannelId> selectedChannels_;
   std::function<void(const Message&, RecordOffset)> onMessage_;
-  ReadJobQueue queue_;
+  internal::ReadJobQueue queue_;
   std::vector<ChunkSlot> chunkSlots_;
 };
 

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "0.8.1"
+#define MCAP_LIBRARY_VERSION "0.9.0"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/0.8.1", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/0.9.0", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -678,9 +678,9 @@ TEST_CASE("Read Order", "[reader][writer]") {
 
 TEST_CASE("ReadJobQueue order", "[reader]") {
   SECTION("successive chunks with out-of-order timestamps") {
-    mcap::ReadJobQueue q(false);
+    mcap::internal::ReadJobQueue q(false);
     {
-      mcap::DecompressChunkJob chunk;
+      mcap::internal::DecompressChunkJob chunk;
       chunk.messageStartTime = 100;
       chunk.messageEndTime = 200;
       chunk.chunkStartOffset = 1000;
@@ -688,7 +688,7 @@ TEST_CASE("ReadJobQueue order", "[reader]") {
       q.push(std::move(chunk));
     }
     {
-      mcap::DecompressChunkJob chunk;
+      mcap::internal::DecompressChunkJob chunk;
       chunk.messageStartTime = 0;
       chunk.messageEndTime = 100;
       chunk.chunkStartOffset = 2000;
@@ -698,19 +698,19 @@ TEST_CASE("ReadJobQueue order", "[reader]") {
 
     {
       auto result = q.pop();
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).messageStartTime == 0);
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).chunkStartOffset == 2000);
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).messageStartTime == 0);
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).chunkStartOffset == 2000);
     }
     {
       auto result = q.pop();
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).messageStartTime == 100);
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).chunkStartOffset == 1000);
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).messageStartTime == 100);
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).chunkStartOffset == 1000);
     }
   }
   SECTION("reverse time order: successive chunks with out-of-order timestamps") {
-    mcap::ReadJobQueue q(true);
+    mcap::internal::ReadJobQueue q(true);
     {
-      mcap::DecompressChunkJob chunk;
+      mcap::internal::DecompressChunkJob chunk;
       chunk.messageStartTime = 100;
       chunk.messageEndTime = 200;
       chunk.chunkStartOffset = 1000;
@@ -718,7 +718,7 @@ TEST_CASE("ReadJobQueue order", "[reader]") {
       q.push(std::move(chunk));
     }
     {
-      mcap::DecompressChunkJob chunk;
+      mcap::internal::DecompressChunkJob chunk;
       chunk.messageStartTime = 0;
       chunk.messageEndTime = 100;
       chunk.chunkStartOffset = 2000;
@@ -728,15 +728,15 @@ TEST_CASE("ReadJobQueue order", "[reader]") {
 
     {
       auto result = q.pop();
-      REQUIRE(std::holds_alternative<mcap::DecompressChunkJob>(result));
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).messageStartTime == 100);
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).chunkStartOffset == 1000);
+      REQUIRE(std::holds_alternative<mcap::internal::DecompressChunkJob>(result));
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).messageStartTime == 100);
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).chunkStartOffset == 1000);
     }
     {
       auto result = q.pop();
-      REQUIRE(std::holds_alternative<mcap::DecompressChunkJob>(result));
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).messageStartTime == 0);
-      REQUIRE(std::get<mcap::DecompressChunkJob>(result).chunkStartOffset == 2000);
+      REQUIRE(std::holds_alternative<mcap::internal::DecompressChunkJob>(result));
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).messageStartTime == 0);
+      REQUIRE(std::get<mcap::internal::DecompressChunkJob>(result).chunkStartOffset == 2000);
     }
   }
 }


### PR DESCRIPTION
**Public-Facing Changes**
* moves `ReadMessageQueue` and associated classes into the `mcap::internal` namespace.
* Adds an explainer for what is covered under the public API.
<!-- describe any changes to the public interface or APIs, or write "None" -->


**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
