### PR TITLE
Fix typedoc configs

### DIFF
--- a/typescript/browser/package.json
+++ b/typescript/browser/package.json
@@ -15,8 +15,10 @@
   "module": "dist/esm/src/index.js",
   "main": "dist/cjs/src/index.js",
   "typings": "dist/esm/src/index.d.ts",
-  "typedoc": {
-    "entryPoint": "src/index.ts"
+  "typedocOptions": {
+    "entryPoints": [
+      "src/index.ts"
+    ]
   },
   "files": [
     "dist",

--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -15,8 +15,10 @@
   "module": "dist/esm/src/index.js",
   "main": "dist/cjs/src/index.js",
   "typings": "dist/esm/src/index.d.ts",
-  "typedoc": {
-    "entryPoint": "src/index.ts"
+  "typedocOptions": {
+    "entryPoints": [
+      "src/index.ts"
+    ]
   },
   "files": [
     "dist",

--- a/typescript/nodejs/package.json
+++ b/typescript/nodejs/package.json
@@ -15,8 +15,10 @@
   "module": "dist/esm/src/index.js",
   "main": "dist/cjs/src/index.js",
   "typings": "dist/esm/src/index.d.ts",
-  "typedoc": {
-    "entryPoint": "src/index.ts"
+  "typedocOptions": {
+    "entryPoints": [
+      "src/index.ts"
+    ]
   },
   "files": [
     "dist",

--- a/typescript/support/package.json
+++ b/typescript/support/package.json
@@ -15,8 +15,10 @@
   "module": "dist/esm/src/index.js",
   "main": "dist/cjs/src/index.js",
   "typings": "dist/esm/src/index.d.ts",
-  "typedoc": {
-    "entryPoint": "src/index.ts"
+  "typedocOptions": {
+    "entryPoints": [
+      "src/index.ts"
+    ]
   },
   "files": [
     "dist",


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

Some changes to typedoc changed/renamed how the "entryPoint" setting works, which was breaking the TS docs at https://mcap.dev/docs/typescript/.

Before:
<img width="276" alt="image" src="https://github.com/foxglove/mcap/assets/14237/38dc0a39-a025-4372-911c-9a6c114055b4">

After:
<img width="337" alt="image" src="https://github.com/foxglove/mcap/assets/14237/a07adb41-1f93-42a0-8005-2aba5c8dd3e5">
