### PR TITLE
go/ros/bag2mcap: re-map 32-bit connection IDs to channel IDs

### DIFF
--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/pierrec/lz4/v4"
@@ -15,6 +16,10 @@ import (
 
 var (
 	BagMagic = []byte("#ROSBAG V2.0\n")
+)
+
+var (
+	ErrTooManyConnections = fmt.Errorf("bag contains more than %d connection IDs", math.MaxUint16)
 )
 
 type BagOp byte
@@ -240,6 +245,23 @@ func processBag(
 	return nil
 }
 
+func channelIDForConnection(knownConnIds *[]uint32, connId uint32) (uint16, error) {
+	// search the known set of connection IDs - we're assuming this linear search is faster
+	// than a hashmap for most bags with <1000 connections.
+	for index, knownConnId := range *knownConnIds {
+		if connId == knownConnId {
+			return uint16(index), nil
+		}
+	}
+	// need to add a new connection ID
+	if len(*knownConnIds) >= math.MaxUint16 {
+		return 0, ErrTooManyConnections
+	}
+	*knownConnIds = append(*knownConnIds, connId)
+	newChannelId := len(*knownConnIds) - 1
+	return uint16(newChannelId), nil
+}
+
 func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions) error {
 	writer, err := mcap.NewWriter(w, opts)
 	if err != nil {
@@ -254,6 +276,7 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions) error {
 		return err
 	}
 	seq := uint32(0)
+	connIds := make([]uint32, 0)
 	schemas := make(map[string]uint16)
 	return processBag(r,
 		func(header, data []byte) error {
@@ -261,7 +284,7 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions) error {
 			if err != nil {
 				return err
 			}
-			connID := binary.LittleEndian.Uint16(conn)
+			connID := binary.LittleEndian.Uint32(conn)
 			topic, err := extractHeaderValue(header, headerTopic)
 			if err != nil {
 				return err
@@ -291,8 +314,12 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions) error {
 				}
 				schemas[key] = schemaID
 			}
+			channelID, err := channelIDForConnection(&connIds, connID)
+			if err != nil {
+				return err
+			}
 			channelInfo := &mcap.Channel{
-				ID:              connID,
+				ID:              channelID,
 				Topic:           string(topic),
 				MessageEncoding: "ros1",
 				SchemaID:        schemas[key],
@@ -305,14 +332,18 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions) error {
 			if err != nil {
 				return err
 			}
-			connID := binary.LittleEndian.Uint16(conn)
+			connID := binary.LittleEndian.Uint32(conn)
 			time, err := extractHeaderValue(header, headerTime)
 			if err != nil {
 				return err
 			}
 			nsecs := rosTimeToNanoseconds(time)
+			channelID, err := channelIDForConnection(&connIds, connID)
+			if err != nil {
+				return err
+			}
 			err = writer.WriteMessage(&mcap.Message{
-				ChannelID:   connID,
+				ChannelID:   channelID,
 				Sequence:    seq,
 				LogTime:     nsecs,
 				PublishTime: nsecs,


### PR DESCRIPTION
### Public-Facing Changes

users with ROS bags that have extremely high connection ID values (perhaps from large or very-long-running stacks) will see their bags get correctly converted and not have connections clobber eachother.

### Description

Fixes a bug where we drop the 2 most significant bytes from the connection header when reading it. This could lead to accidentally merging some channels.
<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
