### PR TITLE
rust: Support writing without chunks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,5 +47,8 @@
   "C_Cpp.default.cppStandard": "c++17",
   "[go]": {
     "editor.defaultFormatter": "golang.go"
+  },
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
   }
 }

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -440,9 +440,10 @@ impl<'a, W: Write + Seek> Writer<'a, W> {
         // (That would leave it in an unspecified state if we bailed here!)
         // Instead briefly swap it out for a null writer while we set up the chunker
         // The writer will only be None if finish() was called.
-        if !self.options.use_chunks {
-            unreachable!("Trying to write to a chunk when chunking is disabled")
-        }
+        assert!(
+            self.options.use_chunks,
+            "Trying to write to a chunk when chunking is disabled"
+        );
 
         let prev_writer = self.writer.take().expect(Self::WHERE_WRITER);
 

--- a/rust/tests/message.rs
+++ b/rust/tests/message.rs
@@ -39,11 +39,22 @@ fn smoke() -> Result<()> {
 
 #[test]
 fn round_trip() -> Result<()> {
+    run_round_trip(true)
+}
+
+#[test]
+fn round_trip_no_chunks() -> Result<()> {
+    run_round_trip(false)
+}
+
+fn run_round_trip(use_chunks: bool) -> Result<()> {
     let mapped = map_mcap("../tests/conformance/data/OneMessage/OneMessage.mcap")?;
     let messages = mcap::MessageStream::new(&mapped)?;
 
     let mut tmp = tempfile()?;
-    let mut writer = mcap::Writer::new(BufWriter::new(&mut tmp))?;
+    let mut writer = mcap::WriteOptions::default()
+        .use_chunks(use_chunks)
+        .create(BufWriter::new(&mut tmp))?;
 
     for m in messages {
         writer.write(&m?)?;
@@ -71,7 +82,7 @@ fn round_trip() -> Result<()> {
             message_count: 1,
             schema_count: 1,
             channel_count: 1,
-            chunk_count: 1,
+            chunk_count: if use_chunks { 1 } else { 0 },
             message_start_time: 2,
             message_end_time: 2,
             channel_message_counts: [(0, 1)].into(),


### PR DESCRIPTION
On very memory-constrained systems like microcontrollers, the overhead of storing all the chunk offset data in memory until the end of the file can be significant. To avoid that, we instead write all Channel, Schema, and Message data directly as records rather than using chunks, and rely on the reader (or an intermediate ingestion process) to generate the index information.

### Changelog
The rust library now (optionally) supports writing unchunked MCAP files for decreased memory footprint.

### Docs

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

In our internal testing, storing chunk data required >40KB of memory for several-minute logs, which is a lot for an embedded system with only 300KB of RAM total. Notably, this grows without bound during the test, since the offsets and data about all chunks needs to be stored until the end of the log when it will be written to the index.

For our usecase, it's acceptable to disable chunking entirely (along with compression and indexing), since we can add those things later during the log upload process.

We're using this internally on an ESP32-S3 and it is working well.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

