### PR TITLE
Log time0

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Fixes #924, removes some duplicated stats tracking data in the Chunk and overall MCAP writer while we're at it.