### PR TITLE
Fix spelling in Readme

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -38,7 +38,7 @@ int main() {
   writer.addChannel(chatterPublisher);
 
   // Create a message payload. This would typically be done by your own
-  // serialiation library. In this example, we manually create ROS1 binary data
+  // serialization library. In this example, we manually create ROS1 binary data
   std::array<std::byte, 4 + 13> payload;
   const uint32_t length = 13;
   std::memcpy(payload.data(), &length, 4);


### PR DESCRIPTION
### Public-Facing Changes
None
### Description
Fixed a spelling error in the CPP API readme.
