### PR TITLE
Website: Add Slack link to header

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -112,6 +112,11 @@ const config = {
             label: "Specification",
           },
           {
+            href: "https://foxglove.dev/slack",
+            label: "Slack",
+            position: "right",
+          },
+          {
             href: "https://github.com/foxglove/mcap",
             label: "GitHub",
             position: "right",


### PR DESCRIPTION
### Public-Facing Changes
Add Slack link to website header.

Rationale: Make it easier to find.