### PR TITLE
feat(cli): allow unrecognized encoding

### DIFF
--- a/go/cli/mcap/README.md
+++ b/go/cli/mcap/README.md
@@ -38,6 +38,8 @@ To install from the latest commit, use
 
     go install github.com/foxglove/mcap/go/cli/mcap@latest
 
+Ensure that the go installation directory is in your path (e.g. `$HOME/go/bin` by default on Ubuntu).
+
 ### Examples:
 
 #### Bag to mcap conversion

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -124,12 +124,11 @@ func printMessages(
 				if _, err = msg.Write(encoded); err != nil {
 					return fmt.Errorf("failed to write message bytes: %w", err)
 				}
-			case "json":
+			// Default encompasses json, which is encoded as UTF8 bytes
+			default:
 				if _, err = msg.Write(message.Data); err != nil {
 					return fmt.Errorf("failed to write message bytes: %w", err)
 				}
-			default:
-				return fmt.Errorf("For schemaless encodings, JSON output only supports: JSON and CBOR. Found: %s", channel.MessageEncoding)
 			}
 		} else {
 			switch schema.Encoding {
@@ -177,12 +176,11 @@ func printMessages(
 				if _, err = msg.Write(bytes); err != nil {
 					return fmt.Errorf("failed to write message bytes: %w", err)
 				}
-			case "jsonschema":
+			// Default encompasses json, which is encoded as UTF8 bytes
+			default:
 				if _, err = msg.Write(message.Data); err != nil {
 					return fmt.Errorf("failed to write message bytes: %w", err)
 				}
-			default:
-				return fmt.Errorf("JSON output only supported for the following encodings - with schema: ros1msg, protobuf, and JSON; schemaless: JSON and CBOR. Found: %s", schema.Encoding)
 			}
 		}
 		target.Topic = channel.Topic

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -110,7 +110,7 @@ func printMessages(
 			}
 			continue
 		}
-		if schema == nil {
+		if schema == nil || schema.Encoding == "" {
 			switch channel.MessageEncoding {
 			case "cbor":
 				var v map[string]interface{}

--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -23,6 +23,7 @@ require (
 	cloud.google.com/go/iam v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
@@ -46,6 +47,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/oauth2 v0.0.0-20220630143837-2104d58473e0 // indirect

--- a/go/cli/mcap/go.sum
+++ b/go/cli/mcap/go.sum
@@ -148,6 +148,8 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
+github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -457,6 +459,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=
 github.com/subosito/gotenv v1.4.0/go.mod h1:mZd6rFysKEcUhUHXJk0C/08wAgyDBFuwEYL7vWWGaGo=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/python/mcap/tests/test_writer.py
+++ b/python/mcap/tests/test_writer.py
@@ -118,13 +118,21 @@ def test_out_of_order_messages():
     assert chunk_index.message_start_time == 0
     assert chunk_index.message_end_time == 100
 
-def test_generate_sample_cbor_data():
+@pytest.mark.parametrize(
+    "null_schema", [(True,), (False,)]
+)
+def test_generate_sample_cbor_data(null_schema: bool):
     file = NamedTemporaryFile("w+b")
     writer = Writer(file, compression=CompressionType.ZSTD)
     writer.start(library="test")
+    schema_id = writer.register_schema(
+        name="sample",
+        encoding="",
+        data="".encode()
+    )
 
     channel_id = writer.register_channel(
-        schema_id=0,
+        schema_id=0 if null_schema else schema_id,
         topic="sample_topic",
         message_encoding="cbor",
     )

--- a/python/mcap/tests/test_writer.py
+++ b/python/mcap/tests/test_writer.py
@@ -1,9 +1,11 @@
 import contextlib
 import json
 from io import BytesIO
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryFile
 from typing import List
 import zlib
+import cbor2
+import subprocess
 
 import lz4.frame
 import pytest
@@ -42,7 +44,7 @@ def generate_sample_data(compression: CompressionType):
     writer.add_message(
         channel_id=channel_id,
         log_time=0,
-        data=json.dumps({"sample": "test"}).encode("utf-8"),
+        data=json.dumps({"sample": "test"}).encode(encoding="utf-8"),
         publish_time=0,
     )
 
@@ -115,3 +117,26 @@ def test_out_of_order_messages():
     chunk_index = next(r for r in records if isinstance(r, ChunkIndex))
     assert chunk_index.message_start_time == 0
     assert chunk_index.message_end_time == 100
+
+def test_generate_sample_cbor_data():
+    file = NamedTemporaryFile("w+b")
+    writer = Writer(file, compression=CompressionType.ZSTD)
+    writer.start(library="test")
+
+    channel_id = writer.register_channel(
+        schema_id=0,
+        topic="sample_topic",
+        message_encoding="cbor",
+    )
+
+    writer.add_message(
+        channel_id=channel_id,
+        log_time=0,
+        data=cbor2.dumps({"sample": "test"}),
+        publish_time=0,
+    )
+
+    writer.finish()
+    file.seek(0)
+    result = subprocess.run(['mcap', 'cat', '--json', file.name], stdout=subprocess.PIPE)
+    assert result.stdout == b'{"topic":"sample_topic","sequence":0,"log_time":0.000000000,"publish_time":0.000000000,"data":{"sample":"test"}}\n'


### PR DESCRIPTION
### Public-Facing Changes

### Description

One can now see raw bytes of messages from `mcap cat --json` along with the metadata

Comments:
- Requires https://github.com/foxglove/mcap/pull/848 to be merged first

Fix: https://github.com/foxglove/mcap/issues/817
