### PR TITLE
Update Cargo.toml

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION

### Public-Facing Changes

Bump the mcap library to v0.9.0 to release the wasm compatible version.
