### PR TITLE
Add avro to well-known encodings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,6 @@
 
   // https://github.com/microsoft/vscode-cpptools/issues/722
   "C_Cpp.autoAddFileAssociations": false,
-  "C_Cpp.default.cppStandard": "c++17"
+  "C_Cpp.default.cppStandard": "c++17",
+  "rust-analyzer.linkedProjects": ["./rust/examples/avro/Cargo.toml"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,5 +40,8 @@
   // https://github.com/microsoft/vscode-cpptools/issues/722
   "C_Cpp.autoAddFileAssociations": false,
   "C_Cpp.default.cppStandard": "c++17",
-  "rust-analyzer.linkedProjects": ["./rust/examples/avro/Cargo.toml"]
+  "rust-analyzer.linkedProjects": ["./rust/examples/avro/Cargo.toml"],
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  }
 }

--- a/rust/examples/avro/Cargo.toml
+++ b/rust/examples/avro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mcap_avro_examples"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+mcap = { path = "../../" }
+apache-avro = { version = "0.16.0" }
+serde = { version = "1.0.178", features = ["derive"] }
+
+[[bin]]
+name = "writer"

--- a/rust/examples/avro/README.md
+++ b/rust/examples/avro/README.md
@@ -1,0 +1,3 @@
+```
+cargo run --bin writer
+```

--- a/rust/examples/avro/src/bin/writer.rs
+++ b/rust/examples/avro/src/bin/writer.rs
@@ -1,0 +1,172 @@
+use apache_avro::Schema;
+use std::borrow::Cow;
+use std::fs::File;
+use std::io::BufWriter;
+use std::sync::Arc;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct Time {
+    sec: i64,
+    nsec: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct Vector3 {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct Quaternion {
+    x: f64,
+    y: f64,
+    z: f64,
+    w: f64,
+}
+
+#[derive(Debug, Serialize)]
+
+struct Pose {
+    position: Vector3,
+    orientation: Quaternion,
+}
+
+#[derive(Debug, Serialize)]
+
+struct PosesInFrame {
+    timestamp: Time,
+    frame_id: String,
+    poses: Vec<Pose>,
+}
+
+fn main() {
+    let raw_schema_time = r#"
+    {
+        "type": "record",
+        "namespace": "foxglove",
+        "name": "Time",
+        "fields": [
+            { "name": "sec", "type": "long" },
+            { "name": "nsec", "type": "long" }
+        ]
+    }"#;
+
+    let raw_schema_vector = r#"
+    {
+        "type": "record",
+        "namespace": "foxglove",
+        "name": "Vector3",
+        "fields": [
+            { "name": "x", "type": "double" },
+            { "name": "y", "type": "double" },
+            { "name": "z", "type": "double" }
+        ]
+    }"#;
+
+    let raw_schema_quaternion = r#"
+    {
+        "type": "record",
+        "namespace": "foxglove",
+        "name": "Quaternion",
+        "fields": [
+            { "name": "x", "type": "double" },
+            { "name": "y", "type": "double" },
+            { "name": "z", "type": "double" },
+            { "name": "w", "type": "double" }
+        ]
+    }"#;
+
+    let raw_schema_pose = r#"
+    {
+        "type": "record",
+        "namespace": "foxglove",
+        "name": "Pose",
+        "fields": [
+            { "name": "position", "type": "Vector3" },
+            { "name": "orientation", "type": "Quaternion" }
+        ]
+    }"#;
+
+    let raw_schema_poses_in_frame = r#"
+    {
+        "type": "record",
+        "namespace": "foxglove",
+        "name": "PosesInFrame",
+        "fields": [
+            { "name": "timestamp", "type": "Time" },
+            { "name": "frame_id", "type": "string" },
+            { "name": "poses", "type": "array", "items": "Pose" }
+        ]
+    }"#;
+
+    let schemas = Schema::parse_list(&[raw_schema_time, raw_schema_vector, raw_schema_quaternion, raw_schema_pose, raw_schema_poses_in_frame]).unwrap();
+
+    // for multiple schemas we need to write them as an array
+    let arr = format!("[{}]", vec![raw_schema_time, raw_schema_vector, raw_schema_quaternion, raw_schema_pose, raw_schema_poses_in_frame].join(","));
+
+    let schema_b = mcap::Schema {
+        name: "foxglove.PosesInFrame".to_string(),
+        encoding: "avro".to_string(),
+        data: Cow::Borrowed(arr.as_bytes()),
+    };
+
+    let channel_poses = mcap::Channel {
+        schema: Some(Arc::new(schema_b.to_owned())),
+        topic: "poses".to_string(),
+        message_encoding: "avro".to_string(),
+        metadata: std::collections::BTreeMap::new(),
+    };
+
+    let mut avro_mcap =
+        mcap::Writer::new(BufWriter::new(File::create("avro.mcap").unwrap())).unwrap();
+
+    avro_mcap
+        .add_channel(&channel_poses)
+        .expect("Couldn't write channel");
+
+    {
+        // fetch_schema_ref? but not accessible cause we don't get the parser that parse_list uses
+        let time_schema = schemas.get(0).unwrap();
+        let vector3_schema = schemas.get(1).unwrap();
+        let quat_schema = schemas.get(2).unwrap();
+        let pose_schema = schemas.get(3).unwrap();
+        let poses_schema = schemas.get(4).unwrap();
+
+        let pose_1 = Pose {
+            position: Vector3 { x: 0.0, y: 0.0, z: 0.0 },
+            orientation: Quaternion { x: 0.0, y: 0.0, z: 0.0, w: 0.0 },
+        };
+
+        let pose_2 = Pose {
+            position: Vector3 { x: 1.0, y: 1.0, z: 1.0 },
+            orientation: Quaternion { x: 0.0, y: 0.0, z: 0.0, w: 0.0 },
+        };
+
+        let poses = PosesInFrame {
+            timestamp: Time {
+                sec: 0i64,
+                nsec: 0i64
+            },
+            frame_id: "frame".to_string(),
+            poses: vec![pose_1, pose_2],
+        };
+
+        let encoded =
+            apache_avro::to_avro_datum_schemata(&poses_schema, [time_schema, vector3_schema, quat_schema, pose_schema].into(), apache_avro::to_value(&poses).unwrap())
+                .unwrap();
+
+        let message = mcap::Message {
+            channel: Arc::new(channel_poses.to_owned()),
+            data: Cow::from(encoded),
+            log_time: 1000000,
+            publish_time: 0,
+            sequence: 0,
+        };
+
+        avro_mcap.write(&message).unwrap();
+    }
+
+    avro_mcap.finish().unwrap();
+}

--- a/rust/examples/avro/src/bin/writer.rs
+++ b/rust/examples/avro/src/bin/writer.rs
@@ -97,7 +97,7 @@ fn main() {
         "fields": [
             { "name": "timestamp", "type": "Time" },
             { "name": "frame_id", "type": "string" },
-            { "name": "poses", "type": "array", "items": "Pose" }
+            { "name": "poses", "type": { "type": "array", "items": "Pose" } }
         ]
     }"#;
 

--- a/website/docs/spec/registry.md
+++ b/website/docs/spec/registry.md
@@ -42,6 +42,10 @@ The Channel `message_encoding` field describes the encoding for all messages wit
 
 - `message_encoding`: [`json`](https://www.json.org/json-en.html)
 
+### avro
+
+- `message_encoding`: [`avro`](https://avro.apache.org/) (binary encoding)
+
 ## Schema encodings
 
 The Schema `encoding` field describes the encoding of a Channel's schema. Typically, this is related to the Channel's `message_encoding`, but they are separate concepts (e.g. there are multiple schema languages for `json`).
@@ -185,6 +189,20 @@ For this example, `schema.name` should be set to `top_level_module::my_module::M
 - `name`: May contain any value
 - `encoding`: `jsonschema`
 - `data`: [JSON Schema](https://json-schema.org)
+
+### avro
+
+- `name`: Fully qualified name of the record type (including namespace), e.g. `example.MyRecord`
+- `encoding`: `avro`
+- `data`: utf8 encoded json object or array with a valid [AVRO schema declaration](https://avro.apache.org/docs/1.11.1/specification/#schema-declaration)
+
+In AVRO schemas a name must be defined before used as noted in the AVRO specification:
+
+> Further, a name must be defined before it is used (“before” in the depth-first, left-to-right traversal of the JSON parse tree, where the types attribute of a protocol is always deemed to come “before” the messages attribute.)
+
+You can define a name inline using a single schema object for `data` or an array of schema objects. If the `data` is an array of schemas, the `name` must reference a single
+"record" within the array of schemas. This referenced record type will be used as the schema for the
+channel and messages. The array of schemas DO NOT represent a union type for channel messages.
 
 ## Profiles
 

--- a/website/docs/spec/registry.md
+++ b/website/docs/spec/registry.md
@@ -196,7 +196,7 @@ For this example, `schema.name` should be set to `top_level_module::my_module::M
 - `encoding`: `avro`
 - `data`: utf8 encoded json object or array with a valid [AVRO schema declaration](https://avro.apache.org/docs/1.11.1/specification/#schema-declaration)
 
-In AVRO schemas a name must be defined before used as noted in the AVRO specification:
+In Avro schemas a name must be defined before used as noted in the Avro specification:
 
 > Further, a name must be defined before it is used (“before” in the depth-first, left-to-right traversal of the JSON parse tree, where the types attribute of a protocol is always deemed to come “before” the messages attribute.)
 


### PR DESCRIPTION
Add [avro](https://avro.apache.org/) as a well-known schema encoding and message encoding. When using the "avro" message encoding, mcap writers indicate the messages on a channel are encoded using the avro binary serialization format. When using "avro" schema encoding, the schema format is a valid avro schema declaration as a JSON string.

A few notes/discussion points:
- In the [avro spec](https://avro.apache.org/docs/1.11.1/specification/#schema-declaration) avro schema declarations can be one of an avro type, a single object, or an array. However, in the proposed mcap spec I have changed the allowed schema declaration and how they are interpreted. The mcap spec will only allow a single object or an array. The array form is not treated as a union and instead the "name" from the schema record references which record declaration from the array is the schema for the messages on channels using the schema. This is different to avro files typically treating this kind of schema declaration as a union type. This is because avro files do not have the concept of channels whereas mcap files do and writers typically write separate schemas on separate channels and topics.
- Avro has two [encoding formats](https://avro.apache.org/docs/1.11.1/specification/#encodings): binary and json. I've opted to have "avro" message encoding refer to the binary format. If we wanted to support both we would need to consider how to disambiguate.

This change also adds a rust example that creates an mcap file with avro.

Related studio PR: https://github.com/foxglove/studio/pull/7008