### PR TITLE
Support 'none' compression option in merge command

### DIFF
--- a/go/cli/mcap/cmd/merge.go
+++ b/go/cli/mcap/cmd/merge.go
@@ -79,6 +79,8 @@ const (
 	AutoCoalescing  = "auto"
 	ForceCoalescing = "force"
 	NoCoalescing    = "none"
+
+	compressionNoneAlias = "none"
 )
 
 func newMCAPMerger(opts mergeOpts) *mcapMerger {
@@ -502,6 +504,11 @@ var mergeCmd = &cobra.Command{
 			defer f.Close()
 			readers = append(readers, namedReader{name: arg, reader: f})
 		}
+
+		if mergeCompression == compressionNoneAlias {
+			mergeCompression = ""
+		}
+
 		opts := mergeOpts{
 			compression:            mergeCompression,
 			chunkSize:              mergeChunkSize,


### PR DESCRIPTION
The merge command documents "none" is an option, but we were not converting that to the appropriate compression string. This led to an "unsupported compression" error when none was supplied. With this commit both "none" and the empty string are accepted.