### PR TITLE
Update go linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
         with:
           go-version-file: go/go.work
       - name: install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
       - run: make lint
       - run: make test
       - name: Check library version

--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -4,7 +4,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
@@ -12,11 +11,9 @@ linters:
     - staticcheck
     - typecheck
     - unused
-    - varcheck
     - gocritic
     - godot
     - gofmt
-    - ifshort
     - misspell
     - prealloc
     - sqlclosecheck


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This upgrades the version of `golangci-lint` to the latest version, and removes three deprecated linters, which now error when included because they are completely unused: https://github.com/foxglove/mcap/pull/1192#issuecomment-2252886768.
