### PR TITLE
Update copy on MCAP home page

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -50,7 +50,7 @@ const FeatureList: FeatureItem[] = [
     title: "Efficient seeking",
     Icon: icons.Turntable,
     description:
-      "Enjoy fast indexed reading – even over a low-bandwidth internet connection.",
+      "Enjoy fast indexed reading, even over a low-bandwidth connection.",
   },
   {
     title: "Optional compression",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -111,10 +111,10 @@ export default function Home(): JSX.Element {
           <p className={styles.blurb}>{blurb}</p>
           <div className={styles.heroButtons}>
             <Link className={styles.heroButtonPrimary} to="/guides">
-              Get Started
+              Get started
             </Link>
             <Link className={styles.heroButtonSecondary} to="/reference">
-              API Reference
+              API reference
             </Link>
           </div>
         </div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -38,7 +38,7 @@ const FeatureList: FeatureItem[] = [
     title: "High-performance writing",
     Icon: icons.SportsCarConvertible,
     description:
-      "Use MCAP's row-oriented, append-only design to minimize disk I/O and reduce the risk of data corruption during unclean shutdowns.",
+      "MCAP uses a row-oriented, append-only design to minimize disk I/O and reduce the risk of data corruption during unclean shutdowns.",
   },
   {
     title: "Self-contained",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -25,7 +25,7 @@ const FeatureList: FeatureItem[] = [
     title: "Pub/sub logging",
     Icon: icons.Robot,
     description:
-      "Store multiple channels of timestamped log data, including pub/sub messages or multimodal sensor data.",
+      "Store multiple channels of timestamped log data, such as pub/sub messages or multimodal sensor data.",
   },
 
   {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -56,7 +56,7 @@ const FeatureList: FeatureItem[] = [
     title: "Optional compression",
     Icon: icons.ZipFile,
     description:
-      "Choose between compressing your data with lz4 or zstd, while still leveraging chunk-based decompression for efficient reading.",
+      "Choose between LZ4 or Zstandard for chunk-based compression, without compromising efficient reading.",
   },
   {
     title: "Multilingual support",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -29,7 +29,7 @@ const FeatureList: FeatureItem[] = [
   },
 
   {
-    title: "Serialization-agnostic format",
+    title: "Serialization-agnostic",
     Icon: icons.DrawerEnvelope,
     description:
       "Record and replay binary messages in any format – like Protobuf, DDS (CDR), ROS, JSON, and more.",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -71,7 +71,7 @@ const FeatureList: FeatureItem[] = [
       "Configure optional features like chunking, indexing, CRC checksums, and compression to make the right tradeoffs for your application.",
   },
   {
-    title: "Production-grade standards",
+    title: "Production-grade",
     Icon: icons.ArmyWoman1,
     description:
       "Become one of the many robotics companies that deploy MCAP in production. As the default log format for ROS 2, MCAP offers long-term support and technical robustness.",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -62,7 +62,7 @@ const FeatureList: FeatureItem[] = [
     title: "Broad language support",
     Icon: icons.ChatTranslate,
     description:
-      "Use native MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, and TypeScript.",
+      "Native reader and writer libraries are available in C++, Go, Python, Rust, Swift, and TypeScript.",
   },
   {
     title: "Flexible",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -44,7 +44,7 @@ const FeatureList: FeatureItem[] = [
     title: "Self-contained",
     Icon: icons.ShipmentPackage,
     description:
-      "Store your data alongside the schemas required to deserialize it, so your files can remain readable even as your codebase evolves.",
+      "MCAP stores message schemas alongside data, so your files remain readable in the future even as your codebase evolves.",
   },
   {
     title: "Efficient seeking",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -65,7 +65,7 @@ const FeatureList: FeatureItem[] = [
       "Use native MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, and TypeScript.",
   },
   {
-    title: "Flexibility",
+    title: "Flexible",
     Icon: icons.YogaLegGrabStretch,
     description:
       "Configure optional features like chunking, indexing, CRC checksums, and compression to make the right tradeoffs for your application.",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -50,7 +50,7 @@ const FeatureList: FeatureItem[] = [
     title: "Efficient seeking",
     Icon: icons.Turntable,
     description:
-      "Get fast indexed reading, even over a low-bandwidth connection.",
+      "MCAP files contain an optional index, allowing for fast, efficient reading, even over a low-bandwidth internet connection.",
   },
   {
     title: "Optional compression",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -74,7 +74,7 @@ const FeatureList: FeatureItem[] = [
     title: "Production-grade",
     Icon: icons.ArmyWoman1,
     description:
-      "Become one of the many robotics companies that deploy MCAP in production. As the default log format for ROS 2, MCAP offers long-term support and technical robustness.",
+      "MCAP is used in production by a wide range of companies, from autonomous vehicles to drones, and is the default log format in ROS 2.",
   },
 ];
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -25,7 +25,7 @@ const FeatureList: FeatureItem[] = [
     title: "Pub/sub logging",
     Icon: icons.Robot,
     description:
-      "Store multiple channels of timestamped log data, like pub/sub messages or multimodal sensor data.",
+      "Store multiple channels of timestamped log data, including pub/sub messages or multimodal sensor data.",
   },
 
   {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -59,7 +59,7 @@ const FeatureList: FeatureItem[] = [
       "Choose between LZ4 or Zstandard for chunk-based compression, without compromising efficient reading.",
   },
   {
-    title: "Multilingual support",
+    title: "Broad language support",
     Icon: icons.ChatTranslate,
     description:
       "Take advantage of native MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, and TypeScript.",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -22,59 +22,59 @@ type FeatureItem = {
 
 const FeatureList: FeatureItem[] = [
   {
-    title: "Pub/Sub logging",
+    title: "Pub/sub logging",
     Icon: icons.Robot,
     description:
-      "MCAP is ideal for storing multiple channels of timestamped log data, such as pub/sub messages or multimodal sensor data.",
+      "Store multiple channels of timestamped log data, like pub/sub messages or multimodal sensor data.",
   },
 
   {
-    title: "Serialization agnostic",
+    title: "Serialization-agnostic container format",
     Icon: icons.DrawerEnvelope,
     description:
-      "MCAP is a container format, allowing you to record and replay binary messages in any format, such as Protobuf, DDS (CDR), ROS, JSON, etc.",
+      "Record and replay binary messages in any format – like Protobuf, DDS (CDR), ROS, JSON, and more.",
   },
   {
     title: "High-performance writing",
     Icon: icons.SportsCarConvertible,
     description:
-      "MCAP utilizes a row-oriented, append-only design. This minimizes disk I/O, and reduces the risk of data corruption during an unclean shutdown. ",
+      "Leverage MCAP's append-only design to minimize disk I/O and reduce the risk of data corruption during an unclean shutdown.",
   },
   {
-    title: "Self-contained",
+    title: "Self-contained files",
     Icon: icons.ShipmentPackage,
     description:
-      "MCAP files are fully self-contained, including schemas required to deserialize each channel. Older files always remain readable, even as your codebase evolves.",
+      "Store your data alongside the schemas required to deserialize it, so your files can remain readable – even as your codebase evolves.",
   },
   {
     title: "Efficient seeking",
     Icon: icons.Turntable,
     description:
-      "MCAP files contain an optional index, allowing for fast, efficient reading, even over a low-bandwidth internet connection.",
+      "Enjoy fast indexed reading – even over a low-bandwidth internet connection.",
   },
   {
     title: "Optional compression",
     Icon: icons.ZipFile,
     description:
-      "Data can be compressed using lz4 or zstd, while still supporting efficient indexed reads using chunk-based decompression.",
+      "Choose between compressing your data with lz4 or zstd, while still leveraging chunk-based decompression for efficient reading.",
   },
   {
-    title: "Multilingual",
+    title: "Multilingual support",
     Icon: icons.ChatTranslate,
     description:
-      "MCAP reader and writer libraries are available in many languages, including C++, Go, Python, Rust, Swift, and Typescript.",
+      "Take advantage of MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, Typescript, and more.",
   },
   {
-    title: "Flexible",
+    title: "Flexibility",
     Icon: icons.YogaLegGrabStretch,
     description:
-      "Features such as chunking, indexing, CRC checksums, and compression are optional. You choose the right tradeoffs for your application.",
+      "Leverage optional features like chunking, indexing, CRC checksums, and compression to make the right tradeoffs for your application.",
   },
   {
-    title: "Production grade",
+    title: "Production-grade performance",
     Icon: icons.ArmyWoman1,
     description:
-      "MCAP is used in production by a wide range of companies, from autonomous vehicles to drones, and is the default log format in ROS 2.",
+      "Find yourself among the robotics companies that trust MCAP, the default log format for ROS 2, as the new industry standard.",
   },
 ];
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -29,7 +29,7 @@ const FeatureList: FeatureItem[] = [
   },
 
   {
-    title: "Serialization-agnostic container format",
+    title: "Serialization-agnostic format",
     Icon: icons.DrawerEnvelope,
     description:
       "Record and replay binary messages in any format – like Protobuf, DDS (CDR), ROS, JSON, and more.",
@@ -38,7 +38,7 @@ const FeatureList: FeatureItem[] = [
     title: "High-performance writing",
     Icon: icons.SportsCarConvertible,
     description:
-      "Leverage MCAP's append-only design to minimize disk I/O and reduce the risk of data corruption during an unclean shutdown.",
+      "Use MCAP's row-oriented, append-only design to minimize disk I/O and reduce the risk of data corruption during unclean shutdowns.",
   },
   {
     title: "Self-contained files",
@@ -50,31 +50,31 @@ const FeatureList: FeatureItem[] = [
     title: "Efficient seeking",
     Icon: icons.Turntable,
     description:
-      "Enjoy fast indexed reading, even over a low-bandwidth connection.",
+      "Get fast indexed reading, even over a low-bandwidth connection.",
   },
   {
     title: "Optional compression",
     Icon: icons.ZipFile,
     description:
-      "Choose between LZ4 or Zstandard for chunk-based compression, without compromising efficient reading.",
+      "Choose between LZ4 or Zstandard for chunk-based compression, while still supporting efficient indexed reads.",
   },
   {
     title: "Broad language support",
     Icon: icons.ChatTranslate,
     description:
-      "Take advantage of native MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, and TypeScript.",
+      "Use native MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, and TypeScript.",
   },
   {
     title: "Flexibility",
     Icon: icons.YogaLegGrabStretch,
     description:
-      "Leverage optional features like chunking, indexing, CRC checksums, and compression to make the right tradeoffs for your application.",
+      "Configure optional features like chunking, indexing, CRC checksums, and compression to make the right tradeoffs for your application.",
   },
   {
-    title: "Production-grade performance",
+    title: "Production-grade standards",
     Icon: icons.ArmyWoman1,
     description:
-      "Find yourself among the robotics companies that trust MCAP, the default log format for ROS 2, as the new industry standard.",
+      "Become one of the many robotics companies that deploy MCAP in production. As the default log format for ROS 2, MCAP offers long-term support and technical robustness.",
   },
 ];
 
@@ -111,10 +111,10 @@ export default function Home(): JSX.Element {
           <p className={styles.blurb}>{blurb}</p>
           <div className={styles.heroButtons}>
             <Link className={styles.heroButtonPrimary} to="/guides">
-              Get started
+              Get Started
             </Link>
             <Link className={styles.heroButtonSecondary} to="/reference">
-              API reference
+              API Reference
             </Link>
           </div>
         </div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -41,7 +41,7 @@ const FeatureList: FeatureItem[] = [
       "Use MCAP's row-oriented, append-only design to minimize disk I/O and reduce the risk of data corruption during unclean shutdowns.",
   },
   {
-    title: "Self-contained files",
+    title: "Self-contained",
     Icon: icons.ShipmentPackage,
     description:
       "Store your data alongside the schemas required to deserialize it, so your files can remain readable even as your codebase evolves.",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -44,7 +44,7 @@ const FeatureList: FeatureItem[] = [
     title: "Self-contained files",
     Icon: icons.ShipmentPackage,
     description:
-      "Store your data alongside the schemas required to deserialize it, so your files can remain readable – even as your codebase evolves.",
+      "Store your data alongside the schemas required to deserialize it, so your files can remain readable even as your codebase evolves.",
   },
   {
     title: "Efficient seeking",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -62,7 +62,7 @@ const FeatureList: FeatureItem[] = [
     title: "Multilingual support",
     Icon: icons.ChatTranslate,
     description:
-      "Take advantage of MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, Typescript, and more.",
+      "Take advantage of native MCAP reader and writer libraries in C++, Go, Python, Rust, Swift, and TypeScript.",
   },
   {
     title: "Flexibility",


### PR DESCRIPTION
### Public-Facing Changes

- Update copy on MCAP home page 
  - All features should be nouns (e.g. "Self-contained files" vs. "Self-contained")
  - All descriptions should start with verbs (e.g. "Stores ..." vs. "MCAP is the ideal format for storing...")