### PR TITLE
Add release process to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,14 @@ The version number is set at build time based on the tag.
 ### C++
 
 1. Update the version in all relevant files
-
-- cpp/bench/conanfile.py
-- cpp/build-docs.sh
-- cpp/build.sh
-- cpp/docs/conanfile.py
-- cpp/examples/conanfile.py
-- cpp/mcap/include/mcap/types.hpp (`MCAP_LIBRARY_VERSION`)
-- cpp/mcap/include/conanfile.py
-- cpp/test/conanfile.py
-
+   - cpp/bench/conanfile.py
+   - cpp/build-docs.sh
+   - cpp/build.sh
+   - cpp/docs/conanfile.py
+   - cpp/examples/conanfile.py
+   - cpp/mcap/include/mcap/types.hpp (`MCAP_LIBRARY_VERSION`)
+   - cpp/mcap/include/conanfile.py
+   - cpp/test/conanfile.py
 2. Tag a release matching the version number `releases/cpp/vX.Y.Z`
 
 ### Python
@@ -75,10 +73,9 @@ There are several python packages; updating any follows a similar process.
 
 1. Update the version in the appropriate `__init.py__` file
 2. Tag a release
-
-- For the core mcap library, match the pattern `releases/python/vX.Y.Z`
-- For other packages, use `releases/python/PACKAGE/vX.Y.Z`
-  - For example, `releases/python/mcap/v1.2.3`
+   - For the core mcap library, match the pattern `releases/python/vX.Y.Z`
+   - For other packages, use `releases/python/PACKAGE/vX.Y.Z`
+     - For example, `releases/python/mcap/v1.2.3`
 
 ### TypeScript
 
@@ -86,8 +83,7 @@ There are several TS packages; updating any follows a similar process.
 
 1. Update the version in the appropriate `package.json`
 2. Tag a release matching `releases/typescript/PACKAGE/vX.Y.Z`
-
-- For example, `releases/typescript/core/v1.2.3`
+   - For example, `releases/typescript/core/v1.2.3`
 
 ### Swift
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,16 @@ The version number is set at build time based on the tag.
 ### C++
 
 1. Update the version in all relevant files
-  - cpp/bench/conanfile.py
-  - cpp/build-docs.sh
-  - cpp/build.sh
-  - cpp/docs/conanfile.py
-  - cpp/examples/conanfile.py
-  - cpp/mcap/include/mcap/types.hpp (`MCAP_LIBRARY_VERSION`)
-  - cpp/mcap/include/conanfile.py
-  - cpp/test/conanfile.py
+
+- cpp/bench/conanfile.py
+- cpp/build-docs.sh
+- cpp/build.sh
+- cpp/docs/conanfile.py
+- cpp/examples/conanfile.py
+- cpp/mcap/include/mcap/types.hpp (`MCAP_LIBRARY_VERSION`)
+- cpp/mcap/include/conanfile.py
+- cpp/test/conanfile.py
+
 2. Tag a release matching the version number `releases/cpp/vX.Y.Z`
 
 ### Python
@@ -73,9 +75,10 @@ There are several python packages; updating any follows a similar process.
 
 1. Update the version in the appropriate `__init.py__` file
 2. Tag a release
-  - For the core mcap library, match the pattern `releases/python/vX.Y.Z`
-  - For other packages, use `releases/python/PACKAGE/vX.Y.Z`
-    + For example, `releases/python/mcap/v1.2.3`
+
+- For the core mcap library, match the pattern `releases/python/vX.Y.Z`
+- For other packages, use `releases/python/PACKAGE/vX.Y.Z`
+  - For example, `releases/python/mcap/v1.2.3`
 
 ### TypeScript
 
@@ -83,7 +86,8 @@ There are several TS packages; updating any follows a similar process.
 
 1. Update the version in the appropriate `package.json`
 2. Tag a release matching `releases/typescript/PACKAGE/vX.Y.Z`
-  - For example, `releases/typescript/core/v1.2.3`
+
+- For example, `releases/typescript/core/v1.2.3`
 
 ### Swift
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,60 @@ Download the latest `mcap-cli` version from the [releases page](https://github.c
 ## License
 
 [MIT License](/LICENSE). Contributors are required to accept the [Contributor License Agreement](https://github.com/foxglove/cla).
+
+## Release process
+
+Release numbering follows a major.minor.patch format, abbreviated as "X.Y.Z" below.
+
+CI will build the appropriate packages once tags are pushed, as described below.
+
+### Go library
+
+1. Update the `Version` in go/mcap/version.go
+2. Tag a release matching the version number `go/mcap/vX.Y.Z`.
+
+### CLI
+
+Tag a release matching `releases/mcap-cli/vX.Y.Z`.
+
+The version number is set at build time based on the tag.
+
+### C++
+
+1. Update the version in all relevant files
+  - cpp/bench/conanfile.py
+  - cpp/build-docs.sh
+  - cpp/build.sh
+  - cpp/docs/conanfile.py
+  - cpp/examples/conanfile.py
+  - cpp/mcap/include/mcap/types.hpp (`MCAP_LIBRARY_VERSION`)
+  - cpp/mcap/include/conanfile.py
+  - cpp/test/conanfile.py
+2. Tag a release matching the version number `releases/cpp/vX.Y.Z`
+
+### Python
+
+There are several python packages; updating any follows a similar process.
+
+1. Update the version in the appropriate `__init.py__` file
+2. Tag a release
+  - For the core mcap library, match the pattern `releases/python/vX.Y.Z`
+  - For other packages, use `releases/python/PACKAGE/vX.Y.Z`
+    + For example, `releases/python/mcap/v1.2.3`
+
+### TypeScript
+
+There are several TS packages; updating any follows a similar process.
+
+1. Update the version in the appropriate `package.json`
+2. Tag a release matching `releases/typescript/PACKAGE/vX.Y.Z`
+  - For example, `releases/typescript/core/v1.2.3`
+
+### Swift
+
+Tag a release matching the version number `releases/swift/vX.Y.Z`
+
+### Rust
+
+1. Update the version in rust/Cargo.toml
+2. Tag a release matching the version number `releases/rust/vX.Y.Z`


### PR DESCRIPTION
This adds a "Release process" section to the readme. I gleaned these instructions by looking at tags & past commits, but they should be reviewed for accuracy.