### PR TITLE
CPP: Attachements Index getter API to return the Attachments

### DIFF
--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/1.3.0"
+    requires = "benchmark/1.7.0", "mcap/1.4.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.3.0
+conan editable add ./mcap mcap/1.4.0
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.3.0
+conan editable add ./mcap mcap/1.4.0
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/1.3.0"
+    requires = "mcap/1.4.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/1.3.0",
+        "mcap/1.4.0",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "1.3.0"
+    version = "1.4.0"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -440,9 +440,9 @@ public:
   const std::multimap<std::string, MetadataIndex>& metadataIndexes() const;
 
   /**
-   * @brief Returns all of the parsed MetadataIndex records. Call `readSummary()`
+   * @brief Returns all of the parsed AttachmentIndex records. Call `readSummary()`
    * first to fully populate this data structure.
-   * The multimap's keys are the `name` field from each indexed Metadata.
+   * The multimap's keys are the `name` field from each indexed Attachments.
    */
   const std::multimap<std::string, AttachmentIndex>& attachmentIndexes() const;
 

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -439,6 +439,13 @@ public:
    */
   const std::multimap<std::string, MetadataIndex>& metadataIndexes() const;
 
+  /**
+   * @brief Returns all of the parsed MetadataIndex records. Call `readSummary()`
+   * first to fully populate this data structure.
+   * The multimap's keys are the `name` field from each indexed Metadata.
+   */
+  const std::multimap<std::string, AttachmentIndex>& attachmentIndexes() const;
+
   // The following static methods are used internally for parsing MCAP records
   // and do not need to be called directly unless you are implementing your own
   // reader functionality or tests.

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -442,7 +442,7 @@ public:
   /**
    * @brief Returns all of the parsed AttachmentIndex records. Call `readSummary()`
    * first to fully populate this data structure.
-   * The multimap's keys are the `name` field from each indexed Attachments.
+   * The multimap's keys are the `name` field from each indexed Attachment.
    */
   const std::multimap<std::string, AttachmentIndex>& attachmentIndexes() const;
 

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -649,6 +649,10 @@ const std::multimap<std::string, MetadataIndex>& McapReader::metadataIndexes() c
   return metadataIndexes_;
 }
 
+const std::multimap<std::string, AttachmentIndex>& McapReader::attachmentIndexes() const {
+  return attachmentIndexes_;
+}
+
 Status McapReader::ReadRecord(IReadable& reader, uint64_t offset, Record* record) {
   // Check that we can read at least 9 bytes (opcode + length)
   auto maxSize = reader.size() - offset;

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "1.3.0"
+#define MCAP_LIBRARY_VERSION "1.4.0"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/1.3.0", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/1.4.0", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
### Changelog
API getters to return the Attachments mapped with name from the mcap files using C++ API
### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

