### PR TITLE
[TypeScript] Add readMetadata() and readAttachments() methods to McapIndexedReader, add validateCrcs arg to readMessages(), export parseRecord and parseMagic

### DIFF
--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -34,8 +34,10 @@ export class McapIndexedReader {
   private readable: IReadable;
   private decompressHandlers?: DecompressHandlers;
 
-  private startTime: bigint | undefined;
-  private endTime: bigint | undefined;
+  private messageStartTime: bigint | undefined;
+  private messageEndTime: bigint | undefined;
+  private attachmentStartTime: bigint | undefined;
+  private attachmentEndTime: bigint | undefined;
 
   private constructor(args: McapIndexedReaderArgs) {
     this.readable = args.readable;
@@ -51,20 +53,20 @@ export class McapIndexedReader {
     this.footer = args.footer;
 
     for (const chunk of args.chunkIndexes) {
-      if (this.startTime == undefined || chunk.messageStartTime < this.startTime) {
-        this.startTime = chunk.messageStartTime;
+      if (this.messageStartTime == undefined || chunk.messageStartTime < this.messageStartTime) {
+        this.messageStartTime = chunk.messageStartTime;
       }
-      if (this.endTime == undefined || chunk.messageEndTime > this.endTime) {
-        this.endTime = chunk.messageEndTime;
+      if (this.messageEndTime == undefined || chunk.messageEndTime > this.messageEndTime) {
+        this.messageEndTime = chunk.messageEndTime;
       }
     }
 
     for (const attachment of args.attachmentIndexes) {
-      if (this.startTime == undefined || attachment.logTime < this.startTime) {
-        this.startTime = attachment.logTime;
+      if (this.attachmentStartTime == undefined || attachment.logTime < this.attachmentStartTime) {
+        this.attachmentStartTime = attachment.logTime;
       }
-      if (this.endTime == undefined || attachment.logTime > this.endTime) {
-        this.endTime = attachment.logTime;
+      if (this.attachmentEndTime == undefined || attachment.logTime > this.attachmentEndTime) {
+        this.attachmentEndTime = attachment.logTime;
       }
     }
   }
@@ -319,8 +321,8 @@ export class McapIndexedReader {
   ): AsyncGenerator<TypedMcapRecords["Message"], void, void> {
     const {
       topics,
-      startTime = this.startTime,
-      endTime = this.endTime,
+      startTime = this.messageStartTime,
+      endTime = this.messageEndTime,
       reverse = false,
       validateCrcs,
     } = args;
@@ -447,8 +449,8 @@ export class McapIndexedReader {
     const {
       name,
       mediaType,
-      startTime = this.startTime,
-      endTime = this.endTime,
+      startTime = this.attachmentStartTime,
+      endTime = this.attachmentEndTime,
       validateCrcs,
     } = args;
 

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -58,6 +58,15 @@ export class McapIndexedReader {
         this.endTime = chunk.messageEndTime;
       }
     }
+
+    for (const attachment of args.attachmentIndexes) {
+      if (this.startTime == undefined || attachment.logTime < this.startTime) {
+        this.startTime = attachment.logTime;
+      }
+      if (this.endTime == undefined || attachment.logTime > this.endTime) {
+        this.endTime = attachment.logTime;
+      }
+    }
   }
 
   private errorWithLibrary(message: string): Error {

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -9,3 +9,4 @@ export * as McapConstants from "./constants";
 export type { IWritable } from "./IWritable";
 
 export * from "./hasMcapPrefix";
+export * from "./parse";


### PR DESCRIPTION
**Public-Facing Changes**
- [TS] Adds readMetadata() and readAttachments() methods to McapIndexedReader
- [TS] Adds validateCrcs arg to readMessages()
- [TS] parseRecord() and parseMagic() methods for lower-level parsing of MCAP data

**Description**
Adds support for metadata and attachments in the TypeScript indexed reader, and exposes two lower level parsing methods for 
situations where you are manually reading MCAP data and want to parse the header or individual records.
