### PR TITLE
go: reduce memory footprint of writer

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.2.0"
+var Version = "v1.3.1"

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -433,6 +433,7 @@ func (w *Writer) flushActiveChunk() error {
 	crc := w.compressedWriter.CRC()
 	compressedlen := w.compressed.Len()
 	uncompressedlen := w.compressedWriter.Size()
+	// the "top fields" are all fields of the chunk record except for the compressed records.
 	topFieldsLen := 8 + 8 + 8 + 4 + 4 + len(w.opts.Compression) + 8
 	msglen := topFieldsLen + compressedlen
 	chunkStartOffset := w.w.Size()


### PR DESCRIPTION
### Changelog

- Changed: reduced memory footprint of writer by removing an uneccessary chunk buffer.

### Description

We are unneccessarily copying the entire compressed chunk into an internal buffer before writing it out - this increases the memory footprint of an mcap writer by the size of a compressed chunk. This isn't too important usually, but when you're running an application that writes 200 MCAP files at once, those 4MB buffers can add up.

This PR removes that chunk buffer and instead uses the `writer.msg` scratch buffer to marshal only the "header" of the chunk. This is all fields of the chunk record besides the compressed data.

This PR also adds a benchmark to demonstrate the memory saving. This benchmark is similar to the existing WriterAllocs benchmark, but:
- we allocate 100 writers and write the nth message to the (n % 100)th writer
- instead of writing the output MCAP to a buffer, the 100 writers all write to io.Discard. This is because we don't care about the output result, and we also want to reduce the effect of the allocated output on the result as much as possible.

Benchmark results:
```
Before:

(python-sNIFi2pF) j@192-168-1-105 mcap %  go test ./... -bench=BenchmarkManyWriterAllocs -benchtime=10s -benchmem
goos: darwin
goarch: arm64
pkg: github.com/foxglove/mcap/go/mcap
BenchmarkManyWriterAllocs/big_chunks_many_messages-8                  22         510907131 ns/op           4038205 messages/sec 515778960 B/op     48796 allocs/op
BenchmarkManyWriterAllocs/small_chunks_many_messages-8                25         458119757 ns/op           4355813 messages/sec 11032190 B/op      79796 allocs/op
BenchmarkManyWriterAllocs/many_channels-8                              2        5889904000 ns/op            345263 messages/sec 4025878024 B/op 22587677 allocs/op
PASS

After:

(python-sNIFi2pF) j@192-168-1-105 mcap %  go test ./... -bench=BenchmarkManyWriterAllocs -benchtime=10s -benchmem
goos: darwin
goarch: arm64
pkg: github.com/foxglove/mcap/go/mcap
BenchmarkManyWriterAllocs/big_chunks_many_messages-8                  22         513380782 ns/op           3988771 messages/sec 341286355 B/op     48698 allocs/op
BenchmarkManyWriterAllocs/small_chunks_many_messages-8                25         464017923 ns/op           4417701 messages/sec  8853856 B/op      79700 allocs/op
BenchmarkManyWriterAllocs/many_channels-8                              2        5858519938 ns/op            347740 messages/sec 2881396708 B/op 22587001 allocs/op
PASS
ok      github.com/foxglove/mcap/go/mcap        43.179s
```

As expected, the write speed is roughly the same, but far fewer bytes are allocated in all benchmark cases.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

MCAP writer copies the full chunk record into a buffer before writing that buffer out to the writer.

</td><td>

MCAP writer copies the chunk header into a buffer, writes it out, then writes out the compressed chunk data.

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

