### PR TITLE
CLI: remove MCAP doctor on chunks with no messages, schemaless channels

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -197,21 +197,29 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 		}
 	}
 
-	if minLogTime != chunk.MessageStartTime && chunkMessageCount != 0 {
-		doctor.error("Chunk.message_start_time %d does not match the earliest message log time %d",
-			chunk.MessageStartTime, minLogTime)
-	}
+	if chunkMessageCount != 0 {
+		if minLogTime != chunk.MessageStartTime {
+			doctor.error(
+				"Chunk.message_start_time %d does not match the earliest message log time %d",
+				chunk.MessageStartTime,
+				minLogTime,
+			)
+		}
 
-	if maxLogTime != chunk.MessageEndTime && chunkMessageCount != 0 {
-		doctor.error("Chunk.message_end_time %d does not match the latest message log time %d",
-			chunk.MessageEndTime, maxLogTime)
-	}
+		if maxLogTime != chunk.MessageEndTime && chunkMessageCount != 0 {
+			doctor.error(
+				"Chunk.message_end_time %d does not match the latest message log time %d",
+				chunk.MessageEndTime,
+				maxLogTime,
+			)
+		}
 
-	if minLogTime < doctor.minLogTime {
-		doctor.minLogTime = minLogTime
-	}
-	if maxLogTime > doctor.maxLogTime {
-		doctor.maxLogTime = maxLogTime
+		if minLogTime < doctor.minLogTime {
+			doctor.minLogTime = minLogTime
+		}
+		if maxLogTime > doctor.maxLogTime {
+			doctor.maxLogTime = maxLogTime
+		}
 	}
 }
 

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -121,6 +121,7 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 
 	var minLogTime uint64 = math.MaxUint64
 	var maxLogTime uint64
+	var chunkMessageCount uint64
 
 	msg := make([]byte, 1024)
 	for {
@@ -186,7 +187,7 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 			if message.LogTime > maxLogTime {
 				maxLogTime = message.LogTime
 			}
-
+			chunkMessageCount++
 			doctor.messageCount++
 
 		default:
@@ -194,12 +195,12 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 		}
 	}
 
-	if minLogTime != chunk.MessageStartTime {
+	if minLogTime != chunk.MessageStartTime && chunkMessageCount != 0 {
 		doctor.error("Chunk.message_start_time %d does not match the earliest message log time %d",
 			chunk.MessageStartTime, minLogTime)
 	}
 
-	if maxLogTime != chunk.MessageEndTime {
+	if maxLogTime != chunk.MessageEndTime && chunkMessageCount != 0 {
 		doctor.error("Chunk.message_end_time %d does not match the latest message log time %d",
 			chunk.MessageEndTime, maxLogTime)
 	}

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -166,8 +166,10 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 			}
 
 			doctor.channels[channel.ID] = channel
-			if _, ok := doctor.schemas[channel.SchemaID]; !ok {
-				doctor.error("Encountered Channel (%d) with unknown Schema (%d)", channel.ID, channel.SchemaID)
+			if channel.SchemaID != 0 {
+				if _, ok := doctor.schemas[channel.SchemaID]; !ok {
+					doctor.error("Encountered Channel (%d) with unknown Schema (%d)", channel.ID, channel.SchemaID)
+				}
 			}
 		case mcap.TokenMessage:
 			message, err := mcap.ParseMessage(data)

--- a/go/cli/mcap/cmd/doctor_test.go
+++ b/go/cli/mcap/cmd/doctor_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoErrorOnMessagelessChunks(t *testing.T) {
+	buf := bytes.Buffer{}
+	writer, err := mcap.NewWriter(&buf, &mcap.WriterOptions{
+		Chunked:   true,
+		ChunkSize: 10,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, writer.WriteHeader(&mcap.Header{"", ""}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:       1,
+		SchemaID: 0,
+		Topic:    "schemaless_topic",
+	}))
+	assert.Nil(t, writer.Close())
+
+	rs := bytes.NewReader(buf.Bytes())
+
+	doctor := newMcapDoctor(rs)
+	err = doctor.Examine()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
### Public-Facing Changes

* Doctor will no longer raise an error if a chunk is present with no messages.
* Doctor will no longer raise an error when a schemaless channel record is present in a chunk. This was previously updated to not report an error, but that change only applied to channels outside of chunks.
* `mcap.Writer` now correctly sets the chunkEndTime to 0 for chunks with no messages, as specified in the spec: https://mcap.dev/specification/index.html#chunk-op0x06 . 
