### PR TITLE
Fix internal links in spec index.md

### DIFF
--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -63,10 +63,10 @@ The following records are allowed to appear in the data section:
 - [Attachment](#attachment-op0x09)
 - [Chunk](#chunk-op0x06)
 - [Message Index](#message-index-op0x07)
-- [Metadata](#metadata-op0x0C)
-- [Data End](#data-end-op0x0F)
+- [Metadata](#metadata-op0x0c)
+- [Data End](#data-end-op0x0f)
 
-The last record in the data section MUST be the [Data End](#data-end-op0x0F) record.
+The last record in the data section MUST be the [Data End](#data-end-op0x0f) record.
 
 #### Use of chunk records
 
@@ -83,9 +83,9 @@ The following records are allowed to appear in the summary section:
 - [Schema](#schema-op0x03)
 - [Channel](#channel-op0x04)
 - [Chunk Index](#chunk-index-op0x08)
-- [Attachment Index](#attachment-index-op0x0A)
-- [Metadata Index](#metadata-index-op0x0D)
-- [Statistics](#statistics-op0x0B)
+- [Attachment Index](#attachment-index-op0x0a)
+- [Metadata Index](#metadata-index-op0x0d)
+- [Statistics](#statistics-op0x0b)
 
 All records in the summary section MUST be grouped by opcode.
 
@@ -97,7 +97,7 @@ Schema records in the summary are duplicates of Schema records throughout the Da
 
 ### Summary Offset Section
 
-The optional summary offset section contains [Summary Offset](#summary-offset-op0x0E) records for fast lookup of summary section records.
+The optional summary offset section contains [Summary Offset](#summary-offset-op0x0e) records for fast lookup of summary section records.
 
 The summary offset section aids random access reading.
 


### PR DESCRIPTION

### Public-Facing Changes

Fixes internal links in https://mcap.dev/spec

### Description

URLs like https://mcap.dev/spec#data-end-op0x0F are incorrect; they should be lower-case (like https://mcap.dev/spec#data-end-op0x0f).

Noticed on the live website.
