### PR TITLE
CLI: fieldToQualifiedMsgType handles fully qualified msg types

### DIFF
--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -20,7 +20,7 @@ var (
 	errSchemaNotFound = errors.New("schema not found")
 )
 
-func getSchema(encoding string, rosType string, directories []string) ([]byte, error) {
+func getSchema(rosType string, directories []string) ([]byte, error) {
 	parts := strings.FieldsFunc(rosType, func(c rune) bool { return c == '/' })
 	if len(parts) < 3 {
 		return nil, fmt.Errorf("expected type %s to match <package>/msg/<type>", rosType)
@@ -41,7 +41,7 @@ func getSchema(encoding string, rosType string, directories []string) ([]byte, e
 		}
 		lines := strings.Split(string(schemaIndex), "\n")
 		for _, line := range lines {
-			expectedMsgDefFilename := baseType + "." + encoding
+			expectedMsgDefFilename := baseType + ".msg"
 			if _, filename := filepath.Split(line); filename == expectedMsgDefFilename {
 				schemaPath := path.Join(dir, "share", rosPkg, line)
 				schema, err := os.ReadFile(schemaPath)
@@ -55,12 +55,12 @@ func getSchema(encoding string, rosType string, directories []string) ([]byte, e
 	return nil, errSchemaNotFound
 }
 
-func getSchemas(encoding string, directories []string, types []string) (map[string][]byte, error) {
+func getSchemas(directories []string, types []string) (map[string][]byte, error) {
 	messageDefinitions := make(map[string][]byte)
 	for _, rosType := range types {
 		rosPackage := strings.Split(rosType, "/")[0]
 		messageDefinition := &bytes.Buffer{}
-		schema, err := getSchema(encoding, rosType, directories)
+		schema, err := getSchema(rosType, directories)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find schema for %s: %w", rosType, err)
 		}
@@ -141,7 +141,7 @@ func getSchemas(encoding string, directories []string, types []string) (map[stri
 				if err != nil {
 					return nil, err
 				}
-				fieldSchema, err := getSchema(encoding, qualifiedType, directories)
+				fieldSchema, err := getSchema(qualifiedType, directories)
 				if err != nil {
 					return nil, fmt.Errorf("failed to find schema for %s: %w", qualifiedType, err)
 				}
@@ -283,7 +283,7 @@ func DB3ToMCAP(w io.Writer, db *sql.DB, opts *mcap.WriterOptions, searchdirs []s
 	for i := range topics {
 		types[i] = topics[i].typ
 	}
-	schemas, err := getSchemas("msg", searchdirs, types)
+	schemas, err := getSchemas(searchdirs, types)
 	if err != nil {
 		return err
 	}

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -86,7 +86,7 @@ func TestDB3MCAPConversion(t *testing.T) {
 
 func TestMergesNonNewlineDelimitedSchemas(t *testing.T) {
 	schemas, err := getSchemas(
-		"msg", []string{"./testdata/galactic"},
+		[]string{"./testdata/galactic"},
 		[]string{"package_a/msg/NoNewline"})
 	assert.Nil(t, err)
 	schema := schemas["package_a/msg/NoNewline"]
@@ -106,7 +106,7 @@ int32 foo
 
 func TestSchemaComposition(t *testing.T) {
 	t.Run("schema dependencies are resolved", func(t *testing.T) {
-		schemas, err := getSchemas("msg", []string{"./testdata/galactic"}, []string{"package_a/msg/TypeA"})
+		schemas, err := getSchemas([]string{"./testdata/galactic"}, []string{"package_a/msg/TypeA"})
 		assert.Nil(t, err)
 
 		schema := schemas["package_a/msg/TypeA"]
@@ -121,7 +121,6 @@ int32 foo
 	})
 	t.Run("schema name resolution works for all forms", func(t *testing.T) {
 		schemas, err := getSchemas(
-			"msg",
 			[]string{"./testdata/get_schema_workspace"},
 			[]string{"example_msgs/msg/ReferencesOtherDefinitions"},
 		)
@@ -201,7 +200,7 @@ func TestSchemaFinding(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		content, err := getSchema("msg", c.rosType, []string{"./testdata/get_schema_workspace"})
+		content, err := getSchema(c.rosType, []string{"./testdata/get_schema_workspace"})
 		assert.Equal(t, c.err, err)
 		assert.Equal(t, c.expectedContent, string(content))
 	}

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -119,6 +119,34 @@ int32 foo
 `
 		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
 	})
+	t.Run("schema name resolution works for all forms", func(t *testing.T) {
+		schemas, err := getSchemas(
+			"msg",
+			[]string{"./testdata/get_schema_workspace"},
+			[]string{"example_msgs/msg/ReferencesOtherDefinitions"},
+		)
+		assert.Nil(t, err)
+		schema, present := schemas["example_msgs/msg/ReferencesOtherDefinitions"]
+		assert.True(t, present)
+		expectedSchema := `
+# reference to message in same package
+Descriptor descriptor
+# qualified with package name
+example_msgs/Triangle triangle
+# qualified with package name
+example_msgs/msg/Square square
+================================================================================
+MSG: example_msgs/Descriptor
+# is a descriptor
+================================================================================
+MSG: example_msgs/Triangle
+# is a triangle
+================================================================================
+MSG: example_msgs/Square
+# is a square
+`
+		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
+	})
 }
 
 func TestMessageTopicRegex(t *testing.T) {

--- a/go/ros/testdata/get_schema_workspace/share/ament_index/resource_index/rosidl_interfaces/example_msgs
+++ b/go/ros/testdata/get_schema_workspace/share/ament_index/resource_index/rosidl_interfaces/example_msgs
@@ -1,2 +1,5 @@
 msg/Descriptor.msg
+msg/Triangle.msg
+msg/Square.msg
 other_subdir/CustomSubdirectory.msg
+other_subdir/ReferencesOtherDefinitions.msg

--- a/go/ros/testdata/get_schema_workspace/share/example_msgs/msg/Square.msg
+++ b/go/ros/testdata/get_schema_workspace/share/example_msgs/msg/Square.msg
@@ -1,0 +1,1 @@
+# is a square

--- a/go/ros/testdata/get_schema_workspace/share/example_msgs/msg/Triangle.msg
+++ b/go/ros/testdata/get_schema_workspace/share/example_msgs/msg/Triangle.msg
@@ -1,0 +1,1 @@
+# is a triangle

--- a/go/ros/testdata/get_schema_workspace/share/example_msgs/other_subdir/ReferencesOtherDefinitions.msg
+++ b/go/ros/testdata/get_schema_workspace/share/example_msgs/other_subdir/ReferencesOtherDefinitions.msg
@@ -1,0 +1,6 @@
+# reference to message in same package
+Descriptor descriptor
+# qualified with package name
+example_msgs/Triangle triangle
+# qualified with package name
+example_msgs/msg/Square square


### PR DESCRIPTION
**Public-Facing Changes**
* Fixes a bug where the function converting a type reference in a `.msg` definition to a qualified type could not handle when a type reference was of the form `<packageName>/msg/<TypeName>`.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
