### PR TITLE
Fix (docs): remove mcap0 from python import path

### DIFF
--- a/website/docs/guides/python/json.md
+++ b/website/docs/guides/python/json.md
@@ -94,8 +94,8 @@ We'll leave the timestamp field for later, when we write the messages into the M
 We'll start with some imports from the Python MCAP library:
 
 ```python
-from mcap.mcap0.writer import Writer
-from mcap.mcap0.well_known import SchemaEncoding, MessageEncoding
+from mcap.writer import Writer
+from mcap.well_known import SchemaEncoding, MessageEncoding
 ```
 
 Open a file where we'll output our MCAP data and write our header:


### PR DESCRIPTION
### Public-Facing Changes

Ran into this earlier; our python examples are incorrect since https://github.com/foxglove/mcap/pull/629

(website docs PR is at https://github.com/foxglove/website/pull/1347)