### PR TITLE
swift: don't try to use ARM intrinsics on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
   name: "mcap",
-  platforms: [.macOS(.v10_15)], // for async/await
+  platforms: [.macOS(.v10_15), .iOS(.v13)], // for async/await
   products: [
     .library(name: "MCAP", targets: ["MCAP"]),
   ],

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -60,6 +60,7 @@ words:
   - golangci
   - infima
   - inputfile
+  - intrinsics
   - jsonschema
   - kaitai
   - libmcap

--- a/swift/crc/CRC32.swift
+++ b/swift/crc/CRC32.swift
@@ -1,6 +1,8 @@
 import struct Foundation.Data
 
-#if arch(arm) || arch(arm64)
+// iOS seems to lack CRC intrinsics
+// See also: https://stackoverflow.com/questions/45625725/does-clang-lack-crc32-for-armv8-aarch64
+#if (arch(arm) || arch(arm64)) && !os(iOS)
   import _Builtin_intrinsics.arm.acle // cspell:disable-line
 #endif
 
@@ -34,7 +36,7 @@ public struct CRC32 {
 
   @inlinable
   public mutating func update(_ data: UnsafeRawBufferPointer) {
-    #if arch(arm) || arch(arm64)
+    #if (arch(arm) || arch(arm64)) && !os(iOS)
       self.updateARM(data)
     #else
       self.update16Byte(data)
@@ -93,7 +95,7 @@ public struct CRC32 {
     }
   }
 
-  #if arch(arm) || arch(arm64)
+  #if (arch(arm) || arch(arm64)) && !os(iOS)
     @inlinable
     internal mutating func updateARM(_ data: UnsafeRawBufferPointer) {
       var offset = 0


### PR DESCRIPTION
### Public-Facing Changes

Fixed built of MCAP Swift library on iOS

### Description

The ARM intrinsics don't seem to work on iOS. Maybe there is some magical compiler flag to enable them, but I couldn't find it.