### PR TITLE
go: add file offset to lexer API

### DIFF
--- a/go/mcap/lexer.go
+++ b/go/mcap/lexer.go
@@ -14,12 +14,12 @@ import (
 
 type countingReader struct {
 	r   io.Reader
-	pos uint64
+	pos int64
 }
 
 func (cr *countingReader) Read(p []byte) (int, error) {
 	n, err := cr.r.Read(p)
-	cr.pos += uint64(n)
+	cr.pos += int64(n)
 	return n, err
 }
 
@@ -211,6 +211,7 @@ func (l *Lexer) Next(p []byte) (TokenType, []byte, error) {
 	for {
 		if !l.inChunk {
 			l.lastOffset.FileOffset = l.reader.pos
+			l.lastOffset.ChunkOffset = RecordNotInChunk
 		} else {
 			l.lastOffset.ChunkOffset = l.reader.pos
 		}
@@ -220,7 +221,6 @@ func (l *Lexer) Next(p []byte) (TokenType, []byte, error) {
 			eof := errors.Is(err, io.EOF)
 			if l.inChunk && (eof || unexpectedEOF) {
 				l.inChunk = false
-				l.lastOffset.ChunkOffset = 0
 				l.reader = l.basereader
 				continue
 			}

--- a/go/mcap/lexer.go
+++ b/go/mcap/lexer.go
@@ -198,8 +198,8 @@ type Lexer struct {
 	decompressors            map[CompressionFormat]ResettableReader
 }
 
-// GetLastTokenOffset returns the TokenOffset of the last token returned from Next().
-func (l *Lexer) GetLastTokenOffset() RecordOffset {
+// GetLastRecordOffset returns the offset of the last record returned from Next().
+func (l *Lexer) GetLastRecordOffset() RecordOffset {
 	return l.lastOffset
 }
 

--- a/go/mcap/lexer_test.go
+++ b/go/mcap/lexer_test.go
@@ -47,7 +47,7 @@ func TestLexUnchunkedFile(t *testing.T) {
 		tokenType, _, err := lexer.Next(nil)
 		require.NoError(t, err)
 		assert.Equal(t, expected.token, tokenType)
-		offset := lexer.GetLastTokenOffset()
+		offset := lexer.GetLastRecordOffset()
 		assert.Equal(t, RecordNotInChunk, offset.ChunkOffset)
 		assert.Equal(t, expected.fileOffset, offset.FileOffset,
 			fmt.Sprintf("expected file offset %d, got %d at index %d", expected.fileOffset, offset.FileOffset, i))
@@ -280,7 +280,7 @@ func TestOffsetsInChunkedFile(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, expected.token, tokenType,
 					fmt.Sprintf("expected token %s but got %s at index %d", expected.token, tokenType, i))
-				offset := lexer.GetLastTokenOffset()
+				offset := lexer.GetLastRecordOffset()
 				assert.Equal(t, expected.offset.FileOffset, offset.FileOffset,
 					fmt.Sprintf("expected file offset %d but got %d at index %d",
 						expected.offset.FileOffset,

--- a/go/mcap/lexer_test.go
+++ b/go/mcap/lexer_test.go
@@ -33,7 +33,7 @@ func TestLexUnchunkedFile(t *testing.T) {
 	require.NoError(t, err)
 	expectations := []struct {
 		token      TokenType
-		fileOffset uint64
+		fileOffset int64
 	}{
 		{TokenHeader, 8},
 		{TokenChannel, 17},
@@ -48,7 +48,7 @@ func TestLexUnchunkedFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expected.token, tokenType)
 		offset := lexer.GetLastTokenOffset()
-		assert.Equal(t, uint64(0), offset.ChunkOffset)
+		assert.Equal(t, RecordNotInChunk, offset.ChunkOffset)
 		assert.Equal(t, expected.fileOffset, offset.FileOffset,
 			fmt.Sprintf("expected file offset %d, got %d at index %d", expected.fileOffset, offset.FileOffset, i))
 	}
@@ -266,14 +266,14 @@ func TestOffsetsInChunkedFile(t *testing.T) {
 				token  TokenType
 				offset RecordOffset
 			}{
-				{TokenHeader, RecordOffset{8, 0}},
+				{TokenHeader, RecordOffset{8, RecordNotInChunk}},
 				{TokenChannel, RecordOffset{17, 0}},
 				{TokenMessage, RecordOffset{17, 9}},
 				{TokenMessage, RecordOffset{17, 18}},
 				{TokenChannel, RecordOffset{93, 0}},
 				{TokenMessage, RecordOffset{93, 9}},
 				{TokenMessage, RecordOffset{93, 18}},
-				{TokenFooter, RecordOffset{259, 0}},
+				{TokenFooter, RecordOffset{259, RecordNotInChunk}},
 			}
 			for i, expected := range expectations {
 				tokenType, _, err := lexer.Next(nil)
@@ -459,8 +459,8 @@ func TestAttachmentHandling(t *testing.T) {
 					assert.Equal(t, c.attachment.CreateTime, ar.CreateTime)
 					assert.Equal(t, c.attachment.Name, ar.Name)
 					assert.Equal(t, c.attachment.MediaType, ar.MediaType)
-					assert.Equal(t, uint64(39), ar.Offset.FileOffset)
-					assert.Equal(t, uint64(0), ar.Offset.ChunkOffset)
+					assert.Equal(t, int64(39), ar.Offset.FileOffset)
+					assert.Equal(t, RecordNotInChunk, ar.Offset.ChunkOffset)
 					data, err := io.ReadAll(ar.Data())
 					require.NoError(t, err)
 					assert.Equal(t, c.attachmentData, data)

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -213,6 +213,15 @@ type Attachment struct {
 	Data       io.Reader
 }
 
+// RecordOffset represents the location of a MCAP record in a file.
+type RecordOffset struct {
+	// FileOffset is the offset from the start of file in bytes.
+	// If the record is in a chunk, this is the file offset of the chunk record.
+	FileOffset uint64
+	// ChunkOffset is the ffset from the start of chunk data if in a chunk, 0 otherwise.
+	ChunkOffset uint64
+}
+
 // AttachmentReader represents an attachment for handling in a streaming manner.
 type AttachmentReader struct {
 	LogTime    uint64
@@ -220,6 +229,7 @@ type AttachmentReader struct {
 	Name       string
 	MediaType  string
 	DataSize   uint64
+	Offset     RecordOffset
 
 	data       *io.LimitedReader
 	baseReader io.Reader

--- a/go/mcap/mcap.go
+++ b/go/mcap/mcap.go
@@ -213,13 +213,15 @@ type Attachment struct {
 	Data       io.Reader
 }
 
+const RecordNotInChunk int64 = -1
+
 // RecordOffset represents the location of a MCAP record in a file.
 type RecordOffset struct {
 	// FileOffset is the offset from the start of file in bytes.
 	// If the record is in a chunk, this is the file offset of the chunk record.
-	FileOffset uint64
-	// ChunkOffset is the ffset from the start of chunk data if in a chunk, 0 otherwise.
-	ChunkOffset uint64
+	FileOffset int64
+	// ChunkOffset is the ffset from the start of chunk data if in a chunk, RecordNotInChunk otherwise.
+	ChunkOffset int64
 }
 
 // AttachmentReader represents an attachment for handling in a streaming manner.

--- a/go/mcap/parse.go
+++ b/go/mcap/parse.go
@@ -267,6 +267,7 @@ func ParseChunkIndex(buf []byte) (*ChunkIndex, error) {
 func parseAttachmentReader(
 	r io.Reader,
 	computeCRC bool,
+	tokenOffset RecordOffset,
 ) (*AttachmentReader, error) {
 	buf := make([]byte, 8)
 	crcReader := newCRCReader(r, computeCRC)
@@ -300,6 +301,7 @@ func parseAttachmentReader(
 		Name:       name,
 		MediaType:  mediaType,
 		DataSize:   dataSize,
+		Offset:     tokenOffset,
 
 		baseReader: r,
 		crcReader:  crcReader,

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -207,12 +207,16 @@ func (r *Reader) Info() (*Info, error) {
 // GetAttachmentReader returns an attachment reader located at the specific offset.
 // The reader must be consumed before the base reader is used again.
 func (r *Reader) GetAttachmentReader(offset uint64) (*AttachmentReader, error) {
-	_, err := r.rs.Seek(int64(offset+9), io.SeekStart)
+	if offset > math.MaxInt64 {
+		return nil, errors.New("attachment offset out of int64 range")
+	}
+	iOffset := int64(offset)
+	_, err := r.rs.Seek(iOffset+9, io.SeekStart)
 	if err != nil {
 		return nil, err
 	}
 	ar, err := parseAttachmentReader(r.rs, true, RecordOffset{
-		FileOffset:  int64(offset),
+		FileOffset:  iOffset,
 		ChunkOffset: RecordNotInChunk,
 	})
 	if err != nil {

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -211,7 +211,7 @@ func (r *Reader) GetAttachmentReader(offset uint64) (*AttachmentReader, error) {
 	if err != nil {
 		return nil, err
 	}
-	ar, err := parseAttachmentReader(r.rs, true)
+	ar, err := parseAttachmentReader(r.rs, true, RecordOffset{FileOffset: offset})
 	if err != nil {
 		return nil, err
 	}

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -211,7 +211,10 @@ func (r *Reader) GetAttachmentReader(offset uint64) (*AttachmentReader, error) {
 	if err != nil {
 		return nil, err
 	}
-	ar, err := parseAttachmentReader(r.rs, true, RecordOffset{FileOffset: offset})
+	ar, err := parseAttachmentReader(r.rs, true, RecordOffset{
+		FileOffset:  int64(offset),
+		ChunkOffset: RecordNotInChunk,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -737,6 +737,8 @@ func TestGetAttachmentReader(t *testing.T) {
 	assert.Equal(t, 3, int(ar.DataSize))
 	assert.Equal(t, 10, int(ar.LogTime))
 	assert.Equal(t, 1000, int(ar.CreateTime))
+	assert.Equal(t, idx.Offset, ar.Offset.FileOffset)
+	assert.Equal(t, uint64(0), ar.Offset.ChunkOffset)
 
 	data, err := io.ReadAll(ar.Data())
 	require.NoError(t, err)

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -737,8 +737,8 @@ func TestGetAttachmentReader(t *testing.T) {
 	assert.Equal(t, 3, int(ar.DataSize))
 	assert.Equal(t, 10, int(ar.LogTime))
 	assert.Equal(t, 1000, int(ar.CreateTime))
-	assert.Equal(t, idx.Offset, ar.Offset.FileOffset)
-	assert.Equal(t, uint64(0), ar.Offset.ChunkOffset)
+	assert.Equal(t, int64(idx.Offset), ar.Offset.FileOffset)
+	assert.Equal(t, RecordNotInChunk, ar.Offset.ChunkOffset)
 
 	data, err := io.ReadAll(ar.Data())
 	require.NoError(t, err)

--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.3.1"
+var Version = "v1.4.0"


### PR DESCRIPTION
### Changelog

- go: added GetLastTokenOffset() API to Lexer. This returns the location of the last yielded record in the file, which the caller can use to build up their own index of records in an MCAP.
### Description

An application reading an MCAP might find some records it wants to use later, but cannot afford to hold all of them in memory until that time. If the MCAP is indexed, the reader might use the index to find these records later, but reading the index requires seeking and reading different parts of the file, which is not free. Also, some MCAPs are not indexed.  Ideally the reader could store of the offsets of those records as it reads past them, then seek directly to them later. However, there's not a great way to do that now.

This PR adds a new method `Lexer.GetLastTokenOffset()`, which returns the offset of the last record yielded by the Lexer. This allows them to seek directly to it later. The returned value is a pair of int64 offsets (file and chunk). 

`int64` was chosen here because then we can use a negative sentinel value `RecordNotInChunk` to mark records that are not in chunks. It also fits well in the Go ecosystem, where:
- The `Seek()` API takes and returns an `int64` position
- `Read()` returns an `int` indicating bytes read, which is equivalent to int64 on 64-bit systems (int32 on 32-bit)
- `len()` returns an `int`

All of this to say, if an offset needs a larger int representation, the caller would not be able to seek to it anyway.




<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

