### PR TITLE
cpp: re-use allocations for message indexes in writer

### DIFF
--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/1.1.0"
+    requires = "benchmark/1.7.0", "mcap/1.2.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.1.0
+conan editable add ./mcap mcap/1.2.0
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.1.0
+conan editable add ./mcap mcap/1.2.0
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/1.1.0"
+    requires = "mcap/1.2.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/1.1.0",
+        "mcap/1.2.0",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "1.1.0"
+    version = "1.2.0"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "1.1.0"
+#define MCAP_LIBRARY_VERSION "1.2.0"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/1.1.0", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/1.2.0", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
### Public-Facing Changes

Writing MCAPs with many channels is faster by anywhere between 1% and 20%, depending on conditions.

comparison on my M1 Mac ([see instruction for interpreting output here](https://github.com/google/benchmark/blob/main/docs/tools.md))
```
Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0366         -0.0366        999498        962936        999439        962867
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            +0.0079         +0.0079        970642        978308        970469        978134
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0035         -0.0036        966292        962882        966269        962830
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0012         -0.0013        979647        978432        979622        978358
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0089         -0.0089        972386        963696        972219        963569
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0092         -0.0092        970476        961573        970408        961519
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0070         -0.0085        973499        966681        973137        964833
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0085         -0.0082        970336        962133        970016        962048
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            -0.0026         -0.0025        966209        963721        966101        963694
BM_McapWriterFileWriterChunkedManyChannels/786432/1                            +0.0049         +0.0048        969798        974541        969773        974414
BM_McapWriterFileWriterChunkedManyChannels/786432/1_pvalue                      0.0757          0.0539      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/786432/1_mean                       -0.0066         -0.0067        973878        967490        973745        967227
BM_McapWriterFileWriterChunkedManyChannels/786432/1_median                     -0.0071         -0.0070        970559        963709        970438        963632
BM_McapWriterFileWriterChunkedManyChannels/786432/1_stddev                     -0.2998         -0.2993          9773          6843          9794          6862
BM_McapWriterFileWriterChunkedManyChannels/786432/1_cv                         -0.2952         -0.2946             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0088         -0.0088       1164213       1153933       1164208       1153912
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0177         -0.0176       1180766       1159902       1180669       1159853
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0113         -0.0111       1167754       1154578       1167433       1154459
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0248         -0.0266       1184387       1155039       1184368       1152875
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0045         -0.0045       1164383       1159173       1164345       1159119
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0210         -0.0209       1177869       1153183       1177726       1153056
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0135         -0.0135       1168071       1152361       1168049       1152289
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0078         -0.0078       1165602       1156542       1165560       1156526
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0095         -0.0095       1167388       1156256       1167309       1156224
BM_McapWriterFileWriterChunkedManyChannels/786432/10                           -0.0071         -0.0071       1164004       1155735       1163964       1155678
BM_McapWriterFileWriterChunkedManyChannels/786432/10_pvalue                     0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/786432/10_mean                      -0.0126         -0.0128       1170444       1155670       1170363       1155399
BM_McapWriterFileWriterChunkedManyChannels/786432/10_median                    -0.0104         -0.0105       1167571       1155387       1167371       1155069
BM_McapWriterFileWriterChunkedManyChannels/786432/10_stddev                    -0.6803         -0.6587          7592          2427          7586          2589
BM_McapWriterFileWriterChunkedManyChannels/786432/10_cv                        -0.6762         -0.6543             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0326         -0.0344       1213645       1174084       1213552       1171855
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0330         -0.0330       1208716       1168878       1208658       1168795
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0364         -0.0364       1210138       1166085       1210035       1166020
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0378         -0.0379       1211322       1165525       1211273       1165395
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0396         -0.0395       1216822       1168683       1216760       1168642
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0362         -0.0362       1211960       1168087       1211910       1168028
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0429         -0.0429       1219859       1167518       1219788       1167418
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0343         -0.0360       1212106       1170546       1212080       1168412
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0363         -0.0362       1213255       1169176       1213045       1169094
BM_McapWriterFileWriterChunkedManyChannels/786432/100                          -0.0333         -0.0333       1210033       1169778       1210010       1169707
BM_McapWriterFileWriterChunkedManyChannels/786432/100_pvalue                    0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/786432/100_mean                     -0.0362         -0.0366       1212786       1168836       1212711       1168337
BM_McapWriterFileWriterChunkedManyChannels/786432/100_median                   -0.0357         -0.0359       1212033       1168780       1211995       1168527
BM_McapWriterFileWriterChunkedManyChannels/786432/100_stddev                   -0.2828         -0.4549          3362          2411          3355          1829
BM_McapWriterFileWriterChunkedManyChannels/786432/100_cv                       -0.2559         -0.4342             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1368         -0.1368       1393100       1202462       1392987       1202433
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1350         -0.1351       1385458       1198355       1385388       1198280
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1302         -0.1302       1384193       1203913       1384116       1203850
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1367         -0.1365       1389787       1199843       1387133       1197779
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1325         -0.1326       1386356       1202605       1386338       1202511
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1265         -0.1264       1384094       1208991       1383915       1208937
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1342         -0.1341       1384786       1198887       1384571       1198861
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1358         -0.1358       1386198       1198016       1386154       1197965
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1357         -0.1357       1398384       1208676       1398300       1208606
BM_McapWriterFileWriterChunkedManyChannels/786432/1000                         -0.1301         -0.1298       1390989       1210078       1390484       1210002
BM_McapWriterFileWriterChunkedManyChannels/786432/1000_pvalue                   0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/786432/1000_mean                    -0.1334         -0.1333       1388335       1203182       1387938       1202922
BM_McapWriterFileWriterChunkedManyChannels/786432/1000_median                  -0.1325         -0.1326       1386277       1202533       1386246       1202472
BM_McapWriterFileWriterChunkedManyChannels/786432/1000_stddev                  -0.0124         +0.0368          4682          4624          4647          4818
BM_McapWriterFileWriterChunkedManyChannels/786432/1000_cv                      +0.1396         +0.1963             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2729         -0.2729       2306402       1676934       2306281       1676901
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2110         -0.2110       2103000       1659205       2102703       1659096
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2257         -0.2258       2108704       1632677       2108669       1632530
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2189         -0.2189       2112389       1650007       2112334       1649913
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2294         -0.2294       2118209       1632269       2118062       1632090
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2250         -0.2250       2108514       1634128       2108405       1634054
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2245         -0.2242       2118429       1642906       2117654       1642794
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2277         -0.2277       2115837       1634150       2115793       1634088
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2132         -0.2132       2111120       1660961       2110937       1660922
BM_McapWriterFileWriterChunkedManyChannels/786432/10000                        -0.2283         -0.2283       2115633       1632650       2115437       1632574
BM_McapWriterFileWriterChunkedManyChannels/786432/10000_pvalue                  0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/786432/10000_mean                   -0.2281         -0.2281       2131824       1645589       2131627       1645496
BM_McapWriterFileWriterChunkedManyChannels/786432/10000_median                 -0.2249         -0.2249       2114011       1638528       2113885       1638441
BM_McapWriterFileWriterChunkedManyChannels/786432/10000_stddev                 -0.7456         -0.7453         61532         15651         61553         15677
BM_McapWriterFileWriterChunkedManyChannels/786432/10000_cv                     -0.6705         -0.6701             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           +0.0054         +0.0053        972845        978052        972783        977913
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           +0.0012         +0.0012        970230        971390        970168        971348
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0250         -0.0250        990398        965645        990349        965573
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0174         -0.0190        982580        965437        982512        963842
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0203         -0.0203        984751        964803        984701        964723
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0192         -0.0192        982201        963379        982136        963281
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0069         -0.0070        976559        969844        976524        969716
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0149         -0.0148        977474        962921        977377        962881
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           +0.0107         +0.0106        976033        986463        976002        986392
BM_McapWriterFileWriterChunkedManyChannels/7864320/1                           -0.0074         -0.0073        978622        971426        978527        971399
BM_McapWriterFileWriterChunkedManyChannels/7864320/1_pvalue                     0.0113          0.0113      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/7864320/1_mean                      -0.0094         -0.0096        979169        969936        979108        969707
BM_McapWriterFileWriterChunkedManyChannels/7864320/1_median                    -0.0105         -0.0105        978048        967744        977952        967645
BM_McapWriterFileWriterChunkedManyChannels/7864320/1_stddev                    +0.2551         +0.2733          5942          7458          5944          7568
BM_McapWriterFileWriterChunkedManyChannels/7864320/1_cv                        +0.2670         +0.2856             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          -0.0078         -0.0078       1160350       1151309       1160273       1151264
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          -0.0058         -0.0058       1165325       1158552       1165285       1158497
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          -0.0046         -0.0046       1160831       1155466       1160725       1155343
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          -0.0029         -0.0029       1155875       1152533       1155836       1152523
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          -0.0040         -0.0039       1161071       1156467       1160985       1156428
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          -0.0076         -0.0076       1162870       1154031       1162742       1153955
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          +0.0008         -0.0010       1157175       1158137       1157112       1155982
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          +0.0006         +0.0006       1156439       1157102       1156397       1157091
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          +0.0010         +0.0010       1154976       1156184       1154887       1156089
BM_McapWriterFileWriterChunkedManyChannels/7864320/10                          +0.0032         +0.0033       1151074       1154809       1150920       1154708
BM_McapWriterFileWriterChunkedManyChannels/7864320/10_pvalue                    0.0890          0.0640      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/7864320/10_mean                     -0.0027         -0.0029       1158599       1155459       1158516       1155188
BM_McapWriterFileWriterChunkedManyChannels/7864320/10_median                   -0.0025         -0.0026       1158762       1155825       1158692       1155662
BM_McapWriterFileWriterChunkedManyChannels/7864320/10_stddev                   -0.4479         -0.4923          4236          2339          4246          2156
BM_McapWriterFileWriterChunkedManyChannels/7864320/10_cv                       -0.4464         -0.4908             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0044         +0.0044       1169607       1174779       1169541       1174704
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0234         +0.0234       1170880       1198279       1170858       1198215
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0094         +0.0083       1169657       1180602       1169575       1179321
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0079         +0.0091       1174606       1183863       1172437       1183149
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         -0.0106         -0.0106       1183861       1171310       1183808       1171266
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0114         +0.0114       1172166       1185546       1172137       1185503
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0027         +0.0028       1169394       1172578       1169292       1172522
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0021         +0.0020       1170504       1172931       1170452       1172824
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0007         +0.0007       1178303       1179130       1178274       1179101
BM_McapWriterFileWriterChunkedManyChannels/7864320/100                         +0.0090         +0.0090       1169553       1180117       1169473       1180021
BM_McapWriterFileWriterChunkedManyChannels/7864320/100_pvalue                   0.0091          0.0073      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/7864320/100_mean                    +0.0060         +0.0060       1172853       1179914       1172585       1179663
BM_McapWriterFileWriterChunkedManyChannels/7864320/100_median                  +0.0076         +0.0073       1170692       1179624       1170655       1179211
BM_McapWriterFileWriterChunkedManyChannels/7864320/100_stddev                  +0.6846         +0.6879          4801          8088          4772          8054
BM_McapWriterFileWriterChunkedManyChannels/7864320/100_cv                      +0.6746         +0.6778             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0442         -0.0442       1222251       1168269       1222155       1168168
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0287         -0.0287       1214050       1179264       1213987       1179149
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0444         -0.0444       1222966       1168640       1222932       1168611
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0197         -0.0198       1205386       1181627       1205299       1181378
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0366         -0.0366       1208614       1164410       1208516       1164340
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0336         -0.0336       1205811       1165331       1205732       1165262
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0376         -0.0374       1219446       1173591       1217078       1171600
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0376         -0.0376       1210643       1165075       1210497       1164971
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0223         -0.0224       1206682       1179751       1206606       1179620
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000                        -0.0374         -0.0374       1212339       1167024       1212314       1166993
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000_pvalue                  0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000_mean                   -0.0342         -0.0342       1212819       1171298       1212512       1171009
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000_median                 -0.0355         -0.0355       1211491       1168455       1211406       1168389
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000_stddev                 +0.0014         +0.0192          6684          6693          6477          6601
BM_McapWriterFileWriterChunkedManyChannels/7864320/1000_cv                     +0.0369         +0.0553             0             0             0             0
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1372         -0.1372       1414802       1220640       1414725       1220588
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1470         -0.1470       1427088       1217277       1426962       1217174
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1441         -0.1441       1432545       1226102       1432490       1226063
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1520         -0.1524       1443357       1223917       1440994       1221442
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1399         -0.1399       1418460       1220087       1418367       1219969
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1437         -0.1437       1428744       1223378       1428594       1223283
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1386         -0.1386       1415175       1219099       1415038       1218985
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1412         -0.1413       1424570       1223467       1424516       1223284
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1297         -0.1296       1424039       1239345       1423870       1239285
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000                       -0.1451         -0.1451       1422856       1216408       1422702       1216290
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000_mean                  -0.1419         -0.1419       1425164       1222972       1424826       1222636
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000_median                -0.1420         -0.1427       1424304       1222009       1424193       1221015
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000_stddev                -0.2384         -0.1871          8570          6527          8055          6548
BM_McapWriterFileWriterChunkedManyChannels/7864320/10000_cv                    -0.1125         -0.0526             0             0             0             0
OVERALL_GEOMEAN                                                                -0.0631         -0.0632             0             0             0             0
```

### Description

We use a hash map { channel ID: message index vector } to store message indexes while writing messages. For M messages in N channels in a chunk, there will always be N separately-allocated vectors containing on average M/N elements.

Before this commit, we destroy and re-create these vectors for every chunk. With a large number of channels, this can result in many allocations and re-allocations as the vectors get rebuilt for every new chunk.

After this commit, we clear the vectors after writing a chunk, allowing us to re-use the allocated memory for the next chunk. This should result in much less work for the allocator while writing.

This commit also contains a new benchmark to demonstrate this behavior. I need to properly measure the results but i've eyeballed a small speedup around ~10% speedup for large numbers of channels.