### PR TITLE
Fix mcap conversion for bzip2 bags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ cpp/examples/protobuf/proto/** linguist-vendored=true linguist-generated=true
 python/mcap-ros1-support/mcap_ros1/vendor/** linguist-vendored=true
 tests/conformance/data/** linguist-generated=true
 typescript/examples/flatbuffer/output/** linguist-generated=true
+go/ros/testdata/markers.bz2.bag filter=lfs diff=lfs merge=lfs -text

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -89,6 +89,26 @@ func BenchmarkBag2MCAP(b *testing.B) {
 	}
 }
 
+func TestConvertsBz2(t *testing.T) {
+	inputfile := "testdata/markers.bz2.bag"
+	f, err := os.Open(inputfile)
+	assert.Nil(t, err)
+	opts := &mcap.WriterOptions{
+		IncludeCRC:  true,
+		Chunked:     true,
+		ChunkSize:   4 * 1024 * 1024,
+		Compression: "",
+	}
+	output := &bytes.Buffer{}
+	assert.Nil(t, Bag2MCAP(output, f, opts))
+
+	reader, err := mcap.NewReader(bytes.NewReader(output.Bytes()))
+	assert.Nil(t, err)
+	info, err := reader.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, 10, int(info.Statistics.MessageCount))
+}
+
 func TestChannelIdForConnection(t *testing.T) {
 	cases := []struct {
 		label             string

--- a/go/ros/testdata/markers.bz2.bag
+++ b/go/ros/testdata/markers.bz2.bag
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48cb3f1497ef0c21eeb9acc5310f6988454e6388c69a01ef578ea891d1fb19e5
+size 14233


### PR DESCRIPTION
Prior to this commit, the bzip2 decompression was broken on bags with more than one chunk. The chunk reader was getting set to a basic reader on the underlying chunk data, rather than a bz2 decompressor (on chunks after the first).

This fixes that and also does a minor refactor to remove the concept of a resettable reader. This was only applicable to the lz4 decompressor previously (out of three - lz4, none, and bz2) and existed to fake generic support for resetting readers when underlying readers didn't support that. Rather than doing that, special case lz4 and use the other two reader types directly.