### PR TITLE
fix python example raw reader topic to match writer

### DIFF
--- a/python/examples/raw/reader.py
+++ b/python/examples/raw/reader.py
@@ -4,5 +4,5 @@ from mcap.reader import make_reader
 
 with open(sys.argv[1], "rb") as f:
     reader = make_reader(f)
-    for schema, channel, message in reader.iter_messages(topics=["/diagnostics"]):
+    for schema, channel, message in reader.iter_messages(topics=["sample_topic"]):
         print(f"{channel.topic} ({schema.name}): {message.data}")


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Fixed python raw example topics to match.

### Description

In the following example code: https://github.com/foxglove/mcap/tree/main/python/examples/raw

the topic specified in the writer (`"sample_topic"`) did not match the topic specified in the reader (`"/diagnostics"`). This led to the reader not being able to read the message that was written by the writer.

I have manually tested that this example now works.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

The reader printed out nothing.

</td><td>

<!--after content goes here-->

The reader prints out the message written by the writer.

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

