### PR TITLE
CLI: Fix schema deduplication in mcap convert

### DIFF
--- a/go/ros/bag2mcap.go
+++ b/go/ros/bag2mcap.go
@@ -260,7 +260,7 @@ func Bag2MCAP(w io.Writer, r io.Reader, opts *mcap.WriterOptions, messageCallbac
 			msgdef := connectionDataHeader["message_definition"]
 			delete(connectionDataHeader, "message_definition")
 
-			key := fmt.Sprintf("%s/%s", topic, connectionDataHeader["md5sum"])
+			key := fmt.Sprintf("%s/%s", typ, connectionDataHeader["md5sum"])
 			if _, ok := schemas[key]; !ok {
 				schemaID := uint16(len(schemas) + 1)
 				msgdefCopy := make([]byte, len(msgdef))


### PR DESCRIPTION
Prior to this commit, if mcap convert got two ROS1 connections with the same schema but different topic, it would write two schema records.

In this situation only one schema record is needed, as long as the type and the md5 sum are aligned.