### PR TITLE
go: reader: use message indexes where available

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -149,13 +149,8 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 				return fmt.Errorf("failed to parse attachment index: %w", err)
 			}
 			// if the chunk overlaps with the requested parameters, load it
-			for _, channel := range it.channels.Slice() {
-				if channel != nil && idx.MessageIndexOffsets[channel.ID] > 0 {
-					if (it.end == 0 && it.start == 0) || (idx.MessageStartTime < it.end && idx.MessageEndTime >= it.start) {
-						it.chunkIndexes = append(it.chunkIndexes, idx)
-					}
-					break
-				}
+			if (it.end == 0 && it.start == 0) || (idx.MessageStartTime < it.end && idx.MessageEndTime >= it.start) {
+				it.chunkIndexes = append(it.chunkIndexes, idx)
 			}
 		case TokenStatistics:
 			stats, err := ParseStatistics(record)

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -119,6 +119,7 @@ func (r *Reader) indexedMessageIterator(
 	return &indexedMessageIterator{
 		lexer:            r.l,
 		rs:               r.rs,
+		recordBuf:        make([]byte, 9),
 		topics:           topicMap,
 		start:            opts.StartNanos,
 		end:              opts.EndNanos,

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -908,7 +908,6 @@ func TestOrderStableWithEquivalentTimestamps(t *testing.T) {
 		}
 		assert.Equal(t, uint64(0), msg.LogTime)
 		msgNumber := binary.LittleEndian.Uint64(msg.Data)
-		fmt.Printf("msgNumber: %d\n", msgNumber)
 		if numRead != 0 {
 			assert.Less(t, msgNumber, lastMessageNumber)
 		}
@@ -958,21 +957,25 @@ func TestReadingBigTimestamps(t *testing.T) {
 
 func BenchmarkReader(b *testing.B) {
 	inputParameters := []struct {
-		name                   string
-		outOfOrderWithinChunks bool
-		chunksOverlap          bool
+		name                    string
+		outOfOrderWithinChunks  bool
+		chunksOverlap           bool
+		writeWithMessageIndexes bool
 	}{
 		{
-			name: "msgs_in_order",
+			name:                    "msgs_in_order",
+			writeWithMessageIndexes: true,
 		},
 		{
-			name:                   "jitter_in_chunk",
-			outOfOrderWithinChunks: true,
+			name:                    "jitter_in_chunk",
+			outOfOrderWithinChunks:  true,
+			writeWithMessageIndexes: true,
 		},
 		{
-			name:                   "chunks_overlap",
-			outOfOrderWithinChunks: true,
-			chunksOverlap:          true,
+			name:                    "chunks_overlap",
+			outOfOrderWithinChunks:  true,
+			chunksOverlap:           true,
+			writeWithMessageIndexes: true,
 		},
 	}
 	for _, inputCfg := range inputParameters {
@@ -980,8 +983,9 @@ func BenchmarkReader(b *testing.B) {
 			b.StopTimer()
 			buf := &bytes.Buffer{}
 			writer, err := NewWriter(buf, &WriterOptions{
-				Chunked:     true,
-				Compression: CompressionZSTD,
+				Chunked:             true,
+				Compression:         CompressionZSTD,
+				SkipMessageIndexing: !inputCfg.writeWithMessageIndexes,
 			})
 			require.NoError(b, err)
 			messageCount := uint64(4000000)

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -963,16 +963,28 @@ func BenchmarkReader(b *testing.B) {
 		writeWithMessageIndexes bool
 	}{
 		{
-			name:                    "msgs_in_order",
+			name: "msgs_in_order",
+		},
+		{
+			name:                    "with_msgindex_msgs_in_order",
 			writeWithMessageIndexes: true,
 		},
 		{
-			name:                    "jitter_in_chunk",
+			name:                   "jitter_in_chunk",
+			outOfOrderWithinChunks: true,
+		},
+		{
+			name:                    "with_msgindex_jitter_in_chunk",
 			outOfOrderWithinChunks:  true,
 			writeWithMessageIndexes: true,
 		},
 		{
-			name:                    "chunks_overlap",
+			name:                   "chunks_overlap",
+			outOfOrderWithinChunks: true,
+			chunksOverlap:          true,
+		},
+		{
+			name:                    "with_msgindex_chunks_overlap",
 			outOfOrderWithinChunks:  true,
 			chunksOverlap:           true,
 			writeWithMessageIndexes: true,

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -792,7 +792,7 @@ type WriterOptions struct {
 	// exact interpretation of this value depends on the compression format.
 	CompressionLevel CompressionLevel
 
-	// SkipMessageIndexing skips the message and chunk indexes for a chunked
+	// SkipMessageIndexing skips writing the message indexes for a chunked
 	// file.
 	SkipMessageIndexing bool
 


### PR DESCRIPTION
This branch mainly exists to prove that using message indexes is slower than not using them.