### PR TITLE
Remove dead members in McapReader

### DIFF
--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -493,8 +493,6 @@ private:
   std::unordered_map<ChannelId, ChannelPtr> channels_;
   ByteOffset dataStart_ = 0;
   ByteOffset dataEnd_ = EndOffset;
-  Timestamp startTime_ = 0;
-  Timestamp endTime_ = 0;
   bool parsedSummary_ = false;
 
   void reset_();

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -363,8 +363,6 @@ void McapReader::reset_() {
   channels_.clear();
   dataStart_ = 0;
   dataEnd_ = EndOffset;
-  startTime_ = 0;
-  endTime_ = 0;
   parsedSummary_ = false;
 }
 


### PR DESCRIPTION
### Changelog
Remove unused `startTime_` and `endTime_` members of `McapReader` that were initialized and never used.

### Docs

None

### Description

This is fairly self evident - if the code compiles it should be the correct change.
