### PR TITLE
CLI: Add capability to specify attachment name

### DIFF
--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	addAttachmentLogTime      uint64
+	addAttachmentName         string
 	addAttachmentCreationTime uint64
 	addAttachmentFilename     string
 	addAttachmentMediaType    string
@@ -166,7 +167,7 @@ var addAttachmentCmd = &cobra.Command{
 				return w.WriteAttachment(&mcap.Attachment{
 					LogTime:    logTime,
 					CreateTime: createTime,
-					Name:       addAttachmentFilename,
+					Name:       utils.DefaultString(addAttachmentName, addAttachmentFilename),
 					MediaType:  addAttachmentMediaType,
 					DataSize:   uint64(contentLength),
 					Data:       attachment,
@@ -186,6 +187,7 @@ var addAttachmentCmd = &cobra.Command{
 func init() {
 	addCmd.AddCommand(addAttachmentCmd)
 	addAttachmentCmd.PersistentFlags().StringVarP(&addAttachmentFilename, "file", "f", "", "filename of attachment to add")
+	addAttachmentCmd.PersistentFlags().StringVarP(&addAttachmentName, "name", "n", "", "name of attachment to add (defaults to filename)")
 	addAttachmentCmd.PersistentFlags().StringVarP(&addAttachmentMediaType, "content-type", "", "application/octet-stream", "content type of attachment")
 	addAttachmentCmd.PersistentFlags().Uint64VarP(&addAttachmentLogTime, "log-time", "", 0, "attachment log time in nanoseconds (defaults to current timestamp)")
 	addAttachmentCmd.PersistentFlags().Uint64VarP(&addAttachmentLogTime, "creation-time", "", 0, "attachment creation time in nanoseconds (defaults to ctime)")

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -268,3 +268,14 @@ func PrettyJSON(data []byte) (string, error) {
 	}
 	return indented.String(), nil
 }
+
+// DefaultString returns the first of the provided strings that is nonempty, or
+// an empty string if they are all empty.
+func DefaultString(strings ...string) string {
+	for _, s := range strings {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/go/cli/mcap/utils/utils_test.go
+++ b/go/cli/mcap/utils/utils_test.go
@@ -45,3 +45,31 @@ func TestGetScheme(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultString(t *testing.T) {
+	cases := []struct {
+		assertion string
+		args      []string
+		output    string
+	}{
+		{
+			"first string",
+			[]string{"hello", "goodbye"},
+			"hello",
+		},
+		{
+			"second string",
+			[]string{"", "hello"},
+			"hello",
+		},
+		{
+			"empty",
+			[]string{"", ""},
+			"",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.output, DefaultString(c.args...))
+	}
+}


### PR DESCRIPTION
Previously this used the filename and couldn't be specified.