### PR TITLE
Implement concat command based on merge command

### DIFF
--- a/go/cli/mcap/cmd/combining_common.go
+++ b/go/cli/mcap/cmd/combining_common.go
@@ -1,0 +1,109 @@
+package cmd
+
+// This file contains the common types and helpers used by both the merge and the concat commands.
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/foxglove/mcap/go/mcap"
+)
+
+type ErrDuplicateMetadataName struct {
+	Name string
+}
+
+func (e ErrDuplicateMetadataName) Is(target error) bool {
+	_, ok := target.(*ErrDuplicateMetadataName)
+	return ok
+}
+
+func (e *ErrDuplicateMetadataName) Error() string {
+	return fmt.Sprintf("metadata name '%s' was previously encountered. "+
+		"Supply --allow-duplicate-metadata to override.", e.Name)
+}
+
+// schemaID uniquely identifies a schema across the inputs.
+type schemaID struct {
+	inputID  int
+	schemaID uint16
+}
+
+// channelID uniquely identifies a channel across the inputs.
+type channelID struct {
+	inputID   int
+	channelID uint16
+}
+
+type HashSum = [md5.Size]byte
+
+const (
+	AutoCoalescing  = "auto"
+	ForceCoalescing = "force"
+	NoCoalescing    = "none"
+)
+
+func hashMetadata(metadata *mcap.Metadata) (string, error) {
+	hasher := md5.New()
+	hasher.Write([]byte(metadata.Name))
+	bytes, err := json.Marshal(metadata.Metadata)
+	if err != nil {
+		return "", err
+	}
+	hasher.Write(bytes)
+	hash := hasher.Sum(nil)
+	return hex.EncodeToString(hash), nil
+}
+
+func getChannelHash(channel *mcap.Channel, coalesceChannels string) HashSum {
+	hasher := md5.New()
+	schemaIDBytes := make([]byte, 2)
+	binary.LittleEndian.PutUint16(schemaIDBytes, channel.SchemaID)
+	hasher.Write(schemaIDBytes)
+	hasher.Write([]byte(channel.Topic))
+	hasher.Write([]byte(channel.MessageEncoding))
+
+	switch coalesceChannels {
+	case AutoCoalescing: // Include channel metadata in hash
+		for key, value := range channel.Metadata {
+			hasher.Write([]byte(key))
+			hasher.Write([]byte(value))
+		}
+	case ForceCoalescing: // Channel metadata is not included in hash
+		break
+	default:
+		die("Invalid value for --coalesce-channels: %s\n", coalesceChannels)
+	}
+
+	return HashSum(hasher.Sum(nil))
+}
+
+func getSchemaHash(schema *mcap.Schema) HashSum {
+	hasher := md5.New()
+	hasher.Write([]byte(schema.Name))
+	hasher.Write([]byte(schema.Encoding))
+	hasher.Write(schema.Data)
+	return HashSum(hasher.Sum(nil))
+}
+
+func outputProfile(profiles []string) string {
+	if len(profiles) == 0 {
+		return ""
+	}
+	firstProfile := profiles[0]
+	for _, profile := range profiles {
+		if profile != firstProfile {
+			return ""
+		}
+	}
+	return firstProfile
+}
+
+type namedReader struct {
+	name   string
+	reader io.Reader
+}

--- a/go/cli/mcap/cmd/concat.go
+++ b/go/cli/mcap/cmd/concat.go
@@ -97,7 +97,8 @@ func (m *mcapConcatenator) addMetadata(w *mcap.Writer, metadata *mcap.Metadata) 
 func (m *mcapConcatenator) addChannel(w *mcap.Writer, inputID int, channel *mcap.Channel) (uint16, error) {
 	outputSchemaID, ok := m.outputSchemaID(inputID, channel.SchemaID)
 	if !ok {
-		return 0, fmt.Errorf("unknown schema on channel %d for input %d topic %s", channel.ID, inputID, channel.Topic)
+		return 0, fmt.Errorf("unknown schema on channel %d for input %d topic %s",
+			channel.ID, inputID, channel.Topic)
 	}
 	key := channelID{inputID, channel.ID}
 	newChannel := &mcap.Channel{
@@ -241,6 +242,11 @@ func (m *mcapConcatenator) concatenateInputs(w io.Writer, inputs []namedReader) 
 					break
 				}
 				return fmt.Errorf("error on input %s: %w", inputName, err)
+			}
+
+			if newMessage.LogTime < timestampOffset {
+				return fmt.Errorf("timestamp %d is less than offset %d, sort input files before concatenating",
+					newMessage.LogTime, timestampOffset)
 			}
 
 			newMessage.LogTime -= timestampOffset


### PR DESCRIPTION
### Public-Facing Changes

Adds a `concat` command to the mcap CLI that combines files with the timestamps rewritten sequentially starting from 0.

### Description

We are using this along with the `filter` command to take small chunks from a lot of files and combine them into one file that we can run simulations on.