### PR TITLE
Fix table output with wide columns

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/foxglove/mcap/go/cli/mcap/utils"
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -89,7 +91,9 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 			header = addRow(header, "end:", "%s", decimalTime(endtime))
 		}
 	}
-	utils.FormatTable(buf, header)
+	if err := printSummaryRows(buf, header); err != nil {
+		return err
+	}
 	if len(info.ChunkIndexes) > 0 {
 		compressionFormatStats := make(map[mcap.CompressionFormat]struct {
 			count            int
@@ -166,7 +170,9 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		}
 		rows = append(rows, row)
 	}
-	utils.FormatTable(buf, rows)
+	if err := printSummaryRows(buf, rows); err != nil {
+		return err
+	}
 	if info.Statistics != nil {
 		fmt.Fprintf(buf, "attachments: %d\n", info.Statistics.AttachmentCount)
 		fmt.Fprintf(buf, "metadata: %d\n", info.Statistics.MetadataCount)
@@ -176,6 +182,26 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 	}
 	_, err := buf.WriteTo(w)
 	return err
+}
+
+// Similar to utils.FormatTable, but optimized for 'expanded' display of nested data
+func printSummaryRows(w io.Writer, rows [][]string) error {
+	buf := &bytes.Buffer{}
+	tw := tablewriter.NewWriter(buf)
+	tw.SetBorder(false)
+	tw.SetAutoWrapText(false)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetColumnSeparator("")
+	tw.AppendBulk(rows)
+	tw.Render()
+	// This tablewriter puts a leading space on the lines for some reason, so
+	// remove it.
+	scanner := bufio.NewScanner(buf)
+	for scanner.Scan() {
+		fmt.Fprintln(w, strings.TrimLeft(scanner.Text(), " "))
+	}
+	return scanner.Err()
 }
 
 var infoCmd = &cobra.Command{

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -184,7 +184,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 	return err
 }
 
-// Similar to utils.FormatTable, but optimized for 'expanded' display of nested data
+// Similar to utils.FormatTable, but optimized for 'expanded' display of nested data.
 func printSummaryRows(w io.Writer, rows [][]string) error {
 	buf := &bytes.Buffer{}
 	tw := tablewriter.NewWriter(buf)

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -134,7 +134,7 @@ var addMetadataCmd = &cobra.Command{
 
 var getMetadataCmd = &cobra.Command{
 	Use:   "metadata",
-	Short: "get metadata by name",
+	Short: "Get metadata by name",
 	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		if len(args) != 1 {

--- a/go/cli/mcap/cmd/metadata.go
+++ b/go/cli/mcap/cmd/metadata.go
@@ -214,7 +214,7 @@ func init() {
 	}
 
 	getCmd.AddCommand(getMetadataCmd)
-	getMetadataCmd.PersistentFlags().StringVarP(&getMetadataName, "name", "n", "", "name of metadata record to create")
+	getMetadataCmd.PersistentFlags().StringVarP(&getMetadataName, "name", "n", "", "name of metadata record to get")
 	err = getMetadataCmd.MarkPersistentFlagRequired("name")
 	if err != nil {
 		die("failed to mark --name flag as required: %s", err)

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,7 +8,6 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -107,21 +105,17 @@ func WithReader(ctx context.Context, filename string, f func(remote bool, rs io.
 }
 
 func FormatTable(w io.Writer, rows [][]string) {
-	buf := &bytes.Buffer{}
-	tw := tablewriter.NewWriter(buf)
+	tw := tablewriter.NewWriter(w)
 	tw.SetBorder(false)
 	tw.SetAutoWrapText(false)
 	tw.SetAlignment(tablewriter.ALIGN_LEFT)
 	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	tw.SetColumnSeparator("")
+	tw.SetTablePadding("\t")
+	tw.SetNoWhiteSpace(true)
+
 	tw.AppendBulk(rows)
 	tw.Render()
-	// This tablewriter puts a leading space on the lines for some reason, so
-	// remove it.
-	scanner := bufio.NewScanner(buf)
-	for scanner.Scan() {
-		fmt.Fprintln(w, strings.TrimLeft(scanner.Text(), " "))
-	}
 }
 
 func Keys[T any](m map[string]T) []string {


### PR DESCRIPTION
### Changelog
Fix: table output from list commands supports wide columns such as large amounts of metadata

### Docs
None

### Description

Previously, listing the metadata for an mcap file with many (>64kb) key/value pairs failed silently.

The Scanner used in the table formatter has a buffer limit of 64kb, and the error result was being ignored. This removes the scanner entirely from most table output. It was introduced to trim leading whitespace from lines, but the formatter accepts other options to make this happen.

I've given the info command its own formatter, which I think is appropriate because it's formatting data differently, even including tabs in its row data. The scanner's error result is now checked, though we shouldn't see this in practice for `mcap info`.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

`mcap list metadata` would silently fail if a record had >64kb

</td><td>

all metadata is output as expected

</td></tr></table>


As a side effect, this also fixes the column alignment for something like `list schemas` that contains linebreaks:

<table><tr><th>Before</th><th>After</th></tr><tr><td>

```
id  name                encoding  data
24  tf2_msgs/TFMessage  ros1msg   geometry_msgs/TransformStamped[] transforms

================================================================================
MSG: geometry_msgs/TransformStamped
# This expresses a transform from coordinate frame header.frame_id
# to the coordinate frame child_frame_id
#
# This message is mostly used by the
# <a href="http://wiki.ros.org/tf">tf</a> package.
# See its documentation for more information.

Header header
string child_frame_id # the frame id of the child frame
Transform transform

```

</td><td>

```
id	name              	encoding	data
24	tf2_msgs/TFMessage	ros1msg 	geometry_msgs/TransformStamped[] transforms

  	                  	        	================================================================================
  	                  	        	MSG: geometry_msgs/TransformStamped
  	                  	        	# This expresses a transform from coordinate frame header.frame_id
  	                  	        	# to the coordinate frame child_frame_id
  	                  	        	#
  	                  	        	# This message is mostly used by the
  	                  	        	# <a href="http://wiki.ros.org/tf">tf</a> package.
  	                  	        	# See its documentation for more information.

  	                  	        	Header header
  	                  	        	string child_frame_id # the frame id of the child frame
  	                  	        	Transform transform

```

</td></tr></table>


This also makes a couple of copy fixes to the inline help for the metadata commands.

Fixes #1189.