### PR TITLE
go/ros: rosmsg parser accepts and/or spaces between field name and type

### DIFF
--- a/go/ros/ros1msg/ros1msg_parser.go
+++ b/go/ros/ros1msg/ros1msg_parser.go
@@ -11,7 +11,7 @@ import (
 
 // Field names are restricted to "an alphabetical character followed by any mixture of alphanumeric and underscores",
 // per http://wiki.ros.org/msg#Fields
-var fieldMatcher = regexp.MustCompile(`([^ ]+) +([a-zA-Z][a-zA-Z0-9_]*)`)
+var fieldMatcher = regexp.MustCompile(`([^ \t]+)[ \t]* [ \t]*([a-zA-Z][a-zA-Z0-9_]*)`)
 
 type Type struct {
 	BaseType  string

--- a/go/ros/ros1msg/ros1msg_parser_test.go
+++ b/go/ros/ros1msg/ros1msg_parser_test.go
@@ -47,6 +47,33 @@ func TestROS1MSGParser(t *testing.T) {
 			},
 		},
 		{
+			"two primitive fields with type and name separated by tab and space",
+			"",
+			`string	 foo
+			 int32 	bar
+			 float32	 	baz`,
+			[]Field{
+				{
+					Name: "foo",
+					Type: Type{
+						BaseType: "string",
+					},
+				},
+				{
+					Name: "bar",
+					Type: Type{
+						BaseType: "int32",
+					},
+				},
+				{
+					Name: "baz",
+					Type: Type{
+						BaseType: "float32",
+					},
+				},
+			},
+		},
+		{
 			"primitive variable-length array",
 			"",
 			`bool[] foo`,


### PR DESCRIPTION
**Public-Facing Changes**
Expands the set of ROS1/2 message definitions accepted by `mcap convert`, by allowing fields that have type and name separated by spaces and/or tabs.
<!-- describe any changes to the public interface or APIs, or write "None" -->


**Description**
the ROS1 msg spec says the type and name of a field are separated by a "space", however in actuality the parser is more lenient:
https://github.com/ros/ros/blob/noetic-devel/core/roslib/src/roslib/msgs.py#L624

what this is doing is breaking a line into parts by space and calling `.strip()` on them, which also removes tab characters. This means the parser accepts fields separated by a combination of whitespace characters (space and tab), so long as there is at least one space in there. This PR mirrors that behavior in the Go parser.
