### PR TITLE
CPP: add getter for metadata indices

### DIFF
--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -428,6 +428,12 @@ public:
    */
   const std::vector<ChunkIndex>& chunkIndexes() const;
 
+  /**
+   * @brief Returns all of the parsed MetadataIndex records. Call `readSummary()`
+   * first to fully populate this data structure.
+   */
+  const std::multimap<std::string, MetadataIndex>& metadataIndexes() const;
+
   // The following static methods are used internally for parsing MCAP records
   // and do not need to be called directly unless you are implementing your own
   // reader functionality or tests.

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -431,6 +431,7 @@ public:
   /**
    * @brief Returns all of the parsed MetadataIndex records. Call `readSummary()`
    * first to fully populate this data structure.
+   * The multimap's keys are the `name` field from each indexed Metadata.
    */
   const std::multimap<std::string, MetadataIndex>& metadataIndexes() const;
 

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -637,6 +637,10 @@ const std::vector<ChunkIndex>& McapReader::chunkIndexes() const {
   return chunkIndexes_;
 }
 
+const std::multimap<std::string, MetadataIndex>& McapReader::metadataIndexes() const {
+  return metadataIndexes_;
+}
+
 Status McapReader::ReadRecord(IReadable& reader, uint64_t offset, Record* record) {
   // Check that we can read at least 9 bytes (opcode + length)
   auto maxSize = reader.size() - offset;


### PR DESCRIPTION
So that I can browse metadata from indices in C++ client