### PR TITLE
Update TypeScript READMEs

### DIFF
--- a/typescript/nodejs/README.md
+++ b/typescript/nodejs/README.md
@@ -6,7 +6,7 @@ The `@mcap/nodejs` package provides utilities for working with MCAP files from N
 
 ## Usage examples
 
-### Reading MCAP files
+### Reading MCAP files in Node.js
 
 ```ts
 import { loadDecompressHandlers } from "@mcap/support";
@@ -22,11 +22,11 @@ const reader = await McapIndexedReader.Initialize({
 });
 ```
 
-### Writing MCAP files
+### Writing MCAP files in Node.js
 
 ```ts
 import zstd from "@foxglove/wasm-zstd";
-import { FileHandleWritable } from "@mcap/support/nodejs";
+import { FileHandleWritable } from "@mcap/nodejs";
 import { McapWriter } from "@mcap/core";
 import { open } from "fs/promises";
 

--- a/typescript/support/README.md
+++ b/typescript/support/README.md
@@ -40,25 +40,6 @@ const reader = await McapIndexedReader.Initialize({
 });
 ```
 
-### Writing MCAP files with Node.js
-
-```ts
-import zstd from "@foxglove/wasm-zstd";
-import { FileHandleWritable } from "@mcap/support/nodejs";
-import { open } from "fs/promises";
-
-const fileHandle = await open("file.mcap", "w");
-
-await zstd.isLoaded;
-const writer = new McapWriter({
-  writable: new FileHandleWritable(fileHandle),
-  compressChunk: (data) => ({
-    compression: "zstd",
-    compressedData: zstd.compress(data),
-  }),
-});
-```
-
 ## License
 
 `@mcap/support` is licensed under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
### Public-Facing Changes

Minor updates to READMEs

### Description

`@mcap/support/nodejs` was an outdated package name. This stuff is not in the `@mcap/support` package anymore but in a separate `@mcap/nodejs` package.

Resolves FG-5991