### PR TITLE
Python: Handle ros2 uint8[] field as str without ValueError

### DIFF
--- a/python/mcap-ros2-support/mcap_ros2/_dynamic.py
+++ b/python/mcap-ros2-support/mcap_ros2/_dynamic.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import base64
+import binascii
 from io import BytesIO
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -422,6 +424,12 @@ def _write_complex_type(
                 array: Union[List[Any], Tuple[Any], Any] = _get_property(
                     ros2_msg, field.name
                 )
+                if ftype.type == "uint8" and isinstance(array, str):
+                    # Special handling for bytes in JSON
+                    try:
+                        array = base64.b64decode(array)
+                    except binascii.Error:
+                        pass
                 if array is None:
                     array = []
                 if (

--- a/python/mcap-ros2-support/tests/test_ros2_writer.py
+++ b/python/mcap-ros2-support/tests/test_ros2_writer.py
@@ -1,5 +1,8 @@
 from io import BytesIO
 
+import json
+import base64
+
 from mcap_ros2.decoder import DecoderFactory
 from mcap_ros2.writer import Writer as Ros2Writer
 
@@ -56,6 +59,37 @@ def test_write_std_msgs_empty_messages():
     for index, msg in enumerate(read_ros2_messages(output)):
         assert msg.channel.topic == "/test"
         assert msg.schema.name == "std_msgs/msg/Empty"
+        assert msg.message.log_time == index
+        assert msg.message.publish_time == index
+        assert msg.message.sequence == index
+
+
+def test_write_bytes_object_from_json_deserialization():
+    output = BytesIO()
+    ros_writer = Ros2Writer(output=output)
+    schema = ros_writer.register_msgdef("test_msgs/BytesMsg", "uint8[] data")
+
+    sample_bytes = bytes([0x77, 0x67, 0x65, 0x80])
+    to_serialize_dict = {"data": base64.b64encode(sample_bytes).decode("utf-8")}
+    sample_json = json.dumps(to_serialize_dict)
+    deserialized_dict = json.loads(sample_json)
+
+    for i in range(0, 10):
+        ros_writer.write_message(
+            topic="/test",
+            schema=schema,
+            message=deserialized_dict,
+            log_time=i,
+            publish_time=i,
+            sequence=i,
+        )
+    ros_writer.finish()
+
+    output.seek(0)
+    for index, msg in enumerate(read_ros2_messages(output)):
+        assert msg.channel.topic == "/test"
+        assert msg.schema.name == "test_msgs/BytesMsg"
+        assert msg.decoded_message.data == sample_bytes
         assert msg.message.log_time == index
         assert msg.message.publish_time == index
         assert msg.message.sequence == index


### PR DESCRIPTION
### Public-Facing Changes

<!-- describe any changes to the public interface or APIs, or write "None" -->

None

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->

When calling the `write_message` method, the message argument often originates from some other serialized form, like `Protobuf` or `JSON`. However, bytes fields can become mismatched during these serialization processes. For instance, even though a Protobuf message may contain bytes fields, using `MessageToDict` to convert it to a Python dictionary will base64 encode those bytes, as it adheres to the [Proto3 JSON mapping guidelines](https://protobuf.dev/programming-guides/proto3/#json).

This leads to a confusing situation for the user. They might assume that the field is still in `bytes` and defined as `uint8[]` in the ROS2 message. But when invoking `write_message`, they encounter the following cryptic error:
```
ValueError: Field "data" is not an array (<class 'str'>) but has array type "uint8[]"
```
While the error is technically correct, it's confusing for users who are not aware of the limitations of JSON or the transformations performed by `MessageToDict`.

This pull request aims to alleviate this issue by adding an additional check to see if the problematic field is base64-encoded. If it is, we decode it and proceed without errors, as demonstrated in `test_write_bytes_object_from_json_deserialization`. If decoding fails, the function will still raise the original error.