### PR TITLE
rust: Make RawMessage fields public

### DIFF
--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -624,8 +624,8 @@ impl<'a> RawMessageStream<'a> {
 }
 
 pub struct RawMessage<'a> {
-    header: records::MessageHeader,
-    data: Cow<'a, [u8]>,
+    pub header: records::MessageHeader,
+    pub data: Cow<'a, [u8]>,
 }
 
 impl<'a> Iterator for RawMessageStream<'a> {


### PR DESCRIPTION
### Changelog
RawMessage fields are now public

### Docs

None

### Description

Currently the `RawMessageStream` is useless because the API does not expose the fields of the `RawMessage` struct. To solve this issue the fields of `RawMessages` are now marked as `pub`.

### References
This PR is the same as https://github.com/foxglove/mcap/pull/934