### PR TITLE
Python: Fix ROS2 message definition parsing on Windows

### DIFF
--- a/python/mcap-ros2-support/mcap_ros2/_dynamic.py
+++ b/python/mcap-ros2-support/mcap_ros2/_dynamic.py
@@ -1,6 +1,5 @@
 """ROS2 message definition parsing and message deserialization."""
 
-import os
 import re
 from io import BytesIO
 from types import SimpleNamespace
@@ -519,7 +518,7 @@ def _for_each_msgdef(
     cur_schema_name = schema_name
 
     # Remove empty lines
-    schema_text = os.linesep.join([s for s in schema_text.splitlines() if s.strip()])
+    schema_text = "\n".join([s for s in schema_text.splitlines() if s.strip()])
 
     # Split schema_text by separator lines containing at least 3 = characters
     # (e.g. "===") using a regular expression


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

Fixes issue on Windows, where empty lines in the ROS2 message definitions would be replaced by `\r\n`.
The regex-patterns don't handle this, which led to an `InvalidFieldDefinition` exception later on in `parse_message_string()`.
See relevant documentation on `os.linesep` here: https://docs.python.org/3/library/os.html#os.linesep
