### PR TITLE
fix python reader support for mcap without summary

### DIFF
--- a/python/mcap/tests/test_reader.py
+++ b/python/mcap/tests/test_reader.py
@@ -234,5 +234,7 @@ def test_no_summary_not_seeking(tmpdir: Path):
 
     with open(filepath, "rb") as f:
         assert len(list(NonSeekingReader(f).iter_messages())) == 200
+    with open(filepath, "rb") as f:
         assert len(list(NonSeekingReader(f).iter_attachments())) == 1
+    with open(filepath, "rb") as f:
         assert len(list(NonSeekingReader(f).iter_metadata())) == 1

--- a/python/mcap/tests/test_reader.py
+++ b/python/mcap/tests/test_reader.py
@@ -217,13 +217,22 @@ def write_no_summary_mcap(filepath: Path):
         writer.finish()
 
 
-@pytest.mark.parametrize("reader_cls", READER_SUBCLASSES)
-def test_no_summary(reader_cls: AnyReaderSubclass, tmpdir: Path):
+def test_no_summary_seeking(tmpdir: Path):
     filepath = tmpdir / "no_summary.mcap"
     write_no_summary_mcap(filepath)
 
     with open(filepath, "rb") as f:
-        reader: McapReader = reader_cls(f)
+        reader = SeekingReader(f)
         assert len(list(reader.iter_messages())) == 200
         assert len(list(reader.iter_attachments())) == 1
         assert len(list(reader.iter_metadata())) == 1
+
+
+def test_no_summary_not_seeking(tmpdir: Path):
+    filepath = tmpdir / "no_summary.mcap"
+    write_no_summary_mcap(filepath)
+
+    with open(filepath, "rb") as f:
+        assert len(list(NonSeekingReader(f).iter_messages())) == 200
+        assert len(list(NonSeekingReader(f).iter_attachments())) == 1
+        assert len(list(NonSeekingReader(f).iter_metadata())) == 1

--- a/python/mcap/tests/test_reader.py
+++ b/python/mcap/tests/test_reader.py
@@ -10,7 +10,7 @@ from mcap.decoder import DecoderFactory
 from mcap.exceptions import DecoderNotFoundError
 from mcap.reader import McapReader, NonSeekingReader, SeekingReader, make_reader
 from mcap.records import Channel, Message, Schema
-from mcap.writer import Writer
+from mcap.writer import IndexType, Writer
 
 DEMO_MCAP = (
     Path(__file__).parent.parent.parent.parent / "testdata" / "mcap" / "demo.mcap"
@@ -195,3 +195,35 @@ def test_non_seeking_used_once():
         _ = list(reader.iter_metadata())
         with pytest.raises(RuntimeError):
             _ = list(reader.iter_metadata())
+
+
+def write_no_summary_mcap(filepath: Path):
+    with open(filepath, "wb") as f:
+        writer = Writer(
+            f,
+            index_types=IndexType.NONE,
+            repeat_channels=False,
+            repeat_schemas=False,
+            use_chunking=False,
+            use_statistics=False,
+            use_summary_offsets=False,
+        )
+        writer.start()
+        writer.add_attachment(10, 10, "my_attach", "text", b"some data")
+        writer.add_metadata("my_meta", {"foo": "bar"})
+        foo_channel = writer.register_channel("/foo", "json", 0)
+        for i in range(200):
+            writer.add_message(foo_channel, 10, json.dumps({"a": 0}).encode("utf8"), 10)
+        writer.finish()
+
+
+@pytest.mark.parametrize("reader_cls", READER_SUBCLASSES)
+def test_no_summary(reader_cls: AnyReaderSubclass, tmpdir: Path):
+    filepath = tmpdir / "no_summary.mcap"
+    write_no_summary_mcap(filepath)
+
+    with open(filepath, "rb") as f:
+        reader: McapReader = SeekingReader(f)
+        assert len(list(reader.iter_messages())) == 200
+        assert len(list(reader.iter_attachments())) == 1
+        assert len(list(reader.iter_metadata())) == 1

--- a/python/mcap/tests/test_reader.py
+++ b/python/mcap/tests/test_reader.py
@@ -223,7 +223,7 @@ def test_no_summary(reader_cls: AnyReaderSubclass, tmpdir: Path):
     write_no_summary_mcap(filepath)
 
     with open(filepath, "rb") as f:
-        reader: McapReader = SeekingReader(f)
+        reader: McapReader = reader_cls(f)
         assert len(list(reader.iter_messages())) == 200
         assert len(list(reader.iter_attachments())) == 1
         assert len(list(reader.iter_metadata())) == 1


### PR DESCRIPTION
When attempting to "proxy" a generator function in python, using `return gen()` is wrong. `return val` constructs a StopIteration exception with `val` and raise it, not doing what you want.

This PR fix this by using `yield from`, also adds a test to secure the no summary mcap processing logic.
