### PR TITLE
Set @mcap/support to 1.0.0 before first publish

### DIFF
--- a/typescript/support/package.json
+++ b/typescript/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/support",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Common decompression for use with MCAP files",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

Follow-up from #868 – realized 1.0.1 is a weird first version number.