### PR TITLE
go: return a bad magic error in check when parsing summary

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -83,7 +83,7 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 	}
 	magic := buf[20:]
 	if !bytes.Equal(magic, Magic) {
-		return fmt.Errorf("not an MCAP file")
+		return &ErrBadMagic{location: magicLocationEnd, actual: magic}
 	}
 	footer, err := ParseFooter(buf[:20])
 	if err != nil {

--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.4.1"
+var Version = "v1.5.0"


### PR DESCRIPTION
### Changelog
- Changed: when attempting to read a corrupt MCAP using using the index, the reader will return an ErrBadMagic instance rather than a bare Error.

### Docs

None.

### Description

it's useful to be able to tell this error apart from errors that might result from i/o, but right now there is no simple way to determine this using `errors.Is`. This PR gives the error a publicly known type, so that callers can check for it.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

