### PR TITLE
Fix bug in ros1msg parser

### DIFF
--- a/go/ros/ros1msg/ros1msg_parser.go
+++ b/go/ros/ros1msg/ros1msg_parser.go
@@ -77,9 +77,13 @@ func resolveDependentFields(
 			// type with its parent package.
 			// 3. The type may be "Header". This is a special case that needs to
 			// translate to std_msgs/Header.
+
+			// Start by assuming the parent package of the field is that of the overall type.
+			fieldParentPackage := parentPackage
+
 			typeIsQualified := strings.Contains(fieldType, "/")
 			if typeIsQualified {
-				parentPackage = strings.Split(fieldType, "/")[0]
+				fieldParentPackage = strings.Split(fieldType, "/")[0]
 			}
 			subdefinition, typeIsPresent := dependencies[fieldType]
 			switch {
@@ -91,14 +95,14 @@ func resolveDependentFields(
 					return nil, fmt.Errorf("dependency Header not found")
 				}
 			case !typeIsPresent && !typeIsQualified:
-				qualifiedType := parentPackage + "/" + fieldType
+				qualifiedType := fieldParentPackage + "/" + fieldType
 				subdefinition, ok = dependencies[qualifiedType]
 				if !ok {
 					return nil, fmt.Errorf("dependency %s not found", qualifiedType)
 				}
 			}
 			recordFields, err = resolveDependentFields(
-				parentPackage,
+				fieldParentPackage,
 				dependencies,
 				subdefinition,
 			)

--- a/go/ros/ros1msg/ros1msg_parser_test.go
+++ b/go/ros/ros1msg/ros1msg_parser_test.go
@@ -276,6 +276,72 @@ func TestROS1MSGParser(t *testing.T) {
 			},
 		},
 		{
+			"relative type different from parent type",
+			"my_package",
+			`my_package/MyType foo
+			===
+			MSG: my_package/MyType
+			my_other_package/MyOtherType foo
+			TypeInParentPackage bar
+			===
+			MSG: my_package/TypeInParentPackage
+			my_other_package/MyOtherType foo
+			===
+			MSG: my_other_package/MyOtherType
+			string data
+			`,
+			[]Field{
+				{
+					Name: "foo",
+					Type: Type{
+						BaseType: "my_package/MyType",
+						IsRecord: true,
+						Fields: []Field{
+							{
+								Name: "foo",
+								Type: Type{
+									BaseType: "my_other_package/MyOtherType",
+									IsRecord: true,
+									Fields: []Field{
+										{
+											Name: "data",
+											Type: Type{
+												BaseType: "string",
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "bar",
+								Type: Type{
+									BaseType: "TypeInParentPackage",
+									IsRecord: true,
+									Fields: []Field{
+										{
+											Name: "foo",
+											Type: Type{
+												BaseType: "my_other_package/MyOtherType",
+												IsRecord: true,
+												Fields: []Field{
+													{
+														Name: "data",
+														Type: Type{
+															BaseType: "string",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"uses tabs instead of spaces",
 			"",
 			"string foo\t# no spaces for me",


### PR DESCRIPTION
Prior to this commit, if a ROS 1 message definition contained both qualified and unqualified complex types in a particular order, it would incorrectly infer the parent package of a succeeding unqualified type, resulting in an erroneous failure to find a submessage definition. For a concrete example, a message definition like this:

```
        Foo foo
        ===
        MSG: Foo
        other_package/Bar bar
        FooBar foobar
        ===
        MSG: other_package/Bar
        string data
        ===
        MSG: original_package/FooBar
        string data
```

would result in the parser attempting to look up other_package/FooBar for FooBar's type definition, instead of looking for it in the parent package of the overall type.