### PR TITLE
go: bump library version to v1.0.0

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v0.4.0"
+var Version = "v1.0.0"


### PR DESCRIPTION
**Public-Facing Changes**
Increases the major version of the the `https://github.com/foxglove/mcap/go` library to 1.