### PR TITLE
Bump CLI version to 1.1.1

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.1.0"
+var Version = "v1.1.1"


### PR DESCRIPTION
This sets the CLI version to 1.1.1.

It looks like this will include a couple of fixes:

- #1052 
- #1049