### PR TITLE
CLI: fix message definition location in subdirectories

### DIFF
--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -32,22 +32,6 @@ func TestDB3MCAPConversion(t *testing.T) {
 			7,
 		},
 		{
-			"galactic bag with irregular msg def search path",
-			"../../testdata/db3/chatter.db3",
-			"./testdata/irregular_galactic",
-			"/chatter",
-			"std_msgs/msg/String",
-			7,
-		},
-		{
-			"galactic bag with irregular msg def search path using symlinked install",
-			"../../testdata/db3/chatter.db3",
-			"./testdata/galactic_irregular_symlinks",
-			"/chatter",
-			"std_msgs/msg/String",
-			7,
-		},
-		{
 			"eloquent bag",
 			"../../testdata/db3/eloquent-twist.db3",
 			"./testdata/eloquent",
@@ -163,5 +147,34 @@ func TestMessageTopicRegex(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			assert.Equal(t, c.match, messageTopicRegex.MatchString(c.input))
 		})
+	}
+}
+
+func TestSchemaFinding(t *testing.T) {
+	cases := []struct {
+		rosType         string
+		expectedContent string
+		err             error
+	}{
+		{
+			"example_msgs/msg/Descriptor",
+			"# is a descriptor\n",
+			nil,
+		},
+		{
+			"example_msgs/msg/CustomSubdirectory",
+			"# is in a custom subdirectory\n",
+			nil,
+		},
+		{
+			"example_msgs/msg/NotHereAtAll",
+			"",
+			errSchemaNotFound,
+		},
+	}
+	for _, c := range cases {
+		content, err := getSchema("msg", c.rosType, []string{"./testdata/get_schema_workspace"})
+		assert.Equal(t, c.err, err)
+		assert.Equal(t, c.expectedContent, string(content))
 	}
 }

--- a/go/ros/testdata/galactic_irregular_symlinks/std_msgs/msg/String.msg
+++ b/go/ros/testdata/galactic_irregular_symlinks/std_msgs/msg/String.msg
@@ -1,1 +1,0 @@
-../../../irregular_galactic/std_msgs/msg/String.msg

--- a/go/ros/testdata/get_schema_workspace/share/ament_index/resource_index/rosidl_interfaces/example_msgs
+++ b/go/ros/testdata/get_schema_workspace/share/ament_index/resource_index/rosidl_interfaces/example_msgs
@@ -1,0 +1,2 @@
+msg/Descriptor.msg
+other_subdir/CustomSubdirectory.msg

--- a/go/ros/testdata/get_schema_workspace/share/example_msgs/msg/Descriptor.msg
+++ b/go/ros/testdata/get_schema_workspace/share/example_msgs/msg/Descriptor.msg
@@ -1,0 +1,1 @@
+# is a descriptor

--- a/go/ros/testdata/get_schema_workspace/share/example_msgs/other_subdir/CustomSubdirectory.msg
+++ b/go/ros/testdata/get_schema_workspace/share/example_msgs/other_subdir/CustomSubdirectory.msg
@@ -1,0 +1,1 @@
+# is in a custom subdirectory

--- a/go/ros/testdata/irregular_galactic/std_msgs/msg/String.msg
+++ b/go/ros/testdata/irregular_galactic/std_msgs/msg/String.msg
@@ -1,6 +1,0 @@
-# This was originally provided as an example message.
-# It is deprecated as of Foxy
-# It is recommended to create your own semantically meaningful message.
-# However if you would like to continue using this please use the equivalent in example_msgs.
-
-string data


### PR DESCRIPTION
**public facing changes**

* modifies the `mcap convert` behavior for ROS 2 .db3 files to
properly use the ament index to find message definitions. This brings with it
the ability to find message definitions in package subdirectories other than
`msg/`.
