### PR TITLE
Support fast summary section rewrites

### DIFF
--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -126,16 +126,17 @@ var addAttachmentCmd = &cobra.Command{
 	Use:   "attachment",
 	Short: "Add an attachment to an MCAP file",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		filename := args[0]
-		tempName := filename + ".new"
-		tmpfile, err := os.Create(tempName)
+
+		f, err := os.OpenFile(filename, os.O_RDWR, os.ModePerm)
 		if err != nil {
-			die("failed to create temp file: %s", err)
+			die("failed to open file: %s", err)
 		}
+		defer f.Close()
+
 		attachment, err := os.Open(addAttachmentFilename)
 		if err != nil {
 			die("failed to open attachment file: %s", err)
@@ -147,39 +148,30 @@ var addAttachmentCmd = &cobra.Command{
 			die("failed to stat file: %s", err)
 		}
 		contentLength := stat.Size()
-		err = utils.WithReader(ctx, filename, func(remote bool, rs io.ReadSeeker) error {
-			if remote {
-				die("not supported on remote MCAP files")
-			}
-			fi, err := os.Stat(addAttachmentFilename)
-			if err != nil {
-				die("failed to stat file %s", addAttachmentFilename)
-			}
-			createTime := uint64(fi.ModTime().UTC().UnixNano())
-			if addAttachmentCreationTime > 0 {
-				createTime = addAttachmentCreationTime
-			}
-			logTime := uint64(time.Now().UTC().UnixNano())
-			if addAttachmentLogTime > 0 {
-				logTime = addAttachmentLogTime
-			}
-			return utils.RewriteMCAP(tmpfile, rs, func(w *mcap.Writer) error {
-				return w.WriteAttachment(&mcap.Attachment{
-					LogTime:    logTime,
-					CreateTime: createTime,
-					Name:       utils.DefaultString(addAttachmentName, addAttachmentFilename),
-					MediaType:  addAttachmentMediaType,
-					DataSize:   uint64(contentLength),
-					Data:       attachment,
-				})
-			})
-		})
+		fi, err := os.Stat(addAttachmentFilename)
 		if err != nil {
-			die("failed to add attachment: %s", err)
+			die("failed to stat file %s", addAttachmentFilename)
 		}
-		err = os.Rename(tempName, filename)
+		createTime := uint64(fi.ModTime().UTC().UnixNano())
+		if addAttachmentCreationTime > 0 {
+			createTime = addAttachmentCreationTime
+		}
+		logTime := uint64(time.Now().UTC().UnixNano())
+		if addAttachmentLogTime > 0 {
+			logTime = addAttachmentLogTime
+		}
+		err = utils.AmendMCAP(f, []*mcap.Attachment{
+			{
+				LogTime:    logTime,
+				CreateTime: createTime,
+				Name:       addAttachmentFilename,
+				MediaType:  addAttachmentMediaType,
+				DataSize:   uint64(contentLength),
+				Data:       attachment,
+			},
+		}, nil)
 		if err != nil {
-			die("failed to rename temporary output: %s", err)
+			die("failed to add attachment: %s. You may need to run `mcap recover` to repair the file.", err)
 		}
 	},
 }

--- a/go/cli/mcap/testutils/buf_read_write_seeker.go
+++ b/go/cli/mcap/testutils/buf_read_write_seeker.go
@@ -1,0 +1,73 @@
+package testutils
+
+import (
+	"fmt"
+	"io"
+)
+
+// BufReadWriteSeeker is an io.ReadWriteSeeker backed by memory.
+type BufReadWriteSeeker struct {
+	buf      []byte
+	offset   int64
+	length   int64
+	capacity int64
+}
+
+func (b *BufReadWriteSeeker) Write(p []byte) (n int, err error) {
+	if b.offset+int64(len(p)) > b.capacity {
+		newBuf := make([]byte, b.capacity*2)
+		copy(newBuf, b.buf)
+		b.buf = newBuf
+		b.capacity = b.capacity * 2
+		return b.Write(p)
+	}
+	if b.offset+int64(len(p)) > b.length {
+		b.length = b.offset + int64(len(p))
+	}
+	n = copy(b.buf[b.offset:], p)
+	b.offset += int64(n)
+	return n, nil
+}
+
+func (b *BufReadWriteSeeker) Read(p []byte) (n int, err error) {
+	n = copy(p, b.buf[b.offset:b.length])
+	b.offset += int64(n)
+	if b.offset > b.length {
+		return n, io.ErrUnexpectedEOF
+	}
+	if b.offset == b.length {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (b *BufReadWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		b.offset = offset
+	case io.SeekCurrent:
+		b.offset += offset
+	case io.SeekEnd:
+		b.offset = b.length + offset
+	}
+	if b.offset < 0 {
+		return 0, fmt.Errorf("cannot seek before start of file")
+	}
+	if b.offset > b.length {
+		return 0, fmt.Errorf("cannot seek past end of file")
+	}
+	return b.offset, nil
+}
+
+func (b *BufReadWriteSeeker) Bytes() []byte {
+	return b.buf[:b.length]
+}
+
+func NewBufReadWriteSeeker() *BufReadWriteSeeker {
+	return &BufReadWriteSeeker{
+		buf:      make([]byte, 1024),
+		offset:   0,
+		length:   0,
+		capacity: 1024,
+	}
+}

--- a/go/cli/mcap/testutils/buf_read_write_seeker_test.go
+++ b/go/cli/mcap/testutils/buf_read_write_seeker_test.go
@@ -1,0 +1,52 @@
+package testutils
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufReadWriteSeeker(t *testing.T) {
+	t.Run("writing", func(t *testing.T) {
+		buf := NewBufReadWriteSeeker()
+		data := []byte("hello, world!")
+		n, err := buf.Write(data)
+		assert.Nil(t, err)
+		assert.Equal(t, len(data), n, "number of bytes written does not match expected")
+		assert.Equal(t, data, buf.Bytes(), "data does not match expected")
+	})
+
+	t.Run("seeking & reading", func(t *testing.T) {
+		buf := NewBufReadWriteSeeker()
+		data := []byte("hello, world!")
+		_, err := buf.Write(data)
+		assert.Nil(t, err)
+
+		_, err = buf.Seek(0, io.SeekStart)
+		assert.Nil(t, err)
+
+		written, err := io.ReadAll(buf)
+		assert.Nil(t, err)
+		assert.Equal(t, data, written, "data does not match expected")
+	})
+
+	t.Run("overwriting", func(t *testing.T) {
+		buf := NewBufReadWriteSeeker()
+		data := []byte("hello, world!")
+		_, err := buf.Write(data)
+		assert.Nil(t, err)
+
+		_, err = buf.Seek(-6, io.SeekCurrent)
+		assert.Nil(t, err)
+
+		_, err = buf.Write([]byte("wrold!"))
+		assert.Nil(t, err)
+
+		_, err = buf.Seek(0, io.SeekStart)
+		assert.Nil(t, err)
+
+		expected := []byte("hello, wrold!")
+		assert.Equal(t, expected, buf.Bytes(), "data does not match expected")
+	})
+}

--- a/go/cli/mcap/utils/checksumming_write_counter.go
+++ b/go/cli/mcap/utils/checksumming_write_counter.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"hash/crc32"
+	"io"
+)
+
+type checksummingWriteCounter struct {
+	w     io.Writer
+	count int64
+	crc   uint32
+}
+
+func (cw *checksummingWriteCounter) Write(p []byte) (n int, err error) {
+	n, err = cw.w.Write(p)
+	cw.count += int64(n)
+	cw.crc = crc32.Update(cw.crc, crc32.IEEETable, p)
+	return n, err
+}
+
+func (cw *checksummingWriteCounter) Count() int64 {
+	return cw.count
+}
+
+func (cw *checksummingWriteCounter) CRC() uint32 {
+	return cw.crc
+}
+
+func newChecksummingWriteCounter(w io.Writer, initialCRC uint32) *checksummingWriteCounter {
+	return &checksummingWriteCounter{
+		w:   w,
+		crc: initialCRC,
+	}
+}

--- a/go/cli/mcap/utils/checksumming_write_counter_test.go
+++ b/go/cli/mcap/utils/checksumming_write_counter_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"bytes"
+	"hash/crc32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChecksummingWriteCounter(t *testing.T) {
+	data := []byte("hello, world!")
+	fullCRC := crc32.ChecksumIEEE(data)
+	initialCRC := crc32.ChecksumIEEE(data[:5])
+	buf := &bytes.Buffer{}
+	cw := newChecksummingWriteCounter(buf, initialCRC)
+	n, err := cw.Write(data[5:])
+	assert.Nil(t, err)
+	assert.Equal(t, len(data[5:]), n, "number of bytes written does not match expected")
+	assert.Equal(t, fullCRC, cw.CRC(), "computed CRC does not match expected")
+	assert.Equal(t, int64(len(data[5:])), cw.Count(), "count does not match expected")
+	assert.Equal(t, data[5:], buf.Bytes(), "data does not match expected")
+}

--- a/go/cli/mcap/utils/mcap_amendment.go
+++ b/go/cli/mcap/utils/mcap_amendment.go
@@ -1,0 +1,454 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+
+	"github.com/foxglove/mcap/go/mcap"
+)
+
+const (
+	SizeRecordLength = 8
+	SizeOpcode       = 1
+	SizeDataEnd      = 4
+	SizeFooter       = 8 + 8 + 4
+	SizeMagic        = 8
+)
+
+// AmendMCAP adds attachment and metadata records to the end of the
+// data section of an existing MCAP, in place. It then writes a new summary
+// section consisting of the existing summary section, plus new attachment and
+// metadata index records as applicable, with all offsets and CRCs updated to
+// account for the new data.
+func AmendMCAP(
+	wsc io.ReadWriteSeeker,
+	attachments []*mcap.Attachment,
+	metadata []*mcap.Metadata,
+) error {
+	lexer, err := mcap.NewLexer(wsc, &mcap.LexerOptions{
+		SkipMagic: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build lexer: %w", err)
+	}
+	defer lexer.Close()
+
+	oldFooter, err := readFooter(wsc)
+	if err != nil {
+		return fmt.Errorf("failed to read footer: %w", err)
+	}
+	oldSummaryStart := oldFooter.SummaryStart
+
+	// seek to the opcode of the data end record
+	oldDataEndOffset := int64(oldSummaryStart - SizeDataEnd - SizeRecordLength - SizeOpcode)
+	oldDataEnd, err := readDataEnd(wsc, oldDataEndOffset)
+	if err != nil {
+		return fmt.Errorf("failed to read data end: %w", err)
+	}
+
+	// Now we are at the old summary start. Parse from here to EOF into a
+	// summarySection structure.
+	summary, err := readSummarySection(wsc)
+	if err != nil {
+		return fmt.Errorf("failed to read summary section: %w", err)
+	}
+
+	// Seek to the location of the old data end record. We will write the new data section records starting here.
+	_, err = wsc.Seek(oldDataEndOffset, io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("failed to seek to data end: %w", err)
+	}
+
+	extraDataLength, attachmentIndexes, metadataIndexes, err := extendDataSection(
+		wsc,
+		oldDataEndOffset,
+		oldDataEnd.DataSectionCRC,
+		attachments,
+		metadata,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to build extra data: %w", err)
+	}
+
+	// the new summary offset is the old data end offset plus the length just written.
+	newSummaryOffset := oldDataEndOffset + int64(extraDataLength)
+
+	// Update summary with the new attachment and metadata indexes.
+	for _, attachmentIndex := range attachmentIndexes {
+		summary.AttachmentIndexes = append(summary.AttachmentIndexes, attachmentIndex)
+		summary.Statistics.AttachmentCount++
+	}
+	for _, metadataIndex := range metadataIndexes {
+		summary.MetadataIndexes = append(summary.MetadataIndexes, metadataIndex)
+		summary.Statistics.MetadataCount++
+	}
+
+	// Write summary out into a well-formed summary section, with all offsets and CRCs updated.
+	err = writeSummaryBytes(wsc, *summary, newSummaryOffset)
+	if err != nil {
+		return fmt.Errorf("failed to build new summary section: %w", err)
+	}
+
+	return nil
+}
+
+// summarySection is a structure that contains all the records in the summary
+// section of an MCAP.
+type summarySection struct {
+	Channels          []*mcap.Channel
+	Schemas           []*mcap.Schema
+	AttachmentIndexes []*mcap.AttachmentIndex
+	MetadataIndexes   []*mcap.MetadataIndex
+	ChunkIndexes      []*mcap.ChunkIndex
+	SummaryOffsets    []*mcap.SummaryOffset
+	Statistics        *mcap.Statistics
+	Footer            *mcap.Footer
+}
+
+// readSummarySection reads MCAP data into a summary section structure. The
+// reader should be positioned at the start of the summary section, and must be
+// positioned at the start of a record.
+func readSummarySection(r io.Reader) (*summarySection, error) {
+	lexer, err := mcap.NewLexer(r, &mcap.LexerOptions{
+		SkipMagic: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct summary section lexer: %w", err)
+	}
+	result := summarySection{}
+	for {
+		tokenType, token, err := lexer.Next(nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to pull next record: %w", err)
+		}
+		switch tokenType {
+		case mcap.TokenChannel:
+			record, err := mcap.ParseChannel(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse channel: %w", err)
+			}
+			result.Channels = append(result.Channels, record)
+		case mcap.TokenSchema:
+			record, err := mcap.ParseSchema(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse schema: %w", err)
+			}
+			result.Schemas = append(result.Schemas, record)
+		case mcap.TokenChunkIndex:
+			record, err := mcap.ParseChunkIndex(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse chunk index: %w", err)
+			}
+			result.ChunkIndexes = append(result.ChunkIndexes, record)
+		case mcap.TokenAttachmentIndex:
+			record, err := mcap.ParseAttachmentIndex(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse attachment index: %w", err)
+			}
+			result.AttachmentIndexes = append(result.AttachmentIndexes, record)
+		case mcap.TokenMetadataIndex:
+			record, err := mcap.ParseMetadataIndex(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse metadata index: %w", err)
+			}
+			result.MetadataIndexes = append(result.MetadataIndexes, record)
+		case mcap.TokenSummaryOffset:
+			record, err := mcap.ParseSummaryOffset(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse summary offset: %w", err)
+			}
+			result.SummaryOffsets = append(result.SummaryOffsets, record)
+		case mcap.TokenStatistics:
+			record, err := mcap.ParseStatistics(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse statistics: %w", err)
+			}
+			result.Statistics = record
+		case mcap.TokenFooter:
+			record, err := mcap.ParseFooter(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse footer: %w", err)
+			}
+			result.Footer = record
+			return &result, nil
+		}
+	}
+}
+
+// buildSummaryBytes constructs a summary byte section from a summarySection
+// structure, including the footer and closing magic, given a start offset. The
+// sections/offset groups may be rewritten in a different order than the in the
+// data the summarySection was originally parsed from. All offsets and CRCs are
+// updated to account.
+func writeSummaryBytes(w io.Writer, section summarySection, summaryStart int64) error {
+	wc := newChecksummingWriteCounter(w, 0)
+	writer, err := mcap.NewWriter(wc, &mcap.WriterOptions{
+		SkipMagic: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct summary section writer: %w", err)
+	}
+
+	fileOffset := summaryStart
+	summaryInset := int64(0)
+	summaryOffsets := []*mcap.SummaryOffset{}
+
+	for _, schema := range section.Schemas {
+		err := writer.WriteSchema(schema)
+		if err != nil {
+			return fmt.Errorf("failed to write schema: %w", err)
+		}
+	}
+	summaryOffsets = append(summaryOffsets, &mcap.SummaryOffset{
+		GroupOpcode: mcap.OpSchema,
+		GroupStart:  uint64(fileOffset),
+		GroupLength: uint64(wc.Count()) - uint64(summaryInset),
+	})
+
+	fileOffset += int64(wc.Count()) - summaryInset
+	summaryInset = int64(wc.Count())
+
+	for _, channel := range section.Channels {
+		err := writer.WriteChannel(channel)
+		if err != nil {
+			return fmt.Errorf("failed to write channel: %w", err)
+		}
+	}
+	summaryOffsets = append(summaryOffsets, &mcap.SummaryOffset{
+		GroupOpcode: mcap.OpChannel,
+		GroupStart:  uint64(fileOffset),
+		GroupLength: uint64(wc.Count()) - uint64(summaryInset),
+	})
+	fileOffset += int64(wc.Count()) - summaryInset
+	summaryInset = int64(wc.Count())
+
+	for _, attachmentIndex := range section.AttachmentIndexes {
+		err := writer.WriteAttachmentIndex(attachmentIndex)
+		if err != nil {
+			return fmt.Errorf("failed to write attachment index: %w", err)
+		}
+	}
+	summaryOffsets = append(summaryOffsets, &mcap.SummaryOffset{
+		GroupOpcode: mcap.OpAttachmentIndex,
+		GroupStart:  uint64(fileOffset),
+		GroupLength: uint64(wc.Count()) - uint64(summaryInset),
+	})
+
+	fileOffset += int64(wc.Count()) - summaryInset
+	summaryInset = int64(wc.Count())
+
+	for _, metadataIndex := range section.MetadataIndexes {
+		err := writer.WriteMetadataIndex(metadataIndex)
+		if err != nil {
+			return fmt.Errorf("failed to write metadata index: %w", err)
+		}
+	}
+	summaryOffsets = append(summaryOffsets, &mcap.SummaryOffset{
+		GroupOpcode: mcap.OpMetadataIndex,
+		GroupStart:  uint64(fileOffset),
+		GroupLength: uint64(wc.Count()) - uint64(summaryInset),
+	})
+
+	fileOffset += int64(wc.Count()) - summaryInset
+	summaryInset = int64(wc.Count())
+
+	for _, chunkIndex := range section.ChunkIndexes {
+		err := writer.WriteChunkIndex(chunkIndex)
+		if err != nil {
+			return fmt.Errorf("failed to write chunk index: %w", err)
+		}
+	}
+	summaryOffsets = append(summaryOffsets, &mcap.SummaryOffset{
+		GroupOpcode: mcap.OpChunkIndex,
+		GroupStart:  uint64(fileOffset),
+		GroupLength: uint64(wc.Count()) - uint64(summaryInset),
+	})
+
+	fileOffset += int64(wc.Count()) - summaryInset
+	summaryInset = int64(wc.Count())
+
+	err = writer.WriteStatistics(section.Statistics)
+	if err != nil {
+		return fmt.Errorf("failed to write statistics: %w", err)
+	}
+
+	summaryOffsets = append(summaryOffsets, &mcap.SummaryOffset{
+		GroupOpcode: mcap.OpStatistics,
+		GroupStart:  uint64(fileOffset),
+		GroupLength: uint64(wc.Count()) - uint64(summaryInset),
+	})
+
+	fileOffset += int64(wc.Count()) - summaryInset
+	summaryInset = int64(wc.Count())
+	summaryOffsetStart := fileOffset
+
+	for _, summaryOffset := range summaryOffsets {
+		err := writer.WriteSummaryOffset(summaryOffset)
+		if err != nil {
+			return fmt.Errorf("failed to write summary offset: %w", err)
+		}
+	}
+
+	// Only compute a CRC if the existing CRC is nonzero. Interpret zero to mean
+	// CRCs disabled.
+	var summaryCRC uint32
+	if section.Footer.SummaryCRC != 0 {
+		summaryCRC = wc.CRC()
+	}
+
+	footer := &mcap.Footer{
+		SummaryStart:       uint64(summaryStart),
+		SummaryOffsetStart: uint64(summaryOffsetStart),
+		SummaryCRC:         summaryCRC,
+	}
+	err = writeFooter(wc, footer)
+	if err != nil {
+		return fmt.Errorf("failed to write footer: %w", err)
+	}
+	_, err = wc.Write(mcap.Magic)
+	if err != nil {
+		return fmt.Errorf("failed to write closing magic: %w", err)
+	}
+	return nil
+}
+
+// writeFooter writes a footer record onto a writer, updating the attached CRC
+// to include the initial bytes.
+func writeFooter(w io.Writer, footer *mcap.Footer) error {
+	buf := make([]byte, 29)
+	buf[0] = byte(mcap.OpFooter)
+	inset := 1
+	binary.LittleEndian.PutUint64(buf[inset:], 20)
+	inset += 8
+	binary.LittleEndian.PutUint64(buf[inset:], footer.SummaryStart)
+	inset += 8
+	binary.LittleEndian.PutUint64(buf[inset:], footer.SummaryOffsetStart)
+	inset += 8
+	var crc uint32
+	if footer.SummaryCRC > 0 {
+		crc = crc32.Update(footer.SummaryCRC, crc32.IEEETable, buf[:inset])
+	}
+	binary.LittleEndian.PutUint32(buf[inset:], crc)
+	inset += 4
+	_, err := w.Write(buf[:inset])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// readFooter reads the footer record from the end of an MCAP.
+func readFooter(rs io.ReadSeeker) (*mcap.Footer, error) {
+	_, err := rs.Seek(-SizeMagic-SizeFooter, io.SeekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to seek to footer: %w", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct lexer: %w", err)
+	}
+	buf := make([]byte, 28)
+	_, err = io.ReadFull(rs, buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read footer: %w", err)
+	}
+	if !bytes.Equal(buf[20:], mcap.Magic) {
+		return nil, fmt.Errorf("invalid magic")
+	}
+	footer, err := mcap.ParseFooter(buf[:20])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse footer: %w", err)
+	}
+	return footer, nil
+}
+
+// readDataEnd reads a data end record at the supplied offset.
+func readDataEnd(rs io.ReadSeeker, offset int64) (*mcap.DataEnd, error) {
+	_, err := rs.Seek(offset, io.SeekStart)
+	if err != nil {
+		return nil, fmt.Errorf("failed to seek to data end: %w", err)
+	}
+	buf := make([]byte, SizeOpcode+SizeRecordLength+SizeDataEnd)
+	_, err = io.ReadFull(rs, buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data end: %w", err)
+	}
+	if buf[0] != byte(mcap.OpDataEnd) {
+		return nil, fmt.Errorf("expected data end opcode but got %d", mcap.OpCode(buf[0]))
+	}
+	dataEnd, err := mcap.ParseDataEnd(buf[SizeOpcode+SizeRecordLength:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse data end: %w", err)
+	}
+	return dataEnd, nil
+}
+
+// extendDataSection writes attachments and metadata records over an existing
+// DataEnd record, and then writes its own DataEnd at the end. It returns slices
+// of attachment and metadata indexes. The startOffset supplied is used to
+// compute offsets in these indexes, and startCRC - expected to be the CRC of
+// the existing data section - is updated with new writes and added to the new
+// data section.
+func extendDataSection(
+	w io.Writer,
+	startOffset int64,
+	startCRC uint32,
+	attachments []*mcap.Attachment,
+	metadata []*mcap.Metadata,
+) (int64, []*mcap.AttachmentIndex, []*mcap.MetadataIndex, error) {
+	cw := newChecksummingWriteCounter(w, startCRC)
+	writer, err := mcap.NewWriter(cw, &mcap.WriterOptions{
+		SkipMagic: true,
+	})
+	if err != nil {
+		return cw.Count(), nil, nil, fmt.Errorf("failed to construct writer: %w", err)
+	}
+	var attachmentIndexes []*mcap.AttachmentIndex
+	for _, attachment := range attachments {
+		offset := cw.Count()
+		attachmentIndex := &mcap.AttachmentIndex{
+			Offset:     uint64(offset) + uint64(startOffset),
+			LogTime:    attachment.LogTime,
+			CreateTime: attachment.CreateTime,
+			DataSize:   attachment.DataSize,
+			Name:       attachment.Name,
+			MediaType:  attachment.MediaType,
+		}
+		err := writer.WriteAttachment(attachment)
+		if err != nil {
+			return cw.Count(), nil, nil, fmt.Errorf("failed to write attachment: %w", err)
+		}
+		attachmentIndex.Length = uint64(cw.Count() - offset)
+		attachmentIndexes = append(attachmentIndexes, attachmentIndex)
+	}
+
+	var metadataIndexes []*mcap.MetadataIndex
+	for _, metadata := range metadata {
+		offset := int64(cw.Count())
+		metadataIndex := &mcap.MetadataIndex{
+			Offset: uint64(offset) + uint64(startOffset),
+			Name:   metadata.Name,
+		}
+		err := writer.WriteMetadata(metadata)
+		if err != nil {
+			return cw.Count(), nil, nil, fmt.Errorf("failed to write metadata: %w", err)
+		}
+		metadataIndex.Length = uint64(cw.Count() - offset)
+		metadataIndexes = append(metadataIndexes, metadataIndex)
+	}
+	// Only compute a CRC if the initial CRC is nonzero, otherwise leave it as zero.
+	var dataSectionCRC uint32
+	if startCRC != 0 {
+		dataSectionCRC = cw.CRC()
+	}
+	newDataEnd := &mcap.DataEnd{
+		DataSectionCRC: dataSectionCRC,
+	}
+	err = writer.WriteDataEnd(newDataEnd)
+	if err != nil {
+		return cw.Count(), nil, nil, fmt.Errorf("failed to write data end: %w", err)
+	}
+	return cw.Count(), attachmentIndexes, metadataIndexes, nil
+}

--- a/go/cli/mcap/utils/mcap_amendment_test.go
+++ b/go/cli/mcap/utils/mcap_amendment_test.go
@@ -1,0 +1,212 @@
+package utils
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/foxglove/mcap/go/cli/mcap/testutils"
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmendsIndexedFile(t *testing.T) {
+	buf := testutils.NewBufReadWriteSeeker()
+	writer, err := mcap.NewWriter(buf, &mcap.WriterOptions{
+		IncludeCRC: true,
+		Chunked:    true,
+		ChunkSize:  1024,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
+	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+		ID:       1,
+		Name:     "s1",
+		Encoding: "txt",
+		Data:     []byte{0x01, 0x02, 0x03},
+	}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:              0,
+		SchemaID:        1,
+		Topic:           "/topic",
+		MessageEncoding: "txt",
+		Metadata: map[string]string{
+			"happy": "days",
+		},
+	}))
+	for i := 0; i < 100; i++ {
+		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+			ChannelID: 0,
+			Data:      []byte{0x01, 0x02, 0x03},
+		}))
+	}
+	assert.Nil(t, writer.Close())
+
+	_, err = buf.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+
+	reader, err := mcap.NewReader(buf)
+	assert.Nil(t, err)
+	initialInfo, err := reader.Info()
+	assert.Nil(t, err)
+	reader.Close()
+
+	assert.Nil(t, AmendMCAP(buf, []*mcap.Attachment{
+		{
+			LogTime:    0,
+			CreateTime: 0,
+			Name:       "a1",
+			MediaType:  "text/plain",
+			DataSize:   10,
+			Data:       bytes.NewReader(make([]byte, 10)),
+		},
+	}, nil))
+
+	_, err = buf.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+	reader, err = mcap.NewReader(buf)
+	assert.Nil(t, err)
+	newInfo, err := reader.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, int(newInfo.Statistics.AttachmentCount))
+	assert.Equal(t, initialInfo.Statistics.MessageCount, newInfo.Statistics.MessageCount)
+	assert.Equal(t, initialInfo.Statistics.ChannelCount, newInfo.Statistics.ChannelCount)
+	assert.Equal(t, initialInfo.Statistics.MetadataCount, newInfo.Statistics.MetadataCount)
+	assert.Equal(t, initialInfo.Channels, newInfo.Channels)
+	assert.Equal(t, initialInfo.Schemas, newInfo.Schemas)
+	assert.Positive(t, newInfo.Footer.SummaryCRC)
+}
+
+func TestDoesNotComputeCRCIfDisabled(t *testing.T) {
+	buf := testutils.NewBufReadWriteSeeker()
+	writer, err := mcap.NewWriter(buf, &mcap.WriterOptions{
+		IncludeCRC: false,
+		Chunked:    true,
+		ChunkSize:  1024,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
+	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+		ID:       1,
+		Name:     "s1",
+		Encoding: "txt",
+		Data:     []byte{0x01, 0x02, 0x03},
+	}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:              0,
+		SchemaID:        1,
+		Topic:           "/topic",
+		MessageEncoding: "txt",
+		Metadata: map[string]string{
+			"happy": "days",
+		},
+	}))
+	for i := 0; i < 100; i++ {
+		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+			ChannelID: 0,
+			Data:      []byte{0x01, 0x02, 0x03},
+		}))
+	}
+	assert.Nil(t, writer.Close())
+
+	_, err = buf.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+
+	reader, err := mcap.NewReader(buf)
+	assert.Nil(t, err)
+	initialInfo, err := reader.Info()
+	assert.Nil(t, err)
+	reader.Close()
+
+	assert.Nil(t, AmendMCAP(buf, []*mcap.Attachment{
+		{
+			LogTime:    0,
+			CreateTime: 0,
+			Name:       "a1",
+			MediaType:  "text/plain",
+			DataSize:   10,
+			Data:       bytes.NewReader(make([]byte, 10)),
+		},
+	}, nil))
+
+	_, err = buf.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+	reader, err = mcap.NewReader(buf)
+	assert.Nil(t, err)
+	newInfo, err := reader.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, int(newInfo.Statistics.AttachmentCount))
+	assert.Equal(t, initialInfo.Statistics.MessageCount, newInfo.Statistics.MessageCount)
+	assert.Equal(t, initialInfo.Statistics.ChannelCount, newInfo.Statistics.ChannelCount)
+	assert.Equal(t, initialInfo.Statistics.MetadataCount, newInfo.Statistics.MetadataCount)
+	assert.Equal(t, initialInfo.Channels, newInfo.Channels)
+	assert.Equal(t, initialInfo.Schemas, newInfo.Schemas)
+	assert.Zero(t, newInfo.Footer.SummaryCRC)
+}
+
+func TestAmendsUnindexedFile(t *testing.T) {
+	buf := testutils.NewBufReadWriteSeeker()
+	writer, err := mcap.NewWriter(buf, &mcap.WriterOptions{
+		IncludeCRC: false,
+		Chunked:    false,
+		ChunkSize:  1024,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
+	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+		ID:       1,
+		Name:     "s1",
+		Encoding: "txt",
+		Data:     []byte{0x01, 0x02, 0x03},
+	}))
+	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+		ID:              0,
+		SchemaID:        1,
+		Topic:           "/topic",
+		MessageEncoding: "txt",
+		Metadata: map[string]string{
+			"happy": "days",
+		},
+	}))
+	for i := 0; i < 100; i++ {
+		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+			ChannelID: 0,
+			Data:      []byte{0x01, 0x02, 0x03},
+		}))
+	}
+	assert.Nil(t, writer.Close())
+
+	_, err = buf.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+
+	reader, err := mcap.NewReader(buf)
+	assert.Nil(t, err)
+	initialInfo, err := reader.Info()
+	assert.Nil(t, err)
+	reader.Close()
+
+	assert.Nil(t, AmendMCAP(buf, []*mcap.Attachment{
+		{
+			LogTime:    0,
+			CreateTime: 0,
+			Name:       "a1",
+			MediaType:  "text/plain",
+			DataSize:   10,
+			Data:       bytes.NewReader(make([]byte, 10)),
+		},
+	}, nil))
+
+	_, err = buf.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+	reader, err = mcap.NewReader(buf)
+	assert.Nil(t, err)
+	newInfo, err := reader.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, int(newInfo.Statistics.AttachmentCount))
+	assert.Equal(t, 100, int(newInfo.Statistics.MessageCount))
+	assert.Equal(t, 1, int(newInfo.Statistics.ChannelCount))
+	assert.Equal(t, 0, int(newInfo.Statistics.MetadataCount))
+	assert.Equal(t, initialInfo.Channels, newInfo.Channels)
+	assert.Equal(t, initialInfo.Schemas, newInfo.Schemas)
+	assert.Zero(t, newInfo.Footer.SummaryCRC)
+}

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -132,124 +131,6 @@ func inferWriterOptions(info *mcap.Info) *mcap.WriterOptions {
 		ChunkSize:   int64(idx.ChunkLength),
 		Compression: idx.Compression,
 	}
-}
-
-// RewriteMCAP rewrites the mcap file wrapped by the provided ReadSeeker and
-// performs the operations described by the supplied fns at the end of writing.
-// It is used for adding metadata and attachments to an existing file. In the
-// future this can be optimized to rewrite only the summary section, which
-// should make it run much faster but will require some tricky modifications of
-// indexes pointing into the summary section.
-func RewriteMCAP(w io.Writer, r io.ReadSeeker, fns ...func(writer *mcap.Writer) error) error {
-	reader, err := mcap.NewReader(r)
-	if err != nil {
-		return fmt.Errorf("failed to open mcap reader: %w", err)
-	}
-	defer reader.Close()
-	info, err := reader.Info()
-	if err != nil {
-		return fmt.Errorf("failed to get mcap info")
-	}
-	opts := inferWriterOptions(info)
-	writer, err := mcap.NewWriter(w, opts)
-	if err != nil {
-		return fmt.Errorf("failed to construct mcap writer: %w", err)
-	}
-	defer writer.Close()
-	if err := writer.WriteHeader(info.Header); err != nil {
-		return fmt.Errorf("failed to rewrite header: %w", err)
-	}
-	_, err = r.Seek(0, io.SeekStart)
-	if err != nil {
-		return fmt.Errorf("failed to seek to reader start: %w", err)
-	}
-	lexer, err := mcap.NewLexer(r, &mcap.LexerOptions{
-		SkipMagic:         false,
-		ValidateChunkCRCs: false,
-		EmitChunks:        false,
-		AttachmentCallback: func(ar *mcap.AttachmentReader) error {
-			return writer.WriteAttachment(&mcap.Attachment{
-				LogTime:    ar.LogTime,
-				CreateTime: ar.CreateTime,
-				Name:       ar.Name,
-				MediaType:  ar.MediaType,
-				DataSize:   ar.DataSize,
-				Data:       ar.Data(),
-			})
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to construct lexer: %w", err)
-	}
-	defer lexer.Close()
-	buf := make([]byte, 1024)
-	schemas := make(map[uint16]bool)
-	channels := make(map[uint16]bool)
-	for {
-		tokenType, token, err := lexer.Next(buf)
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return fmt.Errorf("failed to pull next record: %w", err)
-		}
-		if len(token) > len(buf) {
-			buf = token
-		}
-		switch tokenType {
-		case mcap.TokenChannel:
-			record, err := mcap.ParseChannel(token)
-			if err != nil {
-				return fmt.Errorf("failed to parse channel: %w", err)
-			}
-			if !channels[record.ID] {
-				err := writer.WriteChannel(record)
-				if err != nil {
-					return fmt.Errorf("failed to write channel: %w", err)
-				}
-				channels[record.ID] = true
-			}
-		case mcap.TokenSchema:
-			record, err := mcap.ParseSchema(token)
-			if err != nil {
-				return fmt.Errorf("failed to parse schema: %w", err)
-			}
-			if !schemas[record.ID] {
-				err := writer.WriteSchema(record)
-				if err != nil {
-					return fmt.Errorf("failed to write schema: %w", err)
-				}
-				schemas[record.ID] = true
-			}
-		case mcap.TokenMessage:
-			record, err := mcap.ParseMessage(token)
-			if err != nil {
-				return fmt.Errorf("failed to parse message: %w", err)
-			}
-			err = writer.WriteMessage(record)
-			if err != nil {
-				return fmt.Errorf("failed to write message: %w", err)
-			}
-		case mcap.TokenMetadata:
-			record, err := mcap.ParseMetadata(token)
-			if err != nil {
-				return fmt.Errorf("failed to parse metadata: %w", err)
-			}
-			err = writer.WriteMetadata(record)
-			if err != nil {
-				return fmt.Errorf("failed to write metadata: %w", err)
-			}
-		default:
-			continue
-		}
-	}
-	for _, f := range fns {
-		err = f(writer)
-		if err != nil {
-			return fmt.Errorf("failed to apply writer function: %w", err)
-		}
-	}
-	return nil
 }
 
 func Keys[T any](m map[string]T) []string {

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -27,6 +27,7 @@ type indexedMessageIterator struct {
 	chunkIndexes      []*ChunkIndex
 	attachmentIndexes []*AttachmentIndex
 	metadataIndexes   []*MetadataIndex
+	footer            *Footer
 
 	indexHeap rangeIndexHeap
 
@@ -56,6 +57,7 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse footer: %w", err)
 	}
+	it.footer = footer
 
 	// scan the whole summary section
 	if footer.SummaryStart == 0 {

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -328,6 +328,7 @@ type Info struct {
 	MetadataIndexes   []*MetadataIndex
 	AttachmentIndexes []*AttachmentIndex
 	Header            *Header
+	Footer            *Footer
 }
 
 // ChannelCounts counts the number of messages on each channel in an Info.

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -155,7 +155,6 @@ func (r *Reader) Info() (*Info, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &Info{
 		Statistics:        it.statistics,
 		Channels:          it.channels,
@@ -163,6 +162,7 @@ func (r *Reader) Info() (*Info, error) {
 		AttachmentIndexes: it.attachmentIndexes,
 		MetadataIndexes:   it.metadataIndexes,
 		Schemas:           it.schemas,
+		Footer:            it.footer,
 		Header:            r.header,
 	}, nil
 }


### PR DESCRIPTION
Changes the implementation of "mcap add attachment" and "mcap add metadata" to append to the data section in place, then overwrite an updated summary section with all offsets and CRCs updated.

This makes adding attachments and metadata very fast, and constant time with respect to size of the file. Prior to this commit, each one did an overwrite.