### PR TITLE
typescript: make forward and reverse iterators true opposites with multiple message at same timestamp within a chunk

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -213,6 +213,9 @@ export class ChunkCursor {
 
       result.record.records.sort(([logTimeA], [logTimeB]) => Number(logTimeA - logTimeB));
       if (reverse) {
+        // If we used `logTimeB - logTimeA` as the comparator for reverse iteration, messages with
+        // the same timestamp would not be in reverse order. To avoid this problem we use reverse()
+        // instead.
         result.record.records.reverse();
       }
 

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -211,10 +211,9 @@ export class ChunkCursor {
         continue;
       }
 
+      result.record.records.sort(([logTimeA], [logTimeB]) => Number(logTimeA - logTimeB));
       if (reverse) {
-        result.record.records.sort(([logTimeA], [logTimeB]) => Number(logTimeB - logTimeA));
-      } else {
-        result.record.records.sort(([logTimeA], [logTimeB]) => Number(logTimeA - logTimeB));
+        result.record.records.reverse();
       }
 
       for (let i = 0; i < result.record.records.length; i++) {


### PR DESCRIPTION
### Public-Facing Changes

TypeScript @mcap/core: fixed an issue where `readMessages({ reverse: true })` and `readMessages({ reverse: false })` would return messages in the same order when multiple messages were at the same timestamp.

### Description

`Array#sort()` is a stable sort. This means if multiple messages have the same timestamp, `sort(([a, b]) => b - a)` and `sort(([a, b]) => a - b)` would keep them in the same order. Instead of changing the comparator, we use `Array#reverse()` in the reverse case.

Note that this fix addresses messages within one chunk. It's possible there is still a similar issue when merging across multiple chunks.

Relates to https://github.com/foxglove/studio/issues/5551 / FG-2498