### PR TITLE
C++: Make LZ4 and ZSTD dependencies optional + clang-format

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -47,6 +47,7 @@ test: dev-image
 .PHONY: test-host
 test-host:
 	./test/build/Debug/bin/unit-tests
+	./test/build/Debug/bin/unit-tests-nocompress
 
 .PHONY: hdoc-build
 hdoc-build:

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -150,6 +150,7 @@ private:
   uint64_t size_;
 };
 
+#ifndef MCAP_COMPRESSION_NO_ZSTD
 /**
  * @brief ICompressedReader implementation that decompresses Zstandard
  * (https://facebook.github.io/zstd/) data.
@@ -183,7 +184,9 @@ private:
   Status status_;
   ByteArray uncompressedData_;
 };
+#endif
 
+#ifndef MCAP_COMPRESSION_NO_LZ4
 /**
  * @brief ICompressedReader implementation that decompresses LZ4
  * (https://lz4.github.io/lz4/) data.
@@ -222,6 +225,7 @@ private:
   uint64_t compressedSize_;
   uint64_t uncompressedSize_;
 };
+#endif
 
 struct LinearMessageView;
 
@@ -539,8 +543,12 @@ private:
   RecordReader reader_;
   Status status_;
   BufferReader uncompressedReader_;
+#ifndef MCAP_COMPRESSION_NO_LZ4
   LZ4Reader lz4Reader_;
+#endif
+#ifndef MCAP_COMPRESSION_NO_ZSTD
   ZStdReader zstdReader_;
+#endif
 };
 
 /**
@@ -627,7 +635,9 @@ private:
   Status status_;
   McapReader& mcapReader_;
   RecordReader recordReader_;
+#ifndef MCAP_COMPRESSION_NO_LZ4
   LZ4Reader lz4Reader_;
+#endif
   ReadMessageOptions options_;
   std::unordered_set<ChannelId> selectedChannels_;
   std::function<void(const Message&, RecordOffset)> onMessage_;

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1,9 +1,13 @@
 #include "internal.hpp"
 #include <algorithm>
 #include <cassert>
-#include <lz4frame.h>
-#include <zstd.h>
-#include <zstd_errors.h>
+#ifndef MCAP_COMPRESSION_NO_LZ4
+#  include <lz4frame.h>
+#endif
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+#  include <zstd.h>
+#  include <zstd_errors.h>
+#endif
 
 namespace mcap {
 
@@ -119,6 +123,7 @@ uint64_t FileStreamReader::read(std::byte** output, uint64_t offset, uint64_t si
 
 // LZ4Reader ///////////////////////////////////////////////////////////////////
 
+#ifndef MCAP_COMPRESSION_NO_LZ4
 LZ4Reader::LZ4Reader() {
   const LZ4F_errorCode_t err =
     LZ4F_createDecompressionContext((LZ4F_dctx**)&decompressionContext_, LZ4F_VERSION);
@@ -206,9 +211,11 @@ Status LZ4Reader::decompressAll(const std::byte* data, uint64_t compressedSize,
   }
   return result;
 }
+#endif
 
 // ZStdReader //////////////////////////////////////////////////////////////////
 
+#ifndef MCAP_COMPRESSION_NO_ZSTD
 void ZStdReader::reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) {
   status_ = DecompressAll(data, size, uncompressedSize, &uncompressedData_);
 }
@@ -255,6 +262,7 @@ Status ZStdReader::DecompressAll(const std::byte* data, uint64_t compressedSize,
   }
   return result;
 }
+#endif
 
 // McapReader //////////////////////////////////////////////////////////////////
 
@@ -1197,10 +1205,14 @@ Status McapReader::ParseDataEnd(const Record& record, DataEnd* dataEnd) {
 std::optional<Compression> McapReader::ParseCompression(const std::string_view compression) {
   if (compression == "") {
     return Compression::None;
+#ifndef MCAP_COMPRESSION_NO_LZ4
   } else if (compression == "lz4") {
     return Compression::Lz4;
+#endif
+#ifndef MCAP_COMPRESSION_NO_ZSTD
   } else if (compression == "zstd") {
     return Compression::Zstd;
+#endif
   } else {
     return std::nullopt;
   }
@@ -1251,10 +1263,26 @@ TypedChunkReader::TypedChunkReader()
     , status_{StatusCode::Success} {}
 
 void TypedChunkReader::reset(const Chunk& chunk, Compression compression) {
-  ICompressedReader* decompressor =
-    (compression == Compression::None)  ? static_cast<ICompressedReader*>(&uncompressedReader_)
-    : (compression == Compression::Lz4) ? static_cast<ICompressedReader*>(&lz4Reader_)
-                                        : static_cast<ICompressedReader*>(&zstdReader_);
+  ICompressedReader* decompressor;
+
+  switch (compression) {
+#ifndef MCAP_COMPRESSION_NO_LZ4
+    case Compression::Lz4:
+      decompressor = static_cast<ICompressedReader*>(&lz4Reader_);
+      break;
+#endif
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+    default:
+    case Compression::Zstd:
+      decompressor = static_cast<ICompressedReader*>(&zstdReader_);
+      break;
+#else
+    default:
+#endif
+    case Compression::None:
+      decompressor = static_cast<ICompressedReader*>(&uncompressedReader_);
+      break;
+  }
   decompressor->reset(chunk.records, chunk.compressedSize, chunk.uncompressedSize);
   reader_.reset(*decompressor, 0, decompressor->size());
   status_ = decompressor->status();
@@ -1604,7 +1632,8 @@ LinearMessageView::Iterator::Iterator(LinearMessageView& view)
   }
 }
 
-LinearMessageView::Iterator::Impl::Impl(LinearMessageView& view) : view_(view) {
+LinearMessageView::Iterator::Impl::Impl(LinearMessageView& view)
+    : view_(view) {
   auto dataStart = view.dataStart_;
   auto dataEnd = view.dataEnd_;
   auto readMessageOptions = view.readMessageOptions_;
@@ -1658,16 +1687,18 @@ void LinearMessageView::Iterator::Impl::onMessage(const Message& message, Record
 
   auto& channel = *maybeChannel;
   // make sure the message is on the right topic
-  if (view_.readMessageOptions_.topicFilter && !view_.readMessageOptions_.topicFilter(channel.topic)) {
+  if (view_.readMessageOptions_.topicFilter &&
+      !view_.readMessageOptions_.topicFilter(channel.topic)) {
     return;
   }
   SchemaPtr maybeSchema;
   if (channel.schemaId != 0) {
     maybeSchema = view_.mcapReader_.schema(channel.schemaId);
     if (!maybeSchema) {
-      view_.onProblem_(Status{StatusCode::InvalidSchemaId,
-                        internal::StrCat("channel ", channel.id, " (", channel.topic,
-                                         ") references missing schema id ", channel.schemaId)});
+      view_.onProblem_(
+        Status{StatusCode::InvalidSchemaId,
+               internal::StrCat("channel ", channel.id, " (", channel.topic,
+                                ") references missing schema id ", channel.schemaId)});
       return;
     }
   }
@@ -1840,13 +1871,20 @@ void IndexedMessageReader::decompressChunk(const Chunk& chunk,
   if (*compression == Compression::None) {
     slot.decompressedChunk.insert(slot.decompressedChunk.end(), &chunk.records[0],
                                   &chunk.records[chunk.uncompressedSize]);
-  } else if (*compression == Compression::Lz4) {
+  }
+#ifndef MCAP_COMPRESSION_NO_LZ4
+  else if (*compression == Compression::Lz4) {
     status_ = lz4Reader_.decompressAll(chunk.records, chunk.compressedSize, chunk.uncompressedSize,
                                        &slot.decompressedChunk);
-  } else if (*compression == Compression::Zstd) {
+  }
+#endif
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+  else if (*compression == Compression::Zstd) {
     status_ = ZStdReader::DecompressAll(chunk.records, chunk.compressedSize, chunk.uncompressedSize,
                                         &slot.decompressedChunk);
-  } else {
+  }
+#endif
+  else {
     status_ = Status(StatusCode::UnrecognizedCompression,
                      internal::StrCat("unhandled compression: ", chunk.compression));
   }

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -9,7 +9,9 @@
 #include <vector>
 
 // Forward declaration
+#ifndef MCAP_COMPRESSION_NO_ZSTD
 struct ZSTD_CCtx_s;
+#endif
 
 namespace mcap {
 
@@ -251,6 +253,7 @@ private:
   std::vector<std::byte> buffer_;
 };
 
+#ifndef MCAP_COMPRESSION_NO_LZ4
 /**
  * @brief An in-memory IChunkWriter implementation that holds data in a
  * temporary buffer before flushing to an LZ4-compressed buffer.
@@ -273,7 +276,9 @@ private:
   std::vector<std::byte> compressedBuffer_;
   CompressionLevel compressionLevel_;
 };
+#endif
 
+#ifndef MCAP_COMPRESSION_NO_ZSTD
 /**
  * @brief An in-memory IChunkWriter implementation that holds data in a
  * temporary buffer before flushing to an ZStandard-compressed buffer.
@@ -297,6 +302,7 @@ private:
   std::vector<std::byte> compressedBuffer_;
   ZSTD_CCtx_s* zstdContext_ = nullptr;
 };
+#endif
 
 /**
  * @brief Provides a write interface to an MCAP file.
@@ -445,8 +451,12 @@ private:
   std::unique_ptr<FileWriter> fileOutput_;
   std::unique_ptr<StreamWriter> streamOutput_;
   std::unique_ptr<BufferWriter> uncompressedChunk_;
+#ifndef MCAP_COMPRESSION_NO_LZ4
   std::unique_ptr<LZ4Writer> lz4Chunk_;
+#endif
+#ifndef MCAP_COMPRESSION_NO_ZSTD
   std::unique_ptr<ZStdWriter> zstdChunk_;
+#endif
   std::vector<Schema> schemas_;
   std::vector<Channel> channels_;
   std::vector<AttachmentIndex> attachmentIndex_;

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -27,3 +27,7 @@ target_link_libraries(streamed-writer-conformance ${CONAN_LIBS})
 
 add_executable(unit-tests unit_tests.cpp)
 target_link_libraries(unit-tests ${CONAN_LIBS})
+
+add_executable(unit-tests-nocompress unit_tests.cpp)
+target_link_libraries(unit-tests-nocompress ${CONAN_LIBS})
+target_compile_definitions(unit-tests-nocompress PRIVATE MCAP_COMPRESSION_NO_LZ4 MCAP_COMPRESSION_NO_ZSTD)

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -584,6 +584,7 @@ TEST_CASE("Message index records", "[writer]") {
   REQUIRE(messageIndexChannelIds[1] == channel2.id);
 }
 
+#ifndef MCAP_COMPRESSION_NO_LZ4
 TEST_CASE("LZ4 compression", "[reader][writer]") {
   SECTION("Roundtrip") {
     Buffer buffer;
@@ -781,6 +782,7 @@ TEST_CASE("Read Order", "[reader][writer]") {
     REQUIRE(count == reverse_order_expected.size());
   }
 }
+#endif
 
 TEST_CASE("ReadJobQueue order", "[reader]") {
   SECTION("successive chunks with out-of-order timestamps") {


### PR DESCRIPTION
### Public-Facing Changes

New defines: MCAP_COMPRESSION_NO_ZSTD, MCAP_COMPRESSION_NO_LZ4

### Description

Make LZ4 and ZSTD dependencies optional