### PR TITLE
Add Rust ordered message stream implementation

### DIFF
--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -7,14 +7,6 @@
 //! Consider [memory-mapping](https://docs.rs/memmap/0.7.0/memmap/struct.Mmap.html)
 //! the file - the OS will load (and cache!) it on-demand, without any
 //! further system calls.
-use binrw::prelude::*;
-use byteorder::{ReadBytesExt, LE};
-use crc32fast::hash as crc32;
-use enumset::{enum_set, EnumSet, EnumSetType};
-use log::*;
-use std::cmp::Ordering;
-use std::collections::binary_heap::IntoIter;
-use std::collections::BinaryHeap;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
@@ -23,6 +15,15 @@ use std::{
     mem::size_of,
     sync::Arc,
 };
+
+use binrw::prelude::*;
+use byteorder::{ReadBytesExt, LE};
+use crc32fast::hash as crc32;
+use enumset::{enum_set, EnumSet, EnumSetType};
+use log::*;
+use std::cmp::Ordering;
+use std::collections::binary_heap::IntoIter;
+use std::collections::BinaryHeap;
 
 use crate::{
     io_utils::CountingCrcReader,


### PR DESCRIPTION
### Changelog
Add OrderedMessageStream implementation for reading timestamp ordered messages in Rust.

### Docs

Happy to add a docs change!

### Description

The Python API allows reading in message-timestamp order:

```python
todo
```

This PR brings roughly the same functionality to Rust:

```rust
todo
```

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

Fixes: https://github.com/foxglove/mcap/issues/659
