### PR TITLE
Remove CLA comment from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download the latest `mcap-cli` version from the [releases page](https://github.c
 
 ## License
 
-[MIT License](/LICENSE). Contributors are required to accept the [Contributor License Agreement](https://github.com/foxglove/cla).
+[MIT License](/LICENSE).
 
 ## Release process
 


### PR DESCRIPTION
We have decided to remove the Contributor License Agreement (CLA) from MCAP and other Foxglove open source projects. The project remains MIT licensed, but we no longer require an additional copyright grant from contributors 🎉. 

Per the [GitHub Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license), submitted pull requests are licensed under the same terms (MIT).

<img width="540" alt="image" src="https://github.com/user-attachments/assets/402bd612-3e57-49ab-a91a-532be882ca7e">
