### PR TITLE
go: reader: fall back to linear scan if statistics show messages outside chunks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 // -*- jsonc -*-
 {
-  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
 

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -335,7 +335,25 @@ var catCmd = &cobra.Command{
 				return fmt.Errorf("failed to create reader: %w", err)
 			}
 			defer reader.Close()
-			it, err := reader.Messages(getReadOpts(true)...)
+			info, err := reader.Info()
+			if err != nil {
+				return fmt.Errorf("could not get info about MCAP: %w", err)
+			}
+			// if there are chunk index records present, use the index to read messages efficiently.
+			// Otherwise fall back to a linear scan in case the MCAP is unindexed.
+			useIndex := true
+			if len(info.ChunkIndexes) == 0 {
+				useIndex = false
+				_, err = rs.Seek(0, io.SeekStart)
+				if err != nil {
+					return fmt.Errorf("failed to seek to start: %w", err)
+				}
+				reader, err = mcap.NewReader(rs)
+				if err != nil {
+					return fmt.Errorf("failed to reset reader: %w", err)
+				}
+			}
+			it, err := reader.Messages(getReadOpts(useIndex)...)
 			if err != nil {
 				return fmt.Errorf("failed to read messages: %w", err)
 			}

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -335,25 +335,7 @@ var catCmd = &cobra.Command{
 				return fmt.Errorf("failed to create reader: %w", err)
 			}
 			defer reader.Close()
-			info, err := reader.Info()
-			if err != nil {
-				return fmt.Errorf("could not get info about MCAP: %w", err)
-			}
-			// if there are chunk index records present, use the index to read messages efficiently.
-			// Otherwise fall back to a linear scan in case the MCAP is unindexed.
-			useIndex := true
-			if len(info.ChunkIndexes) == 0 {
-				useIndex = false
-				_, err = rs.Seek(0, io.SeekStart)
-				if err != nil {
-					return fmt.Errorf("failed to seek to start: %w", err)
-				}
-				reader, err = mcap.NewReader(rs)
-				if err != nil {
-					return fmt.Errorf("failed to reset reader: %w", err)
-				}
-			}
-			it, err := reader.Messages(getReadOpts(useIndex)...)
+			it, err := reader.Messages(getReadOpts(true)...)
 			if err != nil {
 				return fmt.Errorf("failed to read messages: %w", err)
 			}

--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.1.1"
+var Version = "v1.2.0"


### PR DESCRIPTION
### Public-Facing Changes

* the go `mcap.Reader` interface now detects unindexed MCAPs and reads messages from them with a linear scan.

### Description

Previously when reading a seekable MCAP file with the go library Reader, it would assume that the MCAP was indexed and return no messages if not. After this PR, if an MCAP is not indexed but contains a statistics record, the reader will use the statistics to determine if there are un-indexed messages in the file.

Fixes https://linear.app/foxglove/issue/FG-6441/mcap-cat-doesnt-display-anything-for-unchunked-file