### PR TITLE
doctor: do not error on schemaless channels

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -293,8 +293,14 @@ func (doctor *mcapDoctor) Examine() error {
 
 			doctor.channels[channel.ID] = channel
 
-			if _, ok := doctor.schemas[channel.SchemaID]; !ok {
-				doctor.error("Encountered Channel (%d) with unknown Schema (%d)", channel.ID, channel.SchemaID)
+			if channel.SchemaID != 0 {
+				if _, ok := doctor.schemas[channel.SchemaID]; !ok {
+					doctor.error(
+						"Encountered Channel (%d) with unknown Schema (%d)",
+						channel.ID,
+						channel.SchemaID,
+					)
+				}
 			}
 		case mcap.TokenMessage:
 			message, err := mcap.ParseMessage(data)


### PR DESCRIPTION
### Public-Facing Changes

`mcap doctor` no longer reports an error for channel records with schema ID 0. This is not an error for message encodings that do not require a schema to decode.

