### PR TITLE
Add append mode to Mcap Writer in the Typescript Core package

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {

--- a/typescript/core/src/ISeekableWriter.ts
+++ b/typescript/core/src/ISeekableWriter.ts
@@ -1,0 +1,9 @@
+import { IWritable } from "./IWritable";
+
+/**
+ * ISeekableWriter describes a writer interface with seek abilities.
+ */
+export interface ISeekableWriter extends IWritable {
+  // Seek the cursor to the given position
+  seek(position: bigint): Promise<void>;
+}

--- a/typescript/core/src/TempBuffer.ts
+++ b/typescript/core/src/TempBuffer.ts
@@ -1,15 +1,19 @@
+import { ISeekableWriter } from "./ISeekableWriter";
 import { IWritable } from "./IWritable";
 import { IReadable } from "./types";
 
 /**
  * In-memory buffer used for reading and writing MCAP files in tests. Can be used as both an IReadable and an IWritable.
  */
-export class TempBuffer implements IReadable, IWritable {
+export class TempBuffer implements IReadable, IWritable, ISeekableWriter {
   #buffer = new ArrayBuffer(1024);
   #size = 0;
 
   position(): bigint {
     return BigInt(this.#size);
+  }
+  async seek(position: bigint): Promise<void> {
+    this.#size = Number(position);
   }
   async write(data: Uint8Array): Promise<void> {
     if (this.#size + data.byteLength > this.#buffer.byteLength) {

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -7,6 +7,7 @@ export { ChunkBuilder as McapChunkBuilder } from "./ChunkBuilder";
 export * as McapTypes from "./types";
 export * as McapConstants from "./constants";
 export type { IWritable } from "./IWritable";
+export type { ISeekableWriter } from "./ISeekableWriter";
 
 export * from "./hasMcapPrefix";
 export * from "./parse";


### PR DESCRIPTION
### Public-Facing Changes

<!-- describe any changes to the public interface or APIs, or write "None" -->

- Added data end offset information to Typescipt Mcap Indexed Reader.
- Added append mode to the Mcap Writer in the Typescript Mcap core package.

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->

- Added data end offset information to Typescipt Mcap Indexed Reader for Mcap appending purposes.
- Added append mode to the Mcap Writer in the Typescript Mcap core package in order to append metadata and attachments to existing Mcap files via the @mcap/core package.
