### PR TITLE
Update example for mcap_ros2.reader

### DIFF
--- a/python/mcap-ros2-support/README.md
+++ b/python/mcap-ros2-support/README.md
@@ -17,7 +17,7 @@ pip install mcap-ros2-support
 from mcap_ros2.reader import read_ros2_messages
 
 for msg in read_ros2_messages("my_data.mcap"):
-    print(f"{msg.topic}: f{msg.ros_msg}")
+    print(f"{msg.channel.topic}: f{msg.ros_msg}")
 ```
 
 ## Stay in touch


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

The example was outdated as commit 8ee1d0f removed the 'topic' member for the McapROS2Message class. It is now under 'channel.topic'
