### PR TITLE
CLI: represent NaNs consistently in cat --json

### DIFF
--- a/go/cli/mcap/utils/ros/json_transcoder_test.go
+++ b/go/cli/mcap/utils/ros/json_transcoder_test.go
@@ -325,6 +325,42 @@ func TestSingleRecordConversion(t *testing.T) {
 			`{"foo":3.14159}`,
 		},
 		{
+			"float32 NaN",
+			"",
+			[]recordField{
+				{
+					name:      "foo",
+					converter: transcoder.float32,
+				},
+			},
+			[]byte{0, 0, 192, 127},
+			`{"foo":"NaN"}`,
+		},
+		{
+			"float32 Infinity",
+			"",
+			[]recordField{
+				{
+					name:      "foo",
+					converter: transcoder.float32,
+				},
+			},
+			[]byte{0, 0, 128, 127},
+			`{"foo":"Infinity"}`,
+		},
+		{
+			"float32 -Infinity",
+			"",
+			[]recordField{
+				{
+					name:      "foo",
+					converter: transcoder.float32,
+				},
+			},
+			[]byte{0, 0, 128, 255},
+			`{"foo":"-Infinity"}`,
+		},
+		{
 			"float64",
 			"",
 			[]recordField{
@@ -335,6 +371,42 @@ func TestSingleRecordConversion(t *testing.T) {
 			},
 			[]byte{24, 106, 203, 110, 105, 118, 1, 64},
 			`{"foo":2.18281828459045}`,
+		},
+		{
+			"float64 NaN",
+			"",
+			[]recordField{
+				{
+					name:      "foo",
+					converter: transcoder.float64,
+				},
+			},
+			[]byte{1, 0, 0, 0, 0, 0, 248, 127},
+			`{"foo":"NaN"}`,
+		},
+		{
+			"float64 Infinity",
+			"",
+			[]recordField{
+				{
+					name:      "foo",
+					converter: transcoder.float64,
+				},
+			},
+			[]byte{0, 0, 0, 0, 0, 0, 240, 127},
+			`{"foo":"Infinity"}`,
+		},
+		{
+			"float64 -Infinity",
+			"",
+			[]recordField{
+				{
+					name:      "foo",
+					converter: transcoder.float64,
+				},
+			},
+			[]byte{0, 0, 0, 0, 0, 0, 240, 255},
+			`{"foo":"-Infinity"}`,
 		},
 		{
 			"time",


### PR DESCRIPTION
### Public-Facing Changes
Rather than printing the `go` default representation of NaNs and Infs, the ROS JSON transcoder now follows the lead of `protojson` when representing NaN float values. 
### Description
See the [protojson docs under "float, double"](https://protobuf.dev/programming-guides/proto3/#json), and the [source code here](https://github.com/protocolbuffers/protobuf-go/blob/f221882bfb484564f1714ae05f197dea2c76898d/internal/encoding/json/encode.go#L148). I chose this because that's the simplest way to get consistent output between the set of transcoders we support currently (ROS1 and protobuf).

