### PR TITLE
mcap filter: don't die on schema id 0

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -307,15 +307,17 @@ func filter(
 				continue
 			}
 			if !channel.written {
-				schema, ok := schemas[channel.SchemaID]
-				if !ok {
-					return fmt.Errorf("encountered channel with topic %s with unknown schema ID %d", channel.Topic, channel.SchemaID)
-				}
-				if !schema.written {
-					if err = mcapWriter.WriteSchema(schema.Schema); err != nil {
-						return err
+				if channel.SchemaID != 0 {
+					schema, ok := schemas[channel.SchemaID]
+					if !ok {
+						return fmt.Errorf("encountered channel with topic %s with unknown schema ID %d", channel.Topic, channel.SchemaID)
 					}
-					schemas[channel.SchemaID] = markableSchema{schema.Schema, true}
+					if !schema.written {
+						if err = mcapWriter.WriteSchema(schema.Schema); err != nil {
+							return err
+						}
+						schemas[channel.SchemaID] = markableSchema{schema.Schema, true}
+					}
 				}
 				if err = mcapWriter.WriteChannel(channel.Channel); err != nil {
 					return err

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -34,7 +34,7 @@ func writeFilterTestInput(t *testing.T, w io.Writer) {
 	}))
 	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
 		ID:       3,
-		SchemaID: 1,
+		SchemaID: 0,
 		Topic:    "radar_a",
 	}))
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
### Public-Facing Changes

CLI commands `filter`, `compress`, `decompress`, and `recover` no longer fail on schemaless channels (schema id = 0).

### Description

Don't fail when encountering schema ID 0.

Fixes FG-4182

See also:
- https://github.com/foxglove/mcap/issues/829
- https://github.com/foxglove/mcap/issues/847
- https://github.com/foxglove/mcap/issues/579