### PR TITLE
Fix python ROS1 example

### DIFF
--- a/python/examples/ros1/reader.py
+++ b/python/examples/ros1/reader.py
@@ -9,7 +9,7 @@ def main():
     with open(sys.argv[1], "rb") as f:
         reader = make_reader(f, decoder_factories=[DecoderFactory()])
         for schema, channel, message, ros_msg in reader.iter_decoded_messages():
-            print(f"{channel.topic} {schema.name} [{message.log_time}]: {ros_msg.data}")
+            print(f"{channel.topic} {schema.name} [{message.log_time}]: {ros_msg}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Public-Facing Changes

Fix python ROS1 example

### Description
Fixes python ROS1 example. Matches the [ros2 reader example](https://github.com/foxglove/mcap/blob/2a1f9c62b30ca88725a2cd6b6227e36c632ab4ab/python/examples/ros2-noenv/reader.py#L8-L12) now


Fixes FG-4717
