### PR TITLE
mcap convert: Fix duplicate type definition in ROS2 schemas

### DIFF
--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -71,7 +71,7 @@ func getSchemas(directories []string, types []string) (map[string][]byte, error)
 		}{
 			{parentPackage: rosPackage, rosType: rosType, schema: schema},
 		}
-		seenSubtypes := make(map[string]struct{})
+		seenSubtypes := map[string]struct{}{rosType: struct{}{}}
 		first := true
 		for len(subdefinitions) > 0 {
 			subdefinition := subdefinitions[0]

--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -71,6 +71,7 @@ func getSchemas(directories []string, types []string) (map[string][]byte, error)
 		}{
 			{parentPackage: rosPackage, rosType: rosType, schema: schema},
 		}
+		seenSubtypes := make(map[string]struct{})
 		first := true
 		for len(subdefinitions) > 0 {
 			subdefinition := subdefinitions[0]
@@ -143,15 +144,21 @@ func getSchemas(directories []string, types []string) (map[string][]byte, error)
 				if err != nil {
 					return nil, fmt.Errorf("failed to find schema for %s: %w", fieldType, err)
 				}
-				subdefinitions = append(subdefinitions, struct {
-					parentPackage string
-					rosType       string
-					schema        []byte
-				}{
-					parentPackage: parentPackage,
-					rosType:       qualifiedType,
-					schema:        fieldSchema,
-				})
+
+				// Only process new subtypes to avoid duplicate type definitions in the schema
+				_, knownSubtype := seenSubtypes[qualifiedType]
+				if !knownSubtype {
+					seenSubtypes[qualifiedType] = struct{}{}
+					subdefinitions = append(subdefinitions, struct {
+						parentPackage string
+						rosType       string
+						schema        []byte
+					}{
+						parentPackage: parentPackage,
+						rosType:       qualifiedType,
+						schema:        fieldSchema,
+					})
+				}
 			}
 		}
 		messageDefinitions[rosType] = messageDefinition.Bytes()

--- a/go/ros/ros2db3_to_mcap.go
+++ b/go/ros/ros2db3_to_mcap.go
@@ -71,7 +71,7 @@ func getSchemas(directories []string, types []string) (map[string][]byte, error)
 		}{
 			{parentPackage: rosPackage, rosType: rosType, schema: schema},
 		}
-		seenSubtypes := map[string]struct{}{rosType: struct{}{}}
+		seenSubtypes := map[string]struct{}{rosType: {}}
 		first := true
 		for len(subdefinitions) > 0 {
 			subdefinition := subdefinitions[0]

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -205,3 +205,24 @@ func TestSchemaFinding(t *testing.T) {
 		assert.Equal(t, c.expectedContent, string(content))
 	}
 }
+
+func TestSchemaDeduplication(t *testing.T) {
+	t.Run("schema dependencies are resolved and subtypes deduplicated", func(t *testing.T) {
+		schemas, err := getSchemas([]string{"./testdata/duplicate_typedefinition"}, []string{"example_msgs/msg/Parent"})
+		assert.Nil(t, err)
+
+		schema := schemas["example_msgs/msg/Parent"]
+		expectedSchema := `
+example_msgs/Descriptor descriptor
+example_msgs/OtherDescriptor other_msg_with_descriptor
+================================================================================
+MSG: example_msgs/Descriptor
+# is a descriptor
+================================================================================
+MSG: example_msgs/OtherDescriptor
+
+example_msgs/Descriptor descriptor
+`
+		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
+	})
+}

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -220,7 +220,6 @@ MSG: example_msgs/Descriptor
 # is a descriptor
 ================================================================================
 MSG: example_msgs/OtherDescriptor
-
 example_msgs/Descriptor descriptor
 `
 		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))

--- a/go/ros/testdata/duplicate_typedefinition/share/ament_index/resource_index/rosidl_interfaces/example_msgs
+++ b/go/ros/testdata/duplicate_typedefinition/share/ament_index/resource_index/rosidl_interfaces/example_msgs
@@ -1,0 +1,3 @@
+msg/Descriptor.msg
+msg/OtherDescriptor.msg
+msg/Parent.msg

--- a/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/Descriptor.msg
+++ b/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/Descriptor.msg
@@ -1,0 +1,1 @@
+# is a descriptor

--- a/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/OtherDescriptor.msg
+++ b/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/OtherDescriptor.msg
@@ -1,2 +1,1 @@
-
 example_msgs/Descriptor descriptor

--- a/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/OtherDescriptor.msg
+++ b/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/OtherDescriptor.msg
@@ -1,0 +1,2 @@
+
+example_msgs/Descriptor descriptor

--- a/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/Parent.msg
+++ b/go/ros/testdata/duplicate_typedefinition/share/example_msgs/msg/Parent.msg
@@ -1,0 +1,2 @@
+example_msgs/Descriptor descriptor
+example_msgs/OtherDescriptor other_msg_with_descriptor


### PR DESCRIPTION
### Public-Facing Changes
FIx `mcap convert` producing ROS2 schemas with duplicate type definitions

### Description
It could happen that `mcap convert` produced ROS2 schemas with duplicated subtype definitions if the subtype was included multiple times by various `.msg` files. This PR fixes this by only processing subtypes that haven't been processed before.

Resolves FG-6369