### PR TITLE
CI: install latest compatible version of conan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - run: pip install conan==1.54.0
+      - run: pip install conan~=1.0
       - run: bash build.sh --build-tests-only
       - run: ./test/build/Debug/bin/unit-tests
 

--- a/cpp/ci.Dockerfile
+++ b/cpp/ci.Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$IMAGE" = "ubuntu:focal" ]; then \
   update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-13 100 \
   ; fi
 
-RUN pip --no-cache-dir install conan==1.54.0
+RUN pip --no-cache-dir install conan~=1.0
 
 WORKDIR /mcap/cpp
 

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -30,6 +30,6 @@ ENV CXX=clang++-13
 
 WORKDIR /src
 
-RUN pip --no-cache-dir install conan==1.54.0
+RUN pip --no-cache-dir install conan~=1.0
 
 CMD [ "./build.sh" ]


### PR DESCRIPTION
**Public-Facing Changes**
No changes to public APIs or code, just CI infrastructure.

**Description**
It seems to be common practice for Conan recipes to publish new revisions of recipes that require newer version of conan itself, without updating the semantic version of the library. This has periodically required us to update our Conan version installed in CI in order to keep CI working. This PR solves this problem by always installing the latest 1.x.x version of Conan available at test time. There are other possible solutions to this problem:

1. We could pin specific recipe revisions in `mcap/conanfile.py`. This would be fine for CI, but would negatively impact users who install `mcap` through Conan, because they are no longer able to select a recipe revision that works for their project.
    1. this is entirely a theoretical concern as far as I can tell - [https://conan.io/center/mcap] shows zero downloads, which indicates to me that nobody is using conan to deploy the MCAP C++ library.
3. We could use [lockfiles](https://docs.conan.io/en/latest/versioning/lockfiles.html) to lock the dependency outside of the `mcap` library itself. This is an experimental feature of Conan, which doesn't bode well for CI stability. Also, it does not allow us to have a build script that adds the `mcap` dependency as editable, which we use because it makes development faster and easier.
<!-- link relevant GitHub issues -->
