### PR TITLE
TypeScript Text Annotations example

### DIFF
--- a/typescript/examples/text-annotation-demo/.eslintrc.js
+++ b/typescript/examples/text-annotation-demo/.eslintrc.js
@@ -1,0 +1,19 @@
+/* eslint-env node */
+module.exports = {
+  env: { es2020: true },
+  ignorePatterns: ["dist"],
+  extends: ["plugin:@foxglove/base", "plugin:@foxglove/jest"],
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      extends: ["plugin:@foxglove/typescript"],
+      parserOptions: {
+        project: "tsconfig.json",
+        tsconfigRootDir: __dirname,
+      },
+    },
+  ],
+  rules: {
+    "no-warning-comments": ["error", { terms: ["fixme"], location: "anywhere" }],
+  },
+};

--- a/typescript/examples/text-annotation-demo/package.json
+++ b/typescript/examples/text-annotation-demo/package.json
@@ -2,7 +2,7 @@
   "name": "@foxglove/text-annotation-demo",
   "version": "0.0.0",
   "private": true,
-  "description": "MCAP validation example",
+  "description": "Demo foxglove.TextAnnotations",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/typescript/examples/text-annotation-demo/package.json
+++ b/typescript/examples/text-annotation-demo/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@foxglove/text-annotation-demo",
+  "version": "0.0.0",
+  "private": true,
+  "description": "MCAP validation example",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/foxglove/mcap.git"
+  },
+  "author": {
+    "name": "Foxglove Technologies",
+    "email": "support@foxglove.dev"
+  },
+  "homepage": "https://foxglove.dev/",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "main": "ts-node --files --project tsconfig.cjs.json scripts/main.ts"
+  },
+  "devDependencies": {
+    "@foxglove/eslint-plugin": "0.21.0",
+    "@mcap/core": "*",
+    "@types/node": "18.13.0",
+    "eslint": "8.34.0",
+    "eslint-config-prettier": "8.6.0",
+    "eslint-plugin-es": "4.1.0",
+    "eslint-plugin-filenames": "1.3.2",
+    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-prettier": "4.2.1",
+    "prettier": "2.8.4",
+    "ts-node": "10.9.1",
+    "typescript": "4.9.5"
+  },
+  "dependencies": {
+    "@foxglove/schemas": "1.3.0"
+  }
+}

--- a/typescript/examples/text-annotation-demo/scripts/Scene.ts
+++ b/typescript/examples/text-annotation-demo/scripts/Scene.ts
@@ -11,7 +11,7 @@ type SceneParams = {
   width: number;
   height: number;
   ballRadius: number;
-  gravityCoeff: number;
+  gravityCoefficient: number;
   frameId: string;
 };
 
@@ -26,18 +26,18 @@ export default class Scene {
   public height: number;
   public aspect: number;
   public ballRadius: number;
-  public gravityCoeff: number;
+  public gravityCoefficient: number;
   public frameId: string;
 
   private ball: Ball;
 
-  constructor({ width, height, ballRadius, gravityCoeff = 0.005, frameId }: SceneParams) {
+  constructor({ width, height, ballRadius, gravityCoefficient = 0.005, frameId }: SceneParams) {
     this.image = new Image(width, height);
     this.width = width;
     this.height = height;
     this.aspect = width / height;
     this.ballRadius = ballRadius;
-    this.gravityCoeff = gravityCoeff;
+    this.gravityCoefficient = gravityCoefficient;
     this.frameId = frameId;
     this.ball = {
       pos: { x: 0.25, y: 0.5 },
@@ -140,7 +140,7 @@ export default class Scene {
   public animateBall(): void {
     this.ball.pos.x += this.ball.vel.x;
     this.ball.pos.y += this.ball.vel.y;
-    this.ball.vel.y += this.gravityCoeff;
+    this.ball.vel.y += this.gravityCoefficient;
     if (this.ball.pos.x < 0 || this.ball.pos.x > 1) {
       this.ball.vel.x *= -0.8;
       this.ball.pos.x = Math.max(0, Math.min(1, this.ball.pos.x));
@@ -167,7 +167,7 @@ export default class Scene {
   }
 }
 
-// 2555
+// 255
 type Color = [number, number, number];
 
 class Image {

--- a/typescript/examples/text-annotation-demo/scripts/Scene.ts
+++ b/typescript/examples/text-annotation-demo/scripts/Scene.ts
@@ -72,6 +72,7 @@ export default class Scene {
       width: this.width,
       height: this.height,
       encoding: "rgb8",
+      // required for encoding Uint8Array in `json` encoding
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       data: Buffer.from(this.image.getData()).toString("base64"),
@@ -99,12 +100,11 @@ export default class Scene {
           x: this.ball.pos.x * this.width - this.ballRadius * 2,
           y: this.ball.pos.y * this.height + this.ballRadius * 2,
         },
-        // floor points
       ].map((point) => ({ x: Math.floor(point.x), y: Math.floor(point.y) })),
       outline_colors: [],
       thickness: 1,
       outline_color: { r: 0, g: 0, b: 1, a: 1 },
-      fill_color: { r: 0, g: 0, b: 1, a: 0.0 },
+      fill_color: { r: 0, g: 0, b: 1, a: 0.3 },
     };
 
     return {

--- a/typescript/examples/text-annotation-demo/scripts/Scene.ts
+++ b/typescript/examples/text-annotation-demo/scripts/Scene.ts
@@ -58,7 +58,7 @@ export default class Scene {
       distortion_model: "rational_polynomial",
       D: [],
       K: [fx, 0, cx, 0, fy, cy, 0, 0, 1],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+      R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
       P: [fx, 0, cx, 0, 0, fy, cy, 0, 0, 0, 1, 0],
     };
 

--- a/typescript/examples/text-annotation-demo/scripts/Scene.ts
+++ b/typescript/examples/text-annotation-demo/scripts/Scene.ts
@@ -1,0 +1,224 @@
+import {
+  CameraCalibration,
+  ImageAnnotations,
+  PointsAnnotation,
+  PointsAnnotationType,
+  RawImage,
+} from "@foxglove/schemas";
+import { Time } from "@foxglove/schemas/schemas/typescript/Time";
+
+type SceneParams = {
+  width: number;
+  height: number;
+  ballRadius: number;
+  gravityCoeff: number;
+  frameId: string;
+};
+
+type Ball = {
+  pos: { x: number; y: number }; // 0-1
+  vel: { x: number; y: number }; // 0-1
+};
+
+export default class Scene {
+  public image: Image;
+  public width: number;
+  public height: number;
+  public aspect: number;
+  public ballRadius: number;
+  public gravityCoeff: number;
+  public frameId: string;
+
+  private ball: Ball;
+
+  constructor({ width, height, ballRadius, gravityCoeff = 0.005, frameId }: SceneParams) {
+    this.image = new Image(width, height);
+    this.width = width;
+    this.height = height;
+    this.aspect = width / height;
+    this.ballRadius = ballRadius;
+    this.gravityCoeff = gravityCoeff;
+    this.frameId = frameId;
+    this.ball = {
+      pos: { x: 0.25, y: 0.5 },
+      vel: { x: 0.1, y: 0.1 },
+    };
+  }
+
+  public getCameraCalibration(time: Time): CameraCalibration {
+    const fx = 500;
+    const fy = 500;
+    const cx = this.width / 2;
+    const cy = this.height / 2;
+    const calibrationMessage: CameraCalibration = {
+      timestamp: time,
+      frame_id: "cam",
+      height: this.height,
+      width: this.width,
+      distortion_model: "rational_polynomial",
+      D: [],
+      K: [fx, 0, cx, 0, fy, cy, 0, 0, 1],
+      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+      P: [fx, 0, cx, 0, 0, fy, cy, 0, 0, 0, 1, 0],
+    };
+
+    return calibrationMessage;
+  }
+
+  getRawImage(time: Time): RawImage {
+    return {
+      timestamp: time,
+      frame_id: this.frameId,
+      width: this.width,
+      height: this.height,
+      encoding: "rgb8",
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      data: Buffer.from(this.image.getData()).toString("base64"),
+    };
+  }
+
+  public getImageAnnotations(time: Time): ImageAnnotations {
+    const ballBoundingPoints: PointsAnnotation = {
+      timestamp: time,
+      type: PointsAnnotationType.LINE_LOOP,
+      points: [
+        {
+          x: this.ball.pos.x * this.width - this.ballRadius * 2,
+          y: this.ball.pos.y * this.height - this.ballRadius * 2,
+        },
+        {
+          x: this.ball.pos.x * this.width + this.ballRadius * 2,
+          y: this.ball.pos.y * this.height - this.ballRadius * 2,
+        },
+        {
+          x: this.ball.pos.x * this.width + this.ballRadius * 2,
+          y: this.ball.pos.y * this.height + this.ballRadius * 2,
+        },
+        {
+          x: this.ball.pos.x * this.width - this.ballRadius * 2,
+          y: this.ball.pos.y * this.height + this.ballRadius * 2,
+        },
+        // floor points
+      ].map((point) => ({ x: Math.floor(point.x), y: Math.floor(point.y) })),
+      outline_colors: [],
+      thickness: 1,
+      outline_color: { r: 0, g: 0, b: 1, a: 1 },
+      fill_color: { r: 0, g: 0, b: 1, a: 0.0 },
+    };
+
+    return {
+      points: [ballBoundingPoints],
+      circles: [],
+      texts: [
+        {
+          timestamp: time,
+          // top left
+          position: {
+            x: Math.floor(this.ball.pos.x * this.width - this.ballRadius * 2),
+            y: Math.floor(this.ball.pos.y * this.height - this.ballRadius * 2),
+          },
+          text: `Position: x: ${Math.floor(this.ball.pos.x * this.width)}, y: ${Math.floor(
+            this.ball.pos.y * this.height,
+          )}`,
+          font_size: 12,
+          text_color: { r: 1, g: 1, b: 1, a: 1 },
+          background_color: { r: 0, g: 0, b: 1, a: 0.7 },
+        },
+        {
+          timestamp: time,
+          position: { x: 15, y: 15 },
+          text: `Time: ${time.sec}.${time.nsec}`,
+          font_size: 12,
+          text_color: { r: 0, g: 0, b: 0, a: 1 },
+          background_color: { r: 1, g: 1, b: 1, a: 1 },
+        },
+      ],
+    };
+  }
+
+  public animateBall(): void {
+    this.ball.pos.x += this.ball.vel.x;
+    this.ball.pos.y += this.ball.vel.y;
+    this.ball.vel.y += this.gravityCoeff;
+    if (this.ball.pos.x < 0 || this.ball.pos.x > 1) {
+      this.ball.vel.x *= -0.8;
+      this.ball.pos.x = Math.max(0, Math.min(1, this.ball.pos.x));
+    }
+    if (this.ball.pos.y < 0 || this.ball.pos.y > 1) {
+      this.ball.vel.y *= -0.8;
+      this.ball.pos.y = Math.max(0, Math.min(1, this.ball.pos.y));
+    }
+  }
+
+  public renderScene(): void {
+    this.animateBall();
+    this.image.clear();
+    this.image.paintCircle(
+      Math.floor(this.ball.pos.x * this.width),
+      Math.floor(this.ball.pos.y * this.height),
+      5,
+      [255, 0, 0],
+    );
+  }
+
+  public getImageData(): Uint8Array {
+    return this.image.getData();
+  }
+}
+
+// 2555
+type Color = [number, number, number];
+
+class Image {
+  width: number;
+  height: number;
+  data: Uint8Array;
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.data = new Uint8Array(width * height * 3);
+  }
+
+  public getData(): Uint8Array {
+    return this.data;
+  }
+
+  public paintCircle(x: number, y: number, radius: number, color: Color): void {
+    const rowRange = [Math.max(0, y - radius), Math.min(this.height - 1, y + radius)] as const;
+    const colRange = [Math.max(0, x - radius), Math.min(this.width - 1, x + radius)] as const;
+    for (let row = rowRange[0]; row <= rowRange[1]; row++) {
+      for (let col = colRange[0]; col <= colRange[1]; col++) {
+        const dist = Math.sqrt((row - y) ** 2 + (col - x) ** 2);
+        if (dist <= radius * 1.1) {
+          const index = (row * this.width + col) * 3;
+          this.data[index] = color[0];
+          this.data[index + 1] = color[1];
+          this.data[index + 2] = color[2];
+        }
+      }
+    }
+  }
+
+  public clear(): void {
+    for (let i = 0, r = 0; r < this.height; r++) {
+      for (let c = 0; c < this.width; c++) {
+        if (r === 0 || r === this.height - 1 || c === 0 || c === this.width - 1) {
+          this.data[i++] = 150;
+          this.data[i++] = 150;
+          this.data[i++] = 255;
+        } else {
+          this.data[i++] =
+            (r % Math.floor(this.width * 0.1) === 0 ? 127 : 0) +
+            (c % Math.floor(this.height * 0.1) === 0 ? 127 : 0);
+          this.data[i++] =
+            (r % Math.floor(this.width * 0.1) === 0 ? 127 : 0) +
+            (c % Math.floor(this.height * 0.1) === 0 ? 127 : 0);
+          this.data[i++] =
+            (r % Math.floor(this.width * 0.1) === 0 ? 127 : 0) +
+            (c % Math.floor(this.height * 0.1) === 0 ? 127 : 0);
+        }
+      }
+    }
+  }
+}

--- a/typescript/examples/text-annotation-demo/scripts/main.ts
+++ b/typescript/examples/text-annotation-demo/scripts/main.ts
@@ -1,0 +1,147 @@
+import {
+  CameraCalibration as CameraCalibrationSchema,
+  RawImage as RawImageSchema,
+  ImageAnnotations as ImageAnnotationsSchema,
+} from "@foxglove/schemas/jsonschema";
+import { Time } from "@foxglove/schemas/schemas/typescript/Time";
+import { McapWriter, IWritable } from "@mcap/core";
+import { open, FileHandle } from "fs/promises";
+
+import Scene from "./Scene";
+
+/**
+ * Convert an integer number of nanoseconds to Time
+ * @param nsec Nanoseconds integer
+ * @returns Time object
+ */
+export function fromNanoSec(nsec: bigint): Time {
+  // From https://github.com/ros/roscpp_core/blob/86720717c0e1200234cc0a3545a255b60fb541ec/rostime/include/ros/impl/time.h#L63
+  // and https://github.com/ros/roscpp_core/blob/7583b7d38c6e1c2e8623f6d98559c483f7a64c83/rostime/src/time.cpp#L536
+  //
+  // Note: BigInt(1e9) is slower than writing out the number
+  return { sec: Number(nsec / 1_000_000_000n), nsec: Number(nsec % 1_000_000_000n) };
+}
+
+// Mcap IWritable interface for nodejs FileHandle
+class FileHandleWritable implements IWritable {
+  private handle: FileHandle;
+  private totalBytesWritten = 0;
+
+  constructor(handle: FileHandle) {
+    this.handle = handle;
+  }
+
+  async write(buffer: Uint8Array): Promise<void> {
+    const written = await this.handle.write(buffer);
+    this.totalBytesWritten += written.bytesWritten;
+  }
+
+  position(): bigint {
+    return BigInt(this.totalBytesWritten);
+  }
+}
+
+const framesPerSecond = 30;
+const lengthSeconds = 10; // seconds
+
+async function main() {
+  const mcapFilePath = "text-annotation-example.mcap";
+  const fileHandle = await open(mcapFilePath, "w");
+  const fileHandleWritable = new FileHandleWritable(fileHandle);
+
+  const mcapFile = new McapWriter({
+    writable: fileHandleWritable,
+    useStatistics: true,
+    useChunks: true,
+    useChunkIndex: true,
+  });
+
+  await mcapFile.start({
+    profile: "",
+    library: "mcap example",
+  });
+
+  const calibrationSchemaId = await mcapFile.registerSchema({
+    name: CameraCalibrationSchema.title,
+    encoding: "jsonschema",
+    data: Buffer.from(JSON.stringify(CameraCalibrationSchema)),
+  });
+
+  const calibrationChannelId = await mcapFile.registerChannel({
+    schemaId: calibrationSchemaId,
+    topic: "calibration",
+    messageEncoding: "json",
+    metadata: new Map(),
+  });
+
+  const imageSchemaId = await mcapFile.registerSchema({
+    name: RawImageSchema.title,
+    encoding: "jsonschema",
+    data: Buffer.from(JSON.stringify(RawImageSchema)),
+  });
+
+  const imageChannelId = await mcapFile.registerChannel({
+    schemaId: imageSchemaId,
+    topic: "camera",
+    messageEncoding: "json",
+    metadata: new Map(),
+  });
+
+  const annotationSchemaId = await mcapFile.registerSchema({
+    name: ImageAnnotationsSchema.title,
+    encoding: "jsonschema",
+    data: Buffer.from(JSON.stringify(ImageAnnotationsSchema)),
+  });
+
+  const annotationsChannelId = await mcapFile.registerChannel({
+    schemaId: annotationSchemaId,
+    topic: "annotations",
+    messageEncoding: "json",
+    metadata: new Map(),
+  });
+
+  let currentTimeSeconds = 0;
+
+  const scene = new Scene({
+    width: 800,
+    height: 600,
+    frameId: "cam",
+    ballRadius: 5,
+    gravityCoeff: 0.005,
+  });
+
+  while (currentTimeSeconds < lengthSeconds) {
+    scene.renderScene();
+
+    const bigTime = BigInt(Math.floor(currentTimeSeconds * 1_000_000_000));
+    const rosTime = fromNanoSec(bigTime);
+
+    await mcapFile.addMessage({
+      channelId: calibrationChannelId,
+      sequence: 0,
+      publishTime: 0n,
+      logTime: bigTime,
+      data: Buffer.from(JSON.stringify(scene.getCameraCalibration(rosTime))),
+    });
+    await mcapFile.addMessage({
+      channelId: imageChannelId,
+      sequence: 0,
+      publishTime: 0n,
+      logTime: bigTime,
+      data: Buffer.from(JSON.stringify(scene.getRawImage(rosTime))),
+    });
+    await mcapFile.addMessage({
+      channelId: annotationsChannelId,
+      sequence: 0,
+      publishTime: 0n,
+      logTime: bigTime,
+      data: Buffer.from(JSON.stringify(scene.getImageAnnotations(rosTime))),
+    });
+
+    currentTimeSeconds += 1 / framesPerSecond;
+  }
+
+  await mcapFile.end();
+}
+
+void main();

--- a/typescript/examples/text-annotation-demo/scripts/main.ts
+++ b/typescript/examples/text-annotation-demo/scripts/main.ts
@@ -92,7 +92,7 @@ async function main() {
     height: 600,
     frameId: "cam",
     ballRadius: 5,
-    gravityCoeff: 0.005,
+    gravityCoefficient: 0.005,
   });
 
   const deltaBetweenFrames = 1 / framesPerSecond;

--- a/typescript/examples/text-annotation-demo/tsconfig.cjs.json
+++ b/typescript/examples/text-annotation-demo/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/typescript/examples/text-annotation-demo/tsconfig.json
+++ b/typescript/examples/text-annotation-demo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@foxglove/tsconfig/base",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../..",
+    "outDir": "./dist/esm",
+    "lib": ["es2020", "dom"],
+    "paths": {
+      "@mcap/core": ["../../core/src"]
+    },
+
+    // required for tsconfig-paths https://github.com/dividab/tsconfig-paths/issues/143
+    "baseUrl": "."
+  },
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,6 +1100,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@foxglove/message-definition@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@foxglove/message-definition@npm:0.2.0"
+  checksum: 8f972dd52cf2f44e8357c8f13ee2136b23548d49d9251fc47c68569a33effe5d082c0681e3b0761751dd27759ac778f1e45de9f52d5925298ccc80e607784159
+  languageName: node
+  linkType: hard
+
 "@foxglove/rosbag@npm:0.2.3":
   version: 0.2.3
   resolution: "@foxglove/rosbag@npm:0.2.3"
@@ -1118,6 +1125,16 @@ __metadata:
   dependencies:
     "@foxglove/rosmsg": ^3.1.0
   checksum: 1e6bcff0f21f431ab41dd703b7b4cbd76007fdea297c1c0d6b9cbddd9affe0f4991ea846be861c6863078555e8927bc64160db5a3a73f3d32d0f14c39e51a285
+  languageName: node
+  linkType: hard
+
+"@foxglove/rosmsg-msgs-common@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@foxglove/rosmsg-msgs-common@npm:3.0.0"
+  dependencies:
+    "@foxglove/message-definition": ^0.2.0
+    "@foxglove/rosmsg": ^4.0.0
+  checksum: 10fd24faa232c528f7b9e28acda82ebf49e092c263bd322edd1adf56601cdf1cf7512bcad3cdf1d0997605852c5e5dd2dfffe00107b8f8ae66f2d40d1b6e450e
   languageName: node
   linkType: hard
 
@@ -1150,10 +1167,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/rosmsg@npm:^4.0.0":
+  version: 4.2.2
+  resolution: "@foxglove/rosmsg@npm:4.2.2"
+  dependencies:
+    "@foxglove/message-definition": ^0.2.0
+    md5-typescript: ^1.0.5
+  bin:
+    gendeps2: bin/gendeps2
+  checksum: b982a6d03e3552b24fc4188e3cf08daddf2054b16c39073068749df2e754d26622ce7548ea0bf9dc424db2b1cec5e76f02e9cb9823e5a4da10b672d6606118f2
+  languageName: node
+  linkType: hard
+
 "@foxglove/rostime@npm:^1.1.2":
   version: 1.1.2
   resolution: "@foxglove/rostime@npm:1.1.2"
   checksum: a4f93001ccfa011f679af9a3d1e04c2d3c499848a9845856bf17f23cf9369ab975b27cd9fd048187002468de6852861bfb2292d5cfcbd85ff43afc274e1279e8
+  languageName: node
+  linkType: hard
+
+"@foxglove/schemas@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@foxglove/schemas@npm:1.3.0"
+  dependencies:
+    "@foxglove/rosmsg-msgs-common": ^3.0.0
+    tslib: ^2.5.0
+  checksum: e4998c51bc874eeeba4c254d68ab5933278dc9c58dc2ec49b33ec8727338d47b971dfca51126b8bbd07f6385acc7f812d5b370e81cb5e6cd47fc026a8a27e93c
   languageName: node
   linkType: hard
 
@@ -1166,6 +1205,26 @@ __metadata:
   checksum: c6fa851381441534ef465f247615c61a3963e80d02a94c7b07a49bb9468ab704c43e6fe7f07f83bacaf5bdc8bce8bf96b02fef5e62c9c427c5e10bd060c24fec
   languageName: node
   linkType: hard
+
+"@foxglove/text-annotation-demo@workspace:typescript/examples/text-annotation-demo":
+  version: 0.0.0-use.local
+  resolution: "@foxglove/text-annotation-demo@workspace:typescript/examples/text-annotation-demo"
+  dependencies:
+    "@foxglove/eslint-plugin": 0.21.0
+    "@foxglove/schemas": 1.3.0
+    "@mcap/core": "*"
+    "@types/node": 18.13.0
+    eslint: 8.34.0
+    eslint-config-prettier: 8.6.0
+    eslint-plugin-es: 4.1.0
+    eslint-plugin-filenames: 1.3.2
+    eslint-plugin-import: 2.27.5
+    eslint-plugin-prettier: 4.2.1
+    prettier: 2.8.4
+    ts-node: 10.9.1
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
 
 "@foxglove/tsconfig@npm:1.1.0":
   version: 1.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,15 +1119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-msgs-common@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "@foxglove/rosmsg-msgs-common@npm:2.1.0"
-  dependencies:
-    "@foxglove/rosmsg": ^3.1.0
-  checksum: 1e6bcff0f21f431ab41dd703b7b4cbd76007fdea297c1c0d6b9cbddd9affe0f4991ea846be861c6863078555e8927bc64160db5a3a73f3d32d0f14c39e51a285
-  languageName: node
-  linkType: hard
-
 "@foxglove/rosmsg-msgs-common@npm:^3.0.0":
   version: 3.0.0
   resolution: "@foxglove/rosmsg-msgs-common@npm:3.0.0"
@@ -1186,23 +1177,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/schemas@npm:1.3.0":
+"@foxglove/schemas@npm:1.3.0, @foxglove/schemas@npm:^1.0.0":
   version: 1.3.0
   resolution: "@foxglove/schemas@npm:1.3.0"
   dependencies:
     "@foxglove/rosmsg-msgs-common": ^3.0.0
     tslib: ^2.5.0
   checksum: e4998c51bc874eeeba4c254d68ab5933278dc9c58dc2ec49b33ec8727338d47b971dfca51126b8bbd07f6385acc7f812d5b370e81cb5e6cd47fc026a8a27e93c
-  languageName: node
-  linkType: hard
-
-"@foxglove/schemas@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@foxglove/schemas@npm:1.0.0"
-  dependencies:
-    "@foxglove/rosmsg-msgs-common": ^2.0.0
-    tslib: ^2
-  checksum: c6fa851381441534ef465f247615c61a3963e80d02a94c7b07a49bb9468ab704c43e6fe7f07f83bacaf5bdc8bce8bf96b02fef5e62c9c427c5e10bd060c24fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add Typescript example that creates text annotations on an image. 
This also upgrades `@foxglove/schemas` to 1.3.0