### PR TITLE
Auto detect Go version in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version-file: go/go.work
       - run: cd go && make build-conformance-binaries
       - run: corepack enable && yarn install --immutable
       - run: yarn test:conformance:generate-inputs --verify
@@ -349,12 +349,12 @@ jobs:
       run:
         working-directory: go
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 1.18.x
       - uses: actions/checkout@v3
         with:
           lfs: true
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go/go.work
       - name: install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
       - run: make lint
@@ -413,7 +413,7 @@ jobs:
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version-file: go/go.work
       - name: Setup environment
         run: ${{ matrix.setup }}
       - name: Build binary


### PR DESCRIPTION
### Public-Facing Changes
N/A

### Description
Go version used by GitHub Actions is read from `go.work` file, so there is a single source of truth for minimum required Go version.