### PR TITLE
cpp: fix header parsing

### DIFF
--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -725,8 +725,11 @@ Status McapReader::ParseHeader(const Record& record, Header* header) {
       !status.ok()) {
     return status;
   }
-  const uint64_t maxSize = record.dataSize - 4 - header->profile.size();
-  if (auto status = internal::ParseString(record.data, maxSize, &header->library); !status.ok()) {
+  const size_t libraryOffset = 4 + header->profile.size();
+  const std::byte* libraryData = &(record.data[libraryOffset]);
+  const size_t maxSize = record.dataSize - libraryOffset;
+  auto status = internal::ParseString(libraryData, maxSize, &header->library);
+  if (!status.ok()) {
     return status;
   }
   return StatusCode::Success;

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -882,3 +882,21 @@ TEST_CASE("RecordOffset equality operators", "[reader]") {
     REQUIRE(b >= a);
   }
 }
+
+TEST_CASE("parsing", "header") {
+  Buffer buffer;
+  writeExampleFile(buffer);
+  mcap::McapWriter writer;
+  mcap::McapWriterOptions opts("myprofile");
+  opts.library = "mylibrary";
+  requireOk(writer.open(buffer, opts));
+  requireOk(writer.close());
+
+  mcap::McapReader reader;
+  auto status = reader.open(buffer);
+  requireOk(status);
+
+  auto header = reader.header();
+  REQUIRE(header.profile == "myprofile");
+  REQUIRE(header.library == "mylibrary");
+}

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -885,18 +885,19 @@ TEST_CASE("RecordOffset equality operators", "[reader]") {
 
 TEST_CASE("parsing", "header") {
   Buffer buffer;
-  writeExampleFile(buffer);
   mcap::McapWriter writer;
-  mcap::McapWriterOptions opts("myprofile");
-  opts.library = "mylibrary";
-  requireOk(writer.open(buffer, opts));
-  requireOk(writer.close());
+  mcap::McapWriterOptions opts("my-profile");
+  opts.library = "my-library";
+  writer.open(buffer, opts);
+  writer.close();
 
   mcap::McapReader reader;
   auto status = reader.open(buffer);
   requireOk(status);
 
   auto header = reader.header();
-  REQUIRE(header.profile == "myprofile");
-  REQUIRE(header.library == "mylibrary");
+  REQUIRE(header != std::nullopt);
+
+  REQUIRE(header->library == "my-library");
+  REQUIRE(header->profile == "my-profile");
 }


### PR DESCRIPTION
### Public-Facing Changes

Header records will now be parsed correctly, instead of duplicating the profile into both profile and library fields.

Fixes https://github.com/foxglove/mcap/issues/887
