### PR TITLE
Go: support full uint64 range in After/Before read options

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -27,8 +27,8 @@ import (
 
 var (
 	catTopics     string
-	catStart      int64
-	catEnd        int64
+	catStart      uint64
+	catEnd        uint64
 	catFormatJSON bool
 )
 
@@ -354,8 +354,8 @@ var catCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(catCmd)
 
-	catCmd.PersistentFlags().Int64VarP(&catStart, "start-secs", "", 0, "start time")
-	catCmd.PersistentFlags().Int64VarP(&catEnd, "end-secs", "", math.MaxInt64, "end time")
+	catCmd.PersistentFlags().Uint64VarP(&catStart, "start-secs", "", 0, "start time")
+	catCmd.PersistentFlags().Uint64VarP(&catEnd, "end-secs", "", math.MaxInt64, "end time")
 	catCmd.PersistentFlags().StringVarP(&catTopics, "topics", "", "", "comma-separated list of topics")
 	catCmd.PersistentFlags().BoolVarP(&catFormatJSON, "json", "", false,
 		`print messages as JSON. Supported message encodings: ros1, protobuf, and json.`)

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -95,8 +95,8 @@ func (r *Reader) unindexedIterator(opts ReadOptions) *unindexedMessageIterator {
 		channels:         make(map[uint16]*Channel),
 		schemas:          make(map[uint16]*Schema),
 		topics:           topicMap,
-		start:            uint64(opts.Start),
-		end:              uint64(opts.End),
+		start:            opts.Start,
+		end:              opts.End,
 		metadataCallback: opts.MetadataCallback,
 	}
 }
@@ -115,8 +115,8 @@ func (r *Reader) indexedMessageIterator(
 		channels:         make(map[uint16]*Channel),
 		schemas:          make(map[uint16]*Schema),
 		topics:           topicMap,
-		start:            uint64(opts.Start),
-		end:              uint64(opts.End),
+		start:            opts.Start,
+		end:              opts.End,
 		indexHeap:        rangeIndexHeap{order: opts.Order},
 		metadataCallback: opts.MetadataCallback,
 	}
@@ -127,7 +127,7 @@ func (r *Reader) Messages(
 ) (MessageIterator, error) {
 	options := ReadOptions{
 		Start:    0,
-		End:      math.MaxInt64,
+		End:      math.MaxUint64,
 		Topics:   nil,
 		UseIndex: true,
 		Order:    FileOrder,

--- a/go/mcap/reader_options.go
+++ b/go/mcap/reader_options.go
@@ -13,8 +13,8 @@ const (
 )
 
 type ReadOptions struct {
-	Start    int64
-	End      int64
+	Start    uint64
+	End      uint64
 	Topics   []string
 	UseIndex bool
 	Order    ReadOrder
@@ -24,7 +24,7 @@ type ReadOptions struct {
 
 type ReadOpt func(*ReadOptions) error
 
-func After(start int64) ReadOpt {
+func After(start uint64) ReadOpt {
 	return func(ro *ReadOptions) error {
 		if ro.End < start {
 			return fmt.Errorf("end cannot come before start")
@@ -34,7 +34,7 @@ func After(start int64) ReadOpt {
 	}
 }
 
-func Before(end int64) ReadOpt {
+func Before(end uint64) ReadOpt {
 	return func(ro *ReadOptions) error {
 		if end < ro.Start {
 			return fmt.Errorf("end cannot come before start")


### PR DESCRIPTION
Prior to this commit, the before/end parameters forced callers to use int64, when messages really support uint64. Reading uint64-valued timestamps out of MCAP files has never been an issue -- just passing uints as parameters to these options.