### PR TITLE
[Python] Add enable_crcs and enable_data_crcs Writer options. Expose chunk_size, compression, and enable_crcs to support writers

### DIFF
--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -1,7 +1,8 @@
 import time
-from typing import Optional, Dict, Any, Tuple
+from io import BufferedWriter
+from typing import Optional, Dict, Any, Tuple, Union, IO
 
-from mcap.writer import Writer as McapWriter
+from mcap.writer import CompressionType, Writer as McapWriter
 from mcap.well_known import MessageEncoding
 import mcap
 
@@ -20,8 +21,19 @@ class Writer:
     MCAP file.
     """
 
-    def __init__(self, output):
-        self._writer = McapWriter(output)
+    def __init__(
+        self,
+        output: Union[str, IO[Any], BufferedWriter],
+        chunk_size: int = 1024 * 1024,
+        compression: CompressionType = CompressionType.ZSTD,
+        enable_crcs: bool = True,
+    ):
+        self._writer = McapWriter(
+            output,
+            chunk_size=chunk_size,
+            compression=compression,
+            enable_crcs=enable_crcs,
+        )
         self._schemas: Dict[str, Tuple[int, str]] = {}
         self._channels: Dict[str, int] = {}
         self._finished = False

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -56,7 +56,7 @@ class Writer:
             published.
         :param sequence: an optional sequence count for messages on this topic.
         """
-        msg_typename = type(message).DESCRIPTOR.full_name
+        msg_typename: str = type(message).DESCRIPTOR.full_name
         if topic in self._channels:
             channel_id = self._channels[topic]
             schema_id, schema_name = self._schemas[topic]

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -1,6 +1,6 @@
 from io import BufferedWriter, BytesIO
 from typing import IO, Any, Dict, Optional, Union
-from mcap.writer import Writer as McapWriter
+from mcap.writer import CompressionType, Writer as McapWriter
 import mcap
 import time
 
@@ -13,8 +13,19 @@ def _library_identifier():
 
 
 class Writer:
-    def __init__(self, output: Union[str, IO[Any], BufferedWriter]):
-        self.__writer = McapWriter(output=output)
+    def __init__(
+        self,
+        output: Union[str, IO[Any], BufferedWriter],
+        chunk_size: int = 1024 * 1024,
+        compression: CompressionType = CompressionType.ZSTD,
+        enable_crcs: bool = True,
+    ):
+        self.__writer = McapWriter(
+            output=output,
+            chunk_size=chunk_size,
+            compression=compression,
+            enable_crcs=enable_crcs,
+        )
         self.__schema_ids: Dict[str, int] = {}
         self.__channel_ids: Dict[str, int] = {}
         self.__writer.start(profile="ros1", library=_library_identifier())
@@ -83,5 +94,5 @@ class Writer:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_, exc_type_, tb_):
+    def __exit__(self, exc_: Any, exc_type_: Any, tb_: Any):
         self.finish()

--- a/python/mcap-ros2-support/mcap_ros2/decoder.py
+++ b/python/mcap-ros2-support/mcap_ros2/decoder.py
@@ -41,9 +41,9 @@ class Decoder:
             type_dict = generate_dynamic(  # type: ignore
                 schema.name, schema.data.decode()
             )
-            decoder = type_dict[schema.name]
-            if decoder is None:
+            if schema.name not in type_dict:
                 raise McapROS2DecodeError(f'schema parsing failed for "{schema.name}"')
+            decoder = type_dict[schema.name]
             self._decoders[schema.id] = decoder
 
         ros_msg = decoder(message.data)

--- a/python/mcap/tests/run_writer_test.py
+++ b/python/mcap/tests/run_writer_test.py
@@ -61,6 +61,8 @@ def write_file(features: List[str], expected_records: List[Dict[str, Any]]) -> b
         use_chunking="ch" in features,
         use_statistics="st" in features,
         use_summary_offsets="sum" in features,
+        enable_crcs=True,
+        enable_data_crcs=True,
     )
     for line in expected_records:
         type, fields = line["type"], line["fields"]


### PR DESCRIPTION
**Public-Facing Changes**
- [Python] Add Writer class constructor args `enable_crcs=True`, `enable_data_crcs=False`
- [Python] Expose `chunk_size`, `compression`, and `enable_crcs` args to Writer constructors for mcap-ros1-support, 
mcap-ros2-support, and mcap-protobuf-support
- [Python] Fixed mcap-ros2-support to throw McapROS2WriteError when schema parsing fails

**Description**
Also includes misc typing improvements
