### PR TITLE
Spec: prohibit zero opcodes

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -92,7 +92,7 @@ The summary offset section aids random access reading.
 
 ## Records
 
-MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for application extensions and user proposals.
+MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for application extensions and user proposals. The opcode 0x00 is an error.
 
 All MCAP records are serialized as follows:
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -92,7 +92,7 @@ The summary offset section aids random access reading.
 
 ## Records
 
-MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for application extensions and user proposals. The opcode 0x00 is an error.
+MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for application extensions and user proposals. 0x00 is not a valid opcode.
 
 All MCAP records are serialized as follows:
 


### PR DESCRIPTION
This makes an explicit prohibition on zero opcodes. Zero opcodes were previously not designated as reserved for either future mcap development or application extensions - nothing was said about them. However some special handling is warranted because readers should not ignore them, or else empty file content (interpreted as zero opcodes followed by zero-length messages) may parse without an error.

This changes the behavior from undefined to defined as an error.