### PR TITLE
fix wording mistake for Message.sequence in specs

### DIFF
--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -171,13 +171,13 @@ A message record encodes a single timestamped message on a channel.
 
 The message encoding and schema must match that of the Channel record corresponding to the message's channel ID.
 
-| Bytes | Name         | Type      | Description                                                                                                     |
-| ----- | ------------ | --------- | --------------------------------------------------------------------------------------------------------------- |
-| 2     | channel_id   | uint16    | Channel ID                                                                                                      |
-| 4     | sequence     | uint32    | Optional message counter assigned by publisher. If not assigned by publisher, must be recorded by the recorder. |
-| 8     | log_time     | Timestamp | Time at which the message was recorded.                                                                         |
-| 8     | publish_time | Timestamp | Time at which the message was published. If not available, must be set to the log time.                         |
-| N     | data         | Bytes     | Message data, to be decoded according to the schema of the channel.                                             |
+| Bytes | Name         | Type      | Description                                                                                                 |
+| ----- | ------------ | --------- | ----------------------------------------------------------------------------------------------------------- |
+| 2     | channel_id   | uint16    | Channel ID                                                                                                  |
+| 4     | sequence     | uint32    | Optional message counter assigned by publisher. If assigned by publisher, must be recorded by the recorder. |
+| 8     | log_time     | Timestamp | Time at which the message was recorded.                                                                     |
+| 8     | publish_time | Timestamp | Time at which the message was published. If not available, must be set to the log time.                     |
+| N     | data         | Bytes     | Message data, to be decoded according to the schema of the channel.                                         |
 
 ### Chunk (op=0x06)
 


### PR DESCRIPTION
### Public-Facing Changes

remove the "not" from description of `Message.sequence` in specs:

"If not assigned by publisher, must be recorded by the recorder." --> "If assigned by publisher, must be recorded by the recorder."

### Description

fix #926
