### PR TITLE
Update dependencies & remove go.work

### DIFF
--- a/go/cli/mcap/README.md
+++ b/go/cli/mcap/README.md
@@ -8,7 +8,10 @@ details.
 ### Installing:
 
 Either install from [releases
-binaries](https://github.com/foxglove/mcap/releases), from [Homebrew](https://formulae.brew.sh/formula/mcap#default), or by using go.
+binaries](https://github.com/foxglove/mcap/releases) or from [Homebrew](https://formulae.brew.sh/formula/mcap#default).
+
+> Note: Installing via 'go install' is not recommended, and is not guaranteed
+> to work.
 
 #### From release binaries
 


### PR DESCRIPTION
Specify that installing with go install is not supported.