### PR TITLE
CLI: search optimistically for message definitions

### DIFF
--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -32,6 +32,22 @@ func TestDB3MCAPConversion(t *testing.T) {
 			7,
 		},
 		{
+			"galactic bag with irregular msg def search path",
+			"../../testdata/db3/chatter.db3",
+			"./testdata/irregular_galactic",
+			"/chatter",
+			"std_msgs/msg/String",
+			7,
+		},
+		{
+			"galactic bag with irregular msg def search path using symlinked install",
+			"../../testdata/db3/chatter.db3",
+			"./testdata/galactic_irregular_symlinks",
+			"/chatter",
+			"std_msgs/msg/String",
+			7,
+		},
+		{
 			"eloquent bag",
 			"../../testdata/db3/eloquent-twist.db3",
 			"./testdata/eloquent",

--- a/go/ros/testdata/galactic_irregular_symlinks/std_msgs/msg/String.msg
+++ b/go/ros/testdata/galactic_irregular_symlinks/std_msgs/msg/String.msg
@@ -1,0 +1,1 @@
+../../../irregular_galactic/std_msgs/msg/String.msg

--- a/go/ros/testdata/irregular_galactic/std_msgs/msg/String.msg
+++ b/go/ros/testdata/irregular_galactic/std_msgs/msg/String.msg
@@ -1,0 +1,6 @@
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string data


### PR DESCRIPTION
**Public-Facing Changes**
Replaces the logic in `mcap convert` for ROS 2 files that looks for schema definitions. Previously we would look for message definitions using the ament resource index, but this is a fragile mechanism especially for workspaces with message definitions in nested subdirectories. Several users have had trouble using this, and debugging why their install space isn't exactly correct is a slog. Instead, `mcap convert` searches for a path with the form `<packageName>/msg/<MsgName>.msg` anywhere in one of the directories specified with `ament-prefix-path`. 


<!-- link relevant GitHub issues -->
