### PR TITLE
[C++] Fix warnings from extra semicolons and missing override keywords

### DIFF
--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -108,7 +108,7 @@ private:
  */
 class MCAP_PUBLIC ICompressedReader : public IReadable {
 public:
-  virtual ~ICompressedReader() = default;
+  virtual ~ICompressedReader() override = default;
 
   /**
    * @brief Reset the reader state, clearing any internal buffers and state, and
@@ -212,7 +212,7 @@ public:
   LZ4Reader& operator=(const LZ4Reader&) = delete;
   LZ4Reader(LZ4Reader&&) = delete;
   LZ4Reader& operator=(LZ4Reader&&) = delete;
-  ~LZ4Reader();
+  ~LZ4Reader() override;
 
 private:
   void* decompressionContext_ = nullptr;  // LZ4F_dctx*

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -356,10 +356,10 @@ struct MCAP_PUBLIC RecordOffset {
 
   RecordOffset() = default;
   explicit RecordOffset(ByteOffset offset_)
-      : offset(offset_){};
+      : offset(offset_){}
   RecordOffset(ByteOffset offset_, ByteOffset chunkOffset_)
       : offset(offset_)
-      , chunkOffset(chunkOffset_){};
+      , chunkOffset(chunkOffset_){}
 
   bool operator==(const RecordOffset& other) const;
   bool operator>(const RecordOffset& other) const;

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -356,10 +356,10 @@ struct MCAP_PUBLIC RecordOffset {
 
   RecordOffset() = default;
   explicit RecordOffset(ByteOffset offset_)
-      : offset(offset_){}
+      : offset(offset_) {}
   RecordOffset(ByteOffset offset_, ByteOffset chunkOffset_)
       : offset(offset_)
-      , chunkOffset(chunkOffset_){}
+      , chunkOffset(chunkOffset_) {}
 
   bool operator==(const RecordOffset& other) const;
   bool operator>(const RecordOffset& other) const;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -191,18 +191,18 @@ private:
  */
 class MCAP_PUBLIC IChunkWriter : public IWritable {
 public:
-  virtual ~IChunkWriter() = default;
+  virtual ~IChunkWriter() override = default;
 
   /**
    * @brief Called when the writer wants to close the current output Chunk.
    * After this call, `data()` and `size()` should return the data and size of
    * the compressed data.
    */
-  virtual void end() = 0;
+  virtual void end() override = 0;
   /**
    * @brief Returns the size in bytes of the uncompressed data.
    */
-  virtual uint64_t size() const = 0;
+  virtual uint64_t size() const override = 0;
   /**
    * @brief Returns the size in bytes of the compressed data. This will only be
    * called after `end()`.


### PR DESCRIPTION
### Public-Facing Changes
- [C++] Fixes `-Wextra-semi`, `-Wsuggest-override`, `-Wsuggest-destructor-override`, and `-Winconsistent-missing-destructor-override` compiler warnings
