### PR TITLE
Fix outdated link in C++ header

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -79,7 +79,7 @@ struct MCAP_PUBLIC McapWriterOptions {
   bool forceCompression = false;
   /**
    * @brief The recording profile. See
-   * <https://github.com/foxglove/mcap/tree/main/docs/specification/profiles>
+   * https://mcap.dev/spec/registry#well-known-profiles
    * for more information on well-known profiles.
    */
   std::string profile;


### PR DESCRIPTION

### Public-Facing Changes

Fix an outdated link to documentation in writer.hpp
