### PR TITLE
cpp: fix warning in examples on msvc

### DIFF
--- a/cpp/examples/bag2mcap.cpp
+++ b/cpp/examples/bag2mcap.cpp
@@ -30,8 +30,8 @@ int main() {
   mcap::Channel topic("/chatter", "ros1", stdMsgsString.id);
   writer.addChannel(topic);
 
-  std::array<std::byte, 4 + 13> payload;
-  const uint32_t length = 13;
+  std::array<std::byte, 4 + 13> payload{};
+  constexpr uint32_t length = 13;
   std::memcpy(payload.data(), &length, 4);
   std::memcpy(payload.data() + 4, "Hello, world!", 13);
 
@@ -48,7 +48,7 @@ int main() {
     std::cerr << "Failed to write message: " << res.message << "\n";
     writer.terminate();
     out.close();
-    std::remove("output.mcap");
+    std::ignore = std::remove("output.mcap");
     return 1;
   }
 

--- a/cpp/examples/jsonschema/writer.cpp
+++ b/cpp/examples/jsonschema/writer.cpp
@@ -65,11 +65,12 @@ int main(int argc, char** argv) {
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count();
 
-  for (uint64_t frame_index = 0; frame_index < NUM_FRAMES; ++frame_index) {
-    mcap::Timestamp frameTime = startTime + (frame_index * 100 * NS_PER_MS);
+  for (uint32_t frame_index = 0; frame_index < NUM_FRAMES; ++frame_index) {
+    mcap::Timestamp frameTime = startTime + (static_cast<uint64_t>(frame_index) * 100 * NS_PER_MS);
 
     auto contentJson = nlohmann::json::object();
-    float p = (2.0 * 2.0 * M_PI * float(frame_index)) / float(NUM_FRAMES);
+    float p = static_cast<float>((2.0 * 2.0 * M_PI * static_cast<double>(frame_index)) /
+                                 static_cast<double>(NUM_FRAMES));
     contentJson["x"] = sin(p);
     contentJson["y"] = cos(p);
     std::string serialized = contentJson.dump();

--- a/cpp/examples/protobuf/CMakeLists.txt
+++ b/cpp/examples/protobuf/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(foxglove_proto_lib PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
 # Unfortunately the protobuf library headers include some unused parameters, which have to be
 # downgraded back to warnings for all targets that depends on them.
 if (MSVC)
-    target_compile_options(foxglove_proto_lib PUBLIC /wd4100)
+    target_compile_options(foxglove_proto_lib PUBLIC /wd4100 /wd4267 /wd4244)
 else()
     target_compile_options(foxglove_proto_lib PUBLIC -Wno-error=unused-parameter)
 endif()

--- a/cpp/examples/protobuf/dynamic_reader.cpp
+++ b/cpp/examples/protobuf/dynamic_reader.cpp
@@ -15,7 +15,7 @@ namespace gp = google::protobuf;
 // Loads the FileDescriptorSet from a protobuf schema definition into a SimpleDescriptorDatabase.
 bool LoadSchema(const mcap::SchemaPtr schema, gp::SimpleDescriptorDatabase* protoDb) {
   gp::FileDescriptorSet fdSet;
-  if (!fdSet.ParseFromArray(static_cast<const void*>(schema->data.data()), schema->data.size())) {
+  if (!fdSet.ParseFromArray(schema->data.data(), static_cast<int>(schema->data.size()))) {
     std::cerr << "failed to parse schema data" << std::endl;
     return false;
   }
@@ -83,8 +83,7 @@ int main(int argc, char** argv) {
       }
     }
     gp::Message* message = protoFactory.GetPrototype(descriptor)->New();
-    if (!message->ParseFromArray(static_cast<const void*>(it->message.data),
-                                 it->message.dataSize)) {
+    if (!message->ParseFromArray(it->message.data, static_cast<int>(it->message.dataSize))) {
       std::cerr << "failed to parse message using included foxglove.PointCloud schema" << std::endl;
       reader.close();
       return 1;

--- a/cpp/examples/protobuf/static_reader.cpp
+++ b/cpp/examples/protobuf/static_reader.cpp
@@ -6,8 +6,6 @@
 #include "foxglove/PointCloud.pb.h"
 #include "mcap/reader.hpp"
 
-namespace gp = google::protobuf;
-
 int main(int argc, char** argv) {
   if (argc != 2) {
     std::cerr << "Usage: " << argv[0] << " <input.mcap>" << std::endl;
@@ -39,8 +37,7 @@ int main(int argc, char** argv) {
       return 1;
     }
     foxglove::PointCloud pointCloud;
-    if (!pointCloud.ParseFromArray(static_cast<const void*>(it->message.data),
-                                   it->message.dataSize)) {
+    if (!pointCloud.ParseFromArray(it->message.data, static_cast<int>(it->message.dataSize))) {
       std::cerr << "could not parse pointcloud message" << std::endl;
       return 1;
     }

--- a/cpp/examples/protobuf/writer.cpp
+++ b/cpp/examples/protobuf/writer.cpp
@@ -10,10 +10,7 @@
 #include <cmath>
 #include <fstream>
 #include <iostream>
-#include <queue>
 #include <random>
-#include <sstream>
-#include <unordered_set>
 
 #define NS_PER_MS 1000000
 #define NS_PER_S 1000000000
@@ -33,8 +30,8 @@ public:
 
   // next produces a random point on the unit sphere, scaled by `scale`.
   std::tuple<float, float, float> next(float scale) {
-    float theta = 2 * M_PI * _distribution(_generator);
-    float phi = acos(1.0 - (2.0 * _distribution(_generator)));
+    float theta = 2 * static_cast<float>(M_PI) * _distribution(_generator);
+    float phi = acos(1.f - (2.f * _distribution(_generator)));
     float x = float((sin(phi) * cos(theta)) * scale);
     float y = float((sin(phi) * sin(theta)) * scale);
     float z = float(cos(phi) * scale);
@@ -124,15 +121,15 @@ int main(int argc, char** argv) {
                                 .count();
   PointGenerator pointGenerator;
   // write 100 pointcloud messages into the output MCAP file.
-  for (uint64_t frameIndex = 0; frameIndex < 100; ++frameIndex) {
+  for (uint32_t frameIndex = 0; frameIndex < 100; ++frameIndex) {
     // Space these frames 100ms apart in time.
-    mcap::Timestamp cloudTime = startTime + (frameIndex * 100 * NS_PER_MS);
+    mcap::Timestamp cloudTime = startTime + (static_cast<uint64_t>(frameIndex) * 100 * NS_PER_MS);
     // Slightly increase the size of the cloud on every frame.
-    float cloudScale = 1.0 + (float(frameIndex) / 50.0);
+    float cloudScale = 1.f + (static_cast<float>(frameIndex) / 50.f);
 
     auto timestamp = pcl.mutable_timestamp();
-    timestamp->set_seconds(cloudTime / NS_PER_S);
-    timestamp->set_nanos(cloudTime % NS_PER_S);
+    timestamp->set_seconds(static_cast<int64_t>(cloudTime) / NS_PER_S);
+    timestamp->set_nanos(static_cast<int>(cloudTime) % NS_PER_S);
 
     // write 1000 points into each pointcloud message.
     size_t offset = 0;
@@ -160,7 +157,7 @@ int main(int argc, char** argv) {
       std::cerr << "Failed to write message: " << res.message << "\n";
       writer.terminate();
       writer.close();
-      std::remove(outputFilename);
+      std::ignore = std::remove(outputFilename);
       return 1;
     }
   }


### PR DESCRIPTION
### Public-Facing Changes

<!-- describe any changes to the public interface or APIs, or write "None" -->
None

### Description

<!-- describe what has changed, and motivation behind those changes -->

- remove unused include
- use explicit type conversion
- ignore C4267 and C4244 for 3rd_party protobuf generate codes
- prefer constexpr

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
