### PR TITLE
Speed up ROS to JSON transcoder

### DIFF
--- a/go/cli/mcap/utils/ros/json_transcoder.go
+++ b/go/cli/mcap/utils/ros/json_transcoder.go
@@ -3,7 +3,6 @@ package ros
 import (
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -210,8 +209,7 @@ func (t *JSONTranscoder) string(w io.Writer, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	enc := json.NewEncoder(w)
-	err = enc.Encode(string(t.buf[:length]))
+	_, err = w.Write([]byte(strconv.QuoteToASCII(string(t.buf[:length]))))
 	if err != nil {
 		return err
 	}
@@ -462,8 +460,8 @@ func (t *JSONTranscoder) record(fields []recordField) converter {
 			buf[0] = '"'
 			buf[1+len(field.name)] = '"'
 			buf[2+len(field.name)] = ':'
-			copy(buf[1:], field.name)
-			_, err := w.Write(buf[:3+len(field.name)])
+			n := copy(buf[1:], field.name)
+			_, err := w.Write(buf[:3+n])
 			if err != nil {
 				return fmt.Errorf("failed to write field %s name: %w", field.name, err)
 			}

--- a/go/cli/mcap/utils/ros/json_transcoder_test.go
+++ b/go/cli/mcap/utils/ros/json_transcoder_test.go
@@ -150,6 +150,24 @@ func TestJSONTranscoding(t *testing.T) {
 			},
 			`{"foo":{"bar":{"baz":"hello"}}}`,
 		},
+		{
+			"array of record",
+			"",
+			`Foo[] foo
+			===
+			MSG: Foo
+			string bar
+			string baz
+			`,
+			[]byte{
+				0x02, 0x00, 0x00, 0x00, // two elements
+				0x03, 0x00, 0x00, 0x00, 'b', 'a', 'z',
+				0x03, 0x00, 0x00, 0x00, 'b', 'a', 'z',
+				0x03, 0x00, 0x00, 0x00, 'b', 'a', 'z',
+				0x03, 0x00, 0x00, 0x00, 'b', 'a', 'z',
+			},
+			`{"foo":[{"bar":"baz","baz":"baz"},{"bar":"baz","baz":"baz"}]}`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
@@ -159,7 +177,7 @@ func TestJSONTranscoding(t *testing.T) {
 			assert.Nil(t, err)
 			err = transcoder.Transcode(buf, bytes.NewReader(c.input))
 			assert.Nil(t, err)
-			assert.JSONEq(t, c.expectedJSON, buf.String())
+			assert.Equal(t, c.expectedJSON, buf.String())
 		})
 	}
 }
@@ -438,7 +456,7 @@ func TestSingleRecordConversion(t *testing.T) {
 			converter := transcoder.record(c.fields)
 			err := converter(buf, bytes.NewBuffer(c.input))
 			assert.Nil(t, err)
-			assert.JSONEq(t, c.output, buf.String())
+			assert.Equal(t, c.output, buf.String())
 		})
 	}
 }


### PR DESCRIPTION
This speeds up the ROS to JSON transcoder by removing dependency on the encoding/json package from both it and the cat command.

Prior to this commit, JSON transcoding spent inordinate amounts of CPU time compacting the JSON the transcoder was emitting, however that JSON was almost compact already. Removing the encoder from the cat command revealed that the encoding of strings out of the transcoder was not compact - they got encoded as a quoted string followed by a newline. Removing encoding/json from the transcoder and replacing it with strconv.QuoteToAscii fixed this.