### PR TITLE
Create a flake.nix that packages the mcap-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ site/
 
 *.db3-shm
 *.db3-wal
+
+result

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -32,6 +32,7 @@ ignorePaths:
   - go
   - rust
   - cpp/examples/protobuf/proto
+  - flak.nix
 
 words:
   - bagfile

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -32,7 +32,8 @@ ignorePaths:
   - go
   - rust
   - cpp/examples/protobuf/proto
-  - flak.nix
+  - flake.nix
+  - flake.lock
 
 words:
   - bagfile

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679944645,
+        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "MCAP nix flake";
+
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        packages = rec {
+          mcap-cli = pkgs.buildGoModule rec {
+            pname = "mcap-cli";
+            version = "0.0.28";
+
+            src = ./go/cli/mcap;
+
+            vendorHash = "sha256-3TSwOgTIaBg5U8UdQ74LmsS8gS05Yw02JjfaIN9fKQQ=";
+
+            # tests are currently failing because the test mcap files are in another directory in the repo
+            doCheck = false;
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
### Public-Facing Changes
None
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description

Added a nix flake so you can use the [nix package manager](https://nixos.org/) to get the mcap-cli. 

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
