### PR TITLE
go/cli: mcap info show channels count

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -167,7 +167,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		rows = append(rows, row)
 	}
 	utils.FormatTable(buf, rows)
-	fmt.Fprintf("channels: %d\n", len(chanIDs))
+	fmt.Fprintf(buf, "channels: %d\n", len(chanIDs))
 	if info.Statistics != nil {
 		fmt.Fprintf(buf, "attachments: %d\n", info.Statistics.AttachmentCount)
 		fmt.Fprintf(buf, "metadata: %d\n", info.Statistics.MetadataCount)

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -167,6 +167,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		rows = append(rows, row)
 	}
 	utils.FormatTable(buf, rows)
+	fmt.Fprintf("channels: %d\n", len(chanIDs))
 	if info.Statistics != nil {
 		fmt.Fprintf(buf, "attachments: %d\n", info.Statistics.AttachmentCount)
 		fmt.Fprintf(buf, "metadata: %d\n", info.Statistics.MetadataCount)


### PR DESCRIPTION
### Public-Facing Changes

<!-- describe any changes to the public interface or APIs, or write "None" -->

show channels count like `channels(45):` in `mcap info` print.

### Description

<!-- describe what has changed, and motivation behind those changes -->

The channels list printed by `mcap info` might have discontinuous sequence numbers due to certain reasons (for example, if one of the topics in the original recorded data has zero messages, then the mcap generated after using `mcap filter` will exhibit this). Therefore, it's important to visually see the number of channels.

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
