### PR TITLE
typescript: Add provenance attestation when publishing to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,11 @@ jobs:
 
   typescript:
     runs-on: ubuntu-latest
+
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -229,29 +234,37 @@ jobs:
       - run: yarn workspace @mcap/browser build
       - run: yarn typescript:test
 
+      - run: yarn workspace @mcap/core pack
       - name: Publish @mcap/core to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
-        run: yarn workspace @mcap/core npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish typescript/core/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+      - run: yarn workspace @mcap/support pack
       - name: Publish @mcap/support to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/support/v') }}
-        run: yarn workspace @mcap/support npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish typescript/support/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+      - run: yarn workspace @mcap/nodejs pack
       - name: Publish @mcap/nodejs to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/nodejs/v') }}
-        run: yarn workspace @mcap/nodejs npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish typescript/nodejs/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+      - run: yarn workspace @mcap/browser pack
       - name: Publish @mcap/browser to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/browser/v') }}
-        run: yarn workspace @mcap/browser npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish typescript/browser/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   typescript-examples:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ site/
 !.yarn/patches
 !.yarn/plugins
 !.yarn/sdks
+*.tgz
 
 *.db3-shm
 *.db3-wal


### PR DESCRIPTION
### Changelog
None

### Description

This adds a provenance attestation to the published package so consumers can verify that the package was built on GitHub Actions:
- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

The package will appear like this on npm:

<img src="https://github.blog/wp-content/uploads/2023/04/npm-package-provenance-3.png?w=488&resize=488%2C394" width="250">
