### PR TITLE
Remove explicit dependency on mcap libs in CLI

### DIFF
--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -5,8 +5,6 @@ go 1.18
 require (
 	cloud.google.com/go/storage v1.23.0
 	github.com/fatih/color v1.13.0
-	github.com/foxglove/mcap/go/mcap v0.4.0
-	github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be
 	github.com/klauspost/compress v1.15.15
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5


### PR DESCRIPTION
Perhaps if we do this, go.work will be respected by go install.