### PR TITLE
spec: add channel UUID

### DIFF
--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -111,7 +111,7 @@ All MCAP records are serialized as follows:
 
 Record type is a single byte opcode, and record content length is a uint64 value.
 
-Records may be extended by adding new fields at the end of existing fields. Readers should ignore any unknown fields.
+Future changes to this specification may extend records by adding new fields at the end of existing fields. Readers should ignore any unknown fields.
 
 > The Footer and Message records will not be extended, since their formats do not allow for backward-compatible size changes.
 


### PR DESCRIPTION
### Public-Facing Changes

* Resolves ambiguity around extending records with new fields. Records may be extended by changes to the specification only.
* Defines zero values for all field types, to be used when a field is missing from a serialized record.
* Adds a UUID field to the Channel record. This allows readers to safely treat channels in different files as the same logical channel.

