### PR TITLE
Fix typescript npm publish CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,9 +215,9 @@ jobs:
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
-        run: yarn workspace @mcap/core publish --access public
+        run: yarn workspace @mcap/core npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   typescript-examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Fix npm publish step for typescript @mcap/core package.

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
