### PR TITLE
fix: LinearMessageView begin does not compare equal to begin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,6 @@ jobs:
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('cpp/**/conanfile.py') }}
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
       - run: make ci-format-check
       - run: make ci
       - run: make test-host

--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/1.2.0"
+    requires = "benchmark/1.7.0", "mcap/1.2.1"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.2.0
+conan editable add ./mcap mcap/1.2.1
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.2.0
+conan editable add ./mcap mcap/1.2.1
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/1.2.0"
+    requires = "mcap/1.2.1"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/1.2.0",
+        "mcap/1.2.1",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "1.2.0"
+    version = "1.2.1"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -657,13 +657,11 @@ struct MCAP_PUBLIC LinearMessageView {
     friend LinearMessageView;
 
     Iterator() = default;
-    Iterator(McapReader& mcapReader, ByteOffset dataStart, ByteOffset dataEnd,
-             const ReadMessageOptions& options, const ProblemCallback& onProblem);
+    Iterator(LinearMessageView& view);
 
     class Impl {
     public:
-      Impl(McapReader& mcapReader, ByteOffset dataStart, ByteOffset dataEnd,
-           const ReadMessageOptions& options, const ProblemCallback& onProblem);
+      Impl(LinearMessageView& view);
 
       Impl(const Impl&) = delete;
       Impl& operator=(const Impl&) = delete;
@@ -674,11 +672,10 @@ struct MCAP_PUBLIC LinearMessageView {
       reference dereference() const;
       bool has_value() const;
 
-      McapReader& mcapReader_;
+      LinearMessageView& view_;
+
       std::optional<TypedRecordReader> recordReader_;
       std::optional<IndexedMessageReader> indexedMessageReader_;
-      ReadMessageOptions readMessageOptions_;
-      const ProblemCallback& onProblem_;
       Message curMessage_;
       std::optional<MessageView> curMessageView_;
 
@@ -686,6 +683,7 @@ struct MCAP_PUBLIC LinearMessageView {
       void onMessage(const Message& message, RecordOffset offset);
     };
 
+    bool begun_ = false;
     std::unique_ptr<Impl> impl_;
   };
 

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1751,8 +1751,8 @@ bool operator==(const LinearMessageView::Iterator& a, const LinearMessageView::I
     // comparing iterators to the beginning of the same view should return true.
     return &(a.impl_->view_) == &(b.impl_->view_);
   }
-  // all other cases return false.
-  return false;
+  // In all other cases, compare by object identity.
+  return &(a) == &(b);
 }
 
 bool operator!=(const LinearMessageView::Iterator& a, const LinearMessageView::Iterator& b) {

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "1.2.0"
+#define MCAP_LIBRARY_VERSION "1.2.1"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/1.2.0", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/1.2.1", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -498,13 +498,32 @@ TEST_CASE("McapReader::readMessages()", "[reader]") {
     auto it = view.begin();
     REQUIRE(it != view.end());
     REQUIRE(it == view.begin());
+    REQUIRE(it == it);
     ++it;
     REQUIRE(it != view.end());
     REQUIRE(it != view.begin());
+    REQUIRE(it == it);
     ++it;
     REQUIRE(it == view.end());
     REQUIRE(it != view.begin());
+    REQUIRE(it == it);
 
+    reader.close();
+  }
+  SECTION("IteratorComparisonEmpty") {
+    Buffer buffer;
+
+    mcap::McapWriter writer;
+    writer.open(buffer, mcap::McapWriterOptions("test"));
+    writer.close();
+
+    mcap::McapReader reader;
+    requireOk(reader.open(buffer));
+
+    auto view = reader.readMessages();
+    auto it = view.begin();
+    REQUIRE(it == view.begin());
+    REQUIRE(it == view.end());
     reader.close();
   }
 }


### PR DESCRIPTION
### Public-Facing Changes

Multiple iterators created from LinearMessageView::begin() will compare to `true`.
### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
