### PR TITLE
Tighten python protobuf dependency to `<=4.21.11` to fix potential segfault

### DIFF
--- a/python/mcap-protobuf-support/setup.cfg
+++ b/python/mcap-protobuf-support/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
 [options]
 install_requires = 
     mcap>=0.0.14
-    protobuf<=4.21.11
+    protobuf>=3.8,<=4.21.11
 install_package_data = True
 packages = find:
 python_requires = >=3.7

--- a/python/mcap-protobuf-support/setup.cfg
+++ b/python/mcap-protobuf-support/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
 [options]
 install_requires = 
     mcap>=0.0.14
-    protobuf
+    protobuf<=4.21.11
 install_package_data = True
 packages = find:
 python_requires = >=3.7


### PR DESCRIPTION
### Public-Facing Changes

Tighten python protobuf dependency to `<=4.21.11` to fix potential segfault

### Description
Reading an mcap file with `mcap-protobuf-support` can lead to a segfault which is very likely related to https://github.com/protocolbuffers/protobuf/issues/12047 (see https://github.com/protocolbuffers/protobuf/issues/12047#issuecomment-1622405787 for reproduction steps). This patch tightens the python protobuf dependency to `<=4.21.11` as the segfault apprently only happens from `4.21.11` onwards.

Fixes FG-3792
