### PR TITLE
CLI: Properly support --name parameter on add attachment

### DIFF
--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -164,7 +164,7 @@ var addAttachmentCmd = &cobra.Command{
 			{
 				LogTime:    logTime,
 				CreateTime: createTime,
-				Name:       addAttachmentFilename,
+				Name:       utils.DefaultString(addAttachmentName, addAttachmentFilename),
 				MediaType:  addAttachmentMediaType,
 				DataSize:   uint64(contentLength),
 				Data:       attachment,


### PR DESCRIPTION
Previously this parameter did not function. Not sure if it never functioned or if we lost the support at some point.