### PR TITLE
Do not create a new TextDecoder for every record

### DIFF
--- a/typescript/core/src/Reader.ts
+++ b/typescript/core/src/Reader.ts
@@ -1,5 +1,8 @@
 import { getBigUint64 } from "./getBigUint64";
 
+// For performance reasons we use a single TextDecoder instance whose internal state is merely
+// the encoding (defaults to UTF-8). This means that a TextDecoder.decode() call is not affected
+// be previous calls.
 const textDecoder = new TextDecoder();
 
 export default class Reader {

--- a/typescript/core/src/Reader.ts
+++ b/typescript/core/src/Reader.ts
@@ -1,9 +1,10 @@
 import { getBigUint64 } from "./getBigUint64";
 
+const textDecoder = new TextDecoder();
+
 export default class Reader {
   #view: DataView;
   offset: number;
-  #textDecoder = new TextDecoder();
 
   constructor(view: DataView, offset = 0) {
     this.#view = view;
@@ -39,7 +40,7 @@ export default class Reader {
     if (this.offset + length > this.#view.byteLength) {
       throw new Error(`String length ${length} exceeds bounds of buffer`);
     }
-    const value = this.#textDecoder.decode(
+    const value = textDecoder.decode(
       new Uint8Array(this.#view.buffer, this.#view.byteOffset + this.offset, length),
     );
     this.offset += length;


### PR DESCRIPTION
### Public-Facing Changes

Do not create a new TextDecoder for every record

### Description
Massively improves read performance by avoiding unnecessary creation / cleanups of TextDecoders.

Before:
```
 [Summary]:
   ticks  total  nonlib   name
   6600    7.2%   46.1%  JavaScript
   7693    8.4%   53.8%  C++
  21411   23.3%  149.6%  GC
  77489   84.4%          Shared libraries
     16    0.0%          Unaccounted
```

After (Notice the drop in GC time):
```
 [Summary]:
   ticks  total  nonlib   name
   3950   10.1%   60.7%  JavaScript
   2555    6.6%   39.2%  C++
    549    1.4%    8.4%  GC
  32426   83.3%          Shared libraries
      5    0.0%          Unaccounted
```