### PR TITLE
Relax version restrictions of protobuf dependency

### DIFF
--- a/python/mcap-protobuf-support/setup.cfg
+++ b/python/mcap-protobuf-support/setup.cfg
@@ -11,9 +11,11 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-install_requires = 
+install_requires =
     mcap>=0.0.14
-    protobuf>=3.8,<=4.21.11
+    # Protobuf versions 4.22-4.24 are excluded as they contain a bug that can cause a segmentation
+    # fault when reading a mcap file: https://github.com/protocolbuffers/protobuf/issues/12047
+    protobuf>=3.8,!=4.22.*,!=4.23.*,!=4.24.*
 install_package_data = True
 packages = find:
 python_requires = >=3.7


### PR DESCRIPTION
### Public-Facing Changes

Relax version restrictions of protobuf dependency

### Description
Changed the protobuf version restrictions to exclude the 4.22-4.24 which could lead to segmentation faults when reading a mcap file. We previously tightened it in https://github.com/foxglove/mcap/pull/919