### PR TITLE
Update mcap dependencies in CLI tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - run: pip install conan==1.53.0
+      - run: pip install conan==1.54.0
       - run: bash build.sh --build-tests-only
       - run: ./test/build/Debug/bin/unit-tests
 

--- a/cpp/ci.Dockerfile
+++ b/cpp/ci.Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$IMAGE" = "ubuntu:focal" ]; then \
   update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-13 100 \
   ; fi
 
-RUN pip --no-cache-dir install conan==1.53.0
+RUN pip --no-cache-dir install conan==1.54.0
 
 WORKDIR /mcap/cpp
 

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -30,6 +30,6 @@ ENV CXX=clang++-13
 
 WORKDIR /src
 
-RUN pip --no-cache-dir install conan==1.53.0
+RUN pip --no-cache-dir install conan==1.54.0
 
 CMD [ "./build.sh" ]

--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -5,15 +5,15 @@ go 1.18
 require (
 	cloud.google.com/go/storage v1.23.0
 	github.com/fatih/color v1.13.0
-	github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb
-	github.com/foxglove/mcap/go/ros v0.0.0-20220630160308-e6a1f32d08fa
-	github.com/klauspost/compress v1.15.12
+	github.com/foxglove/mcap/go/mcap v0.4.0
+	github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be
+	github.com/klauspost/compress v1.15.15
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pierrec/lz4/v4 v4.1.16
+	github.com/pierrec/lz4/v4 v4.1.17
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/protobuf v1.28.0
 )
 

--- a/go/cli/mcap/go.sum
+++ b/go/cli/mcap/go.sum
@@ -136,10 +136,14 @@ github.com/foxglove/mcap/go/mcap v0.0.0-20220630160308-e6a1f32d08fa h1:i1tnYfkVX
 github.com/foxglove/mcap/go/mcap v0.0.0-20220630160308-e6a1f32d08fa/go.mod h1:gQrB8PzccHW69xedSZ0uVDQVgDd3h1qX+otbS6fjSkE=
 github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb h1:coUPtEVqMoSaoyqf2MkuHgO3OcakVuMhyC1a0RG/fmE=
 github.com/foxglove/mcap/go/mcap v0.0.0-20220920234926-92cb87d8b8bb/go.mod h1:LMCS7BVPyHRb7xRXqYuKfM7dUq+MSE7H0dvaYsAQXnc=
+github.com/foxglove/mcap/go/mcap v0.4.0 h1:jsDZZ6qmMKa174EE8Tw0hxeMUdgjz8emTlN8+6FEnXE=
+github.com/foxglove/mcap/go/mcap v0.4.0/go.mod h1:3UsmtxZGHWURgxEgQh3t0cGfyPyLoCGsa/gtS/Y6UPM=
 github.com/foxglove/mcap/go/ros v0.0.0-20220328132551-ffb9c0b0ebdc h1:1Nct2T544wwXnElBQEq7sN8sy6exMGeeRFrY8ifMnEg=
 github.com/foxglove/mcap/go/ros v0.0.0-20220328132551-ffb9c0b0ebdc/go.mod h1:6cXLmjzfxXCScF9sye1jzpvGtWY86np5HC33JlOT0so=
 github.com/foxglove/mcap/go/ros v0.0.0-20220630160308-e6a1f32d08fa h1:HQouvCv0GPRIgoVvg680+m33yVXPN6n3jA3r8Kq4gok=
 github.com/foxglove/mcap/go/ros v0.0.0-20220630160308-e6a1f32d08fa/go.mod h1:6cXLmjzfxXCScF9sye1jzpvGtWY86np5HC33JlOT0so=
+github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be h1:K7lVNHXix6A9Ysz8StgVHp59B0pBAb1HjxH6GITOJMQ=
+github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be/go.mod h1:unwCv59e2oXGhFfSJ4u/A1prNTULz5ZXrGFQEpfNmb0=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
@@ -303,6 +307,8 @@ github.com/klauspost/compress v1.15.10 h1:Ai8UzuomSCDw90e1qNMtb15msBXsNpH6gzkkEN
 github.com/klauspost/compress v1.15.10/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
 github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
+github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -373,6 +379,8 @@ github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.16 h1:kQPfno+wyx6C5572ABwV+Uo3pDFzQ7yhyGchSyRda0c=
 github.com/pierrec/lz4/v4 v4.1.16/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
+github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -430,6 +438,7 @@ github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiu
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -441,6 +450,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=


### PR DESCRIPTION
This should fix an installation error that occurs when installing via

    go install github.com/foxglove/mcap/go/cli/mcap@latest

When running the install locally the build succeeds; I think usage of go workspaces is overriding the dependency specified in the go.mod file. Need to understand the mechanics of that better to propose a long-term fix to keep these in sync. For now this just updates the deps which I expect will resolve the immediate problem.