### PR TITLE
cli: fix segfault bug when using filter args

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -141,7 +141,7 @@ func run(filterOptions *filterOpts, args []string) {
 func compileMatchers(regexStrings []string) ([]regexp.Regexp, error) {
 	matchers := make([]regexp.Regexp, len(regexStrings))
 
-	for _, regexString := range regexStrings {
+	for i, regexString := range regexStrings {
 		// auto-surround with ^$ if not specified.
 		if regexString[:1] != "^" {
 			regexString = "^" + regexString
@@ -153,7 +153,7 @@ func compileMatchers(regexStrings []string) ([]regexp.Regexp, error) {
 		if err != nil {
 			return nil, err
 		}
-		matchers = append(matchers, *regex)
+		matchers[i] = *regex
 	}
 	return matchers, nil
 }

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -359,3 +359,11 @@ func TestRecover(t *testing.T) {
 		}, messageCounter, 0.0)
 	})
 }
+
+func TestCompileMatchers(t *testing.T) {
+	matchers, err := compileMatchers([]string{"camera.*", "lights.*"})
+	assert.Nil(t, err)
+	assert.Equal(t, len(matchers), 2)
+	assert.True(t, matchers[0].MatchString("camera"))
+	assert.True(t, matchers[1].MatchString("lights"))
+}


### PR DESCRIPTION
### Public-Facing Changes

Fixes bug where the MCAP cli would segfault when using `filter -y` or `filter -n`.
### Description

Previously the `compileMatchers` function would build an array of matchers by appending to it, but the array was already initialized with a non-zero length, resulting in the first N entries of that array being uninitialized matchers. This caused a segfault when it came time to use those matchers. 
<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
