### PR TITLE
cli: filter does not duplicate schema records

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -314,12 +314,12 @@ func filter(
 					if err = mcapWriter.WriteSchema(schema.Schema); err != nil {
 						return err
 					}
-					schema.written = true
+					schemas[channel.SchemaID] = markableSchema{schema.Schema, true}
 				}
 				if err = mcapWriter.WriteChannel(channel.Channel); err != nil {
 					return err
 				}
-				channel.written = true
+				channels[message.ChannelID] = markableChannel{channel.Channel, true}
 			}
 			if err = mcapWriter.WriteMessage(message); err != nil {
 				return err


### PR DESCRIPTION
**Public-Facing Changes**
Fixes a bug where `mcap filter` (and filter-derived commands like `compress`) would duplicate channel and schema records with every message.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
Fixes #815 
