### PR TITLE
go: use v1.22 in go.work, update golangci-lint, enable `testifylint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
         with:
           go-version-file: go/go.work
       - name: install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
       - run: make lint
       - run: make test
       - name: Check library version

--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
     - unparam
     - errorlint
     - lll
+    - testifylint
 
 linters-settings:
   gocritic:

--- a/go/Makefile
+++ b/go/Makefile
@@ -8,6 +8,7 @@ lint:
 	make -C mcap lint
 	make -C ros lint
 	make -C cli/mcap lint
+	make -C conformance lint
 
 build-conformance-binaries:
 	make -C conformance build

--- a/go/cli/mcap/cmd/add.go
+++ b/go/cli/mcap/cmd/add.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add records to an existing MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(*cobra.Command, []string) {
 	},
 }
 

--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -52,7 +52,7 @@ func getAttachment(w io.Writer, rs io.ReadSeeker, idx *mcap.AttachmentIndex) err
 var getAttachmentCmd = &cobra.Command{
 	Use:   "attachment",
 	Short: "Get an attachment by name or offset",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
@@ -127,7 +127,7 @@ var getAttachmentCmd = &cobra.Command{
 var addAttachmentCmd = &cobra.Command{
 	Use:   "attachment",
 	Short: "Add an attachment to an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}

--- a/go/cli/mcap/cmd/attachments.go
+++ b/go/cli/mcap/cmd/attachments.go
@@ -38,13 +38,13 @@ func printAttachments(w io.Writer, attachmentIndexes []*mcap.AttachmentIndex) {
 var attachmentsCmd = &cobra.Command{
 	Use:   "attachments",
 	Short: "List attachments in an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		filename := args[0]
-		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+		err := utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)

--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -294,7 +294,7 @@ func printMessages(
 var catCmd = &cobra.Command{
 	Use:   "cat [file]",
 	Short: "Cat the messages in an MCAP file to stdout",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		stat, err := os.Stdin.Stat()
 		if err != nil {
@@ -329,7 +329,7 @@ var catCmd = &cobra.Command{
 			die("supply a file")
 		}
 		filename := args[0]
-		err = utils.WithReader(ctx, filename, func(remote bool, rs io.ReadSeeker) error {
+		err = utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to create reader: %w", err)

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCat(t *testing.T) {
@@ -29,19 +29,19 @@ func TestCat(t *testing.T) {
 	}
 	for _, c := range cases {
 		input, err := os.ReadFile(c.inputfile)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		w := new(bytes.Buffer)
 		r := bytes.NewReader(input)
 		t.Run(c.assertion, func(t *testing.T) {
 			reader, err := mcap.NewReader(r)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			defer reader.Close()
 			it, err := reader.Messages()
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			err = printMessages(w, it, false)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			r.Reset(input)
-			assert.Equal(t, c.expected, w.String())
+			require.Equal(t, c.expected, w.String())
 		})
 	}
 }
@@ -60,19 +60,19 @@ func BenchmarkCat(b *testing.B) {
 	}
 	for _, c := range cases {
 		input, err := os.ReadFile(c.inputfile)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 		w := io.Discard
 		r := bytes.NewReader(input)
 		b.Run(c.assertion, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				func() {
 					reader, err := mcap.NewReader(r)
-					assert.Nil(b, err)
+					require.NoError(b, err)
 					defer reader.Close()
 					it, err := reader.Messages()
-					assert.Nil(b, err)
+					require.NoError(b, err)
 					err = printMessages(w, it, c.formatJSON)
-					assert.Nil(b, err)
+					require.NoError(b, err)
 					r.Reset(input)
 				}()
 			}

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,7 @@ func TestCat(t *testing.T) {
 			err = printMessages(w, it, false)
 			require.NoError(t, err)
 			r.Reset(input)
-			require.Equal(t, c.expected, w.String())
+			assert.Equal(t, c.expected, w.String())
 		})
 	}
 }

--- a/go/cli/mcap/cmd/channels.go
+++ b/go/cli/mcap/cmd/channels.go
@@ -44,13 +44,13 @@ func printChannels(w io.Writer, channels []*mcap.Channel) error {
 var channelsCmd = &cobra.Command{
 	Use:   "channels",
 	Short: "List channels in an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		filename := args[0]
-		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+		err := utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)

--- a/go/cli/mcap/cmd/chunks.go
+++ b/go/cli/mcap/cmd/chunks.go
@@ -46,13 +46,13 @@ func printChunks(w io.Writer, chunkIndexes []*mcap.ChunkIndex) {
 var chunksCmd = &cobra.Command{
 	Use:   "chunks",
 	Short: "List chunks in an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		filename := args[0]
-		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+		err := utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)

--- a/go/cli/mcap/cmd/convert.go
+++ b/go/cli/mcap/cmd/convert.go
@@ -76,7 +76,7 @@ var convertCmd = &cobra.Command{
 	Use:   "convert [input] [output]",
 	Short: "Convert a bag file to an MCAP file",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		filetype, err := checkMagic(args[0])
 		if err != nil {
 			die("magic number check failed: %s", err)
@@ -132,7 +132,7 @@ var convertCmd = &cobra.Command{
 				die("failed to seek to start of file: %s", err)
 			}
 
-			err = ros.Bag2MCAP(bw, f, opts, func(data []byte) error {
+			err = ros.Bag2MCAP(bw, f, opts, func([]byte) error {
 				progressBarErr := progressBar.Add64(1)
 				if progressBarErr != nil {
 					die("failed to increment progressbar: %s", err)
@@ -162,7 +162,7 @@ var convertCmd = &cobra.Command{
 				amentPath += string(os.PathListSeparator) + prefixPath
 			}
 			dirs := strings.FieldsFunc(amentPath, func(c rune) bool { return (c == os.PathListSeparator) })
-			err = ros.DB3ToMCAP(bw, db, opts, dirs, func(b []byte) error {
+			err = ros.DB3ToMCAP(bw, db, opts, dirs, func([]byte) error {
 				progressBarErr := progressBar.Add64(1)
 				if progressBarErr != nil {
 					die("failed to increment progressbar: %s", err)

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -269,7 +269,7 @@ func (doctor *mcapDoctor) Examine() error {
 				doctor.warn("Set the Header.library field to a value that identifies the software that produced the file.")
 			}
 
-			if len(header.Profile) > 0 && header.Profile != "ros1" && header.Profile != "ros2" {
+			if header.Profile != "" && header.Profile != "ros1" && header.Profile != "ros2" {
 				doctor.warn(`Header.profile field "%s" is not a well-known profile.`, header.Profile)
 			}
 		case mcap.TokenFooter:

--- a/go/cli/mcap/cmd/doctor_test.go
+++ b/go/cli/mcap/cmd/doctor_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNoErrorOnMessagelessChunks(t *testing.T) {
@@ -14,21 +14,21 @@ func TestNoErrorOnMessagelessChunks(t *testing.T) {
 		Chunked:   true,
 		ChunkSize: 10,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{
 		Profile: "",
 		Library: "",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       1,
 		SchemaID: 0,
 		Topic:    "schemaless_topic",
 	}))
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 
 	rs := bytes.NewReader(buf.Bytes())
 
 	doctor := newMcapDoctor(rs)
 	err = doctor.Examine()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -413,7 +413,7 @@ usage:
 			"zstd",
 			"compression algorithm to use on output file",
 		)
-		filterCmd.Run = func(cmd *cobra.Command, args []string) {
+		filterCmd.Run = func(_ *cobra.Command, args []string) {
 			filterOptions, err := buildFilterOptions(&filterFlags{
 				output:             *output,
 				includeTopics:      *includeTopics,
@@ -449,7 +449,7 @@ usage:
 			"zstd",
 			"compression algorithm to use on output file",
 		)
-		recoverCmd.Run = func(cmd *cobra.Command, args []string) {
+		recoverCmd.Run = func(_ *cobra.Command, args []string) {
 			filterOptions, err := buildFilterOptions(&filterFlags{
 				output:             *output,
 				chunkSize:          *chunkSize,
@@ -482,7 +482,7 @@ usage:
 			"zstd",
 			"compression algorithm to use on output file",
 		)
-		compressCmd.Run = func(cmd *cobra.Command, args []string) {
+		compressCmd.Run = func(_ *cobra.Command, args []string) {
 			filterOptions, err := buildFilterOptions(&filterFlags{
 				output:             *output,
 				chunkSize:          *chunkSize,
@@ -509,7 +509,7 @@ usage:
 		}
 		output := decompressCmd.PersistentFlags().StringP("output", "o", "", "output filename")
 		chunkSize := decompressCmd.PersistentFlags().Int64P("chunk-size", "", 4*1024*1024, "chunk size of output file")
-		decompressCmd.Run = func(cmd *cobra.Command, args []string) {
+		decompressCmd.Run = func(_ *cobra.Command, args []string) {
 			filterOptions, err := buildFilterOptions(&filterFlags{
 				output:             *output,
 				chunkSize:          *chunkSize,

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func writeFilterTestInput(t *testing.T, w io.Writer) {
@@ -16,50 +17,50 @@ func writeFilterTestInput(t *testing.T, w io.Writer) {
 		Chunked:   true,
 		ChunkSize: 10,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, writer.WriteHeader(&mcap.Header{}))
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID: 1,
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       1,
 		SchemaID: 1,
 		Topic:    "camera_a",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       2,
 		SchemaID: 1,
 		Topic:    "camera_b",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       3,
 		SchemaID: 0,
 		Topic:    "radar_a",
 	}))
 	for i := 0; i < 100; i++ {
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: 1,
 			LogTime:   uint64(i),
 		}))
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: 2,
 			LogTime:   uint64(i),
 		}))
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: 3,
 			LogTime:   uint64(i),
 		}))
 	}
-	assert.Nil(t, writer.WriteAttachment(&mcap.Attachment{
+	require.NoError(t, writer.WriteAttachment(&mcap.Attachment{
 		LogTime: 50,
 		Name:    "attachment",
 		Data:    bytes.NewReader(nil),
 	}))
-	assert.Nil(t, writer.WriteMetadata(&mcap.Metadata{
+	require.NoError(t, writer.WriteMetadata(&mcap.Metadata{
 		Name: "metadata",
 	}))
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 }
 func TestPassthrough(t *testing.T) {
 	opts := &filterOpts{
@@ -74,7 +75,7 @@ func TestPassthrough(t *testing.T) {
 	readBuf := bytes.Buffer{}
 
 	writeFilterTestInput(t, &readBuf)
-	assert.Nil(t, filter(&readBuf, &writeBuf, opts))
+	require.NoError(t, filter(&readBuf, &writeBuf, opts))
 	attachmentCounter := 0
 	metadataCounter := 0
 	schemaCounter := 0
@@ -94,22 +95,22 @@ func TestPassthrough(t *testing.T) {
 			return nil
 		},
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer lexer.Close()
 	for {
 		token, record, err := lexer.Next(nil)
 		if err != nil {
-			assert.ErrorIs(t, err, io.EOF)
+			require.ErrorIs(t, err, io.EOF)
 			break
 		}
 		switch token {
 		case mcap.TokenMessage:
 			message, err := mcap.ParseMessage(record)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			messageCounter[message.ChannelID]++
 		case mcap.TokenChannel:
 			channel, err := mcap.ParseChannel(record)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			channelCounter[channel.ID]++
 		case mcap.TokenSchema:
 			schemaCounter++
@@ -117,12 +118,12 @@ func TestPassthrough(t *testing.T) {
 			metadataCounter++
 		}
 	}
-	assert.Equal(t, 1, attachmentCounter)
-	assert.Equal(t, 1, metadataCounter)
-	assert.InDeltaMapValues(t, map[uint16]int{1: 100, 2: 100, 3: 100}, messageCounter, 0.0)
+	require.Equal(t, 1, attachmentCounter)
+	require.Equal(t, 1, metadataCounter)
+	require.InDeltaMapValues(t, map[uint16]int{1: 100, 2: 100, 3: 100}, messageCounter, 0.0)
 	// schemas and channels should be duplicated once into the summary section
-	assert.Equal(t, 2, schemaCounter)
-	assert.InDeltaMapValues(t, map[uint16]int{1: 2, 2: 2, 3: 2}, channelCounter, 0.0)
+	require.Equal(t, 2, schemaCounter)
+	require.InDeltaMapValues(t, map[uint16]int{1: 2, 2: 2, 3: 2}, channelCounter, 0.0)
 }
 
 func TestFiltering(t *testing.T) {
@@ -218,7 +219,7 @@ func TestFiltering(t *testing.T) {
 			readBuf := bytes.Buffer{}
 
 			writeFilterTestInput(t, &readBuf)
-			assert.Nil(t, filter(&readBuf, &writeBuf, c.opts))
+			require.NoError(t, filter(&readBuf, &writeBuf, c.opts))
 			attachmentCounter := 0
 			metadataCounter := 0
 			lexer, err := mcap.NewLexer(&writeBuf, &mcap.LexerOptions{
@@ -227,7 +228,7 @@ func TestFiltering(t *testing.T) {
 					return nil
 				},
 			})
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			defer lexer.Close()
 			messageCounter := map[uint16]int{
 				1: 0,
@@ -237,21 +238,21 @@ func TestFiltering(t *testing.T) {
 			for {
 				token, record, err := lexer.Next(nil)
 				if err != nil {
-					assert.ErrorIs(t, err, io.EOF)
+					require.ErrorIs(t, err, io.EOF)
 					break
 				}
 				switch token {
 				case mcap.TokenMessage:
 					message, err := mcap.ParseMessage(record)
-					assert.Nil(t, err)
+					require.NoError(t, err)
 					messageCounter[message.ChannelID]++
 				case mcap.TokenMetadata:
 					metadataCounter++
 				}
 			}
-			assert.Equal(t, c.expectedAttachmentCount, attachmentCounter)
-			assert.Equal(t, c.expectedMetadataCount, metadataCounter)
-			assert.InDeltaMapValues(t, c.expectedMessageCount, messageCounter, 0.0)
+			require.Equal(t, c.expectedAttachmentCount, attachmentCounter)
+			require.Equal(t, c.expectedMetadataCount, metadataCounter)
+			require.InDeltaMapValues(t, c.expectedMessageCount, messageCounter, 0.0)
 		})
 	}
 }
@@ -263,7 +264,7 @@ func TestRecover(t *testing.T) {
 		writeFilterTestInput(t, &readBuf)
 		readBuf.Truncate(readBuf.Len() / 2)
 
-		assert.Nil(t, filter(&readBuf, &writeBuf, &filterOpts{
+		require.NoError(t, filter(&readBuf, &writeBuf, &filterOpts{
 			end:                1000,
 			recover:            true,
 			includeAttachments: true,
@@ -283,26 +284,26 @@ func TestRecover(t *testing.T) {
 				return nil
 			},
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		defer lexer.Close()
 		for {
 			token, record, err := lexer.Next(nil)
 			if err != nil {
-				assert.ErrorIs(t, err, io.EOF)
+				require.ErrorIs(t, err, io.EOF)
 				break
 			}
 			switch token {
 			case mcap.TokenMessage:
 				message, err := mcap.ParseMessage(record)
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				messageCounter[message.ChannelID]++
 			case mcap.TokenMetadata:
 				metadataCounter++
 			}
 		}
-		assert.Equal(t, 0, attachmentCounter)
-		assert.Equal(t, 0, metadataCounter)
-		assert.InDeltaMapValues(t, map[uint16]int{
+		require.Equal(t, 0, attachmentCounter)
+		require.Equal(t, 0, metadataCounter)
+		require.InDeltaMapValues(t, map[uint16]int{
 			1: 88,
 			2: 88,
 			3: 88,
@@ -315,7 +316,7 @@ func TestRecover(t *testing.T) {
 		writeFilterTestInput(t, &readBuf)
 		readBuf.Bytes()[0x12b] = 1 // overwrite crc
 
-		assert.Nil(t, filter(&readBuf, &writeBuf, &filterOpts{
+		require.NoError(t, filter(&readBuf, &writeBuf, &filterOpts{
 			end:                1000,
 			recover:            true,
 			includeAttachments: true,
@@ -334,25 +335,25 @@ func TestRecover(t *testing.T) {
 				return nil
 			},
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		for {
 			token, record, err := lexer.Next(nil)
 			if err != nil {
-				assert.ErrorIs(t, err, io.EOF)
+				require.ErrorIs(t, err, io.EOF)
 				break
 			}
 			switch token {
 			case mcap.TokenMessage:
 				message, err := mcap.ParseMessage(record)
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				messageCounter[message.ChannelID]++
 			case mcap.TokenMetadata:
 				metadataCounter++
 			}
 		}
-		assert.Equal(t, 1, attachmentCounter)
-		assert.Equal(t, 1, metadataCounter)
-		assert.InDeltaMapValues(t, map[uint16]int{
+		require.Equal(t, 1, attachmentCounter)
+		require.Equal(t, 1, metadataCounter)
+		require.InDeltaMapValues(t, map[uint16]int{
 			1: 100,
 			2: 99,
 			3: 100,
@@ -362,8 +363,8 @@ func TestRecover(t *testing.T) {
 
 func TestCompileMatchers(t *testing.T) {
 	matchers, err := compileMatchers([]string{"camera.*", "lights.*"})
-	assert.Nil(t, err)
-	assert.Equal(t, len(matchers), 2)
-	assert.True(t, matchers[0].MatchString("camera"))
-	assert.True(t, matchers[1].MatchString("lights"))
+	require.NoError(t, err)
+	assert.Len(t, matchers, 2)
+	require.True(t, matchers[0].MatchString("camera"))
+	require.True(t, matchers[1].MatchString("lights"))
 }

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -89,7 +89,7 @@ func TestPassthrough(t *testing.T) {
 		3: 0,
 	}
 	lexer, err := mcap.NewLexer(&writeBuf, &mcap.LexerOptions{
-		AttachmentCallback: func(ar *mcap.AttachmentReader) error {
+		AttachmentCallback: func(*mcap.AttachmentReader) error {
 			attachmentCounter++
 			return nil
 		},
@@ -222,7 +222,7 @@ func TestFiltering(t *testing.T) {
 			attachmentCounter := 0
 			metadataCounter := 0
 			lexer, err := mcap.NewLexer(&writeBuf, &mcap.LexerOptions{
-				AttachmentCallback: func(ar *mcap.AttachmentReader) error {
+				AttachmentCallback: func(*mcap.AttachmentReader) error {
 					attachmentCounter++
 					return nil
 				},
@@ -278,7 +278,7 @@ func TestRecover(t *testing.T) {
 		attachmentCounter := 0
 		metadataCounter := 0
 		lexer, err := mcap.NewLexer(&writeBuf, &mcap.LexerOptions{
-			AttachmentCallback: func(ar *mcap.AttachmentReader) error {
+			AttachmentCallback: func(*mcap.AttachmentReader) error {
 				attachmentCounter++
 				return nil
 			},
@@ -329,7 +329,7 @@ func TestRecover(t *testing.T) {
 		attachmentCounter := 0
 		metadataCounter := 0
 		lexer, err := mcap.NewLexer(&writeBuf, &mcap.LexerOptions{
-			AttachmentCallback: func(ar *mcap.AttachmentReader) error {
+			AttachmentCallback: func(_ *mcap.AttachmentReader) error {
 				attachmentCounter++
 				return nil
 			},

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -118,12 +118,12 @@ func TestPassthrough(t *testing.T) {
 			metadataCounter++
 		}
 	}
-	require.Equal(t, 1, attachmentCounter)
-	require.Equal(t, 1, metadataCounter)
-	require.InDeltaMapValues(t, map[uint16]int{1: 100, 2: 100, 3: 100}, messageCounter, 0.0)
+	assert.Equal(t, 1, attachmentCounter)
+	assert.Equal(t, 1, metadataCounter)
+	assert.InDeltaMapValues(t, map[uint16]int{1: 100, 2: 100, 3: 100}, messageCounter, 0.0)
 	// schemas and channels should be duplicated once into the summary section
-	require.Equal(t, 2, schemaCounter)
-	require.InDeltaMapValues(t, map[uint16]int{1: 2, 2: 2, 3: 2}, channelCounter, 0.0)
+	assert.Equal(t, 2, schemaCounter)
+	assert.InDeltaMapValues(t, map[uint16]int{1: 2, 2: 2, 3: 2}, channelCounter, 0.0)
 }
 
 func TestFiltering(t *testing.T) {
@@ -250,9 +250,9 @@ func TestFiltering(t *testing.T) {
 					metadataCounter++
 				}
 			}
-			require.Equal(t, c.expectedAttachmentCount, attachmentCounter)
-			require.Equal(t, c.expectedMetadataCount, metadataCounter)
-			require.InDeltaMapValues(t, c.expectedMessageCount, messageCounter, 0.0)
+			assert.Equal(t, c.expectedAttachmentCount, attachmentCounter)
+			assert.Equal(t, c.expectedMetadataCount, metadataCounter)
+			assert.InDeltaMapValues(t, c.expectedMessageCount, messageCounter, 0.0)
 		})
 	}
 }
@@ -301,9 +301,9 @@ func TestRecover(t *testing.T) {
 				metadataCounter++
 			}
 		}
-		require.Equal(t, 0, attachmentCounter)
-		require.Equal(t, 0, metadataCounter)
-		require.InDeltaMapValues(t, map[uint16]int{
+		assert.Equal(t, 0, attachmentCounter)
+		assert.Equal(t, 0, metadataCounter)
+		assert.InDeltaMapValues(t, map[uint16]int{
 			1: 88,
 			2: 88,
 			3: 88,
@@ -351,9 +351,9 @@ func TestRecover(t *testing.T) {
 				metadataCounter++
 			}
 		}
-		require.Equal(t, 1, attachmentCounter)
-		require.Equal(t, 1, metadataCounter)
-		require.InDeltaMapValues(t, map[uint16]int{
+		assert.Equal(t, 1, attachmentCounter)
+		assert.Equal(t, 1, metadataCounter)
+		assert.InDeltaMapValues(t, map[uint16]int{
 			1: 100,
 			2: 99,
 			3: 100,
@@ -365,6 +365,6 @@ func TestCompileMatchers(t *testing.T) {
 	matchers, err := compileMatchers([]string{"camera.*", "lights.*"})
 	require.NoError(t, err)
 	assert.Len(t, matchers, 2)
-	require.True(t, matchers[0].MatchString("camera"))
-	require.True(t, matchers[1].MatchString("lights"))
+	assert.True(t, matchers[0].MatchString("camera"))
+	assert.True(t, matchers[1].MatchString("lights"))
 }

--- a/go/cli/mcap/cmd/get.go
+++ b/go/cli/mcap/cmd/get.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get a record from an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		err := cmd.Help()
 		if err != nil {
 			die("failed to run help command: %s", err)

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -181,14 +181,14 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Report statistics about an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		// check if it's a remote file
 		filename := args[0]
-		err := utils.WithReader(ctx, filename, func(remote bool, rs io.ReadSeeker) error {
+		err := utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)

--- a/go/cli/mcap/cmd/info_test.go
+++ b/go/cli/mcap/cmd/info_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInfo(t *testing.T) {
@@ -22,22 +23,22 @@ func TestInfo(t *testing.T) {
 		if strings.HasSuffix(path, ".mcap") {
 			t.Run(path, func(t *testing.T) {
 				input, err := os.ReadFile(path)
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				r := bytes.NewReader(input)
 				w := new(bytes.Buffer)
 
 				reader, err := mcap.NewReader(r)
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				defer reader.Close()
 				info, err := reader.Info()
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				err = printInfo(w, info)
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			})
 		}
 		return nil
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestHumanBytes(t *testing.T) {

--- a/go/cli/mcap/cmd/list.go
+++ b/go/cli/mcap/cmd/list.go
@@ -7,7 +7,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List records of an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		err := cmd.Help()
 		if err != nil {
 			die("failed to run help command: %s", err)

--- a/go/cli/mcap/cmd/merge.go
+++ b/go/cli/mcap/cmd/merge.go
@@ -489,7 +489,7 @@ type namedReader struct {
 var mergeCmd = &cobra.Command{
 	Use:   "merge file1.mcap [file2.mcap] [file3.mcap]...",
 	Short: "Merge a selection of MCAP files by record timestamp",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if mergeOutputFile == "" && !utils.StdoutRedirected() {
 			die(PleaseRedirect)
 		}

--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -143,7 +143,7 @@ func TestMCAPMerging(t *testing.T) {
 				assert.Nil(t, err)
 
 				messages := make(map[string]int)
-				err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {
+				err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 					messages[channel.Topic]++
 					return nil
 				})
@@ -346,7 +346,7 @@ func TestMultiChannelInput(t *testing.T) {
 	it, err := reader.Messages(mcap.UsingIndex(false))
 	assert.Nil(t, err)
 	messages := make(map[string]int)
-	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {
+	err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 		messages[channel.Topic]++
 		return nil
 	})
@@ -379,7 +379,7 @@ func TestSchemalessChannelInput(t *testing.T) {
 	assert.Nil(t, err)
 	messages := make(map[string]int)
 	schemaIDs := make(map[uint16]int)
-	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {
+	err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 		messages[channel.Topic]++
 		schemaIDs[channel.SchemaID]++
 		return nil
@@ -432,7 +432,7 @@ func TestMultipleSchemalessChannelSingleInput(t *testing.T) {
 	assert.Nil(t, err)
 	messages := make(map[string]int)
 	schemaIDs := make(map[uint16]int)
-	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {
+	err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 		messages[channel.Topic]++
 		schemaIDs[channel.SchemaID]++
 		return nil
@@ -519,7 +519,7 @@ func TestSameSchemasNotDuplicated(t *testing.T) {
 	assert.Nil(t, err)
 	schemas := make(map[uint16]bool)
 	var schemaNames []string
-	err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {
+	err = mcap.Range(it, func(schema *mcap.Schema, _ *mcap.Channel, _ *mcap.Message) error {
 		_, ok := schemas[schema.ID]
 		if !ok {
 			schemas[schema.ID] = true
@@ -566,7 +566,7 @@ func TestChannelCoalesceBehavior(t *testing.T) {
 		it, err := reader.Messages(mcap.UsingIndex(false))
 		assert.Nil(t, err)
 		messages := make(map[uint16]int)
-		err = mcap.Range(it, func(schema *mcap.Schema, channel *mcap.Channel, message *mcap.Message) error {
+		err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 			messages[channel.ID]++
 			return nil
 		})

--- a/go/cli/mcap/cmd/merge_test.go
+++ b/go/cli/mcap/cmd/merge_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type prepInputOptions struct {
@@ -42,13 +43,13 @@ func prepInput(t *testing.T, w io.Writer, schema *mcap.Schema, channel *mcap.Cha
 	}
 
 	writer, err := mcap.NewWriter(w, options.writerOptions)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
+	require.NoError(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
 	if schema.ID != 0 {
-		assert.Nil(t, writer.WriteSchema(schema))
+		require.NoError(t, writer.WriteSchema(schema))
 	}
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:              channel.ID,
 		SchemaID:        schema.ID,
 		Topic:           channel.Topic,
@@ -56,13 +57,13 @@ func prepInput(t *testing.T, w io.Writer, schema *mcap.Schema, channel *mcap.Cha
 		Metadata:        channel.Metadata,
 	}))
 	for i := 0; i < 100; i++ {
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: channel.ID,
 			LogTime:   uint64(i),
 		}))
 	}
 
-	assert.Nil(t, writer.WriteMetadata(&mcap.Metadata{
+	require.NoError(t, writer.WriteMetadata(&mcap.Metadata{
 		Name: "a",
 		Metadata: map[string]string{
 			"b":     "c",
@@ -72,10 +73,10 @@ func prepInput(t *testing.T, w io.Writer, schema *mcap.Schema, channel *mcap.Cha
 
 	if options.attachment != nil {
 		err = writer.WriteAttachment(options.attachment)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	}
 
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 }
 
 func TestMCAPMerging(t *testing.T) {
@@ -130,34 +131,34 @@ func TestMCAPMerging(t *testing.T) {
 					{"buf2", bytes.NewReader(buf2.Bytes())},
 					{"buf3", bytes.NewReader(buf3.Bytes())},
 				}
-				assert.ErrorIs(t, merger.mergeInputs(output, inputs), c.expectedError)
+				require.ErrorIs(t, merger.mergeInputs(output, inputs), c.expectedError)
 				if c.expectedError != nil {
 					return
 				}
 
 				// output should now be a well-formed mcap
 				reader, err := mcap.NewReader(bytes.NewReader(output.Bytes()))
-				assert.Nil(t, err)
-				assert.Equal(t, reader.Header().Profile, "testprofile")
+				require.NoError(t, err)
+				assert.Equal(t, "testprofile", reader.Header().Profile)
 				it, err := reader.Messages(mcap.UsingIndex(false))
-				assert.Nil(t, err)
+				require.NoError(t, err)
 
 				messages := make(map[string]int)
 				err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 					messages[channel.Topic]++
 					return nil
 				})
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 100, messages["/foo"])
 				assert.Equal(t, 100, messages["/bar"])
 				assert.Equal(t, 100, messages["/baz"])
 
 				info, err := reader.Info()
-				assert.Nil(t, err)
-				assert.Equal(t, c.expectedMetadata, len(info.MetadataIndexes))
+				require.NoError(t, err)
+				assert.Len(t, info.MetadataIndexes, c.expectedMetadata)
 				for _, idx := range info.MetadataIndexes {
 					_, err := reader.GetMetadata(idx.Offset)
-					assert.Nil(t, err)
+					require.NoError(t, err)
 				}
 				reader.Close()
 			})
@@ -223,16 +224,16 @@ func TestAttachmentMerging(t *testing.T) {
 			}
 
 			err := merger.mergeInputs(output, inputs)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			reader, err := mcap.NewReader(bytes.NewReader(output.Bytes()))
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			defer reader.Close()
 
 			info, err := reader.Info()
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
-			assert.Equal(t, 2, len(info.AttachmentIndexes))
+			assert.Len(t, info.AttachmentIndexes, 2)
 			for _, attIndex := range info.AttachmentIndexes {
 				assert.Equal(t, &mcap.Attachment{
 					LogTime:    1,
@@ -249,9 +250,9 @@ func TestAttachmentMerging(t *testing.T) {
 				})
 
 				attReader, err := reader.GetAttachmentReader(attIndex.Offset)
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				data, err := io.ReadAll(attReader.Data())
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, []byte{1, 2, 3}, data)
 			}
 		})
@@ -263,57 +264,57 @@ func TestChannelsWithSameSchema(t *testing.T) {
 	writer, err := mcap.NewWriter(buf, &mcap.WriterOptions{
 		Chunked: true,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
 
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID:   1,
 		Name: "foo",
 	}))
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID:   2,
 		Name: "bar",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       1,
 		SchemaID: 2,
 		Topic:    "/bar1",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       2,
 		SchemaID: 2,
 		Topic:    "/bar2",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       3,
 		SchemaID: 1,
 		Topic:    "/foo",
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID: 1,
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID: 2,
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID: 3,
 	}))
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 	merger := newMCAPMerger(mergeOpts{
 		chunked:          true,
 		coalesceChannels: "none",
 	})
 	output := &bytes.Buffer{}
-	assert.Nil(t, merger.mergeInputs(output, []namedReader{{"buf", bytes.NewReader(buf.Bytes())}}))
+	require.NoError(t, merger.mergeInputs(output, []namedReader{{"buf", bytes.NewReader(buf.Bytes())}}))
 	reader, err := mcap.NewReader(bytes.NewReader(output.Bytes()))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	info, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	assert.NotNil(t, info.Schemas)
-	assert.Equal(t, 2, len(info.Schemas))
-	assert.Equal(t, info.Schemas[1].Name, "bar")
-	assert.Equal(t, info.Schemas[2].Name, "foo")
+	require.NotNil(t, info.Schemas)
+	assert.Len(t, info.Schemas, 2)
+	assert.Equal(t, "bar", info.Schemas[1].Name)
+	assert.Equal(t, "foo", info.Schemas[2].Name)
 }
 
 func TestMultiChannelInput(t *testing.T) {
@@ -330,7 +331,7 @@ func TestMultiChannelInput(t *testing.T) {
 		{"buf1", bytes.NewReader(buf1.Bytes())},
 		{"buf2", bytes.NewReader(buf2.Bytes())},
 	}
-	assert.Nil(t, merger.mergeInputs(multiChannelInput, inputs))
+	require.NoError(t, merger.mergeInputs(multiChannelInput, inputs))
 	buf3 := &bytes.Buffer{}
 	prepInput(t, buf3, &mcap.Schema{ID: 2}, &mcap.Channel{ID: 2, Topic: "/baz"})
 	output := &bytes.Buffer{}
@@ -338,19 +339,19 @@ func TestMultiChannelInput(t *testing.T) {
 		{"multiChannelInput", bytes.NewReader(multiChannelInput.Bytes())},
 		{"buf3", bytes.NewReader(buf3.Bytes())},
 	}
-	assert.Nil(t, merger.mergeInputs(output, inputs2))
+	require.NoError(t, merger.mergeInputs(output, inputs2))
 	reader, err := mcap.NewReader(output)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer reader.Close()
-	assert.Equal(t, reader.Header().Profile, "testprofile")
+	assert.Equal(t, "testprofile", reader.Header().Profile)
 	it, err := reader.Messages(mcap.UsingIndex(false))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	messages := make(map[string]int)
 	err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 		messages[channel.Topic]++
 		return nil
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 100, messages["/foo"])
 	assert.Equal(t, 100, messages["/bar"])
 	assert.Equal(t, 100, messages["/baz"])
@@ -369,14 +370,14 @@ func TestSchemalessChannelInput(t *testing.T) {
 		{"buf1", bytes.NewReader(buf1.Bytes())},
 		{"buf2", bytes.NewReader(buf2.Bytes())},
 	}
-	assert.Nil(t, merger.mergeInputs(output, inputs))
+	require.NoError(t, merger.mergeInputs(output, inputs))
 
 	// output should now be a well-formed mcap
 	reader, err := mcap.NewReader(output)
-	assert.Nil(t, err)
-	assert.Equal(t, reader.Header().Profile, "testprofile")
+	require.NoError(t, err)
+	assert.Equal(t, "testprofile", reader.Header().Profile)
 	it, err := reader.Messages(mcap.UsingIndex(false))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	messages := make(map[string]int)
 	schemaIDs := make(map[uint16]int)
 	err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
@@ -384,7 +385,7 @@ func TestSchemalessChannelInput(t *testing.T) {
 		schemaIDs[channel.SchemaID]++
 		return nil
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 100, messages["/foo"])
 	assert.Equal(t, 100, messages["/bar"])
 	assert.Equal(t, 100, schemaIDs[0])
@@ -396,40 +397,40 @@ func TestMultipleSchemalessChannelSingleInput(t *testing.T) {
 	writer, err := mcap.NewWriter(buf, &mcap.WriterOptions{
 		Chunked: true,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{Profile: "testprofile"}))
 
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       1,
 		SchemaID: 0,
 		Topic:    "/foo",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:       2,
 		SchemaID: 0,
 		Topic:    "/bar",
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID: 1,
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID: 2,
 	}))
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 
 	merger := newMCAPMerger(mergeOpts{coalesceChannels: "none"})
 	output := &bytes.Buffer{}
 	inputs := []namedReader{
 		{"buf", bytes.NewReader(buf.Bytes())},
 	}
-	assert.Nil(t, merger.mergeInputs(output, inputs))
+	require.NoError(t, merger.mergeInputs(output, inputs))
 
 	// output should now be a well-formed mcap
 	reader, err := mcap.NewReader(output)
-	assert.Nil(t, err)
-	assert.Equal(t, reader.Header().Profile, "testprofile")
+	require.NoError(t, err)
+	assert.Equal(t, "testprofile", reader.Header().Profile)
 	it, err := reader.Messages(mcap.UsingIndex(false))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	messages := make(map[string]int)
 	schemaIDs := make(map[uint16]int)
 	err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
@@ -437,7 +438,7 @@ func TestMultipleSchemalessChannelSingleInput(t *testing.T) {
 		schemaIDs[channel.SchemaID]++
 		return nil
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, messages["/foo"])
 	assert.Equal(t, 1, messages["/bar"])
 	assert.Equal(t, 2, schemaIDs[0])
@@ -485,9 +486,9 @@ func TestBadInputGivesNamedErrors(t *testing.T) {
 				}
 				output := &bytes.Buffer{}
 				err := merger.mergeInputs(output, inputs)
-				assert.NotNil(t, err)
-				assert.ErrorContains(t, err, "filename")
-				assert.ErrorContains(t, err, c.errContains)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "filename")
+				require.ErrorContains(t, err, c.errContains)
 			})
 		}
 	}
@@ -510,13 +511,13 @@ func TestSameSchemasNotDuplicated(t *testing.T) {
 		{"buf2", bytes.NewReader(buf2.Bytes())},
 		{"buf3", bytes.NewReader(buf3.Bytes())},
 	}
-	assert.Nil(t, merger.mergeInputs(output, inputs))
+	require.NoError(t, merger.mergeInputs(output, inputs))
 	// output should now be a well-formed mcap
 	reader, err := mcap.NewReader(output)
-	assert.Nil(t, err)
-	assert.Equal(t, reader.Header().Profile, "testprofile")
+	require.NoError(t, err)
+	assert.Equal(t, "testprofile", reader.Header().Profile)
 	it, err := reader.Messages(mcap.UsingIndex(false))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	schemas := make(map[uint16]bool)
 	var schemaNames []string
 	err = mcap.Range(it, func(schema *mcap.Schema, _ *mcap.Channel, _ *mcap.Message) error {
@@ -530,8 +531,8 @@ func TestSameSchemasNotDuplicated(t *testing.T) {
 	if err != nil {
 		die("failed to iterate through schemas: %s", err)
 	}
-	assert.Equal(t, 2, len(schemas))
-	assert.Equal(t, schemaNames, []string{"SchemaA", "SchemaB"})
+	assert.Len(t, schemas, 2)
+	assert.Equal(t, []string{"SchemaA", "SchemaB"}, schemaNames)
 }
 
 func TestChannelCoalesceBehavior(t *testing.T) {
@@ -558,19 +559,19 @@ func TestChannelCoalesceBehavior(t *testing.T) {
 			{"buf4", bytes.NewReader(buf4.Bytes())},
 		}
 		merger := newMCAPMerger(mergeOpts{coalesceChannels: coalesceChannels, allowDuplicateMetadata: true})
-		assert.Nil(t, merger.mergeInputs(output, inputs))
+		require.NoError(t, merger.mergeInputs(output, inputs))
 		// output should now be a well-formed mcap
 		reader, err := mcap.NewReader(output)
-		assert.Nil(t, err)
-		assert.Equal(t, reader.Header().Profile, "testprofile")
+		require.NoError(t, err)
+		assert.Equal(t, "testprofile", reader.Header().Profile)
 		it, err := reader.Messages(mcap.UsingIndex(false))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		messages := make(map[uint16]int)
 		err = mcap.Range(it, func(_ *mcap.Schema, channel *mcap.Channel, _ *mcap.Message) error {
 			messages[channel.ID]++
 			return nil
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, messagesByChannel, messages)
 	}
 }

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -68,13 +68,13 @@ func printMetadata(w io.Writer, r io.ReadSeeker, info *mcap.Info) error {
 var listMetadataCmd = &cobra.Command{
 	Use:   "metadata",
 	Short: "List metadata in an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		filename := args[0]
-		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+		err := utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to build mcap reader: %w", err)
@@ -95,7 +95,7 @@ var listMetadataCmd = &cobra.Command{
 var addMetadataCmd = &cobra.Command{
 	Use:   "metadata",
 	Short: "Add metadata to an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
@@ -135,7 +135,7 @@ var addMetadataCmd = &cobra.Command{
 var getMetadataCmd = &cobra.Command{
 	Use:   "metadata",
 	Short: "get metadata by name",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")

--- a/go/cli/mcap/cmd/root.go
+++ b/go/cli/mcap/cmd/root.go
@@ -66,10 +66,10 @@ func makeProfileCloser(pprofProfile bool) func() {
 var rootCmd = &cobra.Command{
 	Use:   "mcap",
 	Short: "\U0001F52A Officially the top-rated CLI tool for slicing and dicing MCAP files.",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRun: func(*cobra.Command, []string) {
 		profileCloser = makeProfileCloser(pprofProfile)
 	},
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+	PersistentPostRun: func(*cobra.Command, []string) {
 		profileCloser()
 	},
 }

--- a/go/cli/mcap/cmd/schemas.go
+++ b/go/cli/mcap/cmd/schemas.go
@@ -98,13 +98,13 @@ func printSchemas(w io.Writer, schemas []*mcap.Schema) {
 var schemasCmd = &cobra.Command{
 	Use:   "schemas",
 	Short: "List schemas in an MCAP file",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {
 			die("Unexpected number of args")
 		}
 		filename := args[0]
-		err := utils.WithReader(ctx, filename, func(matched bool, rs io.ReadSeeker) error {
+		err := utils.WithReader(ctx, filename, func(_ bool, rs io.ReadSeeker) error {
 			reader, err := mcap.NewReader(rs)
 			if err != nil {
 				return fmt.Errorf("failed to get reader: %w", err)

--- a/go/cli/mcap/cmd/sort.go
+++ b/go/cli/mcap/cmd/sort.go
@@ -157,7 +157,7 @@ func sortFile(w io.Writer, r io.ReadSeeker) error {
 var sortCmd = &cobra.Command{
 	Use:   "sort [file] -o output.mcap",
 	Short: "Read an MCAP file and write the messages out physically sorted on log time",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {
 			die("supply a file")
 		}

--- a/go/cli/mcap/cmd/sort_test.go
+++ b/go/cli/mcap/cmd/sort_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSortFile(t *testing.T) {
@@ -13,62 +14,62 @@ func TestSortFile(t *testing.T) {
 	writer, err := mcap.NewWriter(buf, &mcap.WriterOptions{
 		Chunked: true,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{}))
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID:       1,
 		Name:     "foo",
 		Encoding: "ros1",
 		Data:     []byte{},
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:              0,
 		SchemaID:        1,
 		Topic:           "/foo",
 		MessageEncoding: "ros1msg",
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:              2,
 		SchemaID:        0,
 		Topic:           "/bar",
 		MessageEncoding: "ros1msg",
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID:   0,
 		Sequence:    0,
 		LogTime:     100,
 		PublishTime: 0,
 		Data:        []byte{},
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID:   0,
 		Sequence:    0,
 		LogTime:     50,
 		PublishTime: 0,
 		Data:        []byte{},
 	}))
-	assert.Nil(t, writer.WriteMessage(&mcap.Message{
+	require.NoError(t, writer.WriteMessage(&mcap.Message{
 		ChannelID:   2,
 		Sequence:    0,
 		LogTime:     25,
 		PublishTime: 0,
 		Data:        []byte{},
 	}))
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 
 	// sort the file
 	reader := bytes.NewReader(buf.Bytes())
 	w := &bytes.Buffer{}
-	assert.Nil(t, sortFile(w, reader))
+	require.NoError(t, sortFile(w, reader))
 
 	// verify it is now sorted
 	r, err := mcap.NewReader(bytes.NewReader(w.Bytes()))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	it, err := r.Messages(mcap.UsingIndex(false))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	_, _, msg, err := it.Next(nil)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 25, int(msg.LogTime))
 }

--- a/go/cli/mcap/cmd/version.go
+++ b/go/cli/mcap/cmd/version.go
@@ -14,7 +14,7 @@ var printLibraryVersion bool
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Output version information",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(*cobra.Command, []string) {
 		if printLibraryVersion {
 			fmt.Println(mcap.Version)
 		} else {

--- a/go/cli/mcap/testutils/buf_read_write_seeker_test.go
+++ b/go/cli/mcap/testutils/buf_read_write_seeker_test.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBufReadWriteSeeker(t *testing.T) {
@@ -12,41 +12,41 @@ func TestBufReadWriteSeeker(t *testing.T) {
 		buf := NewBufReadWriteSeeker()
 		data := []byte("hello, world!")
 		n, err := buf.Write(data)
-		assert.Nil(t, err)
-		assert.Equal(t, len(data), n, "number of bytes written does not match expected")
-		assert.Equal(t, data, buf.Bytes(), "data does not match expected")
+		require.NoError(t, err)
+		require.Equal(t, len(data), n, "number of bytes written does not match expected")
+		require.Equal(t, data, buf.Bytes(), "data does not match expected")
 	})
 
 	t.Run("seeking & reading", func(t *testing.T) {
 		buf := NewBufReadWriteSeeker()
 		data := []byte("hello, world!")
 		_, err := buf.Write(data)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = buf.Seek(0, io.SeekStart)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		written, err := io.ReadAll(buf)
-		assert.Nil(t, err)
-		assert.Equal(t, data, written, "data does not match expected")
+		require.NoError(t, err)
+		require.Equal(t, data, written, "data does not match expected")
 	})
 
 	t.Run("overwriting", func(t *testing.T) {
 		buf := NewBufReadWriteSeeker()
 		data := []byte("hello, world!")
 		_, err := buf.Write(data)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = buf.Seek(-6, io.SeekCurrent)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = buf.Write([]byte("wrold!"))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = buf.Seek(0, io.SeekStart)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		expected := []byte("hello, wrold!")
-		assert.Equal(t, expected, buf.Bytes(), "data does not match expected")
+		require.Equal(t, expected, buf.Bytes(), "data does not match expected")
 	})
 }

--- a/go/cli/mcap/testutils/buf_read_write_seeker_test.go
+++ b/go/cli/mcap/testutils/buf_read_write_seeker_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,8 +14,8 @@ func TestBufReadWriteSeeker(t *testing.T) {
 		data := []byte("hello, world!")
 		n, err := buf.Write(data)
 		require.NoError(t, err)
-		require.Equal(t, len(data), n, "number of bytes written does not match expected")
-		require.Equal(t, data, buf.Bytes(), "data does not match expected")
+		assert.Equal(t, len(data), n, "number of bytes written does not match expected")
+		assert.Equal(t, data, buf.Bytes(), "data does not match expected")
 	})
 
 	t.Run("seeking & reading", func(t *testing.T) {
@@ -28,7 +29,7 @@ func TestBufReadWriteSeeker(t *testing.T) {
 
 		written, err := io.ReadAll(buf)
 		require.NoError(t, err)
-		require.Equal(t, data, written, "data does not match expected")
+		assert.Equal(t, data, written, "data does not match expected")
 	})
 
 	t.Run("overwriting", func(t *testing.T) {
@@ -47,6 +48,6 @@ func TestBufReadWriteSeeker(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := []byte("hello, wrold!")
-		require.Equal(t, expected, buf.Bytes(), "data does not match expected")
+		assert.Equal(t, expected, buf.Bytes(), "data does not match expected")
 	})
 }

--- a/go/cli/mcap/utils/checksumming_write_counter_test.go
+++ b/go/cli/mcap/utils/checksumming_write_counter_test.go
@@ -5,6 +5,7 @@ import (
 	"hash/crc32"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,8 +17,8 @@ func TestChecksummingWriteCounter(t *testing.T) {
 	cw := newChecksummingWriteCounter(buf, initialCRC)
 	n, err := cw.Write(data[5:])
 	require.NoError(t, err)
-	require.Equal(t, len(data[5:]), n, "number of bytes written does not match expected")
-	require.Equal(t, fullCRC, cw.CRC(), "computed CRC does not match expected")
-	require.Equal(t, int64(len(data[5:])), cw.Count(), "count does not match expected")
-	require.Equal(t, data[5:], buf.Bytes(), "data does not match expected")
+	assert.Equal(t, len(data[5:]), n, "number of bytes written does not match expected")
+	assert.Equal(t, fullCRC, cw.CRC(), "computed CRC does not match expected")
+	assert.Equal(t, int64(len(data[5:])), cw.Count(), "count does not match expected")
+	assert.Equal(t, data[5:], buf.Bytes(), "data does not match expected")
 }

--- a/go/cli/mcap/utils/checksumming_write_counter_test.go
+++ b/go/cli/mcap/utils/checksumming_write_counter_test.go
@@ -5,7 +5,7 @@ import (
 	"hash/crc32"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChecksummingWriteCounter(t *testing.T) {
@@ -15,9 +15,9 @@ func TestChecksummingWriteCounter(t *testing.T) {
 	buf := &bytes.Buffer{}
 	cw := newChecksummingWriteCounter(buf, initialCRC)
 	n, err := cw.Write(data[5:])
-	assert.Nil(t, err)
-	assert.Equal(t, len(data[5:]), n, "number of bytes written does not match expected")
-	assert.Equal(t, fullCRC, cw.CRC(), "computed CRC does not match expected")
-	assert.Equal(t, int64(len(data[5:])), cw.Count(), "count does not match expected")
-	assert.Equal(t, data[5:], buf.Bytes(), "data does not match expected")
+	require.NoError(t, err)
+	require.Equal(t, len(data[5:]), n, "number of bytes written does not match expected")
+	require.Equal(t, fullCRC, cw.CRC(), "computed CRC does not match expected")
+	require.Equal(t, int64(len(data[5:])), cw.Count(), "count does not match expected")
+	require.Equal(t, data[5:], buf.Bytes(), "data does not match expected")
 }

--- a/go/cli/mcap/utils/mcap_amendment_test.go
+++ b/go/cli/mcap/utils/mcap_amendment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/foxglove/mcap/go/cli/mcap/testutils"
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAmendsIndexedFile(t *testing.T) {
@@ -17,15 +18,15 @@ func TestAmendsIndexedFile(t *testing.T) {
 		Chunked:    true,
 		ChunkSize:  1024,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{}))
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID:       1,
 		Name:     "s1",
 		Encoding: "txt",
 		Data:     []byte{0x01, 0x02, 0x03},
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:              0,
 		SchemaID:        1,
 		Topic:           "/topic",
@@ -35,23 +36,23 @@ func TestAmendsIndexedFile(t *testing.T) {
 		},
 	}))
 	for i := 0; i < 100; i++ {
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: 0,
 			Data:      []byte{0x01, 0x02, 0x03},
 		}))
 	}
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 
 	_, err = buf.Seek(0, io.SeekStart)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	reader, err := mcap.NewReader(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	initialInfo, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	reader.Close()
 
-	assert.Nil(t, AmendMCAP(buf, []*mcap.Attachment{
+	require.NoError(t, AmendMCAP(buf, []*mcap.Attachment{
 		{
 			LogTime:    0,
 			CreateTime: 0,
@@ -63,11 +64,11 @@ func TestAmendsIndexedFile(t *testing.T) {
 	}, nil))
 
 	_, err = buf.Seek(0, io.SeekStart)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	reader, err = mcap.NewReader(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	newInfo, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, int(newInfo.Statistics.AttachmentCount))
 	assert.Equal(t, initialInfo.Statistics.MessageCount, newInfo.Statistics.MessageCount)
 	assert.Equal(t, initialInfo.Statistics.ChannelCount, newInfo.Statistics.ChannelCount)
@@ -84,15 +85,15 @@ func TestDoesNotComputeCRCIfDisabled(t *testing.T) {
 		Chunked:    true,
 		ChunkSize:  1024,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{}))
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID:       1,
 		Name:     "s1",
 		Encoding: "txt",
 		Data:     []byte{0x01, 0x02, 0x03},
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:              0,
 		SchemaID:        1,
 		Topic:           "/topic",
@@ -102,23 +103,23 @@ func TestDoesNotComputeCRCIfDisabled(t *testing.T) {
 		},
 	}))
 	for i := 0; i < 100; i++ {
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: 0,
 			Data:      []byte{0x01, 0x02, 0x03},
 		}))
 	}
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 
 	_, err = buf.Seek(0, io.SeekStart)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	reader, err := mcap.NewReader(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	initialInfo, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	reader.Close()
 
-	assert.Nil(t, AmendMCAP(buf, []*mcap.Attachment{
+	require.NoError(t, AmendMCAP(buf, []*mcap.Attachment{
 		{
 			LogTime:    0,
 			CreateTime: 0,
@@ -130,11 +131,11 @@ func TestDoesNotComputeCRCIfDisabled(t *testing.T) {
 	}, nil))
 
 	_, err = buf.Seek(0, io.SeekStart)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	reader, err = mcap.NewReader(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	newInfo, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, int(newInfo.Statistics.AttachmentCount))
 	assert.Equal(t, initialInfo.Statistics.MessageCount, newInfo.Statistics.MessageCount)
 	assert.Equal(t, initialInfo.Statistics.ChannelCount, newInfo.Statistics.ChannelCount)
@@ -151,15 +152,15 @@ func TestAmendsUnindexedFile(t *testing.T) {
 		Chunked:    false,
 		ChunkSize:  1024,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, writer.WriteHeader(&mcap.Header{}))
-	assert.Nil(t, writer.WriteSchema(&mcap.Schema{
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteHeader(&mcap.Header{}))
+	require.NoError(t, writer.WriteSchema(&mcap.Schema{
 		ID:       1,
 		Name:     "s1",
 		Encoding: "txt",
 		Data:     []byte{0x01, 0x02, 0x03},
 	}))
-	assert.Nil(t, writer.WriteChannel(&mcap.Channel{
+	require.NoError(t, writer.WriteChannel(&mcap.Channel{
 		ID:              0,
 		SchemaID:        1,
 		Topic:           "/topic",
@@ -169,23 +170,23 @@ func TestAmendsUnindexedFile(t *testing.T) {
 		},
 	}))
 	for i := 0; i < 100; i++ {
-		assert.Nil(t, writer.WriteMessage(&mcap.Message{
+		require.NoError(t, writer.WriteMessage(&mcap.Message{
 			ChannelID: 0,
 			Data:      []byte{0x01, 0x02, 0x03},
 		}))
 	}
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 
 	_, err = buf.Seek(0, io.SeekStart)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	reader, err := mcap.NewReader(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	initialInfo, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	reader.Close()
 
-	assert.Nil(t, AmendMCAP(buf, []*mcap.Attachment{
+	require.NoError(t, AmendMCAP(buf, []*mcap.Attachment{
 		{
 			LogTime:    0,
 			CreateTime: 0,
@@ -197,11 +198,11 @@ func TestAmendsUnindexedFile(t *testing.T) {
 	}, nil))
 
 	_, err = buf.Seek(0, io.SeekStart)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	reader, err = mcap.NewReader(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	newInfo, err := reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, int(newInfo.Statistics.AttachmentCount))
 	assert.Equal(t, 100, int(newInfo.Statistics.MessageCount))
 	assert.Equal(t, 1, int(newInfo.Statistics.ChannelCount))

--- a/go/cli/mcap/utils/ros/json_transcoder_test.go
+++ b/go/cli/mcap/utils/ros/json_transcoder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONTranscoding(t *testing.T) {
@@ -174,9 +175,9 @@ func TestJSONTranscoding(t *testing.T) {
 			definition := []byte(c.messageDefinition)
 			buf := &bytes.Buffer{}
 			transcoder, err := NewJSONTranscoder(c.parentPackage, definition)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			err = transcoder.Transcode(buf, bytes.NewReader(c.input))
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, c.expectedJSON, buf.String())
 		})
 	}
@@ -184,7 +185,7 @@ func TestJSONTranscoding(t *testing.T) {
 
 func TestSingleRecordConversion(t *testing.T) {
 	transcoder, err := NewJSONTranscoder("", nil)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	cases := []struct {
 		assertion     string
 		parentPackage string
@@ -527,7 +528,7 @@ func TestSingleRecordConversion(t *testing.T) {
 			buf := &bytes.Buffer{}
 			converter := transcoder.record(c.fields)
 			err := converter(buf, bytes.NewBuffer(c.input))
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, c.output, buf.String())
 		})
 	}

--- a/go/conformance/Makefile
+++ b/go/conformance/Makefile
@@ -7,5 +7,9 @@ test:
 	make -C test-write-conformance test
 	make -C test-read-conformance test
 
+lint:
+	golangci-lint run ./test-read-conformance/...
+	golangci-lint run ./test-write-conformance/...
+
 clean:
 	rm -rf bin

--- a/go/conformance/test-read-conformance/main.go
+++ b/go/conformance/test-read-conformance/main.go
@@ -384,9 +384,8 @@ func readIndexed(w io.Writer, filepath string) error {
 
 func main() {
 	filepath := os.Args[1]
-	mode := os.Args[2]
 	var err error
-	if mode == "streamed" {
+	if mode := os.Args[2]; mode == "streamed" {
 		err = readStreamed(os.Stdout, filepath)
 	} else {
 		err = readIndexed(os.Stdout, filepath)

--- a/go/conformance/test-read-conformance/main.go
+++ b/go/conformance/test-read-conformance/main.go
@@ -45,13 +45,13 @@ func (x Field) MarshalJSON() ([]byte, error) {
 	var v any
 	switch t.Name() {
 	case "string":
-		v = fmt.Sprintf("\"%s\"", x.Value)
+		v = fmt.Sprintf("%q", x.Value)
 	case "uint8", "uint16", "uint32", "uint64":
 		v = fmt.Sprintf("\"%d\"", x.Value)
 	case "OpCode":
 		v = fmt.Sprintf("\"%d\"", x.Value)
 	case "CompressionFormat":
-		v = fmt.Sprintf("\"%s\"", x.Value)
+		v = fmt.Sprintf("%q", x.Value)
 	default:
 		switch t.Kind() {
 		case reflect.Map:

--- a/go/conformance/test-read-conformance/read_conformance_test.go
+++ b/go/conformance/test-read-conformance/read_conformance_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLexerConformance(t *testing.T) {
@@ -23,28 +24,28 @@ func TestLexerConformance(t *testing.T) {
 		}
 		return nil
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	for _, input := range inputs {
 		t.Run(input, func(t *testing.T) {
 			output := bytes.Buffer{}
 			err := readStreamed(&output, input)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			expectedBytes, err := os.ReadFile(strings.TrimSuffix(input, ".mcap") + ".json")
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			expectedOutput := TextOutput{}
 			err = json.Unmarshal(expectedBytes, &expectedOutput)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			receivedOutput := TextOutput{}
 			err = json.Unmarshal(output.Bytes(), &receivedOutput)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			expectedRecords, err := json.Marshal(expectedOutput.Records)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			receivedRecords, err := json.Marshal(receivedOutput.Records)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			expectedPretty, err := prettifyJSON(expectedRecords)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			receivedPretty, err := prettifyJSON(receivedRecords)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, string(expectedPretty), string(receivedPretty))
 		})
 	}

--- a/go/conformance/test-write-conformance/write_conformance_test.go
+++ b/go/conformance/test-write-conformance/write_conformance_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriterConformance(t *testing.T) {
@@ -22,14 +23,14 @@ func TestWriterConformance(t *testing.T) {
 		}
 		return nil
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	for _, input := range inputs {
 		t.Run(input, func(t *testing.T) {
 			output := bytes.Buffer{}
 			err := jsonToMCAP(&output, input)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			expectedBytes, err := os.ReadFile(strings.TrimSuffix(input, ".json") + ".mcap")
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedBytes, output.Bytes())
 		})
 	}

--- a/go/go.work
+++ b/go/go.work
@@ -1,4 +1,4 @@
-go 1.20
+go 1.22
 
 use (
 	./cli/mcap

--- a/go/mcap/lexer_test.go
+++ b/go/mcap/lexer_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/pierrec/lz4/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,7 @@ func TestLexUnchunkedFile(t *testing.T) {
 	for _, expectedTokenType := range expected {
 		tokenType, _, err := lexer.Next(nil)
 		require.NoError(t, err)
-		require.Equal(t, expectedTokenType, tokenType)
+		assert.Equal(t, expectedTokenType, tokenType)
 	}
 }
 
@@ -53,7 +54,7 @@ func TestRejectsUnsupportedCompression(t *testing.T) {
 	lexer, err := NewLexer(bytes.NewReader(file))
 	require.NoError(t, err)
 	_, _, err = lexer.Next(nil)
-	require.Equal(t, "unsupported compression: unknown", err.Error())
+	assert.Equal(t, "unsupported compression: unknown", err.Error())
 }
 
 func TestRejectsTooLargeRecords(t *testing.T) {
@@ -108,7 +109,7 @@ func TestRejectsNestedChunks(t *testing.T) {
 	// header, then error
 	tokenType, _, err := lexer.Next(nil)
 	require.NoError(t, err)
-	require.Equal(t, TokenHeader, tokenType)
+	assert.Equal(t, TokenHeader, tokenType)
 	_, _, err = lexer.Next(nil)
 	require.ErrorIs(t, err, ErrNestedChunk)
 }
@@ -130,7 +131,7 @@ func TestBadMagic(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			_, err := NewLexer(bytes.NewReader(c.magic))
-			require.IsType(t, &ErrBadMagic{}, err)
+			assert.IsType(t, &ErrBadMagic{}, err)
 		})
 	}
 }
@@ -176,9 +177,9 @@ func TestCustomDecompressor(t *testing.T) {
 	for i, expectedTokenType := range expected {
 		tokenType, _, err := lexer.Next(nil)
 		require.NoError(t, err)
-		require.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
+		assert.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
 	}
-	require.Positive(t, blockCount)
+	assert.Positive(t, blockCount)
 }
 
 func TestReturnsEOFOnSuccessiveCalls(t *testing.T) {
@@ -226,7 +227,7 @@ func TestLexChunkedFile(t *testing.T) {
 					for i, expectedTokenType := range expected {
 						tokenType, _, err := lexer.Next(nil)
 						require.NoError(t, err)
-						require.Equal(t, expectedTokenType, tokenType,
+						assert.Equal(t, expectedTokenType, tokenType,
 							fmt.Sprintf("expected %s but got %s at index %d", expectedTokenType, tokenType, i))
 					}
 
@@ -253,7 +254,7 @@ func TestSkipsUnknownOpcodes(t *testing.T) {
 	for i, expectedTokenType := range expected {
 		tokenType, _, err := lexer.Next(nil)
 		require.NoError(t, err)
-		require.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
+		assert.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
 	}
 }
 
@@ -283,7 +284,7 @@ func TestChunkCRCValidation(t *testing.T) {
 		for i, expectedTokenType := range expected {
 			tokenType, _, err := lexer.Next(nil)
 			require.NoError(t, err)
-			require.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
+			assert.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
 		}
 	})
 	t.Run("validates file with zero'd CRCs", func(t *testing.T) {
@@ -311,7 +312,7 @@ func TestChunkCRCValidation(t *testing.T) {
 		for i, expectedTokenType := range expected {
 			tokenType, _, err := lexer.Next(nil)
 			require.NoError(t, err)
-			require.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
+			assert.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
 		}
 	})
 	t.Run("validation fails on corrupted file", func(t *testing.T) {
@@ -340,11 +341,11 @@ func TestChunkCRCValidation(t *testing.T) {
 		for i, expectedTokenType := range expected {
 			tokenType, _, err := lexer.Next(nil)
 			require.NoError(t, err)
-			require.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
+			assert.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
 		}
 		_, _, err = lexer.Next(nil)
 		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), "invalid chunk CRC"))
+		assert.True(t, strings.Contains(err.Error(), "invalid chunk CRC"))
 	})
 }
 
@@ -394,18 +395,18 @@ func TestAttachmentHandling(t *testing.T) {
 			lexer, err := NewLexer(file, &LexerOptions{
 				ComputeAttachmentCRCs: true,
 				AttachmentCallback: func(ar *AttachmentReader) error {
-					require.Equal(t, c.attachment.LogTime, ar.LogTime)
-					require.Equal(t, c.attachment.CreateTime, ar.CreateTime)
-					require.Equal(t, c.attachment.Name, ar.Name)
-					require.Equal(t, c.attachment.MediaType, ar.MediaType)
+					assert.Equal(t, c.attachment.LogTime, ar.LogTime)
+					assert.Equal(t, c.attachment.CreateTime, ar.CreateTime)
+					assert.Equal(t, c.attachment.Name, ar.Name)
+					assert.Equal(t, c.attachment.MediaType, ar.MediaType)
 					data, err := io.ReadAll(ar.Data())
 					require.NoError(t, err)
-					require.Equal(t, c.attachmentData, data)
+					assert.Equal(t, c.attachmentData, data)
 					computedCRC, err := ar.ComputedCRC()
 					require.NoError(t, err)
 					parsedCRC, err := ar.ParsedCRC()
 					require.NoError(t, err)
-					require.Equal(t, computedCRC, parsedCRC)
+					assert.Equal(t, computedCRC, parsedCRC)
 					called = true
 					return nil
 				},
@@ -417,7 +418,7 @@ func TestAttachmentHandling(t *testing.T) {
 					require.NoError(t, err)
 				}
 			}
-			require.True(t, called)
+			assert.True(t, called)
 		})
 	}
 }
@@ -455,7 +456,7 @@ func TestChunkEmission(t *testing.T) {
 					for i, expectedTokenType := range expected {
 						tokenType, _, err := lexer.Next(nil)
 						require.NoError(t, err)
-						require.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
+						assert.Equal(t, expectedTokenType, tokenType, fmt.Sprintf("mismatch element %d", i))
 					}
 					_, _, err = lexer.Next(nil)
 					require.ErrorIs(t, err, io.EOF)

--- a/go/mcap/lexer_test.go
+++ b/go/mcap/lexer_test.go
@@ -154,7 +154,7 @@ func TestCustomDecompressor(t *testing.T) {
 	)
 	lzr := lz4.NewReader(nil)
 	blockCount := 0
-	assert.Nil(t, lzr.Apply(lz4.OnBlockDoneOption(func(size int) {
+	assert.Nil(t, lzr.Apply(lz4.OnBlockDoneOption(func(int) {
 		blockCount++
 	})))
 	lexer, err := NewLexer(bytes.NewReader(buf), &LexerOptions{

--- a/go/mcap/mcap_test.go
+++ b/go/mcap/mcap_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,20 +15,20 @@ func TestGetUint16(t *testing.T) {
 	t.Run("uint16 successful read", func(t *testing.T) {
 		x, offset, err := getUint16(buf, 0)
 		require.NoError(t, err)
-		require.Equal(t, uint16(123), x)
-		require.Equal(t, 2, offset)
+		assert.Equal(t, uint16(123), x)
+		assert.Equal(t, 2, offset)
 	})
 	t.Run("uint16 insufficient space", func(t *testing.T) {
 		x, offset, err := getUint16(buf, 1)
 		require.ErrorIs(t, err, io.ErrShortBuffer)
-		require.Equal(t, uint16(0), x)
-		require.Equal(t, 0, offset)
+		assert.Equal(t, uint16(0), x)
+		assert.Equal(t, 0, offset)
 	})
 	t.Run("uint16 offset outside buffer", func(t *testing.T) {
 		x, offset, err := getUint16(buf, 10)
 		require.ErrorIs(t, err, io.ErrShortBuffer)
-		require.Equal(t, uint16(0), x)
-		require.Equal(t, 0, offset)
+		assert.Equal(t, uint16(0), x)
+		assert.Equal(t, 0, offset)
 	})
 }
 
@@ -37,20 +38,20 @@ func TestGetUint32(t *testing.T) {
 		binary.LittleEndian.PutUint32(buf, 123)
 		x, offset, err := getUint32(buf, 0)
 		require.NoError(t, err)
-		require.Equal(t, uint32(123), x)
-		require.Equal(t, 4, offset)
+		assert.Equal(t, uint32(123), x)
+		assert.Equal(t, 4, offset)
 	})
 	t.Run("uint32 insufficient space", func(t *testing.T) {
 		x, offset, err := getUint32(buf, 1)
 		require.ErrorIs(t, err, io.ErrShortBuffer)
-		require.Equal(t, uint32(0), x)
-		require.Equal(t, 0, offset)
+		assert.Equal(t, uint32(0), x)
+		assert.Equal(t, 0, offset)
 	})
 	t.Run("uint32 offset outside buffer", func(t *testing.T) {
 		x, offset, err := getUint32(buf, 10)
 		require.ErrorIs(t, err, io.ErrShortBuffer)
-		require.Equal(t, uint32(0), x)
-		require.Equal(t, 0, offset)
+		assert.Equal(t, uint32(0), x)
+		assert.Equal(t, 0, offset)
 	})
 }
 func TestGetUint64(t *testing.T) {
@@ -59,28 +60,28 @@ func TestGetUint64(t *testing.T) {
 	t.Run("uint64 successful read", func(t *testing.T) {
 		x, offset, err := getUint64(buf, 0)
 		require.NoError(t, err)
-		require.Equal(t, uint64(123), x)
-		require.Equal(t, 8, offset)
+		assert.Equal(t, uint64(123), x)
+		assert.Equal(t, 8, offset)
 	})
 	t.Run("uint64 insufficient space", func(t *testing.T) {
 		x, offset, err := getUint64(buf, 1)
 		require.ErrorIs(t, err, io.ErrShortBuffer)
-		require.Equal(t, uint64(0), x)
-		require.Equal(t, 0, offset)
+		assert.Equal(t, uint64(0), x)
+		assert.Equal(t, 0, offset)
 	})
 	t.Run("uint64 offset outside buffer", func(t *testing.T) {
 		x, offset, err := getUint64(buf, 10)
 		require.ErrorIs(t, err, io.ErrShortBuffer)
-		require.Equal(t, uint64(0), x)
-		require.Equal(t, 0, offset)
+		assert.Equal(t, uint64(0), x)
+		assert.Equal(t, 0, offset)
 	})
 }
 
 func TestPutByte(t *testing.T) {
 	offset, err := putByte(make([]byte, 1), 123)
 	require.NoError(t, err)
-	require.Equal(t, 1, offset)
+	assert.Equal(t, 1, offset)
 	offset, err = putByte(make([]byte, 0), 123)
 	require.ErrorIs(t, err, io.ErrShortBuffer)
-	require.Equal(t, 0, offset)
+	assert.Equal(t, 0, offset)
 }

--- a/go/mcap/mcap_test.go
+++ b/go/mcap/mcap_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetUint16(t *testing.T) {
@@ -13,21 +13,21 @@ func TestGetUint16(t *testing.T) {
 	binary.LittleEndian.PutUint16(buf, 123)
 	t.Run("uint16 successful read", func(t *testing.T) {
 		x, offset, err := getUint16(buf, 0)
-		assert.Nil(t, err)
-		assert.Equal(t, uint16(123), x)
-		assert.Equal(t, 2, offset)
+		require.NoError(t, err)
+		require.Equal(t, uint16(123), x)
+		require.Equal(t, 2, offset)
 	})
 	t.Run("uint16 insufficient space", func(t *testing.T) {
 		x, offset, err := getUint16(buf, 1)
-		assert.ErrorIs(t, err, io.ErrShortBuffer)
-		assert.Equal(t, uint16(0), x)
-		assert.Equal(t, 0, offset)
+		require.ErrorIs(t, err, io.ErrShortBuffer)
+		require.Equal(t, uint16(0), x)
+		require.Equal(t, 0, offset)
 	})
 	t.Run("uint16 offset outside buffer", func(t *testing.T) {
 		x, offset, err := getUint16(buf, 10)
-		assert.ErrorIs(t, err, io.ErrShortBuffer)
-		assert.Equal(t, uint16(0), x)
-		assert.Equal(t, 0, offset)
+		require.ErrorIs(t, err, io.ErrShortBuffer)
+		require.Equal(t, uint16(0), x)
+		require.Equal(t, 0, offset)
 	})
 }
 
@@ -36,21 +36,21 @@ func TestGetUint32(t *testing.T) {
 	t.Run("uint32 successful read", func(t *testing.T) {
 		binary.LittleEndian.PutUint32(buf, 123)
 		x, offset, err := getUint32(buf, 0)
-		assert.Nil(t, err)
-		assert.Equal(t, uint32(123), x)
-		assert.Equal(t, 4, offset)
+		require.NoError(t, err)
+		require.Equal(t, uint32(123), x)
+		require.Equal(t, 4, offset)
 	})
 	t.Run("uint32 insufficient space", func(t *testing.T) {
 		x, offset, err := getUint32(buf, 1)
-		assert.ErrorIs(t, err, io.ErrShortBuffer)
-		assert.Equal(t, uint32(0), x)
-		assert.Equal(t, 0, offset)
+		require.ErrorIs(t, err, io.ErrShortBuffer)
+		require.Equal(t, uint32(0), x)
+		require.Equal(t, 0, offset)
 	})
 	t.Run("uint32 offset outside buffer", func(t *testing.T) {
 		x, offset, err := getUint32(buf, 10)
-		assert.ErrorIs(t, err, io.ErrShortBuffer)
-		assert.Equal(t, uint32(0), x)
-		assert.Equal(t, 0, offset)
+		require.ErrorIs(t, err, io.ErrShortBuffer)
+		require.Equal(t, uint32(0), x)
+		require.Equal(t, 0, offset)
 	})
 }
 func TestGetUint64(t *testing.T) {
@@ -58,29 +58,29 @@ func TestGetUint64(t *testing.T) {
 	binary.LittleEndian.PutUint64(buf, 123)
 	t.Run("uint64 successful read", func(t *testing.T) {
 		x, offset, err := getUint64(buf, 0)
-		assert.Nil(t, err)
-		assert.Equal(t, uint64(123), x)
-		assert.Equal(t, 8, offset)
+		require.NoError(t, err)
+		require.Equal(t, uint64(123), x)
+		require.Equal(t, 8, offset)
 	})
 	t.Run("uint64 insufficient space", func(t *testing.T) {
 		x, offset, err := getUint64(buf, 1)
-		assert.ErrorIs(t, err, io.ErrShortBuffer)
-		assert.Equal(t, uint64(0), x)
-		assert.Equal(t, 0, offset)
+		require.ErrorIs(t, err, io.ErrShortBuffer)
+		require.Equal(t, uint64(0), x)
+		require.Equal(t, 0, offset)
 	})
 	t.Run("uint64 offset outside buffer", func(t *testing.T) {
 		x, offset, err := getUint64(buf, 10)
-		assert.ErrorIs(t, err, io.ErrShortBuffer)
-		assert.Equal(t, uint64(0), x)
-		assert.Equal(t, 0, offset)
+		require.ErrorIs(t, err, io.ErrShortBuffer)
+		require.Equal(t, uint64(0), x)
+		require.Equal(t, 0, offset)
 	})
 }
 
 func TestPutByte(t *testing.T) {
 	offset, err := putByte(make([]byte, 1), 123)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, offset)
+	require.NoError(t, err)
+	require.Equal(t, 1, offset)
 	offset, err = putByte(make([]byte, 0), 123)
-	assert.ErrorIs(t, err, io.ErrShortBuffer)
-	assert.Equal(t, 0, offset)
+	require.ErrorIs(t, err, io.ErrShortBuffer)
+	require.Equal(t, 0, offset)
 }

--- a/go/mcap/parse_test.go
+++ b/go/mcap/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +41,7 @@ func TestParseHeader(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseHeader(c.input)
 			require.ErrorIs(t, err, c.err)
-			require.Equal(t, output, c.output)
+			assert.Equal(t, output, c.output)
 		})
 	}
 }
@@ -106,7 +107,7 @@ func TestParseMetadata(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseMetadata(c.input)
 			require.ErrorIs(t, err, c.err)
-			require.Equal(t, output, c.output)
+			assert.Equal(t, output, c.output)
 		})
 	}
 }
@@ -151,7 +152,7 @@ func TestParseMetadataIndex(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseMetadataIndex(c.input)
 			require.ErrorIs(t, err, c.err)
-			require.Equal(t, output, c.output)
+			assert.Equal(t, output, c.output)
 		})
 	}
 }
@@ -196,7 +197,7 @@ func TestParseFooter(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseFooter(c.input)
 			require.ErrorIs(t, err, c.err)
-			require.Equal(t, output, c.output)
+			assert.Equal(t, output, c.output)
 		})
 	}
 }
@@ -253,7 +254,7 @@ func TestParseSchema(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseSchema(c.input)
 			require.ErrorIs(t, err, c.err)
-			require.Equal(t, output, c.output)
+			assert.Equal(t, output, c.output)
 		})
 	}
 }

--- a/go/mcap/parse_test.go
+++ b/go/mcap/parse_test.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseHeader(t *testing.T) {
@@ -39,8 +39,8 @@ func TestParseHeader(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseHeader(c.input)
-			assert.ErrorIs(t, err, c.err)
-			assert.Equal(t, output, c.output)
+			require.ErrorIs(t, err, c.err)
+			require.Equal(t, output, c.output)
 		})
 	}
 }
@@ -105,8 +105,8 @@ func TestParseMetadata(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseMetadata(c.input)
-			assert.ErrorIs(t, err, c.err)
-			assert.Equal(t, output, c.output)
+			require.ErrorIs(t, err, c.err)
+			require.Equal(t, output, c.output)
 		})
 	}
 }
@@ -150,8 +150,8 @@ func TestParseMetadataIndex(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseMetadataIndex(c.input)
-			assert.ErrorIs(t, err, c.err)
-			assert.Equal(t, output, c.output)
+			require.ErrorIs(t, err, c.err)
+			require.Equal(t, output, c.output)
 		})
 	}
 }
@@ -195,8 +195,8 @@ func TestParseFooter(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseFooter(c.input)
-			assert.ErrorIs(t, err, c.err)
-			assert.Equal(t, output, c.output)
+			require.ErrorIs(t, err, c.err)
+			require.Equal(t, output, c.output)
 		})
 	}
 }
@@ -252,8 +252,8 @@ func TestParseSchema(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, err := ParseSchema(c.input)
-			assert.ErrorIs(t, err, c.err)
-			assert.Equal(t, output, c.output)
+			require.ErrorIs(t, err, c.err)
+			require.Equal(t, output, c.output)
 		})
 	}
 }

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -77,11 +77,11 @@ func TestMessageOrdering(t *testing.T) {
 				found := false
 				for index, item := range rangeIndexHeapTestItems {
 					if reflect.DeepEqual(item, *poppedItem) {
-						require.Equal(t, c.expectedIndexOrder[i], index)
+						assert.Equal(t, c.expectedIndexOrder[i], index)
 						found = true
 					}
 				}
-				require.True(t, found)
+				assert.True(t, found)
 				i++
 			}
 		})

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var rangeIndexHeapTestItems = []rangeIndex{
@@ -66,21 +66,21 @@ func TestMessageOrdering(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			h := &rangeIndexHeap{order: c.order}
 			for _, item := range rangeIndexHeapTestItems {
-				assert.Nil(t, h.HeapPush(item))
+				require.NoError(t, h.HeapPush(item))
 			}
-			assert.Equal(t, h.Len(), len(rangeIndexHeapTestItems))
+			require.Len(t, rangeIndexHeapTestItems, h.Len())
 			i := 0
 			for h.Len() > 0 {
 				poppedItem, err := h.HeapPop()
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				found := false
 				for index, item := range rangeIndexHeapTestItems {
 					if reflect.DeepEqual(item, *poppedItem) {
-						assert.Equal(t, c.expectedIndexOrder[i], index)
+						require.Equal(t, c.expectedIndexOrder[i], index)
 						found = true
 					}
 				}
-				assert.True(t, found)
+				require.True(t, found)
 				i++
 			}
 		})

--- a/go/mcap/range_index_heap_test.go
+++ b/go/mcap/range_index_heap_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,7 +69,7 @@ func TestMessageOrdering(t *testing.T) {
 			for _, item := range rangeIndexHeapTestItems {
 				require.NoError(t, h.HeapPush(item))
 			}
-			require.Len(t, rangeIndexHeapTestItems, h.Len())
+			assert.Len(t, rangeIndexHeapTestItems, h.Len())
 			i := 0
 			for h.Len() > 0 {
 				poppedItem, err := h.HeapPop()

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -72,7 +72,7 @@ func TestIndexedReaderBreaksTiesOnChunkOffset(t *testing.T) {
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		require.Equal(t, expectedTopics[i], channel.Topic)
+		assert.Equal(t, expectedTopics[i], channel.Topic)
 	}
 }
 func TestReaderFallsBackToLinearScan(t *testing.T) {
@@ -122,7 +122,7 @@ func TestReaderFallsBackToLinearScan(t *testing.T) {
 	for _, content := range messageContents {
 		_, _, msg, err := it.Next(nil)
 		require.NoError(t, err)
-		require.Equal(t, content, string(msg.Data))
+		assert.Equal(t, content, string(msg.Data))
 	}
 }
 
@@ -160,8 +160,8 @@ func TestReadPrefixedBytes(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			s, off, err := getPrefixedBytes(c.data, 0)
 			require.ErrorIs(t, c.expectedError, err)
-			require.Equal(t, c.expectedBytes, s)
-			require.Equal(t, c.expectedOffset, off)
+			assert.Equal(t, c.expectedBytes, s)
+			assert.Equal(t, c.expectedOffset, off)
 		})
 	}
 }
@@ -222,8 +222,8 @@ func TestReadPrefixedMap(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			output, offset, err := getPrefixedMap(c.input, 0)
 			require.ErrorIs(t, err, c.err)
-			require.Equal(t, offset, c.newOffset)
-			require.Equal(t, output, c.output)
+			assert.Equal(t, offset, c.newOffset)
+			assert.Equal(t, output, c.output)
 		})
 	}
 }
@@ -262,8 +262,8 @@ func TestReadPrefixedString(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			s, off, err := getPrefixedString(c.data, 0)
 			require.ErrorIs(t, c.expectedError, err)
-			require.Equal(t, c.expectedString, s)
-			require.Equal(t, c.expectedOffset, off)
+			assert.Equal(t, c.expectedString, s)
+			assert.Equal(t, c.expectedOffset, off)
 		})
 	}
 }
@@ -335,12 +335,12 @@ func TestMessageReading(t *testing.T) {
 							require.NoError(t, err)
 							require.NotNil(t, channel)
 							require.NotNil(t, message)
-							require.Equal(t, message.ChannelID, channel.ID)
+							assert.Equal(t, message.ChannelID, channel.ID)
 							require.NotNil(t, schema)
-							require.Equal(t, schema.ID, channel.SchemaID)
+							assert.Equal(t, schema.ID, channel.SchemaID)
 							c++
 						}
-						require.Equal(t, 1000, c)
+						assert.Equal(t, 1000, c)
 					})
 					t.Run("read messages on one topic", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
@@ -361,11 +361,11 @@ func TestMessageReading(t *testing.T) {
 							require.NotNil(t, channel)
 							require.NotNil(t, message)
 							require.NotNil(t, schema)
-							require.Equal(t, message.ChannelID, channel.ID)
-							require.Equal(t, schema.ID, channel.SchemaID)
+							assert.Equal(t, message.ChannelID, channel.ID)
+							assert.Equal(t, schema.ID, channel.SchemaID)
 							c++
 						}
-						require.Equal(t, 500, c)
+						assert.Equal(t, 500, c)
 					})
 					t.Run("read messages on multiple topics", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
@@ -386,11 +386,11 @@ func TestMessageReading(t *testing.T) {
 							require.NotNil(t, channel)
 							require.NotNil(t, message)
 							require.NotNil(t, schema)
-							require.Equal(t, message.ChannelID, channel.ID)
-							require.Equal(t, channel.SchemaID, schema.ID)
+							assert.Equal(t, message.ChannelID, channel.ID)
+							assert.Equal(t, channel.SchemaID, schema.ID)
 							c++
 						}
-						require.Equal(t, 1000, c)
+						assert.Equal(t, 1000, c)
 					})
 					t.Run("read messages in time range", func(t *testing.T) {
 						reader := bytes.NewReader(buf.Bytes())
@@ -411,7 +411,7 @@ func TestMessageReading(t *testing.T) {
 							require.NoError(t, err)
 							c++
 						}
-						require.Equal(t, 100, c)
+						assert.Equal(t, 100, c)
 					})
 				})
 			}
@@ -441,7 +441,7 @@ func TestReaderCounting(t *testing.T) {
 				require.NoError(t, err)
 				c++
 			}
-			require.Equal(t, 1606, c)
+			assert.Equal(t, 1606, c)
 		})
 	}
 }
@@ -572,10 +572,10 @@ func TestMCAPInfo(t *testing.T) {
 			require.NoError(t, err)
 			info, err := r.Info()
 			require.NoError(t, err)
-			require.Equal(t, uint64(len(c.messages)), info.Statistics.MessageCount, "unexpected message count")
-			require.Equal(t, uint32(len(c.channels)), info.Statistics.ChannelCount, "unexpected channel count")
-			require.Equal(t, uint32(len(c.metadata)), info.Statistics.MetadataCount, "unexpected metadata count")
-			require.Equal(
+			assert.Equal(t, uint64(len(c.messages)), info.Statistics.MessageCount, "unexpected message count")
+			assert.Equal(t, uint32(len(c.channels)), info.Statistics.ChannelCount, "unexpected channel count")
+			assert.Equal(t, uint32(len(c.metadata)), info.Statistics.MetadataCount, "unexpected metadata count")
+			assert.Equal(
 				t,
 				uint32(len(c.attachments)),
 				info.Statistics.AttachmentCount,
@@ -589,7 +589,7 @@ func TestMCAPInfo(t *testing.T) {
 				require.NoError(t, err)
 				expectedTopicCounts[channel.Topic]++
 			}
-			require.Equal(t, expectedTopicCounts, info.ChannelCounts())
+			assert.Equal(t, expectedTopicCounts, info.ChannelCounts())
 		})
 	}
 }
@@ -646,7 +646,7 @@ func TestReaderMetadataCallback(t *testing.T) {
 			_, _, _, err = it.Next(nil)
 			require.ErrorIs(t, err, io.EOF)
 
-			require.Equal(t, "foo", recordName)
+			assert.Equal(t, "foo", recordName)
 		})
 	}
 }
@@ -669,7 +669,7 @@ func TestReadingDiagnostics(t *testing.T) {
 		require.NoError(t, err)
 		c++
 	}
-	require.Equal(t, 52, c)
+	assert.Equal(t, 52, c)
 }
 
 func TestReadingMetadata(t *testing.T) {
@@ -700,7 +700,7 @@ func TestReadingMetadata(t *testing.T) {
 	idx := info.MetadataIndexes[0]
 	metadata, err := reader.GetMetadata(idx.Offset)
 	require.NoError(t, err)
-	require.Equal(t, expectedMetadata, metadata)
+	assert.Equal(t, expectedMetadata, metadata)
 }
 
 func TestGetAttachmentReader(t *testing.T) {
@@ -732,15 +732,15 @@ func TestGetAttachmentReader(t *testing.T) {
 	ar, err := reader.GetAttachmentReader(idx.Offset)
 	require.NoError(t, err)
 
-	require.Equal(t, "foo", ar.Name)
-	require.Equal(t, "text", ar.MediaType)
-	require.Equal(t, 3, int(ar.DataSize))
-	require.Equal(t, 10, int(ar.LogTime))
-	require.Equal(t, 1000, int(ar.CreateTime))
+	assert.Equal(t, "foo", ar.Name)
+	assert.Equal(t, "text", ar.MediaType)
+	assert.Equal(t, 3, int(ar.DataSize))
+	assert.Equal(t, 10, int(ar.LogTime))
+	assert.Equal(t, 1000, int(ar.CreateTime))
 
 	data, err := io.ReadAll(ar.Data())
 	require.NoError(t, err)
-	require.Equal(t, []byte{'a', 'b', 'c'}, data)
+	assert.Equal(t, []byte{'a', 'b', 'c'}, data)
 }
 
 func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
@@ -787,7 +787,7 @@ func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
 		addMsg(now)
 	}
 	// ensure that the chunk contains more than one message
-	require.Greater(t, now, uint64(110))
+	assert.Greater(t, now, uint64(110))
 	// add time discontinuity between chunks
 	now -= 55
 
@@ -814,7 +814,7 @@ func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
 		_, _, msg, err := it.Next(nil)
 		require.NoError(t, err)
 		if i != 0 {
-			require.Greater(t, msg.LogTime, lastSeenTimestamp)
+			assert.Greater(t, msg.LogTime, lastSeenTimestamp)
 		}
 		lastSeenTimestamp = msg.LogTime
 	}
@@ -834,7 +834,7 @@ func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
 		_, _, msg, err := reverseIt.Next(nil)
 		require.NoError(t, err)
 		if i != 0 {
-			require.Less(t, msg.LogTime, lastSeenTimestamp)
+			assert.Less(t, msg.LogTime, lastSeenTimestamp)
 		}
 		lastSeenTimestamp = msg.LogTime
 	}
@@ -863,7 +863,7 @@ func TestReadingBigTimestamps(t *testing.T) {
 	t.Run("info works as expected", func(t *testing.T) {
 		info, err := reader.Info()
 		require.NoError(t, err)
-		require.Equal(t, uint64(math.MaxUint64-1), info.Statistics.MessageEndTime)
+		assert.Equal(t, uint64(math.MaxUint64-1), info.Statistics.MessageEndTime)
 	})
 	t.Run("message iteration works as expected", func(t *testing.T) {
 		it, err := reader.Messages(AfterNanos(math.MaxUint64-2), BeforeNanos(math.MaxUint64))
@@ -875,9 +875,9 @@ func TestReadingBigTimestamps(t *testing.T) {
 				break
 			}
 			require.NoError(t, err)
-			require.Equal(t, []byte("hello"), msg.Data)
+			assert.Equal(t, []byte("hello"), msg.Data)
 			count++
 		}
-		require.Equal(t, 1, count)
+		assert.Equal(t, 1, count)
 	})
 }

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -695,7 +696,7 @@ func TestReadingMetadata(t *testing.T) {
 
 	info, err := reader.Info()
 	require.NoError(t, err)
-	require.Len(t, info.MetadataIndexes, 1)
+	assert.Len(t, info.MetadataIndexes, 1)
 	idx := info.MetadataIndexes[0]
 	metadata, err := reader.GetMetadata(idx.Offset)
 	require.NoError(t, err)
@@ -726,7 +727,7 @@ func TestGetAttachmentReader(t *testing.T) {
 
 	info, err := reader.Info()
 	require.NoError(t, err)
-	require.Len(t, info.AttachmentIndexes, 1)
+	assert.Len(t, info.AttachmentIndexes, 1)
 	idx := info.AttachmentIndexes[0]
 	ar, err := reader.GetAttachmentReader(idx.Offset)
 	require.NoError(t, err)

--- a/go/mcap/testutils.go
+++ b/go/mcap/testutils.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func encodedUint16(x uint16) []byte {
@@ -94,19 +94,19 @@ func chunk(t *testing.T, compression CompressionFormat, includeCRC bool, records
 			t.Errorf("failed to create zstd writer: %s", err)
 		}
 		_, err = io.Copy(w, bytes.NewReader(data))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		w.Close()
 	case CompressionLZ4:
 		w := lz4.NewWriter(buf)
 		_, err := io.Copy(w, bytes.NewReader(data))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		w.Close()
 	case CompressionNone:
 		_, err := buf.Write(data)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	default:
 		_, err := buf.Write(data) // unrecognized compression
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	}
 	compressionLen := len(compression)
 	compressedLen := buf.Len()
@@ -114,7 +114,7 @@ func chunk(t *testing.T, compression CompressionFormat, includeCRC bool, records
 	msglen := uint64(8 + 8 + 8 + 4 + 4 + compressionLen + 8 + compressedLen)
 	record := make([]byte, msglen+9)
 	offset, err := putByte(record, byte(OpChunk))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	offset += putUint64(record[offset:], msglen)
 
 	offset += putUint64(record[offset:], 0)   // start

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -34,11 +34,11 @@ func TestMCAPReadWrite(t *testing.T) {
 		offset := 0
 		profile, offset, err := getPrefixedString(record, offset)
 		require.NoError(t, err)
-		require.Equal(t, "ros1", profile)
+		assert.Equal(t, "ros1", profile)
 		library, _, err := getPrefixedString(record, offset)
 		require.NoError(t, err)
-		require.Equal(t, "libfoo v0", library)
-		require.Equal(t, TokenHeader, tokenType)
+		assert.Equal(t, "libfoo v0", library)
+		assert.Equal(t, TokenHeader, tokenType)
 	})
 	t.Run("zero-valued schema IDs permitted", func(t *testing.T) {
 		buf := &bytes.Buffer{}
@@ -138,7 +138,7 @@ func TestOutputDeterminism(t *testing.T) {
 		}
 		t.Run("output hashes consistently", func(t *testing.T) {
 			newHash := fmt.Sprintf("%x", md5.Sum(buf.Bytes()))
-			require.Equal(t, hash, newHash)
+			assert.Equal(t, hash, newHash)
 		})
 	}
 }
@@ -211,11 +211,11 @@ func TestChunkedReadWrite(t *testing.T) {
 			require.NoError(t, w.Close())
 			assert.Len(t, w.ChunkIndexes, 2)
 			require.Empty(t, w.AttachmentIndexes)
-			require.Equal(t, uint64(2), w.Statistics.MessageCount)
-			require.Equal(t, uint32(0), w.Statistics.AttachmentCount)
-			require.Equal(t, uint32(2), w.Statistics.ChannelCount)
-			require.Equal(t, uint32(2), w.Statistics.ChunkCount)
-			require.Equal(t, int(w.Offset()), buf.Len())
+			assert.Equal(t, uint64(2), w.Statistics.MessageCount)
+			assert.Equal(t, uint32(0), w.Statistics.AttachmentCount)
+			assert.Equal(t, uint32(2), w.Statistics.ChannelCount)
+			assert.Equal(t, uint32(2), w.Statistics.ChunkCount)
+			assert.Equal(t, int(w.Offset()), buf.Len())
 			lexer, err := NewLexer(buf)
 			require.NoError(t, err)
 			defer lexer.Close()
@@ -245,7 +245,7 @@ func TestChunkedReadWrite(t *testing.T) {
 			} {
 				tokenType, _, err := lexer.Next(nil)
 				require.NoError(t, err)
-				require.Equal(t, expected, tokenType,
+				assert.Equal(t, expected, tokenType,
 					fmt.Sprintf("want %s got %s at %d", expected, tokenType, i))
 			}
 		})
@@ -300,8 +300,8 @@ func TestChunkBoundaryIndexing(t *testing.T) {
 	require.NoError(t, w.Close())
 	t.Run("chunk indexes correct", func(t *testing.T) {
 		assert.Len(t, w.ChunkIndexes, 2)
-		require.Equal(t, 100, int(w.ChunkIndexes[0].MessageStartTime)) // first message
-		require.Equal(t, 1, int(w.ChunkIndexes[1].MessageStartTime))   // second message
+		assert.Equal(t, 100, int(w.ChunkIndexes[0].MessageStartTime)) // first message
+		assert.Equal(t, 1, int(w.ChunkIndexes[1].MessageStartTime))   // second message
 	})
 }
 
@@ -352,7 +352,7 @@ func TestIndexStructures(t *testing.T) {
 	t.Run("chunk indexes correct", func(t *testing.T) {
 		assert.Len(t, w.ChunkIndexes, 1)
 		chunkIndex := w.ChunkIndexes[0]
-		require.Equal(t, &ChunkIndex{
+		assert.Equal(t, &ChunkIndex{
 			MessageStartTime: 1,
 			MessageEndTime:   1,
 			ChunkStartOffset: 105,
@@ -369,7 +369,7 @@ func TestIndexStructures(t *testing.T) {
 	t.Run("attachment indexes correct", func(t *testing.T) {
 		assert.Len(t, w.AttachmentIndexes, 1)
 		attachmentIndex := w.AttachmentIndexes[0]
-		require.Equal(t, &AttachmentIndex{
+		assert.Equal(t, &AttachmentIndex{
 			Offset:     38,
 			Length:     67,
 			LogTime:    100,
@@ -424,10 +424,10 @@ func TestStatistics(t *testing.T) {
 		Data:      bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04}),
 	}))
 	require.NoError(t, w.Close())
-	require.Equal(t, uint64(1000), w.Statistics.MessageCount)
-	require.Equal(t, uint32(1), w.Statistics.ChannelCount)
-	require.Equal(t, uint32(1), w.Statistics.AttachmentCount)
-	require.Equal(t, 42, int(w.Statistics.ChunkCount))
+	assert.Equal(t, uint64(1000), w.Statistics.MessageCount)
+	assert.Equal(t, uint32(1), w.Statistics.ChannelCount)
+	assert.Equal(t, uint32(1), w.Statistics.AttachmentCount)
+	assert.Equal(t, 42, int(w.Statistics.ChunkCount))
 	assert.Len(t, w.ChunkIndexes, 42)
 	assert.Len(t, w.AttachmentIndexes, 1)
 }
@@ -484,11 +484,11 @@ func TestUnchunkedReadWrite(t *testing.T) {
 
 	require.Empty(t, w.ChunkIndexes)
 	assert.Len(t, w.AttachmentIndexes, 1)
-	require.Equal(t, "image/jpeg", w.AttachmentIndexes[0].MediaType)
-	require.Equal(t, uint64(1), w.Statistics.MessageCount)
-	require.Equal(t, uint32(1), w.Statistics.AttachmentCount)
-	require.Equal(t, uint32(1), w.Statistics.ChannelCount)
-	require.Equal(t, uint32(0), w.Statistics.ChunkCount)
+	assert.Equal(t, "image/jpeg", w.AttachmentIndexes[0].MediaType)
+	assert.Equal(t, uint64(1), w.Statistics.MessageCount)
+	assert.Equal(t, uint32(1), w.Statistics.AttachmentCount)
+	assert.Equal(t, uint32(1), w.Statistics.ChannelCount)
+	assert.Equal(t, uint32(0), w.Statistics.ChunkCount)
 
 	lexer, err := NewLexer(buf)
 	require.NoError(t, err)
@@ -511,7 +511,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 	} {
 		tokenType, _, err := lexer.Next(nil)
 		require.NoError(t, err)
-		require.Equal(t, expected, tokenType, fmt.Sprintf("want %s got %s", expected, tokenType))
+		assert.Equal(t, expected, tokenType, fmt.Sprintf("want %s got %s", expected, tokenType))
 	}
 }
 
@@ -541,14 +541,14 @@ func TestLibraryString(t *testing.T) {
 			defer lexer.Close()
 			tokenType, record, err := lexer.Next(nil)
 			require.NoError(t, err)
-			require.Equal(t, TokenHeader, tokenType)
+			assert.Equal(t, TokenHeader, tokenType)
 			offset := 0
 			profile, offset, err := getPrefixedString(record, offset)
 			require.NoError(t, err)
-			require.Equal(t, "ros1", profile)
+			assert.Equal(t, "ros1", profile)
 			library, _, err := getPrefixedString(record, offset)
 			require.NoError(t, err)
-			require.Equal(t, library, c.output)
+			assert.Equal(t, library, c.output)
 		})
 	}
 }
@@ -559,7 +559,7 @@ func TestMakePrefixedMap(t *testing.T) {
 			"foo": "bar",
 			"bar": "foo",
 		})
-		require.Equal(t, flatten(
+		assert.Equal(t, flatten(
 			encodedUint32(2*4+2*4+4*3), // map length
 			encodedUint32(3),
 			[]byte("bar"),
@@ -739,5 +739,5 @@ func TestBYOCompressor(t *testing.T) {
 	}
 	require.NoError(t, writer.Close())
 	assertReadable(t, bytes.NewReader(buf.Bytes()))
-	require.Positive(t, blockCount)
+	assert.Positive(t, blockCount)
 }

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/pierrec/lz4/v4"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const libraryString = "libfoo v0"
@@ -18,31 +18,31 @@ func TestMCAPReadWrite(t *testing.T) {
 	t.Run("test header", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		w, err := NewWriter(buf, &WriterOptions{Compression: CompressionZSTD, OverrideLibrary: true})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		err = w.WriteHeader(&Header{
 			Profile: "ros1",
 			Library: libraryString,
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		lexer, err := NewLexer(buf)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		defer lexer.Close()
 		tokenType, record, err := lexer.Next(nil)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		// body of the header is the profile, followed by the metadata map
 		offset := 0
 		profile, offset, err := getPrefixedString(record, offset)
-		assert.Nil(t, err)
-		assert.Equal(t, "ros1", profile)
+		require.NoError(t, err)
+		require.Equal(t, "ros1", profile)
 		library, _, err := getPrefixedString(record, offset)
-		assert.Nil(t, err)
-		assert.Equal(t, "libfoo v0", library)
-		assert.Equal(t, TokenHeader, tokenType)
+		require.NoError(t, err)
+		require.Equal(t, "libfoo v0", library)
+		require.Equal(t, TokenHeader, tokenType)
 	})
 	t.Run("zero-valued schema IDs permitted", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		w, err := NewWriter(buf, &WriterOptions{Compression: CompressionLZ4})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		err = w.WriteChannel(&Channel{
 			ID:              0,
 			SchemaID:        0,
@@ -52,12 +52,12 @@ func TestMCAPReadWrite(t *testing.T) {
 				"key": "val",
 			},
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("positive schema IDs rejected if schema unknown", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		w, err := NewWriter(buf, &WriterOptions{Compression: CompressionLZ4})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		err = w.WriteChannel(&Channel{
 			ID:              0,
 			SchemaID:        1,
@@ -67,7 +67,7 @@ func TestMCAPReadWrite(t *testing.T) {
 				"key": "val",
 			},
 		})
-		assert.ErrorIs(t, err, ErrUnknownSchema)
+		require.ErrorIs(t, err, ErrUnknownSchema)
 	})
 }
 
@@ -82,19 +82,19 @@ func TestOutputDeterminism(t *testing.T) {
 			ChunkSize:       1024,
 			OverrideLibrary: true,
 		})
-		assert.Nil(t, err)
-		assert.Nil(t, w.WriteHeader(&Header{
+		require.NoError(t, err)
+		require.NoError(t, w.WriteHeader(&Header{
 			Profile: "ros1",
 			Library: libraryString,
 		}))
-		assert.Nil(t, w.WriteSchema(&Schema{
+		require.NoError(t, w.WriteSchema(&Schema{
 			ID:       1,
 			Name:     "foo",
 			Encoding: "ros1msg",
 			Data:     []byte{},
 		}))
 		for i := 0; i < 3; i++ {
-			assert.Nil(t, w.WriteChannel(&Channel{
+			require.NoError(t, w.WriteChannel(&Channel{
 				ID:              uint16(i),
 				Topic:           fmt.Sprintf("/test-%d", i),
 				MessageEncoding: "ros1",
@@ -104,7 +104,7 @@ func TestOutputDeterminism(t *testing.T) {
 		}
 		for i := 0; i < 1000; i++ {
 			channelID := uint16(i % 3)
-			assert.Nil(t, w.WriteMessage(&Message{
+			require.NoError(t, w.WriteMessage(&Message{
 				ChannelID:   channelID,
 				Sequence:    0,
 				LogTime:     100,
@@ -117,27 +117,27 @@ func TestOutputDeterminism(t *testing.T) {
 				},
 			}))
 		}
-		assert.Nil(t, w.WriteAttachment(&Attachment{
+		require.NoError(t, w.WriteAttachment(&Attachment{
 			Name:      "file.jpg",
 			LogTime:   0,
 			MediaType: "image/jpeg",
 			DataSize:  4,
 			Data:      bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04}),
 		}))
-		assert.Nil(t, w.WriteAttachment(&Attachment{
+		require.NoError(t, w.WriteAttachment(&Attachment{
 			Name:      "file2.jpg",
 			LogTime:   0,
 			MediaType: "image/jpeg",
 			DataSize:  4,
 			Data:      bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04}),
 		}))
-		assert.Nil(t, w.Close())
+		require.NoError(t, w.Close())
 		if i == 0 {
 			hash = fmt.Sprintf("%x", md5.Sum(buf.Bytes()))
 		}
 		t.Run("output hashes consistently", func(t *testing.T) {
 			newHash := fmt.Sprintf("%x", md5.Sum(buf.Bytes()))
-			assert.Equal(t, hash, newHash)
+			require.Equal(t, hash, newHash)
 		})
 	}
 }
@@ -157,18 +157,18 @@ func TestChunkedReadWrite(t *testing.T) {
 				IncludeCRC:      true,
 				OverrideLibrary: true,
 			})
-			assert.Nil(t, err)
-			assert.Nil(t, w.WriteHeader(&Header{
+			require.NoError(t, err)
+			require.NoError(t, w.WriteHeader(&Header{
 				Profile: "ros1",
 				Library: libraryString,
 			}))
-			assert.Nil(t, w.WriteSchema(&Schema{
+			require.NoError(t, w.WriteSchema(&Schema{
 				ID:       1,
 				Name:     "schema",
 				Encoding: "msg",
 				Data:     []byte{},
 			}))
-			assert.Nil(t, w.WriteChannel(&Channel{
+			require.NoError(t, w.WriteChannel(&Channel{
 				ID:              1,
 				Topic:           "/test",
 				MessageEncoding: "ros1",
@@ -177,13 +177,13 @@ func TestChunkedReadWrite(t *testing.T) {
 					"callerid": "100", // cspell:disable-line
 				},
 			}))
-			assert.Nil(t, w.WriteChannel(&Channel{
+			require.NoError(t, w.WriteChannel(&Channel{
 				ID:              2,
 				Topic:           "/test2",
 				MessageEncoding: "ros1",
 				SchemaID:        1,
 			}))
-			assert.Nil(t, w.WriteMessage(&Message{
+			require.NoError(t, w.WriteMessage(&Message{
 				ChannelID:   1,
 				Sequence:    0,
 				LogTime:     100,
@@ -195,7 +195,7 @@ func TestChunkedReadWrite(t *testing.T) {
 					4,
 				},
 			}))
-			assert.Nil(t, w.WriteMessage(&Message{
+			require.NoError(t, w.WriteMessage(&Message{
 				ChannelID:   2,
 				Sequence:    0,
 				LogTime:     100,
@@ -207,16 +207,16 @@ func TestChunkedReadWrite(t *testing.T) {
 					4,
 				},
 			}))
-			assert.Nil(t, w.Close())
-			assert.Equal(t, 2, len(w.ChunkIndexes))
-			assert.Equal(t, 0, len(w.AttachmentIndexes))
-			assert.Equal(t, uint64(2), w.Statistics.MessageCount)
-			assert.Equal(t, uint32(0), w.Statistics.AttachmentCount)
-			assert.Equal(t, uint32(2), w.Statistics.ChannelCount)
-			assert.Equal(t, uint32(2), w.Statistics.ChunkCount)
-			assert.Equal(t, int(w.Offset()), buf.Len())
+			require.NoError(t, w.Close())
+			require.Len(t, w.ChunkIndexes, 2)
+			require.Empty(t, w.AttachmentIndexes)
+			require.Equal(t, uint64(2), w.Statistics.MessageCount)
+			require.Equal(t, uint32(0), w.Statistics.AttachmentCount)
+			require.Equal(t, uint32(2), w.Statistics.ChannelCount)
+			require.Equal(t, uint32(2), w.Statistics.ChunkCount)
+			require.Equal(t, int(w.Offset()), buf.Len())
 			lexer, err := NewLexer(buf)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			defer lexer.Close()
 			for i, expected := range []TokenType{
 				TokenHeader,
@@ -243,8 +243,8 @@ func TestChunkedReadWrite(t *testing.T) {
 				TokenFooter,
 			} {
 				tokenType, _, err := lexer.Next(nil)
-				assert.Nil(t, err)
-				assert.Equal(t, expected, tokenType,
+				require.NoError(t, err)
+				require.Equal(t, expected, tokenType,
 					fmt.Sprintf("want %s got %s at %d", expected, tokenType, i))
 			}
 		})
@@ -262,13 +262,13 @@ func TestChunkBoundaryIndexing(t *testing.T) {
 		Compression:     CompressionZSTD,
 		OverrideLibrary: true,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = w.WriteHeader(&Header{
 		Profile: "ros1",
 		Library: libraryString,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.WriteSchema(&Schema{
+	require.NoError(t, err)
+	require.NoError(t, w.WriteSchema(&Schema{
 		ID:       1,
 		Name:     "schema",
 		Data:     []byte{},
@@ -281,26 +281,26 @@ func TestChunkBoundaryIndexing(t *testing.T) {
 		MessageEncoding: "ros1",
 		Metadata:        make(map[string]string),
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.WriteMessage(&Message{
+	require.NoError(t, err)
+	require.NoError(t, w.WriteMessage(&Message{
 		ChannelID:   1,
 		Sequence:    uint32(1),
 		LogTime:     uint64(100),
 		PublishTime: uint64(2),
 		Data:        []byte("Hello, world!"),
 	}))
-	assert.Nil(t, w.WriteMessage(&Message{
+	require.NoError(t, w.WriteMessage(&Message{
 		ChannelID:   1,
 		Sequence:    uint32(1),
 		LogTime:     uint64(1),
 		PublishTime: uint64(2),
 		Data:        []byte("Hello, world!"),
 	}))
-	assert.Nil(t, w.Close())
+	require.NoError(t, w.Close())
 	t.Run("chunk indexes correct", func(t *testing.T) {
-		assert.Equal(t, 2, len(w.ChunkIndexes))
-		assert.Equal(t, 100, int(w.ChunkIndexes[0].MessageStartTime)) // first message
-		assert.Equal(t, 1, int(w.ChunkIndexes[1].MessageStartTime))   // second message
+		require.Len(t, w.ChunkIndexes, 2)
+		require.Equal(t, 100, int(w.ChunkIndexes[0].MessageStartTime)) // first message
+		require.Equal(t, 1, int(w.ChunkIndexes[1].MessageStartTime))   // second message
 	})
 }
 
@@ -312,13 +312,13 @@ func TestIndexStructures(t *testing.T) {
 		Compression:     CompressionZSTD,
 		OverrideLibrary: true,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = w.WriteHeader(&Header{
 		Profile: "ros1",
 		Library: libraryString,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.WriteSchema(&Schema{
+	require.NoError(t, err)
+	require.NoError(t, w.WriteSchema(&Schema{
 		ID:       1,
 		Name:     "schema",
 		Data:     []byte{},
@@ -331,15 +331,15 @@ func TestIndexStructures(t *testing.T) {
 		MessageEncoding: "ros1",
 		Metadata:        make(map[string]string),
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.WriteMessage(&Message{
+	require.NoError(t, err)
+	require.NoError(t, w.WriteMessage(&Message{
 		ChannelID:   1,
 		Sequence:    uint32(1),
 		LogTime:     uint64(1),
 		PublishTime: uint64(2),
 		Data:        []byte("Hello, world!"),
 	}))
-	assert.Nil(t, w.WriteAttachment(&Attachment{
+	require.NoError(t, w.WriteAttachment(&Attachment{
 		Name:       "file.jpg",
 		LogTime:    100,
 		CreateTime: 99,
@@ -347,11 +347,11 @@ func TestIndexStructures(t *testing.T) {
 		DataSize:   4,
 		Data:       bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04}),
 	}))
-	assert.Nil(t, w.Close())
+	require.NoError(t, w.Close())
 	t.Run("chunk indexes correct", func(t *testing.T) {
-		assert.Equal(t, 1, len(w.ChunkIndexes))
+		require.Len(t, w.ChunkIndexes, 1)
 		chunkIndex := w.ChunkIndexes[0]
-		assert.Equal(t, &ChunkIndex{
+		require.Equal(t, &ChunkIndex{
 			MessageStartTime: 1,
 			MessageEndTime:   1,
 			ChunkStartOffset: 105,
@@ -366,9 +366,9 @@ func TestIndexStructures(t *testing.T) {
 		}, chunkIndex)
 	})
 	t.Run("attachment indexes correct", func(t *testing.T) {
-		assert.Equal(t, 1, len(w.AttachmentIndexes))
+		require.Len(t, w.AttachmentIndexes, 1)
 		attachmentIndex := w.AttachmentIndexes[0]
-		assert.Equal(t, &AttachmentIndex{
+		require.Equal(t, &AttachmentIndex{
 			Offset:     38,
 			Length:     67,
 			LogTime:    100,
@@ -388,18 +388,18 @@ func TestStatistics(t *testing.T) {
 		Compression:     CompressionZSTD,
 		OverrideLibrary: true,
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.WriteHeader(&Header{
+	require.NoError(t, err)
+	require.NoError(t, w.WriteHeader(&Header{
 		Profile: "ros1",
 		Library: libraryString,
 	}))
-	assert.Nil(t, w.WriteSchema(&Schema{
+	require.NoError(t, w.WriteSchema(&Schema{
 		ID:       1,
 		Name:     "schema",
 		Encoding: "msg",
 		Data:     []byte{},
 	}))
-	assert.Nil(t, w.WriteChannel(&Channel{
+	require.NoError(t, w.WriteChannel(&Channel{
 		ID:              1,
 		SchemaID:        1,
 		Topic:           "/test",
@@ -407,7 +407,7 @@ func TestStatistics(t *testing.T) {
 		Metadata:        make(map[string]string),
 	}))
 	for i := 0; i < 1000; i++ {
-		assert.Nil(t, w.WriteMessage(&Message{
+		require.NoError(t, w.WriteMessage(&Message{
 			ChannelID:   1,
 			Sequence:    uint32(i),
 			LogTime:     uint64(i),
@@ -415,38 +415,38 @@ func TestStatistics(t *testing.T) {
 			Data:        []byte("Hello, world!"),
 		}))
 	}
-	assert.Nil(t, w.WriteAttachment(&Attachment{
+	require.NoError(t, w.WriteAttachment(&Attachment{
 		Name:      "file.jpg",
 		LogTime:   0,
 		MediaType: "image/jpeg",
 		DataSize:  4,
 		Data:      bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04}),
 	}))
-	assert.Nil(t, w.Close())
-	assert.Equal(t, uint64(1000), w.Statistics.MessageCount)
-	assert.Equal(t, uint32(1), w.Statistics.ChannelCount)
-	assert.Equal(t, uint32(1), w.Statistics.AttachmentCount)
-	assert.Equal(t, 42, int(w.Statistics.ChunkCount))
-	assert.Equal(t, 42, len(w.ChunkIndexes))
-	assert.Equal(t, 1, len(w.AttachmentIndexes))
+	require.NoError(t, w.Close())
+	require.Equal(t, uint64(1000), w.Statistics.MessageCount)
+	require.Equal(t, uint32(1), w.Statistics.ChannelCount)
+	require.Equal(t, uint32(1), w.Statistics.AttachmentCount)
+	require.Equal(t, 42, int(w.Statistics.ChunkCount))
+	require.Len(t, w.ChunkIndexes, 42)
+	require.Len(t, w.AttachmentIndexes, 1)
 }
 
 func TestUnchunkedReadWrite(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w, err := NewWriter(buf, &WriterOptions{OverrideLibrary: true})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = w.WriteHeader(&Header{
 		Profile: "ros1",
 		Library: libraryString,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = w.WriteSchema(&Schema{
 		ID:       1,
 		Name:     "schema",
 		Encoding: "msg",
 		Data:     []byte{},
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = w.WriteChannel(&Channel{
 		ID:              1,
 		SchemaID:        1,
@@ -456,7 +456,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 			"callerid": "100", // cspell:disable-line
 		},
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = w.WriteMessage(&Message{
 		ChannelID:   1,
 		Sequence:    0,
@@ -469,7 +469,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 			4,
 		},
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = w.WriteAttachment(&Attachment{
 		Name:      "file.jpg",
@@ -478,19 +478,19 @@ func TestUnchunkedReadWrite(t *testing.T) {
 		DataSize:  4,
 		Data:      bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04}),
 	})
-	assert.Nil(t, err)
-	assert.Nil(t, w.Close())
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
 
-	assert.Equal(t, 0, len(w.ChunkIndexes))
-	assert.Equal(t, 1, len(w.AttachmentIndexes))
-	assert.Equal(t, "image/jpeg", w.AttachmentIndexes[0].MediaType)
-	assert.Equal(t, uint64(1), w.Statistics.MessageCount)
-	assert.Equal(t, uint32(1), w.Statistics.AttachmentCount)
-	assert.Equal(t, uint32(1), w.Statistics.ChannelCount)
-	assert.Equal(t, uint32(0), w.Statistics.ChunkCount)
+	require.Empty(t, w.ChunkIndexes)
+	require.Len(t, w.AttachmentIndexes, 1)
+	require.Equal(t, "image/jpeg", w.AttachmentIndexes[0].MediaType)
+	require.Equal(t, uint64(1), w.Statistics.MessageCount)
+	require.Equal(t, uint32(1), w.Statistics.AttachmentCount)
+	require.Equal(t, uint32(1), w.Statistics.ChannelCount)
+	require.Equal(t, uint32(0), w.Statistics.ChunkCount)
 
 	lexer, err := NewLexer(buf)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer lexer.Close()
 	for _, expected := range []TokenType{
 		TokenHeader,
@@ -509,8 +509,8 @@ func TestUnchunkedReadWrite(t *testing.T) {
 		TokenFooter,
 	} {
 		tokenType, _, err := lexer.Next(nil)
-		assert.Nil(t, err)
-		assert.Equal(t, expected, tokenType, fmt.Sprintf("want %s got %s", expected, tokenType))
+		require.NoError(t, err)
+		require.Equal(t, expected, tokenType, fmt.Sprintf("want %s got %s", expected, tokenType))
 	}
 }
 
@@ -528,26 +528,26 @@ func TestLibraryString(t *testing.T) {
 		t.Run("library string is automatically filled", func(t *testing.T) {
 			buf := &bytes.Buffer{}
 			w, err := NewWriter(buf, &WriterOptions{})
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			err = w.WriteHeader(&Header{
 				Profile: "ros1",
 				Library: c.input,
 			})
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			w.Close()
 			lexer, err := NewLexer(buf)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			defer lexer.Close()
 			tokenType, record, err := lexer.Next(nil)
-			assert.Nil(t, err)
-			assert.Equal(t, tokenType, TokenHeader)
+			require.NoError(t, err)
+			require.Equal(t, TokenHeader, tokenType)
 			offset := 0
 			profile, offset, err := getPrefixedString(record, offset)
-			assert.Nil(t, err)
-			assert.Equal(t, "ros1", profile)
+			require.NoError(t, err)
+			require.Equal(t, "ros1", profile)
 			library, _, err := getPrefixedString(record, offset)
-			assert.Nil(t, err)
-			assert.Equal(t, library, c.output)
+			require.NoError(t, err)
+			require.Equal(t, library, c.output)
 		})
 	}
 }
@@ -558,7 +558,7 @@ func TestMakePrefixedMap(t *testing.T) {
 			"foo": "bar",
 			"bar": "foo",
 		})
-		assert.Equal(t, flatten(
+		require.Equal(t, flatten(
 			encodedUint32(2*4+2*4+4*3), // map length
 			encodedUint32(3),
 			[]byte("bar"),
@@ -611,19 +611,19 @@ func BenchmarkWriterAllocs(b *testing.B) {
 					ChunkSize: int64(c.chunkSize),
 					Chunked:   true,
 				})
-				assert.Nil(b, err)
-				assert.Nil(b, writer.WriteHeader(&Header{
+				require.NoError(b, err)
+				require.NoError(b, writer.WriteHeader(&Header{
 					Profile: "ros1",
 					Library: "foo",
 				}))
 				for i := 0; i < c.channelCount; i++ {
-					assert.Nil(b, writer.WriteSchema(&Schema{
+					require.NoError(b, writer.WriteSchema(&Schema{
 						ID:       uint16(i),
 						Name:     stringData,
 						Encoding: "ros1msg",
 						Data:     messageData,
 					}))
-					assert.Nil(b, writer.WriteChannel(&Channel{
+					require.NoError(b, writer.WriteChannel(&Channel{
 						ID:              uint16(i),
 						SchemaID:        uint16(i),
 						Topic:           stringData,
@@ -636,7 +636,7 @@ func BenchmarkWriterAllocs(b *testing.B) {
 				channelID := 0
 				messageCount := 0
 				for messageCount < c.messageCount {
-					assert.Nil(b, writer.WriteMessage(&Message{
+					require.NoError(b, writer.WriteMessage(&Message{
 						ChannelID:   uint16(channelID),
 						Sequence:    0,
 						LogTime:     uint64(messageCount),
@@ -674,26 +674,26 @@ func TestWriteAttachment(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 			writer, err := NewWriter(buf, &WriterOptions{})
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			err = writer.WriteAttachment(c.attachment)
-			assert.ErrorIs(t, err, c.err)
+			require.ErrorIs(t, err, c.err)
 		})
 	}
 }
 
 func assertReadable(t *testing.T, rs io.ReadSeeker) {
 	reader, err := NewReader(rs)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = reader.Info()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	it, err := reader.Messages()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	for {
 		_, _, _, err := it.Next(nil)
 		if err != nil {
-			assert.ErrorIs(t, err, io.EOF)
+			require.ErrorIs(t, err, io.EOF)
 			break
 		}
 	}
@@ -704,7 +704,7 @@ func TestBYOCompressor(t *testing.T) {
 	// example - custom lz4 settings
 	lzw := lz4.NewWriter(nil)
 	blockCount := 0
-	assert.Nil(t, lzw.Apply(lz4.OnBlockDoneOption(func(int) {
+	require.NoError(t, lzw.Apply(lz4.OnBlockDoneOption(func(int) {
 		blockCount++
 	})))
 
@@ -713,16 +713,16 @@ func TestBYOCompressor(t *testing.T) {
 		ChunkSize:  1024,
 		Compressor: NewCustomCompressor("lz4", lzw),
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	assert.Nil(t, writer.WriteHeader(&Header{}))
-	assert.Nil(t, writer.WriteSchema(&Schema{
+	require.NoError(t, writer.WriteHeader(&Header{}))
+	require.NoError(t, writer.WriteSchema(&Schema{
 		ID:       1,
 		Name:     "schema",
 		Encoding: "ros1msg",
 		Data:     []byte{},
 	}))
-	assert.Nil(t, writer.WriteChannel(&Channel{
+	require.NoError(t, writer.WriteChannel(&Channel{
 		ID:              0,
 		SchemaID:        1,
 		Topic:           "/foo",
@@ -730,13 +730,13 @@ func TestBYOCompressor(t *testing.T) {
 	}))
 
 	for i := 0; i < 100; i++ {
-		assert.Nil(t, writer.WriteMessage(&Message{
+		require.NoError(t, writer.WriteMessage(&Message{
 			ChannelID: 0,
 			Sequence:  0,
 			LogTime:   uint64(i),
 		}))
 	}
-	assert.Nil(t, writer.Close())
+	require.NoError(t, writer.Close())
 	assertReadable(t, bytes.NewReader(buf.Bytes()))
-	assert.Positive(t, blockCount)
+	require.Positive(t, blockCount)
 }

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -704,7 +704,7 @@ func TestBYOCompressor(t *testing.T) {
 	// example - custom lz4 settings
 	lzw := lz4.NewWriter(nil)
 	blockCount := 0
-	assert.Nil(t, lzw.Apply(lz4.OnBlockDoneOption(func(size int) {
+	assert.Nil(t, lzw.Apply(lz4.OnBlockDoneOption(func(int) {
 		blockCount++
 	})))
 

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pierrec/lz4/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -208,7 +209,7 @@ func TestChunkedReadWrite(t *testing.T) {
 				},
 			}))
 			require.NoError(t, w.Close())
-			require.Len(t, w.ChunkIndexes, 2)
+			assert.Len(t, w.ChunkIndexes, 2)
 			require.Empty(t, w.AttachmentIndexes)
 			require.Equal(t, uint64(2), w.Statistics.MessageCount)
 			require.Equal(t, uint32(0), w.Statistics.AttachmentCount)
@@ -298,7 +299,7 @@ func TestChunkBoundaryIndexing(t *testing.T) {
 	}))
 	require.NoError(t, w.Close())
 	t.Run("chunk indexes correct", func(t *testing.T) {
-		require.Len(t, w.ChunkIndexes, 2)
+		assert.Len(t, w.ChunkIndexes, 2)
 		require.Equal(t, 100, int(w.ChunkIndexes[0].MessageStartTime)) // first message
 		require.Equal(t, 1, int(w.ChunkIndexes[1].MessageStartTime))   // second message
 	})
@@ -349,7 +350,7 @@ func TestIndexStructures(t *testing.T) {
 	}))
 	require.NoError(t, w.Close())
 	t.Run("chunk indexes correct", func(t *testing.T) {
-		require.Len(t, w.ChunkIndexes, 1)
+		assert.Len(t, w.ChunkIndexes, 1)
 		chunkIndex := w.ChunkIndexes[0]
 		require.Equal(t, &ChunkIndex{
 			MessageStartTime: 1,
@@ -366,7 +367,7 @@ func TestIndexStructures(t *testing.T) {
 		}, chunkIndex)
 	})
 	t.Run("attachment indexes correct", func(t *testing.T) {
-		require.Len(t, w.AttachmentIndexes, 1)
+		assert.Len(t, w.AttachmentIndexes, 1)
 		attachmentIndex := w.AttachmentIndexes[0]
 		require.Equal(t, &AttachmentIndex{
 			Offset:     38,
@@ -427,8 +428,8 @@ func TestStatistics(t *testing.T) {
 	require.Equal(t, uint32(1), w.Statistics.ChannelCount)
 	require.Equal(t, uint32(1), w.Statistics.AttachmentCount)
 	require.Equal(t, 42, int(w.Statistics.ChunkCount))
-	require.Len(t, w.ChunkIndexes, 42)
-	require.Len(t, w.AttachmentIndexes, 1)
+	assert.Len(t, w.ChunkIndexes, 42)
+	assert.Len(t, w.AttachmentIndexes, 1)
 }
 
 func TestUnchunkedReadWrite(t *testing.T) {
@@ -482,7 +483,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 	require.NoError(t, w.Close())
 
 	require.Empty(t, w.ChunkIndexes)
-	require.Len(t, w.AttachmentIndexes, 1)
+	assert.Len(t, w.AttachmentIndexes, 1)
 	require.Equal(t, "image/jpeg", w.AttachmentIndexes[0].MediaType)
 	require.Equal(t, uint64(1), w.Statistics.MessageCount)
 	require.Equal(t, uint32(1), w.Statistics.AttachmentCount)

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/foxglove/go-rosbag"
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,15 +41,15 @@ func TestBag2MCAPPreservesChannelMetadata(t *testing.T) {
 		case mcap.TokenChannel:
 			ch, err := mcap.ParseChannel(token)
 			require.NoError(t, err)
-			require.Equal(t, len(expectedKeys), len(ch.Metadata))
+			assert.Equal(t, len(expectedKeys), len(ch.Metadata))
 			for _, k := range expectedKeys {
-				require.Contains(t, ch.Metadata, k)
+				assert.Contains(t, ch.Metadata, k)
 			}
 			channelCount++
 		default:
 		}
 	}
-	require.Equal(t, 3, channelCount)
+	assert.Equal(t, 3, channelCount)
 }
 
 func TestDeduplicatesSchemas(t *testing.T) {
@@ -99,8 +100,8 @@ func TestDeduplicatesSchemas(t *testing.T) {
 
 	info, err := reader.Info()
 	require.NoError(t, err)
-	require.Equal(t, 2, int(info.Statistics.ChannelCount))
-	require.Equal(t, 1, int(info.Statistics.SchemaCount))
+	assert.Equal(t, 2, int(info.Statistics.ChannelCount))
+	assert.Equal(t, 1, int(info.Statistics.SchemaCount))
 }
 
 func BenchmarkBag2MCAP(b *testing.B) {
@@ -159,7 +160,7 @@ func TestConvertsBz2(t *testing.T) {
 	require.NoError(t, err)
 	info, err := reader.Info()
 	require.NoError(t, err)
-	require.Equal(t, 10, int(info.Statistics.MessageCount))
+	assert.Equal(t, 10, int(info.Statistics.MessageCount))
 }
 
 func TestChannelIdForConnection(t *testing.T) {
@@ -192,7 +193,7 @@ func TestChannelIdForConnection(t *testing.T) {
 		t.Run(c.label, func(t *testing.T) {
 			channelID, err := channelIDForConnection(c.connID)
 			require.ErrorIs(t, err, c.expectedErr)
-			require.Equal(t, c.expectedChannelID, channelID)
+			assert.Equal(t, c.expectedChannelID, channelID)
 		})
 	}
 }

--- a/go/ros/bag2mcap_test.go
+++ b/go/ros/bag2mcap_test.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/foxglove/go-rosbag"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBag2MCAPPreservesChannelMetadata(t *testing.T) {
 	inputFile := "./testdata/markers.bag"
 	expectedKeys := []string{"md5sum", "topic"}
 	f, err := os.Open(inputFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	writer := &bytes.Buffer{}
 	err = Bag2MCAP(writer, f, &mcap.WriterOptions{
 		IncludeCRC:  true,
@@ -26,37 +26,37 @@ func TestBag2MCAPPreservesChannelMetadata(t *testing.T) {
 		ChunkSize:   4 * 1024 * 1024,
 		Compression: mcap.CompressionNone,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	lexer, err := mcap.NewLexer(writer)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	channelCount := 0
 	for {
 		tokenType, token, err := lexer.Next(nil)
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		switch tokenType {
 		case mcap.TokenChannel:
 			ch, err := mcap.ParseChannel(token)
-			assert.Nil(t, err)
-			assert.Equal(t, len(expectedKeys), len(ch.Metadata))
+			require.NoError(t, err)
+			require.Equal(t, len(expectedKeys), len(ch.Metadata))
 			for _, k := range expectedKeys {
-				assert.Contains(t, ch.Metadata, k)
+				require.Contains(t, ch.Metadata, k)
 			}
 			channelCount++
 		default:
 		}
 	}
-	assert.Equal(t, 3, channelCount)
+	require.Equal(t, 3, channelCount)
 }
 
 func TestDeduplicatesSchemas(t *testing.T) {
 	buf := &bytes.Buffer{}
 	bw, err := rosbag.NewWriter(buf)
-	assert.Nil(t, err)
-	assert.Nil(t, bw.WriteBagHeader(rosbag.BagHeader{}))
-	assert.Nil(t, bw.WriteConnection(&rosbag.Connection{
+	require.NoError(t, err)
+	require.NoError(t, bw.WriteBagHeader(rosbag.BagHeader{}))
+	require.NoError(t, bw.WriteConnection(&rosbag.Connection{
 		Conn:  0,
 		Topic: "yo",
 		Data: rosbag.ConnectionHeader{
@@ -65,7 +65,7 @@ func TestDeduplicatesSchemas(t *testing.T) {
 			MD5Sum: "123",
 		},
 	}))
-	assert.Nil(t, bw.WriteConnection(&rosbag.Connection{
+	require.NoError(t, bw.WriteConnection(&rosbag.Connection{
 		Conn:  1,
 		Topic: "yoo",
 		Data: rosbag.ConnectionHeader{
@@ -74,20 +74,20 @@ func TestDeduplicatesSchemas(t *testing.T) {
 			MD5Sum: "123",
 		},
 	}))
-	assert.Nil(t, bw.WriteMessage(&rosbag.Message{
+	require.NoError(t, bw.WriteMessage(&rosbag.Message{
 		Conn: 0,
 		Time: 0,
 		Data: []byte{},
 	}))
-	assert.Nil(t, bw.WriteMessage(&rosbag.Message{
+	require.NoError(t, bw.WriteMessage(&rosbag.Message{
 		Conn: 1,
 		Time: 0,
 		Data: []byte{},
 	}))
-	assert.Nil(t, bw.Close())
+	require.NoError(t, bw.Close())
 
 	output := &bytes.Buffer{}
-	assert.Nil(t, Bag2MCAP(output, buf, &mcap.WriterOptions{
+	require.NoError(t, Bag2MCAP(output, buf, &mcap.WriterOptions{
 		IncludeCRC: true,
 		Chunked:    true,
 		ChunkSize:  1024,
@@ -95,12 +95,12 @@ func TestDeduplicatesSchemas(t *testing.T) {
 
 	rs := bytes.NewReader(output.Bytes())
 	reader, err := mcap.NewReader(rs)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	info, err := reader.Info()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, int(info.Statistics.ChannelCount))
-	assert.Equal(t, 1, int(info.Statistics.SchemaCount))
+	require.NoError(t, err)
+	require.Equal(t, 2, int(info.Statistics.ChannelCount))
+	require.Equal(t, 1, int(info.Statistics.SchemaCount))
 }
 
 func BenchmarkBag2MCAP(b *testing.B) {
@@ -121,9 +121,9 @@ func BenchmarkBag2MCAP(b *testing.B) {
 	}
 	for _, c := range cases {
 		stats, err := os.Stat(c.inputfile)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 		input, err := os.ReadFile(c.inputfile)
-		assert.Nil(b, err)
+		require.NoError(b, err)
 		reader := &bytes.Reader{}
 		writer := bytes.NewBuffer(make([]byte, 4*1024*1024*1024))
 		b.ResetTimer()
@@ -133,7 +133,7 @@ func BenchmarkBag2MCAP(b *testing.B) {
 				reader.Reset(input)
 				writer.Reset()
 				err = Bag2MCAP(writer, reader, opts)
-				assert.Nil(b, err)
+				require.NoError(b, err)
 				elapsed := time.Since(t0)
 				megabytesRead := stats.Size() / (1024 * 1024)
 				b.ReportMetric(float64(megabytesRead)/elapsed.Seconds(), "MB/sec")
@@ -145,7 +145,7 @@ func BenchmarkBag2MCAP(b *testing.B) {
 func TestConvertsBz2(t *testing.T) {
 	inputfile := "testdata/markers.bz2.bag"
 	f, err := os.Open(inputfile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	opts := &mcap.WriterOptions{
 		IncludeCRC:  true,
 		Chunked:     true,
@@ -153,13 +153,13 @@ func TestConvertsBz2(t *testing.T) {
 		Compression: "",
 	}
 	output := &bytes.Buffer{}
-	assert.Nil(t, Bag2MCAP(output, f, opts))
+	require.NoError(t, Bag2MCAP(output, f, opts))
 
 	reader, err := mcap.NewReader(bytes.NewReader(output.Bytes()))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	info, err := reader.Info()
-	assert.Nil(t, err)
-	assert.Equal(t, 10, int(info.Statistics.MessageCount))
+	require.NoError(t, err)
+	require.Equal(t, 10, int(info.Statistics.MessageCount))
 }
 
 func TestChannelIdForConnection(t *testing.T) {
@@ -191,8 +191,8 @@ func TestChannelIdForConnection(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.label, func(t *testing.T) {
 			channelID, err := channelIDForConnection(c.connID)
-			assert.ErrorIs(t, err, c.expectedErr)
-			assert.Equal(t, c.expectedChannelID, channelID)
+			require.ErrorIs(t, err, c.expectedErr)
+			require.Equal(t, c.expectedChannelID, channelID)
 		})
 	}
 }

--- a/go/ros/ros1msg/ros1msg_parser_test.go
+++ b/go/ros/ros1msg/ros1msg_parser_test.go
@@ -3,7 +3,7 @@ package ros1msg
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestROS1MSGParser(t *testing.T) {
@@ -371,8 +371,8 @@ func TestROS1MSGParser(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			fields, err := ParseMessageDefinition(c.parentPackage, []byte(c.messageDefinition))
-			assert.Nil(t, err)
-			assert.Equal(t, c.fields, fields)
+			require.NoError(t, err)
+			require.Equal(t, c.fields, fields)
 		})
 	}
 }

--- a/go/ros/ros1msg/ros1msg_parser_test.go
+++ b/go/ros/ros1msg/ros1msg_parser_test.go
@@ -3,6 +3,7 @@ package ros1msg
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -372,7 +373,7 @@ func TestROS1MSGParser(t *testing.T) {
 		t.Run(c.assertion, func(t *testing.T) {
 			fields, err := ParseMessageDefinition(c.parentPackage, []byte(c.messageDefinition))
 			require.NoError(t, err)
-			require.Equal(t, c.fields, fields)
+			assert.Equal(t, c.fields, fields)
 		})
 	}
 }

--- a/go/ros/ros2db3_to_mcap_test.go
+++ b/go/ros/ros2db3_to_mcap_test.go
@@ -60,9 +60,9 @@ func TestDB3MCAPConversion(t *testing.T) {
 
 			info, err := reader.Info()
 			require.NoError(t, err)
-			require.Equal(t, uint64(c.expectedMessageCount), info.Statistics.MessageCount)
+			assert.Equal(t, uint64(c.expectedMessageCount), info.Statistics.MessageCount)
 			assert.Len(t, info.Channels, 1)
-			require.Equal(t, c.expectedTopic, info.Channels[1].Topic)
+			assert.Equal(t, c.expectedTopic, info.Channels[1].Topic)
 			messageCount := 0
 			it, err := reader.Messages(mcap.WithTopics([]string{c.expectedTopic}))
 			require.NoError(t, err)
@@ -75,11 +75,11 @@ func TestDB3MCAPConversion(t *testing.T) {
 					t.Errorf("failed to pull message from serialized file: %s", err)
 				}
 				require.NotEmpty(t, message.Data)
-				require.Equal(t, c.expectedTopic, channel.Topic)
-				require.Equal(t, c.expectedSchemaName, schema.Name)
+				assert.Equal(t, c.expectedTopic, channel.Topic)
+				assert.Equal(t, c.expectedSchemaName, schema.Name)
 				messageCount++
 			}
-			require.Equal(t, c.expectedMessageCount, messageCount)
+			assert.Equal(t, c.expectedMessageCount, messageCount)
 		})
 	}
 }
@@ -101,7 +101,7 @@ string data
 MSG: package_b/TypeB
 int32 foo
 `
-	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(schema)))
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(schema)))
 }
 
 func TestBoundedFields(t *testing.T) {
@@ -129,7 +129,7 @@ package_b/TypeB[<=10]
 MSG: package_b/TypeB
 int32 foo
 `
-	require.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
+	assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
 }
 
 func TestSchemaComposition(t *testing.T) {
@@ -145,7 +145,7 @@ package_b/TypeB FancyType
 MSG: package_b/TypeB
 int32 foo
 `
-		require.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
+		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
 	})
 }
 
@@ -173,7 +173,7 @@ func TestMessageTopicRegex(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
-			require.Equal(t, c.match, messageTopicRegex.MatchString(c.input))
+			assert.Equal(t, c.match, messageTopicRegex.MatchString(c.input))
 		})
 	}
 }
@@ -202,8 +202,8 @@ func TestSchemaFinding(t *testing.T) {
 	}
 	for _, c := range cases {
 		content, err := getSchema(c.rosType, []string{"./testdata/get_schema_workspace"})
-		require.Equal(t, c.err, err)
-		require.Equal(t, c.expectedContent, string(content))
+		assert.Equal(t, c.err, err)
+		assert.Equal(t, c.expectedContent, string(content))
 	}
 }
 
@@ -223,6 +223,6 @@ MSG: example_msgs/Descriptor
 MSG: example_msgs/OtherDescriptor
 example_msgs/Descriptor descriptor
 `
-		require.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
+		assert.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(schema)))
 	})
 }


### PR DESCRIPTION
### Public-Facing Changes

None.

### Description
- Updates go to `v1.22` in go.work. This doesn't affect the required go version for our packages. However, at least v1.21 is require for this new golangci-lint version. 
- Upgrades golangci-lint to 1.56.2 - this is newer, and matches the version we use for internal projects.
- enable `testifylint` - most significantly this forces all error assertions to use "require" instead of "assert". "require" halts the test at the point of failure, rather than assert which allows the test to keep going. IMO this is a significantly better experience, because usually after an error check fails, every other check will also fail and you'll also get a bunch of nil-dereference tracebacks.