### PR TITLE
cli: sort does not duplicate channels and schemas on every message

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"reflect"
 
 	"github.com/fatih/color"
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
@@ -159,53 +158,15 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 			if schema.ID == 0 {
 				doctor.error("Schema.ID 0 is reserved. Do not make Schema records with ID 0.")
 			}
-			if previous, ok := doctor.schemas[schema.ID]; ok {
-				duplicate := true
-				if schema.Name != previous.Name {
-					doctor.error("Two schema records with same ID %d but different names (%s != %s)", schema.ID, schema.Name, previous.Name)
-					duplicate = false
-				}
-				if schema.Encoding != previous.Encoding {
-					doctor.error("Two schema records with same ID %d but different encodings (%s != %s)", schema.ID, schema.Encoding, previous.Encoding)
-					duplicate = false
-				}
-				if !bytes.Equal(schema.Data, previous.Data) {
-					doctor.error("Two schema records with different data present with same ID %d", schema.ID)
-					duplicate = false
-				}
-				if duplicate {
-					doctor.warn("duplicate schema records with ID %d", schema.ID)
-				}
-			} else {
-				doctor.schemas[schema.ID] = schema
-			}
 
+			doctor.schemas[schema.ID] = schema
 		case mcap.TokenChannel:
 			channel, err := mcap.ParseChannel(data)
 			if err != nil {
 				doctor.error("Error parsing Channel: %s", err)
 			}
-			if previous, ok := doctor.channels[channel.ID]; ok {
-				duplicate := true
-				if channel.Topic != previous.Topic {
-					doctor.error("Two channel records with same ID %d but different topics (%s != %s)", channel.ID, channel.Topic, previous.Topic)
-					duplicate = false
-				}
-				if channel.MessageEncoding != previous.MessageEncoding {
-					doctor.error("Two channel records with same ID %d but different message encodings (%s != %s)", channel.ID, channel.MessageEncoding, previous.MessageEncoding)
-					duplicate = false
-				}
-				if !reflect.DeepEqual(channel.Metadata, previous.Metadata) {
-					doctor.error("Two channel records with different metadata present with same ID %d", channel.ID)
-					duplicate = false
-				}
-				if duplicate {
-					doctor.warn("duplicate channel records with ID %d", channel.ID)
-				}
-			} else {
-				doctor.channels[channel.ID] = channel
-			}
 
+			doctor.channels[channel.ID] = channel
 			if channel.SchemaID != 0 {
 				if _, ok := doctor.schemas[channel.SchemaID]; !ok {
 					doctor.error("Encountered Channel (%d) with unknown Schema (%d)", channel.ID, channel.SchemaID)

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"reflect"
 
 	"github.com/fatih/color"
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
@@ -158,15 +159,53 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk) {
 			if schema.ID == 0 {
 				doctor.error("Schema.ID 0 is reserved. Do not make Schema records with ID 0.")
 			}
+			if previous, ok := doctor.schemas[schema.ID]; ok {
+				duplicate := true
+				if schema.Name != previous.Name {
+					doctor.error("Two schema records with same ID %d but different names (%s != %s)", schema.ID, schema.Name, previous.Name)
+					duplicate = false
+				}
+				if schema.Encoding != previous.Encoding {
+					doctor.error("Two schema records with same ID %d but different encodings (%s != %s)", schema.ID, schema.Encoding, previous.Encoding)
+					duplicate = false
+				}
+				if !bytes.Equal(schema.Data, previous.Data) {
+					doctor.error("Two schema records with different data present with same ID %d", schema.ID)
+					duplicate = false
+				}
+				if duplicate {
+					doctor.warn("duplicate schema records with ID %d", schema.ID)
+				}
+			} else {
+				doctor.schemas[schema.ID] = schema
+			}
 
-			doctor.schemas[schema.ID] = schema
 		case mcap.TokenChannel:
 			channel, err := mcap.ParseChannel(data)
 			if err != nil {
 				doctor.error("Error parsing Channel: %s", err)
 			}
+			if previous, ok := doctor.channels[channel.ID]; ok {
+				duplicate := true
+				if channel.Topic != previous.Topic {
+					doctor.error("Two channel records with same ID %d but different topics (%s != %s)", channel.ID, channel.Topic, previous.Topic)
+					duplicate = false
+				}
+				if channel.MessageEncoding != previous.MessageEncoding {
+					doctor.error("Two channel records with same ID %d but different message encodings (%s != %s)", channel.ID, channel.MessageEncoding, previous.MessageEncoding)
+					duplicate = false
+				}
+				if !reflect.DeepEqual(channel.Metadata, previous.Metadata) {
+					doctor.error("Two channel records with different metadata present with same ID %d", channel.ID)
+					duplicate = false
+				}
+				if duplicate {
+					doctor.warn("duplicate channel records with ID %d", channel.ID)
+				}
+			} else {
+				doctor.channels[channel.ID] = channel
+			}
 
-			doctor.channels[channel.ID] = channel
 			if channel.SchemaID != 0 {
 				if _, ok := doctor.schemas[channel.SchemaID]; !ok {
 					doctor.error("Encountered Channel (%d) with unknown Schema (%d)", channel.ID, channel.SchemaID)

--- a/go/cli/mcap/cmd/sort.go
+++ b/go/cli/mcap/cmd/sort.go
@@ -123,7 +123,7 @@ func sortFile(w io.Writer, r io.ReadSeeker) error {
 		return fmt.Errorf("failed to read messages: %w", err)
 	}
 	schemas := make(map[uint16]*mcap.Schema)
-	channels := make(map[uint16]*mcap.Schema)
+	channels := make(map[uint16]*mcap.Channel)
 	message := mcap.Message{}
 	for {
 		schema, channel, _, err := it.NextInto(&message)
@@ -138,6 +138,7 @@ func sortFile(w io.Writer, r io.ReadSeeker) error {
 				if err != nil {
 					return fmt.Errorf("failed to write schema: %w", err)
 				}
+				schemas[schema.ID] = schema
 			}
 		}
 		if _, ok := channels[channel.ID]; !ok {
@@ -145,6 +146,7 @@ func sortFile(w io.Writer, r io.ReadSeeker) error {
 			if err != nil {
 				return fmt.Errorf("failed to write channel: %w", err)
 			}
+			channels[channel.ID] = channel
 		}
 		err = writer.WriteMessage(&message)
 		if err != nil {


### PR DESCRIPTION
### Changelog

- fixed: `mcap sort` would rewrite the schema and channel for every message in the output file. This is fixed.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

