### PR TITLE
Go indexed reader: locate summary section end by scanning for footer

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 
@@ -79,10 +78,6 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 	for {
 		tokenType, record, err := lexer.Next(nil)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				it.hasReadSummarySection = true
-				return nil
-			}
 			return fmt.Errorf("failed to get next token: %w", err)
 		}
 		switch tokenType {
@@ -138,6 +133,9 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 				return fmt.Errorf("failed to parse statistics: %w", err)
 			}
 			it.statistics = stats
+		case TokenFooter:
+			it.hasReadSummarySection = true
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
This reverts to previous behavior of determining the end of the summary section in the indexed reader by scanning for the footer. This change was introduced unnecessarily in the eventual implementation of the surrounding feature.