### PR TITLE
Bump typescript mcap/core version to 1.3.0

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Public-Facing Changes
Bump version number of typescript mcap/core package to 1.3.0
