### PR TITLE
Bump go library version

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.0.1"
+var Version = "v1.0.3"


### PR DESCRIPTION
This skips v1.0.2 - that tag was pushed but this file wasn't updated, so the tag is wrong.