### PR TITLE
Remove close() call from protobuf writer example

### DIFF
--- a/cpp/examples/protobuf/writer.cpp
+++ b/cpp/examples/protobuf/writer.cpp
@@ -156,7 +156,6 @@ int main(int argc, char** argv) {
     if (!res.ok()) {
       std::cerr << "Failed to write message: " << res.message << "\n";
       writer.terminate();
-      writer.close();
       std::ignore = std::remove(outputFilename);
       return 1;
     }


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Calling close() after terminate() doesn't make sense for a couple reasons. First, close() itself calls terminate(). Second, close() attempts to write additional data to the file, and we are doing it here after a write already failed, so it might not be expected to succeed.

On the other hand, it looks like the possible error codes from write() are NotOpen, InvalidChannelId, or InvalidSchemaId. In all of these cases it might actually be fine to call close(), as long as we didn't already call terminate()?

On the third hand, ~McapWriter also calls close() so maybe we completely remove this? 🤷