### PR TITLE
Rust: Make RawMessage fields publicly accessible

### DIFF
--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -618,8 +618,8 @@ impl<'a> RawMessageStream<'a> {
 }
 
 pub struct RawMessage<'a> {
-    header: records::MessageHeader,
-    data: Cow<'a, [u8]>,
+    pub header: records::MessageHeader,
+    pub data: Cow<'a, [u8]>,
 }
 
 impl<'a> Iterator for RawMessageStream<'a> {


### PR DESCRIPTION
Fixes #647, and maybe says something about how often that API is used. :stuck_out_tongue: 