### PR TITLE
`mcap info` prints channel metadata

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
-        "encoding/json"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -146,14 +146,14 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		if info.Statistics != nil {
 			row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
 		}
-                if len(channel.Metadata) > 0 {
-                        mdJSON, _ := json.Marshal(channel.Metadata)
-                        mdJSONStr := string(mdJSON)
-                        if len(mdJSONStr) > 50 {
-                            mdJSONStr = mdJSONStr[0:47] + "..."
-                        }
-                        row = append(row, mdJSONStr)
-                }
+		if len(channel.Metadata) > 0 {
+			mdJSON, _ := json.Marshal(channel.Metadata)
+			mdJSONStr := string(mdJSON)
+			if len(mdJSONStr) > 50 {
+				mdJSONStr = mdJSONStr[0:47] + "..."
+			}
+			row = append(row, mdJSONStr)
+		}
 		switch {
 		case schema != nil:
 			row = append(row, fmt.Sprintf(" : %s [%s]", schema.Name, schema.Encoding))

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -147,12 +147,12 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 			row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
 		}
                 if len(channel.Metadata) > 0 {
-                        mdJson, _ := json.Marshal(channel.Metadata)
-                        mdJsonStr := string(mdJson)
-                        if len(mdJsonStr) > 50 {
-                            mdJsonStr = mdJsonStr[0:47] + "..."
+                        mdJSON, _ := json.Marshal(channel.Metadata)
+                        mdJSONStr := string(mdJSON)
+                        if len(mdJSONStr) > 50 {
+                            mdJSONStr = mdJSONStr[0:47] + "..."
                         }
-                        row = append(row, fmt.Sprintf("%s", mdJsonStr))
+                        row = append(row, mdJSONStr)
                 }
 		switch {
 		case schema != nil:

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+        "encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -145,6 +146,14 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		if info.Statistics != nil {
 			row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
 		}
+                if len(channel.Metadata) > 0 {
+                        mdJson, _ := json.Marshal(channel.Metadata)
+                        mdJsonStr := string(mdJson)
+                        if len(mdJsonStr) > 50 {
+                            mdJsonStr = mdJsonStr[0:47] + "..."
+                        }
+                        row = append(row, fmt.Sprintf("%s", mdJsonStr))
+                }
 		switch {
 		case schema != nil:
 			row = append(row, fmt.Sprintf(" : %s [%s]", schema.Name, schema.Encoding))


### PR DESCRIPTION
### Public-Facing Changes
`mcap info` did not show channel metadata. Now it will print (up to 50 characters of) json-marshalled channel metadata.

### Description
Example output after this change on `tests/conformance/data/TenMessages/TenMessages-rch-rsh-st.mcap`:
```
library:
profile:
messages:  10
duration:  9ns
start:     0.000000000
end:       0.000000009
channels:
	(1) example  10 msgs (1111111111.11 Hz)  {"foo":"bar"}   : Example [c]
attachments: 0
metadata: 0
```
Before this change:
```
library:
profile:
messages:  10
duration:  9ns
start:     0.000000000
end:       0.000000009
channels:
	(1) example  10 msgs (1111111111.11 Hz)  : Example [c]
attachments: 0
metadata: 0
```
For channels that don't include metadata, there's no change in behavior

### Motivation
At work, we use channel metadata to record which physical device a channel was recorded on. This means multiple channels can exist in the same mcap file with the same topic name. It's hard to distinguish between them without the channel metadata.

