### PR TITLE
cpp: add conan lockfiles for leaf packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - run: pip install conan==1.54.0
+      - run: pip install conan==1.58.0
       - run: bash build.sh --build-tests-only
       - run: ./test/build/Debug/bin/unit-tests
 

--- a/cpp/bench/conan.lock
+++ b/cpp/bench/conan.lock
@@ -1,0 +1,47 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "options": "benchmark:enable_exceptions=True\nbenchmark:enable_lto=False\nbenchmark:fPIC=True\nbenchmark:shared=False",
+    "requires": [
+     "1",
+     "2"
+    ],
+    "path": "conanfile.py",
+    "context": "host"
+   },
+   "1": {
+    "ref": "benchmark/1.7.0",
+    "options": "enable_exceptions=True\nenable_lto=False\nfPIC=True\nshared=False",
+    "package_id": "6ffd97553e96f917fad2fb55bed2ff9792012f38",
+    "context": "host"
+   },
+   "2": {
+    "ref": "mcap/0.9.0",
+    "options": "lz4:fPIC=True\nlz4:shared=False\nzstd:fPIC=True\nzstd:shared=False\nzstd:threading=True",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "requires": [
+     "3",
+     "4"
+    ],
+    "context": "host"
+   },
+   "3": {
+    "ref": "lz4/1.9.4",
+    "options": "fPIC=True\nshared=False",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "context": "host"
+   },
+   "4": {
+    "ref": "zstd/1.5.2",
+    "options": "fPIC=True\nshared=False\nthreading=True",
+    "package_id": "21fe575bc61c7876dbea6bcaa88c986c622ccc02",
+    "context": "host"
+   }
+  },
+  "revisions_enabled": false
+ },
+ "version": "0.4",
+ "profile_host": "[settings]\narch=armv8\narch_build=armv8\nbuild_type=Release\ncompiler=apple-clang\ncompiler.libcxx=libc++\ncompiler.version=14\nos=Macos\nos_build=Macos\n[options]\n[build_requires]\n[env]\n"
+}

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -6,13 +6,13 @@ conan config init
 
 conan editable add ./mcap mcap/0.9.0
 conan install test --install-folder test/build/Debug \
-  -s compiler.cppstd=17 -s build_type=Debug --build missing
+  -s compiler.cppstd=17 -s build_type=Debug --build missing -l test/conan.lock
 
 if [ "$1" != "--build-tests-only" ]; then
   conan install bench --install-folder bench/build/Release \
-    -s compiler.cppstd=17 -s build_type=Release --build missing
+    -s compiler.cppstd=17 -s build_type=Release --build missing -l bench/conan.lock
   conan install examples --install-folder examples/build/Release \
-    -s compiler.cppstd=17 -s build_type=Release --build missing
+    -s compiler.cppstd=17 -s build_type=Release --build missing -l examples/conan.lock
   conan build examples --build-folder examples/build/Release
   conan build bench --build-folder bench/build/Release
 fi

--- a/cpp/ci.Dockerfile
+++ b/cpp/ci.Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$IMAGE" = "ubuntu:focal" ]; then \
   update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-13 100 \
   ; fi
 
-RUN pip --no-cache-dir install conan==1.54.0
+RUN pip --no-cache-dir install conan==1.58.0
 
 WORKDIR /mcap/cpp
 

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -30,6 +30,6 @@ ENV CXX=clang++-13
 
 WORKDIR /src
 
-RUN pip --no-cache-dir install conan==1.54.0
+RUN pip --no-cache-dir install conan==1.58.0
 
 CMD [ "./build.sh" ]

--- a/cpp/examples/conan.lock
+++ b/cpp/examples/conan.lock
@@ -1,0 +1,72 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "options": "catch2:default_reporter=None\ncatch2:with_main=False\ncatch2:with_prefix=False\nprotobuf:debug_suffix=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_rtti=True\nprotobuf:with_zlib=True\nzlib:fPIC=True\nzlib:shared=False",
+    "requires": [
+     "1",
+     "4",
+     "6",
+     "7"
+    ],
+    "path": "conanfile.py",
+    "context": "host"
+   },
+   "1": {
+    "ref": "mcap/0.9.0",
+    "options": "lz4:fPIC=True\nlz4:shared=False\nzstd:fPIC=True\nzstd:shared=False\nzstd:threading=True",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "requires": [
+     "2",
+     "3"
+    ],
+    "context": "host"
+   },
+   "2": {
+    "ref": "lz4/1.9.4",
+    "options": "fPIC=True\nshared=False",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "context": "host"
+   },
+   "3": {
+    "ref": "zstd/1.5.2",
+    "options": "fPIC=True\nshared=False\nthreading=True",
+    "package_id": "21fe575bc61c7876dbea6bcaa88c986c622ccc02",
+    "context": "host"
+   },
+   "4": {
+    "ref": "protobuf/3.21.1",
+    "options": "debug_suffix=True\nfPIC=True\nlite=False\nshared=False\nwith_rtti=True\nwith_zlib=True\nzlib:fPIC=True\nzlib:shared=False",
+    "package_id": "be2a0a2807bb180398bafcdcd02b31ceea4093ed",
+    "requires": [
+     "5"
+    ],
+    "context": "host"
+   },
+   "5": {
+    "ref": "zlib/1.2.12",
+    "options": "fPIC=True\nshared=False",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "context": "host"
+   },
+   "6": {
+    "ref": "nlohmann_json/3.10.5",
+    "options": "",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "context": "host"
+   },
+   "7": {
+    "ref": "catch2/2.13.8",
+    "options": "default_reporter=None\nwith_main=False\nwith_prefix=False",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "context": "host"
+   }
+  },
+  "revisions_enabled": false
+ },
+ "version": "0.4",
+ "profile_host": "[settings]\narch=armv8\narch_build=armv8\nbuild_type=Release\ncompiler=apple-clang\ncompiler.libcxx=libc++\ncompiler.version=14\nos=Macos\nos_build=Macos\n[options]\n[build_requires]\n[env]\n"
+}

--- a/cpp/test/conan.lock
+++ b/cpp/test/conan.lock
@@ -1,0 +1,56 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "options": "catch2:default_reporter=None\ncatch2:with_main=False\ncatch2:with_prefix=False",
+    "requires": [
+     "1",
+     "2",
+     "5"
+    ],
+    "path": "conanfile.py",
+    "context": "host"
+   },
+   "1": {
+    "ref": "catch2/2.13.8",
+    "options": "default_reporter=None\nwith_main=False\nwith_prefix=False",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "context": "host"
+   },
+   "2": {
+    "ref": "mcap/0.9.0",
+    "options": "lz4:fPIC=True\nlz4:shared=False\nzstd:fPIC=True\nzstd:shared=False\nzstd:threading=True",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "requires": [
+     "3",
+     "4"
+    ],
+    "context": "host"
+   },
+   "3": {
+    "ref": "lz4/1.9.4",
+    "options": "fPIC=True\nshared=False",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "context": "host"
+   },
+   "4": {
+    "ref": "zstd/1.5.2",
+    "options": "fPIC=True\nshared=False\nthreading=True",
+    "package_id": "21fe575bc61c7876dbea6bcaa88c986c622ccc02",
+    "context": "host"
+   },
+   "5": {
+    "ref": "nlohmann_json/3.10.5",
+    "options": "",
+    "package_id": "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+    "prev": "0",
+    "context": "host"
+   }
+  },
+  "revisions_enabled": false
+ },
+ "version": "0.4",
+ "profile_host": "[settings]\narch=armv8\narch_build=armv8\nbuild_type=Release\ncompiler=apple-clang\ncompiler.libcxx=libc++\ncompiler.version=14\nos=Macos\nos_build=Macos\n[options]\n[build_requires]\n[env]\n"
+}


### PR DESCRIPTION
**Public-Facing Changes**
* No change to libraries or code, just adjusting the process used in CI for testing with conan.

**Description**
We currently don't lock Conan dependencies in CI, which means our tests sometimes break when dependencies change. A real-world example is where a new revision for [lz4/v1.9.4](https://conan.io/center/lz4?version=1.9.4) was added which increases its minimum Conan version required to v1.54.0. This isn't a breaking change in the library (which is why the lz4 version number did not increase) but is a breaking change to the `conanfile.py` recipe.

This PR uses `conan lock` to pin recipe versions for all of our dependencies for toplevel targets that we build. 