### PR TITLE
@mcap/core: Fix error when skipping chunks

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -120,6 +120,7 @@ export class ChunkCursor {
       }
     }
     if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
+      this.#orderedMessageOffsets = [];
       return;
     }
 


### PR DESCRIPTION
### Public-Facing Changes

@mcap/core: fixed an error when reading topics that were only present in some of the file's chunks.

### Description

Fixes #1147, a regression which I believe was caused by #1037. Calling `loadMessageIndexes()` is supposed to guarantee that `#orderedMessageOffsets` is set.