### PR TITLE
Add SkipMagic option to go writer

### DIFF
--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -777,6 +777,10 @@ type WriterOptions struct {
 	// SkipSummaryOffsets skips summary offset records.
 	SkipSummaryOffsets bool
 
+	// SkipMagic skips the magic bytes at the start of the file. This may be
+	// useful for resuming writes midway through a file.
+	SkipMagic bool
+
 	// OverrideLibrary causes the default header library to be overridden, not
 	// appended to.
 	OverrideLibrary bool
@@ -817,8 +821,10 @@ func encoderLevelFromZstd(level CompressionLevel) zstd.EncoderLevel {
 // NewWriter returns a new MCAP writer.
 func NewWriter(w io.Writer, opts *WriterOptions) (*Writer, error) {
 	writer := newWriteSizer(w, opts.IncludeCRC)
-	if _, err := writer.Write(Magic); err != nil {
-		return nil, err
+	if !opts.SkipMagic {
+		if _, err := writer.Write(Magic); err != nil {
+			return nil, err
+		}
 	}
 	compressed := bytes.Buffer{}
 	var compressedWriter *countingCRCWriter


### PR DESCRIPTION
Adds a "SkipMagic" option to the go writer. When provided, the leading magic bytes will not be written. This may be used for appending to an existing MCAP file.