### PR TITLE
do not render hz if no messages

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -145,8 +145,12 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		}
 		if info.Statistics != nil {
 			channelMessageCount := info.Statistics.ChannelMessageCounts[chanID]
-			frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
-			row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
+			if channelMessageCount > 1 {
+				frequency := 1e9 * float64(channelMessageCount) / float64(end-start)
+				row = append(row, fmt.Sprintf("%*d msgs (%.2f Hz)", maxCountWidth, channelMessageCount, frequency))
+			} else {
+				row = append(row, fmt.Sprintf("%*d msgs", maxCountWidth, channelMessageCount))
+			}
 		}
 		switch {
 		case schema != nil:


### PR DESCRIPTION
### Public-Facing Changes

For `mcap info`, removes channel hz display if there are no or one messages in a channel. This avoids displaying an ugly `NaN` or `Inf`.

Before:
```
j@192-168-1-108 python % mcap info ~/this.mcap                                
library:   python mcap 1.1.1                                        
profile:                                                            
messages:  1                                                        
duration:  0s                                                       
start:     2023-11-02T05:34:10.165983+11:00 (1698863650.165983000)  
end:       2023-11-02T05:34:10.165983+11:00 (1698863650.165983000)  
compression:
        zstd: [1/1 chunks] [234.00 B/153.00 B (34.62%)] 
channels:
        (1) sample_topic  0 msgs (NaN Hz)    : sample [jsonschema]  
        (2) sample_topic  1 msgs (+Inf Hz)   : sample [jsonschema]  
attachments: 0
metadata: 0
```

After:
```
j@192-168-1-108 mcap % ./bin/mcap info ~/this.mcap                          
library:   python mcap 1.1.1                                        
profile:                                                            
messages:  1                                                        
duration:  0s                                                       
start:     2023-11-02T05:34:10.165983+11:00 (1698863650.165983000)  
end:       2023-11-02T05:34:10.165983+11:00 (1698863650.165983000)  
compression:
        zstd: [1/1 chunks] [234.00 B/153.00 B (34.62%)] 
channels:
        (1) sample_topic  0 msgs   : sample [jsonschema]  
        (2) sample_topic  1 msgs   : sample [jsonschema]  
attachments: 0
metadata: 0
```

