### PR TITLE
go: reader: read files with chunk indexes but not message indexes correctly.

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -195,8 +195,8 @@ func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
 
 	compressedChunkLength := chunkIndex.ChunkLength
 	if uint64(cap(it.recordBuf)) < compressedChunkLength {
-		newSize := int(float64(compressedChunkLength) * chunkBufferGrowthMultiple)
-		it.recordBuf = make([]byte, newSize)
+		newCapacity := int(float64(compressedChunkLength) * chunkBufferGrowthMultiple)
+		it.recordBuf = make([]byte, compressedChunkLength, newCapacity)
 	} else {
 		it.recordBuf = it.recordBuf[:compressedChunkLength]
 	}

--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -147,13 +147,8 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 				return fmt.Errorf("failed to parse attachment index: %w", err)
 			}
 			// if the chunk overlaps with the requested parameters, load it
-			for _, channel := range it.channels.Slice() {
-				if channel != nil && idx.MessageIndexOffsets[channel.ID] > 0 {
-					if (it.end == 0 && it.start == 0) || (idx.MessageStartTime < it.end && idx.MessageEndTime >= it.start) {
-						it.chunkIndexes = append(it.chunkIndexes, idx)
-					}
-					break
-				}
+			if (it.end == 0 && it.start == 0) || (idx.MessageStartTime < it.end && idx.MessageEndTime >= it.start) {
+				it.chunkIndexes = append(it.chunkIndexes, idx)
 			}
 		case TokenStatistics:
 			stats, err := ParseStatistics(record)


### PR DESCRIPTION
### Changelog
- Fixed: if reading an MCAP file written with chunk index records but no message index records, the go MCAP reader would mistakenly yield no messages.
- Fixed: the indexed MCAP reader would occasionally read too many bytes when reading a chunk.
### Docs

None.

### Description

#### Message indexes
Right now the go indexed reader does not rely on message index records for anything except to check if a chunk contains messages for that topic. This is incorrect - if a chunk index does not contain message index offsets, it can mean either:
- there are no messages in this chunk
- message indexes are not available for this chunk

See the spec: https://mcap.dev/spec#chunk-index-op0x08

#### chunk buffer sizing
- When resizing the chunk buffer between chunk reads, the reader grows the chunk buffer by a multiple of the new chunk size if it's not big enough. However, it would not correctly set the `len` for that buffer, causing the next read to read more past the end of the chunk record into the chunk buffer. This does not cause the reader to yield incorrect information because we use use the contents of the chunk to determine how long the compressed data in it is. However, it causes more bytes to be read than neccessary. Also, it's possible to construct an MCAP where this would cause an "unexpected EOF" error.

