### PR TITLE
CLI: scan in log time order when using index

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -168,8 +168,12 @@ func (w *jsonOutputWriter) writeMessage(
 
 func getReadOpts(useIndex bool) []mcap.ReadOpt {
 	topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
-	opts := []mcap.ReadOpt{mcap.UsingIndex(useIndex), mcap.WithTopics(topics)}
 
+	opts := []mcap.ReadOpt{mcap.WithTopics(topics)}
+
+	if useIndex {
+		opts = append(opts, mcap.UsingIndex(true), mcap.InOrder(mcap.LogTimeOrder))
+	}
 	catStart := catStartNano
 	if catStartSec > 0 {
 		catStart = catStartSec * 1e9


### PR DESCRIPTION
This changes the cat command to do a log-time order scan when it is able to use the index (e.g seekable reader).

This was the intent of the existing code (there is no other reason for it to try to use the index), but it was not supplying both necessary parameters.