### PR TITLE
Go: Allocate less in indexed message chunk loading

### DIFF
--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/foxglove/mcap/go/mcap v0.4.0
 	github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be
-	github.com/klauspost/compress v1.15.15
+	github.com/klauspost/compress v1.16.7
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pierrec/lz4/v4 v4.1.17

--- a/go/cli/mcap/go.sum
+++ b/go/cli/mcap/go.sum
@@ -309,6 +309,8 @@ github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kE
 github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
 github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -168,9 +168,11 @@ func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
 	case CompressionNone:
 		chunkData = parsedChunk.Records
 	case CompressionZSTD:
-		it.zstdDecoder, err = zstd.NewReader(nil)
-		if err != nil {
-			return fmt.Errorf("failed to read zstd chunk: %w", err)
+		if it.zstdDecoder == nil {
+			it.zstdDecoder, err = zstd.NewReader(nil)
+			if err != nil {
+				return fmt.Errorf("failed to instantiate zstd decoder: %w", err)
+			}
 		}
 		chunkData = make([]byte, 0, parsedChunk.UncompressedSize)
 		chunkData, err = it.zstdDecoder.DecodeAll(parsedChunk.Records, chunkData)

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -177,7 +177,8 @@ func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
 		} else {
 			it.lz4Reader.Reset(bytes.NewReader(parsedChunk.Records))
 		}
-		chunkData, err = io.ReadAll(it.lz4Reader)
+		chunkData = make([]byte, parsedChunk.UncompressedSize)
+		_, err = io.ReadFull(it.lz4Reader, chunkData)
 		if err != nil {
 			return fmt.Errorf("failed to decompress lz4 chunk: %w", err)
 		}


### PR DESCRIPTION
Prior to this commit, when reading a chunk into memory we would read it (internally, in io.ReadAll) into a resizing buffer and need to resize it several times up to final size. Since we know the final size in advance we can preallocate and save those allocations/copies.