### PR TITLE
go: bump version to v1.4.1

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.4.0"
+var Version = "v1.4.1"


### PR DESCRIPTION
increasing the version number so we can tag a new go version.