### PR TITLE
add page with guide to install mcap with cmake

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -94,7 +94,7 @@ manager can be used with the included
 
 ### CMake
 
-For how to use MCAP with CMake see the [cmake](website/docs/guides/cpp/cmake.md) page.
+For using MCAP with CMake, the third-party [olympus-robotics/mcap_builder](https://github.com/olympus-robotics/mcap_builder) repository provides a helpful wrapper.
 
 ### Alternatives
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -86,9 +86,18 @@ following dependencies:
 If your project does not need `lz4` or `zstd` support, you can optionally disable these by defining
 `MCAP_COMPRESSION_NO_LZ4` or `MCAP_COMPRESSION_NO_ZSTD` respectively.
 
+### Conan
+
 To simplify installation of dependencies, the [Conan](https://conan.io/) package
 manager can be used with the included
 [conanfile.py](https://github.com/foxglove/mcap/blob/main/cpp/mcap/conanfile.py).
+
+### CMake
+
+For how to use MCAP with CMake see the [cmake](website/docs/guides/cpp/cmake.md) page.
+
+### Alternatives
+
 If you use an alternative approach, such as CMake's FetchContent or directly
 vendoring the dependencies, make sure you use versions equal or greater than the
 versions listed above.

--- a/website/docs/guides/cpp/cmake.md
+++ b/website/docs/guides/cpp/cmake.md
@@ -4,6 +4,6 @@ description: Build and use MCAP C++ library with CMake.
 
 # Build MCAP with CMake
 
-If you want to add MCAP to your C++ project that uses CMake, the [mcap_build](https://github.com/olympus-robotics/mcap_builder) repository provides a helpful wrapper.
+If you want to add MCAP to your C++ project that uses CMake, the third-party [olympus-robotics/mcap_builder](https://github.com/olympus-robotics/mcap_builder) repository provides a helpful wrapper.
 
-The [readme](https://github.com/olympus-robotics/mcap_builder/blob/main/README.md) file in the repository provides all the steps and the context needed.
+The readme file in that repository provides the steps and the context needed.

--- a/website/docs/guides/cpp/cmake.md
+++ b/website/docs/guides/cpp/cmake.md
@@ -1,0 +1,9 @@
+---
+description: Build and use MCAP C++ library with CMake.
+---
+
+# Build MCAP with CMake
+
+If you want to add MCAP to your C++ project that uses CMake, the [mcap_build](https://github.com/olympus-robotics/mcap_builder) repository provides a helpful wrapper.
+
+The [readme](https://github.com/olympus-robotics/mcap_builder/blob/main/README.md) file in the repository provides all the steps and the context needed.


### PR DESCRIPTION
### Changelog
Add a page to `website` with the guide on how to install MCAP with Cmake.

### Description
This follows conversation from https://foxglove.slack.com/archives/C02H1JXG3C3/p1719462475680899