### PR TITLE
Fix metadata rendering issue

### DIFF
--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -25,13 +25,12 @@ var (
 
 func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 	rows := make([][]string, 0, len(info.MetadataIndexes))
-	headers := []string{
+	rows = append(rows, []string{
 		"name",
 		"offset",
 		"length",
 		"metadata",
-	}
-	rows = append(rows, headers)
+	})
 	for _, idx := range info.MetadataIndexes {
 		offset := idx.Offset + 1 + 8
 		if offset > math.MaxInt64 {
@@ -59,7 +58,7 @@ func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 			idx.Name,
 			fmt.Sprintf("%d", idx.Offset),
 			fmt.Sprintf("%d", idx.Length),
-      string(jsonSerialized),
+			string(jsonSerialized),
 		})
 	}
 	utils.FormatTable(w, rows)

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -25,12 +25,16 @@ var (
 
 func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 	rows := make([][]string, 0, len(info.MetadataIndexes))
-	rows = append(rows, []string{
+	headers := []string{
 		"name",
 		"offset",
 		"length",
 		"metadata",
-	})
+	}
+	rows = append(rows, headers)
+	// jsonRowSeparator is used to replace the newline characters
+	// so that the metadata displayed is formatted and wrapped correctly
+	jsonRowSeparator := "\n" + strings.Repeat("\t", len(headers)-1) + strings.Repeat(" ", len(headers)-1)
 	for _, idx := range info.MetadataIndexes {
 		offset := idx.Offset + 1 + 8
 		if offset > math.MaxInt64 {
@@ -62,7 +66,7 @@ func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 			idx.Name,
 			fmt.Sprintf("%d", idx.Offset),
 			fmt.Sprintf("%d", idx.Length),
-			prettyJSON,
+			strings.ReplaceAll(prettyJSON, "\n", jsonRowSeparator),
 		})
 	}
 	utils.FormatTable(w, rows)

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -32,9 +32,6 @@ func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 		"metadata",
 	}
 	rows = append(rows, headers)
-	// jsonRowSeparator is used to replace the newline characters
-	// so that the metadata displayed is formatted and wrapped correctly
-	jsonRowSeparator := "\n" + strings.Repeat("\t", len(headers)-1) + strings.Repeat(" ", len(headers)-1)
 	for _, idx := range info.MetadataIndexes {
 		offset := idx.Offset + 1 + 8
 		if offset > math.MaxInt64 {
@@ -58,15 +55,11 @@ func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal metadata to JSON: %w", err)
 		}
-		prettyJSON, err := utils.PrettyJSON(jsonSerialized)
-		if err != nil {
-			return fmt.Errorf("failed to pretty JSON: %w", err)
-		}
 		rows = append(rows, []string{
 			idx.Name,
 			fmt.Sprintf("%d", idx.Offset),
 			fmt.Sprintf("%d", idx.Length),
-			strings.ReplaceAll(prettyJSON, "\n", jsonRowSeparator),
+      string(jsonSerialized),
 		})
 	}
 	utils.FormatTable(w, rows)


### PR DESCRIPTION
### Description

Prior to this commit, the printed metadata was wrapped/formatted incorrectly when running `mcap list metadata`. This commit fixes it by removing the pretty json format – making the metadata column print only 1 line.
