### PR TITLE
compatibility with old python versions

### DIFF
--- a/python/mcap-protobuf-support/mcap_protobuf/reader.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/reader.py
@@ -10,6 +10,7 @@ instantiate the :py:class:`mcap.reader.McapReader` with a
 MyProtoClass(data="hello")
 MyProtoClass(data="goodbye")
 """
+from __future__ import annotations
 import warnings
 from datetime import datetime
 from os import PathLike


### PR DESCRIPTION
### Public-Facing Changes

Fixes: TypeError: 'ABCMeta' object is not subscriptable

### Description

using python 3.8.10
