### PR TITLE
[go/cli] Fix uint64 bug in `mcap cat`

### DIFF
--- a/go/cli/mcap/utils/ros/json_transcoder.go
+++ b/go/cli/mcap/utils/ros/json_transcoder.go
@@ -277,7 +277,7 @@ func (t *JSONTranscoder) int64(w io.Writer, r io.Reader) error {
 }
 
 func (t *JSONTranscoder) uint64(w io.Writer, r io.Reader) error {
-	_, err := io.ReadFull(r, t.buf[:4])
+	_, err := io.ReadFull(r, t.buf[:8])
 	if err != nil {
 		return err
 	}

--- a/go/cli/mcap/utils/ros/json_transcoder.go
+++ b/go/cli/mcap/utils/ros/json_transcoder.go
@@ -282,7 +282,7 @@ func (t *JSONTranscoder) uint64(w io.Writer, r io.Reader) error {
 		return err
 	}
 	x := binary.LittleEndian.Uint64(t.buf[:8])
-	t.formattedNumber = strconv.AppendInt(t.formattedNumber, int64(x), 10)
+	t.formattedNumber = strconv.AppendUint(t.formattedNumber, x, 10)
 	_, err = w.Write(t.formattedNumber)
 	if err != nil {
 		return err

--- a/go/cli/mcap/utils/ros/json_transcoder_test.go
+++ b/go/cli/mcap/utils/ros/json_transcoder_test.go
@@ -312,8 +312,8 @@ func TestSingleRecordConversion(t *testing.T) {
 					converter: transcoder.uint64,
 				},
 			},
-			[]byte{0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07},
-			`{"foo":506381209866536711}`,
+			[]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			`{"foo":18446744073709551615}`,
 		},
 		{
 			"float32",

--- a/go/cli/mcap/utils/ros/json_transcoder_test.go
+++ b/go/cli/mcap/utils/ros/json_transcoder_test.go
@@ -179,6 +179,8 @@ func TestJSONTranscoding(t *testing.T) {
 			err = transcoder.Transcode(buf, bytes.NewReader(c.input))
 			require.NoError(t, err)
 			assert.Equal(t, c.expectedJSON, buf.String())
+			// ensure each test has a clean buffer
+			transcoder.buf = make([]byte, 8)
 		})
 	}
 }
@@ -530,6 +532,8 @@ func TestSingleRecordConversion(t *testing.T) {
 			err := converter(buf, bytes.NewBuffer(c.input))
 			require.NoError(t, err)
 			assert.Equal(t, c.output, buf.String())
+			// ensure each test has a clean buffer
+			transcoder.buf = make([]byte, 8)
 		})
 	}
 }

--- a/go/cli/mcap/utils/ros/json_transcoder_test.go
+++ b/go/cli/mcap/utils/ros/json_transcoder_test.go
@@ -276,8 +276,8 @@ func TestSingleRecordConversion(t *testing.T) {
 					converter: transcoder.uint8,
 				},
 			},
-			[]byte{0x01},
-			`{"foo":1}`,
+			[]byte{0xff},
+			`{"foo":255}`,
 		},
 		{
 			"uint16",
@@ -288,8 +288,8 @@ func TestSingleRecordConversion(t *testing.T) {
 					converter: transcoder.uint16,
 				},
 			},
-			[]byte{0x07, 0x07},
-			`{"foo":1799}`,
+			[]byte{0xff, 0xff},
+			`{"foo":65535}`,
 		},
 		{
 			"uint32",
@@ -300,8 +300,8 @@ func TestSingleRecordConversion(t *testing.T) {
 					converter: transcoder.uint32,
 				},
 			},
-			[]byte{0x07, 0x07, 0x07, 0x07},
-			`{"foo":117901063}`,
+			[]byte{0xff, 0xff, 0xff, 0xff},
+			`{"foo":4294967295}`,
 		},
 		{
 			"uint64",


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
`mcap cat` is not reading `uint64` ros1 msgs  properly

### Description

Super minor, but looks like the `JSONTranscoder` for `ros1msg` is only reading 4 bytes for the `uint64` type.


