### PR TITLE
Speed up the info subcommand

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -1,6 +1,7 @@
 package mcap
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -67,13 +68,7 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 		return fmt.Errorf("failed to seek to summary start")
 	}
 
-	summarySection := make([]byte, footer.SummaryOffsetStart-footer.SummaryStart)
-	_, err = io.ReadFull(it.rs, summarySection)
-	if err != nil {
-		return fmt.Errorf("failed to read summary section")
-	}
-
-	lexer, err := NewLexer(bytes.NewReader(summarySection), &LexerOptions{
+	lexer, err := NewLexer(bufio.NewReader(it.rs), &LexerOptions{
 		SkipMagic: true,
 	})
 	if err != nil {


### PR DESCRIPTION
Reads full summary section into memory before parsing, rather than pulling it into memory over multiple calls to Read(). Will use more memory than before (I think memory usage for the associated data will double during the function call) but outside the function call should be same as before.

I think the users who will benefit from this will be,
* Users with huge numbers of chunks
* Users with slow and/or remote disks