### PR TITLE
go: make time range options backwards-compatible

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -168,10 +168,10 @@ func getReadOpts(useIndex bool) []mcap.ReadOpt {
 	topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
 	opts := []mcap.ReadOpt{mcap.UsingIndex(useIndex), mcap.WithTopics(topics)}
 	if catStart != 0 {
-		opts = append(opts, mcap.After(catStart*1e9))
+		opts = append(opts, mcap.AfterNanos(catStart*1e9))
 	}
 	if catEnd != math.MaxInt64 {
-		opts = append(opts, mcap.Before(catEnd*1e9))
+		opts = append(opts, mcap.BeforeNanos(catEnd*1e9))
 	}
 	return opts
 }

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -84,7 +84,7 @@ func Range(it MessageIterator, f func(*Schema, *Channel, *Message) error) error 
 	}
 }
 
-func (r *Reader) unindexedIterator(opts ReadOptions) *unindexedMessageIterator {
+func (r *Reader) unindexedIterator(opts *ReadOptions) *unindexedMessageIterator {
 	opts.Finalize()
 	topicMap := make(map[string]bool)
 	for _, topic := range opts.Topics {
@@ -103,7 +103,7 @@ func (r *Reader) unindexedIterator(opts ReadOptions) *unindexedMessageIterator {
 }
 
 func (r *Reader) indexedMessageIterator(
-	opts ReadOptions,
+	opts *ReadOptions,
 ) *indexedMessageIterator {
 	opts.Finalize()
 	topicMap := make(map[string]bool)
@@ -162,11 +162,11 @@ func (r *Reader) Messages(
 			if err != nil {
 				return nil, fmt.Errorf("failed to seek to start: %w", err)
 			}
-			return r.unindexedIterator(options), nil
+			return r.unindexedIterator(&options), nil
 		}
-		return r.indexedMessageIterator(options), nil
+		return r.indexedMessageIterator(&options), nil
 	}
-	return r.unindexedIterator(options), nil
+	return r.unindexedIterator(&options), nil
 }
 
 // Get the Header record from this MCAP.
@@ -183,7 +183,7 @@ func (r *Reader) Info() (*Info, error) {
 	if r.rs == nil {
 		return nil, fmt.Errorf("cannot get info from non-seekable reader")
 	}
-	it := r.indexedMessageIterator(ReadOptions{
+	it := r.indexedMessageIterator(&ReadOptions{
 		UseIndex: true,
 	})
 	err := it.parseSummarySection()

--- a/go/mcap/reader_options.go
+++ b/go/mcap/reader_options.go
@@ -13,15 +13,16 @@ const (
 )
 
 type ReadOptions struct {
-	Start      int64
-	End        int64
-	StartNanos uint64
-	EndNanos   uint64
-	Topics     []string
-	UseIndex   bool
-	Order      ReadOrder
+	Start    int64
+	End      int64
+	Topics   []string
+	UseIndex bool
+	Order    ReadOrder
 
 	MetadataCallback func(*Metadata) error
+
+	StartNanos uint64
+	EndNanos   uint64
 }
 
 func (ro *ReadOptions) Finalize() {

--- a/go/mcap/reader_options.go
+++ b/go/mcap/reader_options.go
@@ -13,7 +13,9 @@ const (
 )
 
 type ReadOptions struct {
-	Start    int64
+	// Deprecated: use StartNanos instead
+	Start int64
+	// Deprecated: use EndNanos instead
 	End      int64
 	Topics   []string
 	UseIndex bool

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -396,8 +396,8 @@ func TestMessageReading(t *testing.T) {
 						r, err := NewReader(reader)
 						assert.Nil(t, err)
 						it, err := r.Messages(
-							After(100),
-							Before(200),
+							AfterNanos(100),
+							BeforeNanos(200),
 							UsingIndex(useIndex),
 						)
 						assert.Nil(t, err)
@@ -865,7 +865,7 @@ func TestReadingBigTimestamps(t *testing.T) {
 		assert.Equal(t, uint64(math.MaxUint64-1), info.Statistics.MessageEndTime)
 	})
 	t.Run("message iteration works as expected", func(t *testing.T) {
-		it, err := reader.Messages(After(math.MaxUint64-2), Before(math.MaxUint64))
+		it, err := reader.Messages(AfterNanos(math.MaxUint64-2), BeforeNanos(math.MaxUint64))
 		assert.Nil(t, err)
 		count := 0
 		for {


### PR DESCRIPTION
### Public-Facing Changes

Fixed: updated changes from #1068 to be backwards-compatible.

### Description

#1068 changed the type of some public API interfaces, which is a breaking change. To avoid needing to publish a v2 library, we deprecate those APIs and introduce new ones that take the new type.
