### PR TITLE
Don't clear channels on writer close()

### DIFF
--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -473,7 +473,6 @@ void McapWriter::terminate() {
   zstdChunk_.reset();
 #endif
 
-  channels_.clear();
   attachmentIndex_.clear();
   metadataIndex_.clear();
   chunkIndex_.clear();


### PR DESCRIPTION
### Changelog
Don't clear channels on writer close(). This matches the behavior schemas has, allowing for stable ids after closing and opening a new file with the same reader. See https://foxglove.slack.com/archives/C02H1JXG3C3/p1720827358364829?thread_ts=1720825408.044619&cid=C02H1JXG3C3

Alternatives to this involve more bookkeeping on the recorder implementation side to re-register all schemas/channels on split.

### Docs

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Manual testing, using Basis. YMMV.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

