### PR TITLE
spec: Clarify legal contents of chunk records

### DIFF
--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -181,7 +181,7 @@ The message encoding and schema must match that of the Channel record correspond
 
 ### Chunk (op=0x06)
 
-A Chunk contains a batch of Schema, Channel, and Message records. The batch of records contained in a chunk may be compressed or uncompressed.
+A Chunk contains a batch of records. Readers should expect Schema, Channel, and Message records to be present in chunks, but future spec changes or user extensions may include others. The batch of records contained in a chunk may be compressed or uncompressed.
 
 All messages in the chunk must reference channels recorded earlier in the file (in a previous chunk, earlier in the current chunk, or earlier in the data section).
 


### PR DESCRIPTION
Prior to this commit, the wording of the spec implied that only channel, schema, and message records are allowed in chunks. This could lead tooling implementers to validate that assertion.

This is inconsistent with our support for extensible record types. Users should be able to put custom records in chunks as well, and readers that parse chunks should ignore unrecognized records rather than error on them.