### PR TITLE
Better example for metadata name

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -61,6 +61,7 @@ words:
   - libmcap
   - mcap
   - msgdef
+  - mycompany
   - nanos
   - nanosec
   - noenv

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -279,7 +279,8 @@ A metadata record contains arbitrary user data in key-value pairs.
 
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |
-| 4 + N | name | String | Example: `mycompany`. |
+| 4 + N | name | String | Example: `my_company_name_hardware_info`. |
+| 4 + N | metadata | `Map<string, string>` | Example keys: `part_id`, `serial`, `board_revision` |
 | 4 + N | metadata | `Map<string, string>` | Example keys: `robot_id`, `git_sha`, `timezone`, `run_id`. |
 
 ### Metadata Index (op=0x0D)

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -279,7 +279,7 @@ A metadata record contains arbitrary user data in key-value pairs.
 
 | Bytes | Name | Type | Description |
 | --- | --- | --- | --- |
-| 4 + N | name | String | Example: `map_metadata`. |
+| 4 + N | name | String | Example: `mycompany`. |
 | 4 + N | metadata | `Map<string, string>` | Example keys: `robot_id`, `git_sha`, `timezone`, `run_id`. |
 
 ### Metadata Index (op=0x0D)


### PR DESCRIPTION
### Public-Facing Changes
The metadata `name` of `map_metadata` is redundant, we know it is a metadata record so we don't need that in the name. Also, the `map` part doesn't match any of the example key/values in the next line.