### PR TITLE
Stop example protobuf code from leaking

### DIFF
--- a/cpp/examples/protobuf/dynamic_reader.cpp
+++ b/cpp/examples/protobuf/dynamic_reader.cpp
@@ -8,6 +8,7 @@
 #include <google/protobuf/dynamic_message.h>
 
 #include "mcap/reader.hpp"
+#include <memory>
 #include <vector>
 
 namespace gp = google::protobuf;
@@ -82,7 +83,7 @@ int main(int argc, char** argv) {
         return 1;
       }
     }
-    gp::Message* message = protoFactory.GetPrototype(descriptor)->New();
+    auto message = std::unique_ptr<gp::Message>(protoFactory.GetPrototype(descriptor)->New());
     if (!message->ParseFromArray(it->message.data, static_cast<int>(it->message.dataSize))) {
       std::cerr << "failed to parse message using included foxglove.PointCloud schema" << std::endl;
       reader.close();

--- a/website/docs/guides/cpp/protobuf.md
+++ b/website/docs/guides/cpp/protobuf.md
@@ -162,7 +162,7 @@ descriptor = protoPool.FindMessageTypeByName(it->schema->name);
 We can use this descriptor to parse our message:
 
 ```cpp
-  auto message = std::unique_ptr<gp::Message>(protoFactory.GetPrototype(descriptor)->New());
+auto message = std::unique_ptr<gp::Message>(protoFactory.GetPrototype(descriptor)->New());
 if (!message->ParseFromArray(static_cast<const void*>(it->message.data),
                               it->message.dataSize)) {
   std::cerr << "failed to parse message using included schema" << std::endl;

--- a/website/docs/guides/cpp/protobuf.md
+++ b/website/docs/guides/cpp/protobuf.md
@@ -32,6 +32,7 @@ We also include the MCAP reader implementation:
 ```
 
 And standard library dependencies:
+
 ```cpp
 #include <memory>
 ```

--- a/website/docs/guides/cpp/protobuf.md
+++ b/website/docs/guides/cpp/protobuf.md
@@ -31,6 +31,11 @@ We also include the MCAP reader implementation:
 #include "mcap/reader.hpp"
 ```
 
+And standard library dependencies:
+```cpp
+#include <memory>
+```
+
 Use the `mcap::McapReader::open()` method to open an MCAP file for reading:
 
 ```cpp
@@ -157,7 +162,7 @@ descriptor = protoPool.FindMessageTypeByName(it->schema->name);
 We can use this descriptor to parse our message:
 
 ```cpp
-gp::Message* message = protoFactory.GetPrototype(descriptor)->New();
+  auto message = std::unique_ptr<gp::Message>(protoFactory.GetPrototype(descriptor)->New());
 if (!message->ParseFromArray(static_cast<const void*>(it->message.data),
                               it->message.dataSize)) {
   std::cerr << "failed to parse message using included schema" << std::endl;


### PR DESCRIPTION
### Changelog
protobufs allocated with `New()` must be `delete`d later.

### Docs
None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Leaks

</td><td>

Doesn't leak (leaks less?)

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

