### PR TITLE
[Rust - bugfix] read_record_from_slice checking wrong size of buffer wrong

### DIFF
--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -1207,7 +1207,7 @@ mod test {
     fn test_read_record_from_slice_parses_for_big_enough_records() {
         let res = read_record_from_slice(&mut [0_u8; 9].as_slice());
         assert!(res.is_ok());
-        // Not a very strong test, but we're not testing that it parses for buffer size of 10 here
+        // Not a very strong test, but we are only testing that it checks the buffer size correctly
         assert!(matches!(res, Ok(Record::Unknown { opcode: _, data: _ })));
     }
 }


### PR DESCRIPTION
### Public-Facing Changes

There should be no changes in public API caused by this change.

### Description

`read_record_from_slice` was checking that buffer size is bigger than 5 but was trying to read a `u8` and `u64` which are in total 9 bytes. This was causing panics when reading malformed mcap files or otherwise malformed streams.

I added some simple tests as well but they aren't very robust (I don't check parsing of records).