### PR TITLE
doctor: warn on duplicate matching schemas and channels

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -70,9 +70,9 @@ func (doctor *mcapDoctor) fatalf(format string, v ...any) {
 func (doctor *mcapDoctor) examineSchema(schema *mcap.Schema) {
 	if schema.Encoding == "" {
 		if len(schema.Data) == 0 {
-			doctor.warn("Schema with ID: %d, Name: %s has empty Encoding and Data fields", schema.ID, schema.Name)
+			doctor.warn("Schema with ID: %d, Name: %q has empty Encoding and Data fields", schema.ID, schema.Name)
 		} else {
-			doctor.error("Schema with ID: %d has empty Encoding but Data contains: %s", schema.ID, string(schema.Data))
+			doctor.error("Schema with ID: %d has empty Encoding but Data contains: %q", schema.ID, string(schema.Data))
 		}
 	}
 
@@ -82,14 +82,14 @@ func (doctor *mcapDoctor) examineSchema(schema *mcap.Schema) {
 	previous := doctor.schemasInDataSection[schema.ID]
 	if previous != nil {
 		if schema.Name != previous.Name {
-			doctor.error("Two schema records with same ID %d but different names (%s != %s)",
+			doctor.error("Two schema records with same ID %d but different names (%q != %q)",
 				schema.ID,
 				schema.Name,
 				previous.Name,
 			)
 		}
 		if schema.Encoding != previous.Encoding {
-			doctor.error("Two schema records with same ID %d but different encodings (%s != %s)",
+			doctor.error("Two schema records with same ID %d but different encodings (%q != %q)",
 				schema.ID,
 				schema.Encoding,
 				previous.Encoding,
@@ -123,14 +123,14 @@ func (doctor *mcapDoctor) examineChannel(channel *mcap.Channel) {
 			)
 		}
 		if channel.Topic != previous.Topic {
-			doctor.error("Two channel records with same ID %d but different topics (%s != %s)",
+			doctor.error("Two channel records with same ID %d but different topics (%q != %q)",
 				channel.ID,
 				channel.Topic,
 				previous.Topic,
 			)
 		}
 		if channel.MessageEncoding != previous.MessageEncoding {
-			doctor.error("Two channel records with same ID %d but different message encodings (%s != %s)",
+			doctor.error("Two channel records with same ID %d but different message encodings (%q != %q)",
 				channel.ID,
 				channel.MessageEncoding,
 				previous.MessageEncoding,
@@ -190,7 +190,7 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk, startOffset uint64) {
 			return
 		}
 	default:
-		doctor.error("Unsupported compression format: %s", chunk.Compression)
+		doctor.error("Unsupported compression format: %q", chunk.Compression)
 		return
 	}
 
@@ -266,7 +266,7 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk, startOffset uint64) {
 			}
 
 			if message.LogTime < doctor.maxLogTime {
-				errStr := fmt.Sprintf("Message.log_time %d on %s is less than the latest log time %d",
+				errStr := fmt.Sprintf("Message.log_time %d on %q is less than the latest log time %d",
 					message.LogTime, channel.Topic, doctor.maxLogTime)
 				if strictMessageOrder {
 					doctor.error(errStr)
@@ -373,7 +373,7 @@ func (doctor *mcapDoctor) Examine() error {
 			}
 
 			if header.Profile != "" && header.Profile != "ros1" && header.Profile != "ros2" {
-				doctor.warn(`Header.profile field "%s" is not a well-known profile.`, header.Profile)
+				doctor.warn(`Header.profile field %q is not a well-known profile.`, header.Profile)
 			}
 		case mcap.TokenFooter:
 			footer, err = mcap.ParseFooter(data)
@@ -403,7 +403,7 @@ func (doctor *mcapDoctor) Examine() error {
 				doctor.error("Got a Message record for channel: %d before a channel info.", message.ChannelID)
 			}
 			if message.LogTime < lastMessageTime {
-				doctor.error("Message.log_time %d on %s is less than the previous message record time %d",
+				doctor.error("Message.log_time %d on %q is less than the previous message record time %d",
 					message.LogTime, channel.Topic, lastMessageTime)
 			}
 			lastMessageTime = message.LogTime
@@ -568,7 +568,7 @@ func (doctor *mcapDoctor) Examine() error {
 		}
 		if chunk.Compression != chunkIndex.Compression.String() {
 			doctor.error(
-				"Chunk at offset %d has compression %s, but its chunk index has compression %s",
+				"Chunk at offset %d has compression %q, but its chunk index has compression %q",
 				chunkOffset,
 				chunk.Compression,
 				chunkIndex.Compression,
@@ -576,7 +576,7 @@ func (doctor *mcapDoctor) Examine() error {
 		}
 		if uint64(len(chunk.Records)) != chunkIndex.CompressedSize {
 			doctor.error(
-				"Chunk at offset %d has data length %d, but its chunk index has compressed size %s",
+				"Chunk at offset %d has data length %d, but its chunk index has compressed size %d",
 				chunkOffset,
 				len(chunk.Records),
 				chunkIndex.CompressedSize,

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -67,7 +67,7 @@ func (doctor *mcapDoctor) fatalf(format string, v ...any) {
 	os.Exit(1)
 }
 
-func (doctor *mcapDoctor) checkSchema(schema *mcap.Schema) {
+func (doctor *mcapDoctor) examineSchema(schema *mcap.Schema) {
 	if schema.Encoding == "" {
 		if len(schema.Data) == 0 {
 			doctor.warn("Schema with ID: %d, Name: %s has empty Encoding and Data fields", schema.ID, schema.Name)
@@ -101,18 +101,18 @@ func (doctor *mcapDoctor) checkSchema(schema *mcap.Schema) {
 	}
 	if doctor.inSummarySection {
 		if previous == nil {
-			doctor.error("schema with id %d in summary section does not exist in data section", schema.ID)
+			doctor.error("Schema with id %d in summary section does not exist in data section", schema.ID)
 		}
 		doctor.schemaIDsInSummarySection[schema.ID] = true
 	} else {
 		if previous != nil {
-			doctor.warn("duplicate schema records in data section with ID %d", schema.ID)
+			doctor.warn("Duplicate schema records in data section with ID %d", schema.ID)
 		}
 		doctor.schemasInDataSection[schema.ID] = schema
 	}
 }
 
-func (doctor *mcapDoctor) checkChannel(channel *mcap.Channel) {
+func (doctor *mcapDoctor) examineChannel(channel *mcap.Channel) {
 	previous := doctor.channelsInDataSection[channel.ID]
 	if previous != nil {
 		if channel.SchemaID != previous.SchemaID {
@@ -143,12 +143,12 @@ func (doctor *mcapDoctor) checkChannel(channel *mcap.Channel) {
 	}
 	if doctor.inSummarySection {
 		if previous == nil {
-			doctor.error("channel with ID %d in summary section does not exist in data section", channel.ID)
+			doctor.error("Channel with ID %d in summary section does not exist in data section", channel.ID)
 		}
 		doctor.channelIDsInSummarySection[channel.ID] = true
 	} else {
 		if previous != nil {
-			doctor.warn("duplicate channel records in data section with ID %d", channel.ID)
+			doctor.warn("Duplicate channel records in data section with ID %d", channel.ID)
 		}
 		doctor.channelsInDataSection[channel.ID] = channel
 	}
@@ -246,13 +246,13 @@ func (doctor *mcapDoctor) examineChunk(chunk *mcap.Chunk, startOffset uint64) {
 			if err != nil {
 				doctor.error("Failed to parse schema:", err)
 			}
-			doctor.checkSchema(schema)
+			doctor.examineSchema(schema)
 		case mcap.TokenChannel:
 			channel, err := mcap.ParseChannel(data)
 			if err != nil {
 				doctor.error("Error parsing Channel: %s", err)
 			}
-			doctor.checkChannel(channel)
+			doctor.examineChannel(channel)
 		case mcap.TokenMessage:
 			message, err := mcap.ParseMessage(data)
 			if err != nil {
@@ -385,13 +385,13 @@ func (doctor *mcapDoctor) Examine() error {
 			if err != nil {
 				doctor.error("Failed to parse schema:", err)
 			}
-			doctor.checkSchema(schema)
+			doctor.examineSchema(schema)
 		case mcap.TokenChannel:
 			channel, err := mcap.ParseChannel(data)
 			if err != nil {
 				doctor.error("Error parsing Channel: %s", err)
 			}
-			doctor.checkChannel(channel)
+			doctor.examineChannel(channel)
 		case mcap.TokenMessage:
 			message, err := mcap.ParseMessage(data)
 			if err != nil {

--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -431,7 +431,7 @@ func (doctor *mcapDoctor) Examine() Diagnosis {
 			pos, err := doctor.reader.Seek(0, io.SeekCurrent)
 			if err != nil {
 				// cannot continue if seek fails
-				die("failed to determine read cursor: %s", err)
+				doctor.fatalf("failed to determine read cursor: %s", err)
 			}
 			chunkStartOffset := uint64(pos - int64(len(data)) - 9)
 			doctor.examineChunk(chunk, chunkStartOffset)
@@ -523,7 +523,7 @@ func (doctor *mcapDoctor) Examine() Diagnosis {
 
 		_, err := doctor.reader.Seek(int64(chunkOffset), io.SeekStart)
 		if err != nil {
-			die("failed to seek to chunk offset: %s", err)
+			doctor.fatalf("failed to seek to chunk offset: %s", err)
 		}
 		tokenType, data, err := lexer.Next(msg)
 		if err != nil {

--- a/go/cli/mcap/cmd/doctor_test.go
+++ b/go/cli/mcap/cmd/doctor_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
@@ -28,6 +29,28 @@ func TestNoErrorOnMessagelessChunks(t *testing.T) {
 
 	rs := bytes.NewReader(buf.Bytes())
 
+	doctor := newMcapDoctor(rs)
+	err = doctor.Examine()
+	require.NoError(t, err)
+}
+
+func TestRequiresDuplicatedSchemasForIndexedMessages(t *testing.T) {
+	rs, err := os.Open("../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-pad.mcap")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, rs.Close())
+	}()
+	doctor := newMcapDoctor(rs)
+	err = doctor.Examine()
+	require.Error(t, err, "encountered 2 errors")
+}
+
+func TestPassesIndexedMessagesWithRepeatedSchemas(t *testing.T) {
+	rs, err := os.Open("../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-pad-rch-rsh.mcap")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, rs.Close())
+	}()
 	doctor := newMcapDoctor(rs)
 	err = doctor.Examine()
 	require.NoError(t, err)

--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -225,7 +225,7 @@ A Chunk Index record exists for every Chunk in the file.
 | 8     | compressed_size       | uint64                | The size of the chunk `records` field.                                                                                                                                                   |
 | 8     | uncompressed_size     | uint64                | The uncompressed size of the chunk `records` field. This field should match the value in the corresponding Chunk record.                                                                 |
 
-A Schema and Channel record MUST exist in the summary section for all channels referenced by chunk index records.
+A Schema and Channel record MUST exist in the summary section for all messages in chunks that are indexed by Chunk Index records.
 
 > Why? The typical use case for file readers using an index is fast random access to a specific message timestamp. Channel is a prerequisite for decoding Message record data. Without an easy-to-access copy of the Channel records, readers would need to search for Channel records from the start of the file, degrading random access read performance.
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
- Added: `mcap doctor` now warns if a schema or channel record is duplicated in the data section. Some writers do this and it wastes space, though reading still works.
- Added: `mcap doctor` now prints an error if an MCAP contains messages in indexed chunks where their channel and schema information are not duplicated in the summary section. This is required by the spec: https://mcap.dev/spec#chunk-index-op0x08


### Docs

Spec updated to clarify what channels and schemas must be repeated in the summary section.

### Description


<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

