### PR TITLE
add note recommending against mixed chunking

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -59,7 +59,6 @@ The following records are allowed to appear in the data section:
 - [Chunk](#chunk-op0x06)
 - [Message Index](#message-index-op0x07)
 - [Metadata](#metadata-op0x0C)
-
 - [Data End](#data-end-op0x0F)
 
 The last record in the data section MUST be the [Data End](#data-end-op0x0F) record.

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -65,7 +65,7 @@ The last record in the data section MUST be the [Data End](#data-end-op0x0F) rec
 
 #### Use of chunk records
 
-MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. Schema, Channel, and Message records must either all be written inside chunks, or all outside of chunks. Reader implementations may assume that if any Chunk records exist, all Schema, Channel, and Message records can be found inside Chunk records.
+MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. Schema, Channel, and Message records must either all be written inside chunks, or all outside of chunks. Reader implementations may assume that if any Chunk records exist, all Schema, Channel, and Message records in the data section can be found inside Chunk records.
 
 ### Summary Section
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -59,9 +59,14 @@ The following records are allowed to appear in the data section:
 - [Chunk](#chunk-op0x06)
 - [Message Index](#message-index-op0x07)
 - [Metadata](#metadata-op0x0C)
+
 - [Data End](#data-end-op0x0F)
 
 The last record in the data section MUST be the [Data End](#data-end-op0x0F) record.
+
+#### Use of chunk records
+
+MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. Schema, Channel, and Message records must either all be written inside chunks, or all outside of chunks. A data section containing Chunk records may not contain any Schema, Channel, or Message records and vice-versa.
 
 ### Summary Section
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -65,7 +65,9 @@ The last record in the data section MUST be the [Data End](#data-end-op0x0F) rec
 
 #### Use of chunk records
 
-MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. Schema, Channel, and Message records must either all be written inside chunks, or all outside of chunks. Reader implementations may assume that if any Chunk records exist, all Schema, Channel, and Message records in the data section can be found inside Chunk records.
+MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. For MCAPs that include [Chunk Index](#chunk-index-op0x08) records in the summary section, all Message records should be written into Chunk records.
+
+> Why? The presence of Chunk Index records in the summary section indicates to readers that the MCAP is indexed, and they can use those records to look up messages by log time or topic. However, Message records outside of chunks cannot be indexed, and may not be found by readers using the index.
 
 ### Summary Section
 

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -66,7 +66,7 @@ The last record in the data section MUST be the [Data End](#data-end-op0x0F) rec
 
 #### Use of chunk records
 
-MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. Schema, Channel, and Message records must either all be written inside chunks, or all outside of chunks. A data section containing Chunk records may not contain any Schema, Channel, or Message records and vice-versa.
+MCAP files can have Schema, Channel, and Message records written directly to the data section, or they can be written into Chunk records to facilitate indexing and compression. Schema, Channel, and Message records must either all be written inside chunks, or all outside of chunks. Reader implementations may assume that if any Chunk records exist, all Schema, Channel, and Message records can be found inside Chunk records.
 
 ### Summary Section
 

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -22,14 +22,6 @@ var (
 	verbose bool
 )
 
-type chunkingState int
-
-const (
-	chunkingUnknown        chunkingState = 0
-	dataSectionIsChunked   chunkingState = 1
-	dataSectionIsUnChunked chunkingState = 2
-)
-
 type mcapDoctor struct {
 	reader io.ReadSeeker
 
@@ -235,7 +227,7 @@ func (doctor *mcapDoctor) Examine() error {
 	var lastToken mcap.TokenType
 	var dataEnd *mcap.DataEnd
 	var footer *mcap.Footer
-	var chunkingState chunkingState = chunkingUnknown
+	var messageOutsideChunk bool
 	msg := make([]byte, 1024)
 	for {
 		tokenType, data, err := lexer.Next(msg)
@@ -279,11 +271,6 @@ func (doctor *mcapDoctor) Examine() error {
 			if err != nil {
 				doctor.error("Failed to parse schema:", err)
 			}
-			if chunkingState != dataSectionIsChunked {
-				chunkingState = dataSectionIsUnChunked
-			} else {
-				doctor.error("encountered a Schema record in data section that includes Chunk records")
-			}
 
 			if schema.Encoding == "" {
 				if len(schema.Data) == 0 {
@@ -303,11 +290,6 @@ func (doctor *mcapDoctor) Examine() error {
 			if err != nil {
 				doctor.error("Error parsing Channel: %s", err)
 			}
-			if chunkingState != dataSectionIsChunked {
-				chunkingState = dataSectionIsUnChunked
-			} else {
-				doctor.error("encountered a Channel record in data section that includes Chunk records")
-			}
 
 			doctor.channels[channel.ID] = channel
 
@@ -319,11 +301,7 @@ func (doctor *mcapDoctor) Examine() error {
 			if err != nil {
 				doctor.error("Error parsing Message: %s", err)
 			}
-			if chunkingState != dataSectionIsChunked {
-				chunkingState = dataSectionIsUnChunked
-			} else {
-				doctor.error("encountered a Message record in data section that includes Chunk records")
-			}
+			messageOutsideChunk = true
 			channel := doctor.channels[message.ChannelID]
 			if channel == nil {
 				doctor.error("Got a Message record for channel: %d before a channel info.", message.ChannelID)
@@ -348,21 +326,22 @@ func (doctor *mcapDoctor) Examine() error {
 			if err != nil {
 				doctor.error("Error parsing Message: %s", err)
 			}
-			if chunkingState != dataSectionIsUnChunked {
-				chunkingState = dataSectionIsChunked
-			} else {
-				doctor.error("encountered a Chunk record in data section that includes Schema, Channel, or Message records")
-			}
 			doctor.examineChunk(chunk)
 		case mcap.TokenMessageIndex:
 			_, err := mcap.ParseMessageIndex(data)
 			if err != nil {
 				doctor.error("Failed to parse message index:", err)
 			}
+			if messageOutsideChunk {
+				doctor.warn("encountered a message index in file with message records outside chunks. Messages outside of chunks cannot be indexed and will be missed by indexed readers.")
+			}
 		case mcap.TokenChunkIndex:
 			chunkIndex, err := mcap.ParseChunkIndex(data)
 			if err != nil {
 				doctor.error("Failed to parse chunk index:", err)
+			}
+			if messageOutsideChunk {
+				doctor.warn("encountered a chunk index in file with message records outside chunks. Messages outside of chunks cannot be indexed and will be missed by indexed readers.")
 			}
 			if _, ok := doctor.chunkIndexes[chunkIndex.ChunkStartOffset]; ok {
 				doctor.error("Multiple chunk indexes found for chunk at offset", chunkIndex.ChunkStartOffset)


### PR DESCRIPTION
**Public-Facing Changes**
* The MCAP specification now recommends against MCAPs from mixing chunked-and un-chunked writing in the same file.
* `mcap doctor` now reports a warning for MCAPs containing Message records in the data section with Chunk Indexes in the summary section.