### PR TITLE
fix negative timestamp in cpp protobuf example

### DIFF
--- a/cpp/examples/protobuf/writer.cpp
+++ b/cpp/examples/protobuf/writer.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv) {
 
     auto timestamp = pcl.mutable_timestamp();
     timestamp->set_seconds(static_cast<int64_t>(cloudTime) / NS_PER_S);
-    timestamp->set_nanos(static_cast<int>(cloudTime) % NS_PER_S);
+    timestamp->set_nanos(static_cast<int>(cloudTime % NS_PER_S));
 
     // write 1000 points into each pointcloud message.
     size_t offset = 0;


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

Example code generates negative nanosecond values in the timestamp.

Before:
![Screenshot from 2023-09-30 07-56-12](https://github.com/foxglove/mcap/assets/2640499/c980ddb2-6d15-4536-b409-7a95ed1142c2)

After:
![Screenshot from 2023-09-30 07-54-56](https://github.com/foxglove/mcap/assets/2640499/4095a85f-d7c5-4f16-8f6c-9a59acd30df5)
