### PR TITLE
[C++] Add setChunkOptions method

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -389,6 +389,17 @@ public:
   Status write(const Metadata& metadata);
 
   /**
+   * @brief Set the chunk size, compression type, and compression level to use
+   * for the next Chunk record. This will close any open chunk and start a new
+   * one with the specified options.
+   *
+   * @param chunkSize Upper limit of the chunk size in bytes.
+   * @param type Compression type to use.
+   * @param level Compression level to use.
+   */
+  void setChunkOptions(size_t chunkSize, Compression type, CompressionLevel level);
+
+  /**
    * @brief Current MCAP file-level statistics. This is written as a Statistics
    * record in the Summary section of the MCAP file.
    */

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -640,6 +640,30 @@ Status McapWriter::write(const Metadata& metadata) {
   return StatusCode::Success;
 }
 
+void McapWriter::setChunkOptions(size_t chunkSize, Compression type, CompressionLevel level) {
+  closeLastChunk();
+
+  uncompressedChunk_.reset();
+  lz4Chunk_.reset();
+  zstdChunk_.reset();
+
+  chunkSize_ = chunkSize;
+  compression_ = type;
+
+  switch (type) {
+    case Compression::None:
+    default:
+      uncompressedChunk_ = std::make_unique<BufferWriter>();
+      break;
+    case Compression::Lz4:
+      lz4Chunk_ = std::make_unique<LZ4Writer>(level, chunkSize);
+      break;
+    case Compression::Zstd:
+      zstdChunk_ = std::make_unique<ZStdWriter>(level, chunkSize);
+      break;
+  }
+}
+
 const Statistics& McapWriter::statistics() const {
   return statistics_;
 }


### PR DESCRIPTION
### Public-Facing Changes
- [C++] McapWriter.setChunkOptions() for closing the current chunk and starting a new chunk with new options (chunk size and compression settings)

### Description

The C++ library gives fine-grained control over closing the current chunk and starting a new chunk, but the compression and chunk size options cannot be modified after opening a file for writing. This new method allows a new chunk to be started with new chunk size and compression options. This is practically useful when writing channels to separate parts of an MCAP file, such as writing small compressible topics first with 1MB size + ZSTD, followed by large incompressible video/image topics with 4MB size + NONE.