### PR TITLE
CLI: info: handle durations > 2**63

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -35,6 +35,19 @@ func humanBytes(numBytes uint64) string {
 	return fmt.Sprintf("%.2f %s", displayedValue, prefixes[prefixIndex])
 }
 
+func getDurationNs(start uint64, end uint64) float64 {
+	// subtracts start from end, returning the result as a 64-bit float.
+	// float64 can store the entire range of possible durations [-2**64 - 1, 2**64 - 1],
+	// albeit with some loss of precision.
+	diff := end - start
+	signMultiplier := 1.0
+	if start > end {
+		diff = start - end
+		signMultiplier = -1.0
+	}
+	return float64(diff) * signMultiplier
+}
+
 func printInfo(w io.Writer, info *mcap.Info) error {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "library: %s\n", info.Header.Library)
@@ -45,7 +58,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		fmt.Fprintf(buf, "messages: %d\n", info.Statistics.MessageCount)
 		start = info.Statistics.MessageStartTime
 		end = info.Statistics.MessageEndTime
-		durationNs := float64(end) - float64(start)
+		durationNs := getDurationNs(start, end)
 		durationInSeconds = durationNs / 1e9
 		starttime := time.Unix(int64(start/1e9), int64(start%1e9))
 		endtime := time.Unix(int64(end/1e9), int64(end%1e9))

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -37,7 +37,7 @@ func humanBytes(numBytes uint64) string {
 
 func getDurationNs(start uint64, end uint64) float64 {
 	// subtracts start from end, returning the result as a 64-bit float.
-	// float64 can store the entire range of possible durations [-2**64 - 1, 2**64 - 1],
+	// float64 can represent the entire range of possible durations (-2**64, 2**64),
 	// albeit with some loss of precision.
 	diff := end - start
 	signMultiplier := 1.0


### PR DESCRIPTION
### Public-Facing Changes
`mcap info` on files with a duration > 2**63s will have their duration, start and end times printed correctly.
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description
* fix a bug in decimalTime which would print timestamps > 2^63ns as negative numbers
* fix a bug where very long durations in MCAP would be printed as negative.

For the linked file in #822, returns:
```
$ mcap info
library: libmcap 1.0.0
profile: 
messages: 300
duration: 18446744073.620s
start: 0.000000000
end: 18446744073.619617024
compression:
        zstd: [1/1 chunks] [221.93 KiB/3.77 KiB (98.30%)] [0.00 B/sec] 
channels:
        (1) image              100 msgs (0.00 Hz)   : foxglove.CompressedImage [protobuf]    
        (2) camera_info        100 msgs (0.00 Hz)   : foxglove.CameraCalibration [protobuf]  
        (3) image_annotations  100 msgs (0.00 Hz)   : foxglove.ImageAnnotations [protobuf]   
attachments: 0
metadata: 0
```

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
Fixes #822 