### PR TITLE
go: add ordered lexer as a reader implementation

### DIFF
--- a/go/conformance/test-read-conformance/read_conformance_test.go
+++ b/go/conformance/test-read-conformance/read_conformance_test.go
@@ -3,14 +3,60 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/foxglove/mcap/go/mcap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func getLogTime(fields []any) uint64 {
+	for _, field := range fields {
+		tup, ok := field.([]any)
+		if !ok {
+			panic(fmt.Sprintf("field tuple is: %v", field))
+		}
+		if tup[0] == "log_time" {
+			val, err := strconv.ParseUint(tup[1].(string), 10, 64)
+			if err != nil {
+				panic(err.Error())
+			}
+			return val
+		}
+	}
+	panic(fmt.Sprintf("where's the log_time in %v", fields))
+}
+
+func sortMessages(output TextOutput) {
+	//hack: assumes messages are contiguous within a file
+	firstMessageIdx := 0
+	lastMessageIdx := 0
+	for i := 0; i < len(output.Records); i++ {
+		if output.Records[i].Type == "Message" && firstMessageIdx == 0 {
+			firstMessageIdx = i
+		}
+		if firstMessageIdx != 0 && output.Records[i].Type != "Message" {
+			lastMessageIdx = i
+		}
+		if firstMessageIdx != 0 && lastMessageIdx != 0 {
+			break
+		}
+	}
+	messages := output.Records[firstMessageIdx:lastMessageIdx]
+	sort.Slice(messages, func(i, j int) bool {
+		logTimeI := getLogTime(messages[i].Fields)
+		logTimeJ := getLogTime(messages[j].Fields)
+		return logTimeI < logTimeJ
+	})
+}
 
 func TestLexerConformance(t *testing.T) {
 	inputs := []string{}
@@ -28,13 +74,17 @@ func TestLexerConformance(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			output := bytes.Buffer{}
 			err := readStreamed(&output, input)
-			assert.Nil(t, err)
+			if errors.Is(err, mcap.ErrInsufficientSummary) {
+				return
+			}
+			require.NoError(t, err)
 			expectedBytes, err := os.ReadFile(strings.TrimSuffix(input, ".mcap") + ".json")
 			assert.Nil(t, err)
 			expectedOutput := TextOutput{}
 			err = json.Unmarshal(expectedBytes, &expectedOutput)
 			assert.Nil(t, err)
 			receivedOutput := TextOutput{}
+			sortMessages(expectedOutput)
 			err = json.Unmarshal(output.Bytes(), &receivedOutput)
 			assert.Nil(t, err)
 			expectedRecords, err := json.Marshal(expectedOutput.Records)

--- a/go/go.work
+++ b/go/go.work
@@ -1,4 +1,4 @@
-go 1.20
+go 1.22
 
 use (
 	./cli/mcap

--- a/go/mcap/ordered_lexer.go
+++ b/go/mcap/ordered_lexer.go
@@ -1,0 +1,382 @@
+package mcap
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+)
+
+var ErrWouldExceedMemoryLimit = errors.New("input requires too large of a message buffer")
+var ErrInsufficientSummary = errors.New("input does not contain required summary information")
+var ErrChunksNotIndexed = fmt.Errorf("%w: need chunk indexes", ErrInsufficientSummary)
+var ErrNoStatistics = fmt.Errorf("%w: need a statistics record", ErrInsufficientSummary)
+
+type recordIndex struct {
+	token     TokenType
+	timestamp uint64
+	offset    uint64
+	length    uint64
+}
+
+// OrderedLexer reads MCAP files record by record, yielding message records in ascending logTime
+// order.
+type OrderedLexer struct {
+	chunkContent   []byte
+	recordBuf      []byte
+	recordIndexes  []recordIndex
+	curRecordIndex int
+
+	chunkLoader chunkLoader
+
+	chunkTags            []chunkTag
+	curChunk             int
+	readyToYieldMessages bool
+	lexer                *Lexer
+}
+
+type chunkTag struct {
+	uncompressedSize uint64
+	mergeWithNext    bool
+}
+
+// tagChunksForMerging produces a chunkTag for every ChunkIndex in `info`. This tag determines
+// whether that chunk must be merged with one or more after it during reading.
+func tagChunksForMerging(info *Info) []chunkTag {
+	// ensure chunk indexes are sorted in physical order
+	sort.Slice(info.ChunkIndexes, func(i, j int) bool {
+		return info.ChunkIndexes[i].ChunkStartOffset < info.ChunkIndexes[j].ChunkStartOffset
+	})
+
+	chunkTags := make([]chunkTag, len(info.ChunkIndexes))
+	mergeUpTo := 0
+	for i, ci := range info.ChunkIndexes {
+		chunkTags[i].uncompressedSize = ci.UncompressedSize
+		// find the last chunk index that overlaps with this one, and ensure that this chunk
+		// and all between are merged into it.
+		for j := i + 1; j < len(info.ChunkIndexes); j++ {
+			if info.ChunkIndexes[j].MessageStartTime < ci.MessageEndTime {
+				if j > mergeUpTo {
+					mergeUpTo = j
+				}
+			}
+		}
+		if i < mergeUpTo {
+			chunkTags[i].mergeWithNext = true
+		}
+	}
+	return chunkTags
+}
+
+// getMaxRecordSize determines the largest single record which will be read from this MCAP during
+// lexing. This is used to pre-allocate the record buffer that the lexer reads into.
+func getMaxRecordSize(info *Info) uint64 {
+	// assume chunks are the largest records that we'll have to buffer.
+	realChunkSize := func(chunkIndex *ChunkIndex) uint64 {
+		// https://dev/spec#chunk-op0x06
+		return 8 + 8 + 8 + 4 + 4 + uint64(len(chunkIndex.Compression)) + 8 + chunkIndex.CompressedSize
+	}
+	var maxChunkRecordSize uint64
+	for _, chunkIndex := range info.ChunkIndexes {
+		size := realChunkSize(chunkIndex)
+		if size > maxChunkRecordSize {
+			maxChunkRecordSize = size
+		}
+	}
+	return maxChunkRecordSize
+}
+
+// NewOrderedLexer constructs a reader. It inspects the summary section of the MCAP, checking for
+// overlapping chunks. For any range of chunks that overlap in time range, they are tagged as
+// needing to be merged together in order to be sorted. It then determines the size of chunk buffer
+// required, and returns an error if this is greater than `maxBufferSize`.
+func NewOrderedLexer(
+	r io.Reader,
+	info *Info,
+	maxBufferSize uint64,
+	attachmentCallback func(*AttachmentReader) error,
+) (*OrderedLexer, error) {
+	if err := checkIndexes(info); err != nil {
+		return nil, err
+	}
+
+	chunkTags := tagChunksForMerging(info)
+
+	requiredBufferSize := determineRequiredBufferSize(chunkTags)
+	if requiredBufferSize > maxBufferSize {
+		return nil, ErrWouldExceedMemoryLimit
+	}
+	lexer, err := NewLexer(r, &LexerOptions{EmitChunks: true, AttachmentCallback: attachmentCallback})
+	if err != nil {
+		return nil, err
+	}
+	return &OrderedLexer{
+		chunkContent: make([]byte, 0, requiredBufferSize),
+		recordBuf:    make([]byte, getMaxRecordSize(info)),
+		chunkTags:    chunkTags,
+		lexer:        lexer,
+	}, nil
+}
+
+// checkIndexes determines whether the information in the MCAP summary is sufficient to read
+// messages in order.
+func checkIndexes(info *Info) error {
+	if info.Statistics == nil {
+		return ErrNoStatistics
+	}
+	if len(info.ChunkIndexes) == 0 && info.Statistics.MessageCount != 0 {
+		return ErrChunksNotIndexed
+	}
+	return nil
+}
+
+// determineRequiredBufferSize sums up the uncompressed size of chunks that need to be merged
+// together, and from there determines the maximum chunk buffer size needed to read this file
+// in log time order.
+func determineRequiredBufferSize(chunkTags []chunkTag) uint64 {
+	var maxBufferSize uint64
+	for i := len(chunkTags) - 1; i >= 0; i-- {
+		chunkTag := chunkTags[i]
+		if chunkTag.mergeWithNext {
+			maxBufferSize += chunkTag.uncompressedSize
+		} else {
+			maxBufferSize = chunkTag.uncompressedSize
+		}
+	}
+	return maxBufferSize
+}
+
+// Next yields the next record from the reader. If none remain, returns io.EOF.
+//
+// Initially, records are read from the MCAP with an Lexer, and are yielded immediately.
+// When chunk records are found, these are decompressed into `chunkContent`, and a sorted array
+// of recordIndex structs is maintained for every record in the `chunkContent` buffer.
+// If the content of the chunk buffer needs to be merged with more chunks, the lexer continues
+// until all required chunks are loaded into `chunkContent`. Then, the OrderedLexer switches
+// to yielding records from the chunk buffer until it is exhausted, at which point it switches back.
+func (ol *OrderedLexer) Next([]byte) (TokenType, []byte, error) {
+	for {
+		if ol.readyToYieldMessages {
+			if ol.curRecordIndex < len(ol.recordIndexes) {
+				recordIndex := ol.recordIndexes[ol.curRecordIndex]
+				ol.curRecordIndex++
+				buf := ol.chunkContent[recordIndex.offset : recordIndex.offset+recordIndex.length]
+				return recordIndex.token, buf, nil
+			}
+			ol.readyToYieldMessages = false
+			ol.curRecordIndex = 0
+			ol.recordIndexes = ol.recordIndexes[:0]
+			ol.chunkContent = ol.chunkContent[:0]
+		}
+		token, buf, err := ol.lexer.Next(ol.recordBuf)
+		if len(buf) > len(ol.recordBuf) {
+			ol.recordBuf = buf
+		}
+		if err != nil {
+			return TokenError, nil, err
+		}
+		switch token {
+		case TokenChunk:
+			chunk, err := ParseChunk(buf)
+			if err != nil {
+				return TokenError, nil, err
+			}
+			newChunkContent, newRecordIndexes, err := ol.chunkLoader.loadChunk(chunk, ol.chunkContent, ol.recordIndexes)
+			if err != nil {
+				return TokenError, nil, err
+			}
+			chunkTag := ol.chunkTags[ol.curChunk]
+			ol.curChunk++
+			ol.chunkContent = newChunkContent
+			ol.recordIndexes = newRecordIndexes
+			ol.readyToYieldMessages = !chunkTag.mergeWithNext
+		default:
+			return token, buf, err
+		}
+	}
+}
+
+func (ol *OrderedLexer) Close() {
+	if ol.lexer != nil {
+		ol.lexer.Close()
+	}
+	ol.chunkLoader.Close()
+}
+
+type chunkLoader struct {
+	zstd *zstd.Decoder
+	lz4  *lz4.Reader
+}
+
+func (l *chunkLoader) getZstdDecoder(r io.Reader) (io.Reader, error) {
+	if l.zstd == nil {
+		decoder, err := zstd.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		l.zstd = decoder
+	} else {
+		err := l.zstd.Reset(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return l.zstd, nil
+}
+
+func (l *chunkLoader) getLZ4Decoder(r io.Reader) io.Reader {
+	if l.lz4 == nil {
+		l.lz4 = lz4.NewReader(r)
+	} else {
+		l.lz4.Reset(r)
+	}
+	return l.lz4
+}
+
+// loadChunk appends the decompressed records from `chunk` into `intoBuf`, and inserts record
+// indexes to `indexes` for the records in this chunk. record indexes are maintained in log-time
+// order.
+func (l *chunkLoader) loadChunk(
+	chunk *Chunk,
+	intoBuf []byte,
+	indexes []recordIndex,
+) ([]byte, []recordIndex, error) {
+	// Grow `intoBuf` to fit the new uncompressed records in chunk.
+	initialLength := uint64(len(intoBuf))
+	newLength := initialLength + chunk.UncompressedSize
+	if uint64(cap(intoBuf)) < newLength {
+		intoBuf = append(intoBuf, make([]byte, chunk.UncompressedSize)...)
+	} else {
+		intoBuf = intoBuf[:newLength]
+	}
+
+	// remaining bytes in the record are the chunk data
+	var chunkReader *crcReader
+	computeCrc := chunk.UncompressedCRC != 0
+	format := CompressionFormat(chunk.Compression)
+	byteReader := bytes.NewReader(chunk.Records)
+	switch format {
+	case CompressionNone:
+		chunkReader = newCRCReader(byteReader, computeCrc)
+	case CompressionZSTD:
+		cr, err := l.getZstdDecoder(byteReader)
+		if err != nil {
+			return nil, nil, err
+		}
+		chunkReader = newCRCReader(cr, computeCrc)
+	case CompressionLZ4:
+		chunkReader = newCRCReader(l.getLZ4Decoder(byteReader), computeCrc)
+	default:
+		return nil, nil, fmt.Errorf("unsupported compression: %s", chunk.Compression)
+	}
+	_, err := io.ReadFull(chunkReader, intoBuf[initialLength:])
+	if err != nil {
+		return nil, nil, err
+	}
+	if chunk.UncompressedCRC != 0 && chunkReader.Checksum() != chunk.UncompressedCRC {
+		return nil, nil, fmt.Errorf("invalid chunk CRC: expected %d, got %d", chunk.UncompressedCRC, chunkReader.Checksum())
+	}
+
+	for i := initialLength; i < newLength; {
+		if uint64(len(intoBuf)) < i+1+8 {
+			return nil, nil, fmt.Errorf("expected another record in chunk, but left with %d bytes", uint64(len(intoBuf))-i)
+		}
+		opcodeAndLengthBuf := intoBuf[i : i+1+8]
+		op := OpCode(opcodeAndLengthBuf[0])
+		recordLen := binary.LittleEndian.Uint64(opcodeAndLengthBuf[1:])
+		recordStart := i + 1 + 8
+		if uint64(len(intoBuf)) < recordStart+recordLen {
+			return nil, nil, fmt.Errorf(
+				"%s record in chunk has length %d bytes but only %d remaining in chunk",
+				op.String(), recordLen, uint64(len(intoBuf))-recordStart)
+		}
+		recordContent := intoBuf[recordStart : recordStart+recordLen]
+		if uint64(len(recordContent)) < recordLen {
+			return nil, nil, fmt.Errorf(
+				"expected %d bytes remaining in chunk, for %s record, found %d",
+				recordLen,
+				op.String(),
+				len(recordContent),
+			)
+		}
+		recordIndex := recordIndex{
+			offset: recordStart,
+			length: recordLen,
+		}
+		switch op {
+		case OpMessage:
+			logTime, err := getLogTimeOfMessageSlice(recordContent)
+			if err != nil {
+				return nil, nil, fmt.Errorf("could not parse message in chunk: %w", err)
+			}
+			recordIndex.timestamp = logTime
+			recordIndex.token = TokenMessage
+		case OpChannel:
+			recordIndex.token = TokenChannel
+		case OpSchema:
+			recordIndex.token = TokenSchema
+		default:
+			return nil, nil, fmt.Errorf("unexpected record type in chunk buffer: %s", op.String())
+		}
+		indexes = isort(indexes, recordIndex)
+		i = recordStart + recordLen
+	}
+	return intoBuf, indexes, nil
+}
+
+func (l *chunkLoader) Close() {
+	if l.zstd != nil {
+		l.zstd.Close()
+	}
+}
+
+// Parses the logTime from a buffer containing a Message record.
+// This is cheaper than ParseMessage because it does not allocate a new object.
+func getLogTimeOfMessageSlice(buf []byte) (uint64, error) {
+	// https://dev/spec#message-op0x05
+	if len(buf) < 2+4+8 {
+		return 0, io.ErrShortBuffer
+	}
+	return binary.LittleEndian.Uint64(buf[2+4:]), nil
+}
+
+// isort inserts a new recordIndex into an already-sorted array of record indexes. The array
+// is returned with the new index in order.
+func isort(indexes []recordIndex, newIndex recordIndex) []recordIndex {
+	pos := len(indexes)
+	switch newIndex.token {
+	case TokenChannel:
+		// place channels before all the messages
+		for ; pos > 0; pos-- {
+			if indexes[pos-1].token != TokenMessage {
+				break
+			}
+		}
+	case TokenSchema:
+		// place schemas before all channels and messages
+		for ; pos > 0; pos-- {
+			if indexes[pos-1].token == TokenSchema {
+				break
+			}
+		}
+	case TokenMessage:
+		// place messages after all other record types, and messages with equal or lesser timestamp
+		for ; pos > 0; pos-- {
+			if indexes[pos-1].token != TokenMessage {
+				break
+			}
+			if indexes[pos-1].timestamp <= newIndex.timestamp {
+				break
+			}
+		}
+	default:
+		panic("invariant: isort caller should ensure all indexed records are channels, messages or schemas")
+	}
+	return slices.Insert(indexes, pos, newIndex)
+}

--- a/go/mcap/ordered_lexer_test.go
+++ b/go/mcap/ordered_lexer_test.go
@@ -1,0 +1,335 @@
+package mcap
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type msg struct {
+	logTime   uint64
+	channelID uint16
+}
+
+func a(logTime uint64) msg {
+	return msg{logTime: logTime, channelID: 1}
+}
+func b(logTime uint64) msg {
+	return msg{logTime: logTime, channelID: 2}
+}
+
+func makeMcap(t *testing.T, messages []msg) []byte {
+	buf := bytes.NewBuffer(nil)
+	// expect 5 messages to fit per chunk, even if two schema and channel records have been written to
+	// the chunk also.
+	w, err := NewWriter(buf, &WriterOptions{
+		ChunkSize:   500,
+		Chunked:     true,
+		Compression: CompressionNone,
+		IncludeCRC:  true,
+	})
+	assert.Nil(t, err)
+	wroteChannelA := false
+	wroteChannelB := false
+	msgData := make([]byte, 50)
+	assert.Nil(t, w.WriteHeader(&Header{}))
+	for i, msg := range messages {
+		if msg.channelID == 1 && !wroteChannelA {
+			assert.Nil(t, w.WriteSchema(&Schema{
+				ID:       1,
+				Name:     "schema_a",
+				Encoding: "jsonschema",
+				Data:     []byte("{}"),
+			}))
+			assert.Nil(t, w.WriteChannel(&Channel{
+				ID:              1,
+				Topic:           "a",
+				MessageEncoding: "json",
+				SchemaID:        1,
+			}))
+			wroteChannelA = true
+		}
+		if msg.channelID == 2 && !wroteChannelB {
+			assert.Nil(t, w.WriteSchema(&Schema{
+				ID:       2,
+				Name:     "schema_b",
+				Encoding: "jsonschema",
+				Data:     []byte("{}"),
+			}))
+			assert.Nil(t, w.WriteChannel(&Channel{
+				ID:              2,
+				Topic:           "a",
+				MessageEncoding: "json",
+				SchemaID:        2,
+			}))
+			wroteChannelB = true
+		}
+		assert.Nil(t, w.WriteMessage(&Message{
+			ChannelID:   msg.channelID,
+			Sequence:    uint32(i),
+			LogTime:     msg.logTime,
+			PublishTime: msg.logTime,
+			Data:        msgData,
+		}))
+	}
+	assert.Nil(t, w.Close())
+
+	return buf.Bytes()
+}
+
+func getInfo(t assert.TestingT, rs io.ReadSeeker) *Info {
+	reader, err := NewReader(rs)
+	assert.Nil(t, err)
+	info, err := reader.Info()
+	assert.Nil(t, err)
+	_, err = rs.Seek(0, io.SeekStart)
+	assert.Nil(t, err)
+	return info
+}
+
+func TestReadsInOrder(t *testing.T) {
+	cases := []struct {
+		assertion string
+		messages  []msg
+	}{
+		{
+			assertion: "in-order file stays in order",
+			messages:  []msg{a(1), a(2), a(3), a(4), a(5), a(6), a(7)},
+		},
+		{
+			assertion: "resilient to some disordering",
+			messages:  []msg{a(2), a(1), a(4), a(3), a(7), a(6), a(5)},
+		},
+		{
+			assertion: "totally backwards",
+			messages:  []msg{a(7), a(6), a(5), a(4), a(3), a(2), a(1)},
+		},
+		{
+			assertion: "later channel first",
+			messages:  []msg{a(4), a(5), a(6), a(7), a(8), a(9), b(1), b(2), b(3)},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			testfile := makeMcap(t, c.messages)
+			rs := bytes.NewReader(testfile)
+			info := getInfo(t, rs)
+			schemaASeen := false
+			schemaBSeen := false
+			channelASeen := false
+			channelBSeen := false
+			sortedMessages := make([]msg, len(c.messages))
+			copy(sortedMessages, c.messages)
+			sort.Slice(sortedMessages, func(i, j int) bool {
+				return sortedMessages[i].logTime < sortedMessages[j].logTime
+			})
+			reader, err := NewOrderedLexer(rs, info, 1024, nil)
+			assert.Nil(t, err)
+
+			buf := make([]byte, 1024)
+			curMessageIndex := 0
+			for {
+				tkn, content, err := reader.Next(buf)
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				assert.Nil(t, err)
+				switch tkn {
+				case TokenSchema:
+					schema, err := ParseSchema(content)
+					assert.Nil(t, err)
+					switch schema.ID {
+					case 1:
+						schemaASeen = true
+					case 2:
+						schemaBSeen = true
+					default:
+						assert.Fail(t, "unexpected schema ID %d", schema.ID)
+					}
+				case TokenChannel:
+					channel, err := ParseChannel(content)
+					assert.Nil(t, err)
+					switch channel.ID {
+					case 1:
+						assert.True(t, schemaASeen)
+						channelASeen = true
+					case 2:
+						assert.True(t, schemaBSeen)
+						channelBSeen = true
+					default:
+						assert.Fail(t, "unexpected channel ID %d", channel.ID)
+					}
+				case TokenMessage:
+					expectedMessage := sortedMessages[curMessageIndex]
+					curMessageIndex++
+					msg, err := ParseMessage(content)
+					assert.Nil(t, err)
+					assert.Equal(t, expectedMessage.channelID, msg.ChannelID)
+					assert.Equal(t, expectedMessage.logTime, msg.LogTime)
+					switch msg.ChannelID {
+					case 1:
+						assert.True(t, channelASeen)
+					case 2:
+						assert.True(t, channelBSeen)
+					default:
+						assert.Fail(t, "unexpected channel id %d", msg.ChannelID)
+					}
+				}
+			}
+			assert.Equal(t, curMessageIndex, len(c.messages))
+		})
+	}
+}
+
+func TestGuardsMemoryUse(t *testing.T) {
+	cases := []struct {
+		assertion     string
+		minBufferSize uint64
+		messages      []msg
+	}{
+		{
+			assertion:     "two chunks in order",
+			minBufferSize: 559,
+			messages:      []msg{a(1), a(2), a(3), a(4), a(5), a(6), a(7)},
+		},
+		{
+			assertion:     "disordered messages",
+			minBufferSize: 875,
+			messages:      []msg{a(4), a(5), a(6), a(7), a(8), a(9), b(1), b(2), b(3)},
+		},
+		{
+			assertion:     "many chunks, last contains early messages",
+			minBufferSize: 1936,
+			messages: []msg{
+				a(10), a(11), a(12), a(13), a(14), a(15), a(16), a(17), a(18), a(19),
+				a(20), a(21), a(22), a(23), a(24), a(25), a(26), a(27), a(28), a(29),
+				a(0), a(1), a(2),
+			},
+		},
+		{
+			assertion:     "many chunks, early disorder only",
+			minBufferSize: 1126,
+			messages: []msg{
+				a(1), a(2), a(3), a(4), a(5), a(6), a(7), a(8), a(9), a(0),
+				a(10), a(11), a(12), a(13), a(14), a(15), a(16), a(17), a(18), a(19),
+				a(20), a(21), a(22), a(23), a(24), a(25), a(26), a(27), a(28), a(29),
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			testfile := makeMcap(t, c.messages)
+			rs := bytes.NewReader(testfile)
+			info := getInfo(t, rs)
+			_, err := NewOrderedLexer(rs, info, c.minBufferSize-1, nil)
+			assert.ErrorIs(t, err, ErrWouldExceedMemoryLimit)
+
+			_, err = rs.Seek(0, io.SeekStart)
+			assert.Nil(t, err)
+			_, err = NewOrderedLexer(rs, info, c.minBufferSize, nil)
+			assert.Nil(t, err)
+		})
+	}
+}
+
+func BenchmarkMCAPReaders(b *testing.B) {
+	cases := []struct {
+		assertion string
+		readFunc  func(b *testing.B, rs io.ReadSeeker) uint64
+	}{
+		{
+			assertion: "lexer",
+			readFunc: func(b *testing.B, rs io.ReadSeeker) uint64 {
+				lexer, err := NewLexer(rs, &LexerOptions{ValidateChunkCRCs: true})
+				assert.Nil(b, err)
+				defer lexer.Close()
+				buf := make([]byte, 4*1024*1024)
+				var count uint64
+				for {
+					tkn, newBuf, err := lexer.Next(buf)
+					if tkn == TokenMessage {
+						count++
+					}
+					if len(newBuf) > len(buf) {
+						buf = newBuf
+					}
+					if errors.Is(err, io.EOF) {
+						return count
+					}
+					assert.Nil(b, err)
+				}
+			},
+		}, {
+			assertion: "ordered lexer",
+			readFunc: func(b *testing.B, rs io.ReadSeeker) uint64 {
+				info := getInfo(b, rs)
+				ol, err := NewOrderedLexer(rs, info, 64*1024*1024, nil)
+				assert.Nil(b, err)
+				buf := make([]byte, 4*1024*1024)
+				var count uint64
+				for {
+					tkn, newBuf, err := ol.Next(buf)
+					if len(newBuf) >= len(buf) {
+						buf = newBuf
+					}
+					if tkn == TokenMessage {
+						count++
+					}
+					if errors.Is(err, io.EOF) {
+						return count
+					}
+					assert.Nil(b, err)
+				}
+			},
+		}, {
+			assertion: "reader",
+			readFunc: func(b *testing.B, rs io.ReadSeeker) uint64 {
+				reader, err := NewReader(rs)
+				assert.Nil(b, err)
+				defer reader.Close()
+				buf := make([]byte, 4*1024*1024)
+				it, err := reader.Messages(InOrder(LogTimeOrder))
+				assert.Nil(b, err)
+				var count uint64
+				for {
+					_, _, _, err := it.Next(buf)
+					if errors.Is(err, io.EOF) {
+						return count
+					}
+					assert.Nil(b, err)
+					count++
+				}
+			},
+		},
+	}
+	filename := "../../testdata/mcap/demo.mcap"
+	stat, err := os.Stat(filename)
+	assert.Nil(b, err)
+	size := stat.Size()
+	var myCount uint64
+	for _, c := range cases {
+		b.Run(c.assertion, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				handle, err := os.Open(filename)
+				assert.Nil(b, err)
+				t0 := time.Now()
+				count := c.readFunc(b, handle)
+				elapsed := time.Since(t0)
+				handle.Close()
+				if myCount == 0 {
+					myCount = count
+				}
+				assert.Nil(b, err)
+				assert.Equal(b, myCount, count)
+				b.ReportMetric(float64(size/(1024*1024))/elapsed.Seconds(), "MB/s")
+			}
+		})
+	}
+}

--- a/tests/conformance/scripts/run-tests/runners/CppStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/CppStreamedReaderTestRunner.ts
@@ -8,6 +8,7 @@ import { StreamedReadTestResult } from "../types";
 
 export default class CppStreamedReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "cpp-streamed-reader";
+  readonly sortsMessages = false;
 
   async runReadTest(filePath: string): Promise<StreamedReadTestResult> {
     const { stdout } = await promisify(exec)(`./streamed-reader-conformance ${filePath}`, {

--- a/tests/conformance/scripts/run-tests/runners/GoStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/GoStreamedReaderTestRunner.ts
@@ -1,13 +1,14 @@
 import { exec } from "child_process";
 import { join } from "path";
 import { promisify } from "util";
-import { TestVariant } from "variants/types";
+import { TestFeatures, TestVariant } from "variants/types";
 
 import { StreamedReadTestRunner } from "./TestRunner";
 import { StreamedReadTestResult } from "../types";
 
 export default class GoStreamedReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "go-streamed-reader";
+  readonly sortsMessages = true;
 
   async runReadTest(filePath: string): Promise<StreamedReadTestResult> {
     const { stdout } = await promisify(exec)(`./bin/test-read-conformance ${filePath} streamed`, {
@@ -16,7 +17,10 @@ export default class GoStreamedReaderTestRunner extends StreamedReadTestRunner {
     return JSON.parse(stdout) as StreamedReadTestResult;
   }
 
-  supportsVariant(_variant: TestVariant): boolean {
-    return true;
+  supportsVariant(variant: TestVariant): boolean {
+    return (
+      variant.features.has(TestFeatures.UseChunkIndex) &&
+      variant.features.has(TestFeatures.UseStatistics)
+    );
   }
 }

--- a/tests/conformance/scripts/run-tests/runners/KaitaiStructReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/KaitaiStructReaderTestRunner.ts
@@ -163,6 +163,7 @@ async function compileMcapClass(): Promise<Mcap> {
 
 export default class KaitaiStructReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "ksy-reader";
+  readonly sortsMessages = false;
 
   supportsVariant(_variant: TestVariant): boolean {
     return true;

--- a/tests/conformance/scripts/run-tests/runners/PythonStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/PythonStreamedReaderTestRunner.ts
@@ -7,6 +7,7 @@ import { StreamedReadTestResult } from "../types";
 
 export default class PythonStreamedReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "py-streamed-reader";
+  readonly sortsMessages = false;
 
   async runReadTest(filePath: string): Promise<StreamedReadTestResult> {
     const { stdout } = await promisify(exec)(

--- a/tests/conformance/scripts/run-tests/runners/RustReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/RustReaderTestRunner.ts
@@ -8,6 +8,7 @@ import { StreamedReadTestResult } from "../types";
 
 export default class RustReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "rust-streamed-reader";
+  readonly sortsMessages = false;
 
   async runReadTest(filePath: string): Promise<StreamedReadTestResult> {
     const { stdout } = await promisify(exec)(`./conformance_reader ${filePath}`, {

--- a/tests/conformance/scripts/run-tests/runners/SwiftStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/SwiftStreamedReaderTestRunner.ts
@@ -8,6 +8,7 @@ import { StreamedReadTestResult } from "../types";
 
 export default class SwiftStreamedReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "swift-streamed-reader";
+  readonly sortsMessages = false;
 
   async runReadTest(filePath: string): Promise<StreamedReadTestResult> {
     const { stdout } = await promisify(exec)(

--- a/tests/conformance/scripts/run-tests/runners/TypescriptStreamedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/TypescriptStreamedReaderTestRunner.ts
@@ -9,6 +9,7 @@ import { StreamedReadTestResult } from "../types";
 export default class TypescriptStreamedReaderTestRunner extends StreamedReadTestRunner {
   readonly name = "ts-streamed-reader";
   readonly readsDataEnd = true;
+  readonly sortsMessages = false;
 
   supportsVariant(_variant: TestVariant): boolean {
     return true;


### PR DESCRIPTION
### Public-Facing Changes

<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
