### PR TITLE
cli: info does not segfault on large byte values

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -28,12 +28,16 @@ func decimalTime(t time.Time) string {
 
 func humanBytes(numBytes uint64) string {
 	prefixes := []string{"B", "KiB", "MiB", "GiB"}
-	displayedValue := float64(numBytes)
-	prefixIndex := 0
-	for ; displayedValue > 1024 && prefixIndex < len(prefixes); prefixIndex++ {
-		displayedValue /= 1024
+
+	for index, p := range prefixes {
+		displayedValue := float64(numBytes) / (math.Pow(1024, float64(index)))
+		if displayedValue <= 1024 {
+			return fmt.Sprintf("%.2f %s", displayedValue, p)
+		}
 	}
-	return fmt.Sprintf("%.2f %s", displayedValue, prefixes[prefixIndex])
+	lastIndex := len(prefixes) - 1
+	displayedValue := float64(numBytes) / (math.Pow(1024, float64(lastIndex)))
+	return fmt.Sprintf("%.2f %s", displayedValue, prefixes[lastIndex])
 }
 
 func getDurationNs(start uint64, end uint64) float64 {

--- a/go/cli/mcap/cmd/info_test.go
+++ b/go/cli/mcap/cmd/info_test.go
@@ -39,3 +39,21 @@ func TestInfo(t *testing.T) {
 	})
 	assert.Nil(t, err)
 }
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		n      uint64
+		result string
+	}{
+		{2, "2.00 B"},
+		{1024 * 2, "2.00 KiB"},
+		{1024 * 1024 * 2, "2.00 MiB"},
+		{1024 * 1024 * 1024 * 2, "2.00 GiB"},
+		{1024 * 1024 * 1024 * 1024 * 2, "2048.00 GiB"},
+	}
+	for _, c := range cases {
+		t.Run(c.result, func(t *testing.T) {
+			assert.Equal(t, c.result, humanBytes(c.n))
+		})
+	}
+}


### PR DESCRIPTION
### Public-Facing Changes

* CLI: fixes a segfault when an MCAP contains >1024 GiB of data OR results in an greater "data rate" than 1024GiB/s

### Description

Previously the `humanBytes` function would segfault when presented with a number > 1024^4.