### PR TITLE
mcap cli: Add support for Azure Storage Accounts and AWS S3 remote files

### DIFF
--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -3,7 +3,7 @@ module github.com/foxglove/mcap/go/cli/mcap
 go 1.18
 
 require (
-	cloud.google.com/go/storage v1.23.0
+	gocloud.dev v0.30.0
 	github.com/fatih/color v1.13.0
 	github.com/foxglove/mcap/go/mcap v0.4.0
 	github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be


### PR DESCRIPTION
### Public-Facing Changes

You can now use mcap cli with Azure Storage Accounts and AWS S3 remote files, as well as GCS. 

### Description

Uses [gocloud.dev](gocloud.dev) from Google to build generic clients for Azure, AWS and Google Cloud. 



Note: I am yet to test all these changes on every cloud environment
- [ ] Verify on Azure
- [x] Verify on AWS S3
- [ ] Verify on GCS

#### Azure Usage
TODO

#### AWS Usage 
- You must have an authenticated AWS session in your environment. 
- You must set the aws region of the s3 bucket, either through `~/.aws/config` or `AWS_REGION=...`



#### GSC Usage
Hopefully unchanged (need to check)