### PR TITLE
Don't run docs-deploy job on Dependabot PRs

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -100,6 +100,7 @@ jobs:
 
   docs-deploy:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     needs:
       - docs-home
       - docs-cpp


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

This PR failed to run `docs-deploy` because it was authored by dependabot: https://github.com/foxglove/mcap/pull/977

This copies similar logic that we use in `ci.yml` to exclude this job for dependabot. It's okay to skip because this job is not marked as a required check.