### PR TITLE
Avoid divide by zero in info on subsecond inputs

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -78,7 +78,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 			fmt.Fprintf(buf, "[%s/%s (%.2f%%)] ",
 				humanBytes(v.uncompressedSize), humanBytes(v.compressedSize), compressionRatio)
 			if durationInSeconds > 0 {
-				fmt.Fprintf(buf, "[%s/sec] ", humanBytes(v.compressedSize/uint64(durationInSeconds)))
+				fmt.Fprintf(buf, "[%s/sec] ", humanBytes(uint64(float64(v.compressedSize)/durationInSeconds)))
 			}
 			fmt.Fprintf(buf, "\n")
 		}


### PR DESCRIPTION
Prior to this commit, if the duration of an mcap file were less than a second we would divide by zero when computing the frequency on a topic. This was because a float was getting cast to uint64 and getting truncated before being used as the denominator in the frequency computation.