### PR TITLE
Fix `mcap cat` SIGSEGV when no schema present

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -197,10 +197,10 @@ func printMessages(
 			die("Failed to read next message: %s", err)
 		}
 		if !formatJSON {
-                        schemaName := "no schema"
-                        if schema != nil {
-                            schemaName = schema.Name
-                        }
+			schemaName := "no schema"
+			if schema != nil {
+				schemaName = schema.Name
+			}
 			if len(message.Data) > 10 {
 				fmt.Fprintf(w, "%d %s [%s] %v...\n", message.LogTime, channel.Topic, schemaName, message.Data[:10])
 			} else {

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -197,10 +197,14 @@ func printMessages(
 			die("Failed to read next message: %s", err)
 		}
 		if !formatJSON {
+                        schemaName := "no schema"
+                        if schema != nil {
+                            schemaName = schema.Name
+                        }
 			if len(message.Data) > 10 {
-				fmt.Fprintf(w, "%d %s [%s] %v...\n", message.LogTime, channel.Topic, schema.Name, message.Data[:10])
+				fmt.Fprintf(w, "%d %s [%s] %v...\n", message.LogTime, channel.Topic, schemaName, message.Data[:10])
 			} else {
-				fmt.Fprintf(w, "%d %s [%s] %v\n", message.LogTime, channel.Topic, schema.Name, message.Data)
+				fmt.Fprintf(w, "%d %s [%s] %v\n", message.LogTime, channel.Topic, schemaName, message.Data)
 			}
 			continue
 		}

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -21,6 +21,11 @@ func TestCat(t *testing.T) {
 			"../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap",
 			"2 example [Example] [1 2 3]\n",
 		},
+		{
+			"OneSchemalessMessage",
+			"../../../../tests/conformance/data/OneSchemalessMessage/OneSchemalessMessage-ch-chx-mx-pad-rch-st.mcap",
+			"2 example [no schema] [1 2 3]\n",
+		},
 	}
 	for _, c := range cases {
 		input, err := os.ReadFile(c.inputfile)

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -138,14 +138,14 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 	for _, chanID := range chanIDs {
 		channel := info.Channels[chanID]
 		schema := info.Schemas[channel.SchemaID]
-		channelMessageCount := info.Statistics.ChannelMessageCounts[chanID]
-		frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
 		width := digits(uint64(chanID)) + 2
 		padding := strings.Repeat(" ", maxChanIDWidth-width)
 		row := []string{
 			fmt.Sprintf("\t(%d)%s%s", channel.ID, padding, channel.Topic),
 		}
 		if info.Statistics != nil {
+			channelMessageCount := info.Statistics.ChannelMessageCounts[chanID]
+			frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
 			row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
 		}
 		switch {

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -131,7 +131,10 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		}
 	}
 
-	maxChanIDWidth := digits(uint64(chanIDs[len(chanIDs)-1])) + 3
+	maxChanIDWidth := 0
+	if len(chanIDs) > 0 {
+		maxChanIDWidth = digits(uint64(chanIDs[len(chanIDs)-1])) + 3
+	}
 	for _, chanID := range chanIDs {
 		channel := info.Channels[chanID]
 		schema := info.Schemas[channel.SchemaID]

--- a/go/cli/mcap/cmd/info_test.go
+++ b/go/cli/mcap/cmd/info_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/foxglove/mcap/go/mcap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfo(t *testing.T) {
+	cases := []struct {
+		assertion string
+		inputfile string
+		expected  string
+	}{
+		{
+			"OneMessage",
+			"../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap",
+			`library:
+profile:
+messages:  1
+duration:  0s
+start:     0.000000002
+end:       0.000000002
+compression:
+	: [1/1 chunks] [115.00 B/115.00 B (0.00%)]
+channels:
+	(1) example  1 msgs (+Inf Hz)   : Example [c]
+attachments: 0
+metadata: 0`,
+		},
+		{
+			"OneSchemalessMessage",
+			"../../../../tests/conformance/data/OneSchemalessMessage/OneSchemalessMessage-ch-chx-mx-pad-rch-st.mcap",
+			`library:
+profile:
+messages:  1
+duration:  0s
+start:     0.000000002
+end:       0.000000002
+compression:
+	: [1/1 chunks] [70.00 B/70.00 B (0.00%)]
+channels:
+	(1) example  1 msgs (+Inf Hz)   : <no schema>
+attachments: 0
+metadata: 0`,
+		},
+		{
+			"OneSchemalessMessage_NoChannels",
+			"../../../../tests/conformance/data/OneSchemalessMessage/OneSchemalessMessage.mcap",
+			`library:
+profile:
+channels:
+attachments: unknown
+metadata: unknown`,
+		},
+	}
+	for _, c := range cases {
+		input, err := os.ReadFile(c.inputfile)
+		assert.Nil(t, err)
+		r := bytes.NewReader(input)
+		w := new(bytes.Buffer)
+
+		t.Run(c.assertion, func(t *testing.T) {
+			reader, err := mcap.NewReader(r)
+			assert.Nil(t, err)
+			defer reader.Close()
+			info, err := reader.Info()
+			assert.Nil(t, err)
+			err = printInfo(w, info)
+			assert.Nil(t, err)
+
+			// for each line, strip leading/trailing whitespace
+			// this prevents test failures from formatting changes
+			actualLines := strings.Split(strings.TrimSpace(w.String()), "\n")
+			expectedLines := strings.Split(strings.TrimSpace(c.expected), "\n")
+
+			for i, line := range actualLines {
+				actualLines[i] = strings.TrimSpace(line)
+			}
+			for i, line := range expectedLines {
+				expectedLines[i] = strings.TrimSpace(line)
+			}
+
+			actualStripped := strings.Join(actualLines, "\n")
+			expectedStripped := strings.Join(expectedLines, "\n")
+
+			assert.Equal(t, expectedStripped, actualStripped)
+		})
+	}
+}

--- a/go/cli/mcap/cmd/info_test.go
+++ b/go/cli/mcap/cmd/info_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,84 +12,30 @@ import (
 )
 
 func TestInfo(t *testing.T) {
-	cases := []struct {
-		assertion string
-		inputfile string
-		expected  string
-	}{
-		{
-			"OneMessage",
-			"../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap",
-			`library:
-profile:
-messages:  1
-duration:  0s
-start:     0.000000002
-end:       0.000000002
-compression:
-	: [1/1 chunks] [115.00 B/115.00 B (0.00%)]
-channels:
-	(1) example  1 msgs (+Inf Hz)   : Example [c]
-attachments: 0
-metadata: 0`,
-		},
-		{
-			"OneSchemalessMessage",
-			"../../../../tests/conformance/data/OneSchemalessMessage/OneSchemalessMessage-ch-chx-mx-pad-rch-st.mcap",
-			`library:
-profile:
-messages:  1
-duration:  0s
-start:     0.000000002
-end:       0.000000002
-compression:
-	: [1/1 chunks] [70.00 B/70.00 B (0.00%)]
-channels:
-	(1) example  1 msgs (+Inf Hz)   : <no schema>
-attachments: 0
-metadata: 0`,
-		},
-		{
-			"OneSchemalessMessage_NoChannels",
-			"../../../../tests/conformance/data/OneSchemalessMessage/OneSchemalessMessage.mcap",
-			`library:
-profile:
-channels:
-attachments: unknown
-metadata: unknown`,
-		},
-	}
-	for _, c := range cases {
-		input, err := os.ReadFile(c.inputfile)
-		assert.Nil(t, err)
-		r := bytes.NewReader(input)
-		w := new(bytes.Buffer)
+	err := filepath.Walk("../../../../tests/conformance/data/", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".mcap") {
+			t.Run(path, func(t *testing.T) {
+				input, err := os.ReadFile(path)
+				assert.Nil(t, err)
+				r := bytes.NewReader(input)
+				w := new(bytes.Buffer)
 
-		t.Run(c.assertion, func(t *testing.T) {
-			reader, err := mcap.NewReader(r)
-			assert.Nil(t, err)
-			defer reader.Close()
-			info, err := reader.Info()
-			assert.Nil(t, err)
-			err = printInfo(w, info)
-			assert.Nil(t, err)
-
-			// for each line, strip leading/trailing whitespace
-			// this prevents test failures from formatting changes
-			actualLines := strings.Split(strings.TrimSpace(w.String()), "\n")
-			expectedLines := strings.Split(strings.TrimSpace(c.expected), "\n")
-
-			for i, line := range actualLines {
-				actualLines[i] = strings.TrimSpace(line)
-			}
-			for i, line := range expectedLines {
-				expectedLines[i] = strings.TrimSpace(line)
-			}
-
-			actualStripped := strings.Join(actualLines, "\n")
-			expectedStripped := strings.Join(expectedLines, "\n")
-
-			assert.Equal(t, expectedStripped, actualStripped)
-		})
-	}
+				reader, err := mcap.NewReader(r)
+				assert.Nil(t, err)
+				defer reader.Close()
+				info, err := reader.Info()
+				assert.Nil(t, err)
+				err = printInfo(w, info)
+				assert.Nil(t, err)
+			})
+		}
+		return nil
+	})
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
### Public-Facing Changes
`mcap cat` used to crash on some valid, but uncommon files. This fixes the crash.

### Description
Mcap spec [allows for a missing schema](https://mcap.dev/spec#channel-op0x04).
Currently, `mcap cat` crashes with a nil pointer dereference on such a file (unless you pass `--json`).
After this change, `mcap cat` will print `[no schema]` instead of a schema for schemaless channels.

Also added another test to `cat_test.go`, and added tests for `mcap info` in `info_test.go`

