### PR TITLE
rust: add async reading functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,8 @@ jobs:
         with:
           toolchain: stable
           default: true
-      - run: cd rust && cargo build --example=conformance_reader
+      - run: cargo build --example=conformance_reader --example=conformance_reader_async --features=tokio
+        working-directory: rust
       - run: yarn install --immutable
       - run: yarn test:conformance:generate-inputs --verify
       - run: yarn test:conformance --runner rust-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,6 +491,7 @@ jobs:
           toolchain: stable
           default: true
           components: "rustfmt, clippy"
+      - run: rustup target add wasm32-unknown-unknown
       - run: cargo fmt --all -- --check
       - run: cargo clippy -- --no-deps
       - run: cargo clippy --no-default-features -- --no-deps
@@ -501,6 +502,8 @@ jobs:
       - run: cargo clippy --no-default-features --features tokio,zstd -- --no-deps
       - run: cargo build --all-features
       - run: cargo test --all-features
+      - run: cargo build --all-features --target wasm32-unknown-unknown
+      - run: cargo check --all-features --target wasm32-unknown-unknown
       - name: "publish to crates.io"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/rust/v')
         run: cargo publish --token ${{ secrets.RUST_CRATES_IO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,8 +496,11 @@ jobs:
       - run: cargo clippy --no-default-features -- --no-deps
       - run: cargo clippy --no-default-features --features lz4 -- --no-deps
       - run: cargo clippy --no-default-features --features zstd -- --no-deps
-      - run: cargo build
-      - run: cargo test
+      - run: cargo clippy --no-default-features --features tokio -- --no-deps
+      - run: cargo clippy --no-default-features --features tokio,lz4 -- --no-deps
+      - run: cargo clippy --no-default-features --features tokio,zstd -- --no-deps
+      - run: cargo build --all-features
+      - run: cargo test --all-features
       - name: "publish to crates.io"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/rust/v')
         run: cargo publish --token ${{ secrets.RUST_CRATES_IO_TOKEN }}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,7 +43,7 @@ anyhow = "1"
 atty = "0.2"
 camino = "1.0"
 clap = { version = "3.2", features = ["derive"]}
-criterion = "0.5.1"
+criterion = { version = "0.5.1", features = ["async_tokio"] }
 itertools = "0.10"
 memmap = "0.7"
 rayon = "1.5"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,6 @@ thiserror = "1.0"
 lz4 = { version = "1", optional = true }
 async-compression = { version = "*", features = ["tokio", "zstd"], optional = true }
 tokio = { version = "1", features = ["io-util"] , optional = true }
-tokio-stream = { version = "*", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 zstd = { version = "0.11", features = ["wasm"], optional = true }
@@ -37,7 +36,7 @@ zstd = { version = "0.11", features = ["zstdmt"], optional = true }
 default = ["zstd", "lz4"]
 zstd = ["dep:zstd"]
 lz4 = ["dep:lz4"]
-tokio = ["dep:async-compression", "dep:tokio", "dep:tokio-stream"]
+tokio = ["dep:async-compression", "dep:tokio"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,7 +23,7 @@ num_cpus = "1.13"
 paste = "1.0"
 thiserror = "1.0"
 lz4 = { version = "1", optional = true }
-async-compression = { version = "*", features = ["tokio", "zstd"], optional = true }
+async-compression = { version = "*", features = ["tokio"], optional = true }
 tokio = { version = "1", features = ["io-util"] , optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -34,7 +34,7 @@ zstd = { version = "0.11", features = ["zstdmt"], optional = true }
 
 [features]
 default = ["zstd", "lz4"]
-zstd = ["dep:zstd"]
+zstd = ["dep:zstd", "async-compression/zstd"]
 lz4 = ["dep:lz4"]
 tokio = ["dep:async-compression", "dep:tokio"]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -61,3 +61,7 @@ harness = false
 opt-level = 3
 debug = true
 lto = true
+
+[[example]]
+name = "conformance_reader_async"
+required-features = ["tokio"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 tempfile = "3.3"
-tokio = { version = "1", features = ["io-util", "macros", "rt"] }
+tokio = { version = "1", features = ["io-util", "macros", "rt", "fs"] }
 
 [[bench]]
 name = "reader"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 num_cpus = "1.13"
 paste = "1.0"
 thiserror = "1.0"
-lz4 = { version = "1", optional = true }
+lz4 = { version = "1.27", optional = true }
 async-compression = { version = "*", features = ["tokio"], optional = true }
 tokio = { version = "1", features = ["io-util"] , optional = true }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 
@@ -22,7 +22,10 @@ log = "0.4"
 num_cpus = "1.13"
 paste = "1.0"
 thiserror = "1.0"
-lz4_flex = { version = "0.11.1", optional = true }
+lz4 = { version = "1", optional = true }
+async-compression = { version = "*", features = ["tokio", "zstd"], optional = true }
+tokio = { version = "1", features = ["io-util"] , optional = true }
+tokio-stream = { version = "*", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 zstd = { version = "0.11", features = ["wasm"], optional = true }
@@ -33,7 +36,8 @@ zstd = { version = "0.11", features = ["zstdmt"], optional = true }
 [features]
 default = ["zstd", "lz4"]
 zstd = ["dep:zstd"]
-lz4 = ["dep:lz4_flex"]
+lz4 = ["dep:lz4"]
+tokio = ["dep:async-compression", "dep:tokio", "dep:tokio-stream"]
 
 [dev-dependencies]
 anyhow = "1"
@@ -48,6 +52,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 tempfile = "3.3"
+tokio = { version = "1", features = ["io-util", "macros", "rt"] }
 
 [[bench]]
 name = "reader"

--- a/rust/benches/reader.rs
+++ b/rust/benches/reader.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use mcap::{Channel, Message, MessageStream, Schema};
+use mcap::{parse_record, Channel, Message, MessageStream, Schema};
 use std::borrow::Cow;
 use std::io::Cursor;
 use std::sync::Arc;
@@ -79,6 +79,51 @@ fn bench_read_messages(c: &mut Criterion) {
             }
         });
     });
+    #[cfg(feature = "tokio")]
+    {
+        use mcap::tokio::read::RecordReader;
+        use tokio::runtime::Builder;
+
+        let rt = Builder::new_current_thread().build().unwrap();
+        group.bench_function("AsyncMessageStream_1M_uncompressed", |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut reader = RecordReader::new(Cursor::new(&mcap_data_uncompressed));
+                let mut record = Vec::new();
+                let mut count = 0;
+                while let Some(result) = reader.next_record(&mut record).await {
+                    count += 1;
+                    std::hint::black_box(parse_record(result.unwrap(), &record).unwrap());
+                }
+                assert_eq!(count, N + 118);
+            });
+        });
+
+        group.bench_function("AsyncMessageStream_1M_zstd", |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut reader = RecordReader::new(Cursor::new(&mcap_data_zstd));
+                let mut record = Vec::new();
+                let mut count = 0;
+                while let Some(result) = reader.next_record(&mut record).await {
+                    count += 1;
+                    std::hint::black_box(parse_record(result.unwrap(), &record).unwrap());
+                }
+                assert_eq!(count, N + 118);
+            });
+        });
+
+        group.bench_function("AsyncMessageStream_1M_lz4", |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut reader = RecordReader::new(Cursor::new(&mcap_data_lz4));
+                let mut record = Vec::new();
+                let mut count = 0;
+                while let Some(result) = reader.next_record(&mut record).await {
+                    count += 1;
+                    std::hint::black_box(parse_record(result.unwrap(), &record).unwrap());
+                }
+                assert_eq!(count, N + 118);
+            });
+        });
+    }
 
     group.finish();
 }

--- a/rust/examples/common/serialization.rs
+++ b/rust/examples/common/serialization.rs
@@ -1,0 +1,133 @@
+use mcap::records::Record;
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+// We don't want to force Serde on users just for the sake of the conformance tests.
+// (In what context would you want to serialize individual records of a MCAP?)
+// Stamp out and stringify them ourselves:
+
+fn get_type(rec: &Record<'_>) -> &'static str {
+    match rec {
+        Record::Header(_) => "Header",
+        Record::Footer(_) => "Footer",
+        Record::Schema { .. } => "Schema",
+        Record::Channel(_) => "Channel",
+        Record::Message { .. } => "Message",
+        Record::Chunk { .. } => "Chunk",
+        Record::MessageIndex(_) => "MessageIndex",
+        Record::ChunkIndex(_) => "ChunkIndex",
+        Record::Attachment { .. } => "Attachment",
+        Record::AttachmentIndex(_) => "AttachmentIndex",
+        Record::Statistics(_) => "Statistics",
+        Record::Metadata(_) => "Metadata",
+        Record::MetadataIndex(_) => "MetadataIndex",
+        Record::SummaryOffset(_) => "SummaryOffset",
+        Record::DataEnd(_) => "DataEnd",
+        Record::Unknown { opcode, .. } => {
+            panic!("Unknown record in conformance test: (op {opcode})")
+        }
+    }
+}
+
+fn get_fields(rec: &Record<'_>) -> Value {
+    fn b2s(bytes: &[u8]) -> Vec<String> {
+        bytes.iter().map(|b| b.to_string()).collect()
+    }
+    fn m2s(map: &BTreeMap<u16, u64>) -> BTreeMap<String, String> {
+        map.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    match rec {
+        Record::Header(h) => json!([["library", h.library], ["profile", h.profile]]),
+        Record::Footer(f) => json!([
+            ["summary_crc", f.summary_crc.to_string()],
+            ["summary_offset_start", f.summary_offset_start.to_string()],
+            ["summary_start", f.summary_start.to_string()]
+        ]),
+        Record::Schema { header, data } => json!([
+            ["data", b2s(data)],
+            ["encoding", header.encoding],
+            ["id", header.id.to_string()],
+            ["name", header.name]
+        ]),
+        Record::Channel(c) => json!([
+            ["id", c.id.to_string()],
+            ["message_encoding", c.message_encoding],
+            ["metadata", c.metadata],
+            ["schema_id", c.schema_id.to_string()],
+            ["topic", c.topic]
+        ]),
+        Record::Message { header, data } => json!([
+            ["channel_id", header.channel_id.to_string()],
+            ["data", b2s(data)],
+            ["log_time", header.log_time.to_string()],
+            ["publish_time", header.publish_time.to_string()],
+            ["sequence", header.sequence.to_string()]
+        ]),
+        Record::Chunk { .. } => unreachable!("Chunks are flattened"),
+        Record::MessageIndex(_) => unreachable!("MessageIndexes are skipped"),
+        Record::ChunkIndex(i) => json!([
+            ["chunk_length", i.chunk_length.to_string()],
+            ["chunk_start_offset", i.chunk_start_offset.to_string()],
+            ["compressed_size", i.compressed_size.to_string()],
+            ["compression", i.compression],
+            ["message_end_time", i.message_end_time.to_string()],
+            ["message_index_length", i.message_index_length.to_string()],
+            ["message_index_offsets", m2s(&i.message_index_offsets)],
+            ["message_start_time", i.message_start_time.to_string()],
+            ["uncompressed_size", i.uncompressed_size.to_string()]
+        ]),
+        Record::Attachment { header, data } => json!([
+            ["create_time", header.create_time.to_string()],
+            ["data", b2s(data)],
+            ["log_time", header.log_time.to_string()],
+            ["media_type", header.media_type],
+            ["name", header.name]
+        ]),
+        Record::AttachmentIndex(i) => json!([
+            ["create_time", i.create_time.to_string()],
+            ["data_size", i.data_size.to_string()],
+            ["length", i.length.to_string()],
+            ["log_time", i.log_time.to_string()],
+            ["media_type", i.media_type],
+            ["name", i.name],
+            ["offset", i.offset.to_string()]
+        ]),
+        Record::Statistics(s) => json!([
+            ["attachment_count", s.attachment_count.to_string()],
+            ["channel_count", s.channel_count.to_string()],
+            ["channel_message_counts", m2s(&s.channel_message_counts)],
+            ["chunk_count", s.chunk_count.to_string()],
+            ["message_count", s.message_count.to_string()],
+            ["message_end_time", s.message_end_time.to_string()],
+            ["message_start_time", s.message_start_time.to_string()],
+            ["metadata_count", s.metadata_count.to_string()],
+            ["schema_count", s.schema_count.to_string()]
+        ]),
+        Record::Metadata(m) => json!([["metadata", m.metadata], ["name", m.name]]),
+        Record::MetadataIndex(i) => json!([
+            ["length", i.length.to_string()],
+            ["name", i.name],
+            ["offset", i.offset.to_string()]
+        ]),
+        Record::SummaryOffset(s) => json!([
+            ["group_length", s.group_length.to_string()],
+            ["group_opcode", s.group_opcode.to_string()],
+            ["group_start", s.group_start.to_string()]
+        ]),
+        Record::DataEnd(d) => json!([["data_section_crc", d.data_section_crc.to_string()]]),
+        Record::Unknown { opcode, .. } => {
+            panic!("Unknown record in conformance test: (op {opcode})")
+        }
+    }
+}
+
+pub fn as_json(view: &Record<'_>) -> Value {
+    let typename = get_type(view);
+    let fields = get_fields(view);
+    json!({"type": typename, "fields": fields})
+}

--- a/rust/examples/conformance_reader.rs
+++ b/rust/examples/conformance_reader.rs
@@ -1,136 +1,11 @@
-use mcap::records::Record;
-
-use std::{collections::BTreeMap, env, process};
+#[path = "common/serialization.rs"]
+mod serialization;
 
 use serde_json::{json, Value};
 
-// We don't want to force Serde on users just for the sake of the conformance tests.
-// (In what context would you want to serialize individual records of a MCAP?)
-// Stamp out and stringify them ourselves:
-
-fn get_type(rec: &Record<'_>) -> &'static str {
-    match rec {
-        Record::Header(_) => "Header",
-        Record::Footer(_) => "Footer",
-        Record::Schema { .. } => "Schema",
-        Record::Channel(_) => "Channel",
-        Record::Message { .. } => "Message",
-        Record::Chunk { .. } => "Chunk",
-        Record::MessageIndex(_) => "MessageIndex",
-        Record::ChunkIndex(_) => "ChunkIndex",
-        Record::Attachment { .. } => "Attachment",
-        Record::AttachmentIndex(_) => "AttachmentIndex",
-        Record::Statistics(_) => "Statistics",
-        Record::Metadata(_) => "Metadata",
-        Record::MetadataIndex(_) => "MetadataIndex",
-        Record::SummaryOffset(_) => "SummaryOffset",
-        Record::DataEnd(_) => "DataEnd",
-        Record::Unknown { opcode, .. } => {
-            panic!("Unknown record in conformance test: (op {opcode})")
-        }
-    }
-}
-
-fn get_fields(rec: &Record<'_>) -> Value {
-    fn b2s(bytes: &[u8]) -> Vec<String> {
-        bytes.iter().map(|b| b.to_string()).collect()
-    }
-    fn m2s(map: &BTreeMap<u16, u64>) -> BTreeMap<String, String> {
-        map.iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect()
-    }
-
-    match rec {
-        Record::Header(h) => json!([["library", h.library], ["profile", h.profile]]),
-        Record::Footer(f) => json!([
-            ["summary_crc", f.summary_crc.to_string()],
-            ["summary_offset_start", f.summary_offset_start.to_string()],
-            ["summary_start", f.summary_start.to_string()]
-        ]),
-        Record::Schema { header, data } => json!([
-            ["data", b2s(data)],
-            ["encoding", header.encoding],
-            ["id", header.id.to_string()],
-            ["name", header.name]
-        ]),
-        Record::Channel(c) => json!([
-            ["id", c.id.to_string()],
-            ["message_encoding", c.message_encoding],
-            ["metadata", c.metadata],
-            ["schema_id", c.schema_id.to_string()],
-            ["topic", c.topic]
-        ]),
-        Record::Message { header, data } => json!([
-            ["channel_id", header.channel_id.to_string()],
-            ["data", b2s(data)],
-            ["log_time", header.log_time.to_string()],
-            ["publish_time", header.publish_time.to_string()],
-            ["sequence", header.sequence.to_string()]
-        ]),
-        Record::Chunk { .. } => unreachable!("Chunks are flattened"),
-        Record::MessageIndex(_) => unreachable!("MessageIndexes are skipped"),
-        Record::ChunkIndex(i) => json!([
-            ["chunk_length", i.chunk_length.to_string()],
-            ["chunk_start_offset", i.chunk_start_offset.to_string()],
-            ["compressed_size", i.compressed_size.to_string()],
-            ["compression", i.compression],
-            ["message_end_time", i.message_end_time.to_string()],
-            ["message_index_length", i.message_index_length.to_string()],
-            ["message_index_offsets", m2s(&i.message_index_offsets)],
-            ["message_start_time", i.message_start_time.to_string()],
-            ["uncompressed_size", i.uncompressed_size.to_string()]
-        ]),
-        Record::Attachment { header, data } => json!([
-            ["create_time", header.create_time.to_string()],
-            ["data", b2s(data)],
-            ["log_time", header.log_time.to_string()],
-            ["media_type", header.media_type],
-            ["name", header.name]
-        ]),
-        Record::AttachmentIndex(i) => json!([
-            ["create_time", i.create_time.to_string()],
-            ["data_size", i.data_size.to_string()],
-            ["length", i.length.to_string()],
-            ["log_time", i.log_time.to_string()],
-            ["media_type", i.media_type],
-            ["name", i.name],
-            ["offset", i.offset.to_string()]
-        ]),
-        Record::Statistics(s) => json!([
-            ["attachment_count", s.attachment_count.to_string()],
-            ["channel_count", s.channel_count.to_string()],
-            ["channel_message_counts", m2s(&s.channel_message_counts)],
-            ["chunk_count", s.chunk_count.to_string()],
-            ["message_count", s.message_count.to_string()],
-            ["message_end_time", s.message_end_time.to_string()],
-            ["message_start_time", s.message_start_time.to_string()],
-            ["metadata_count", s.metadata_count.to_string()],
-            ["schema_count", s.schema_count.to_string()]
-        ]),
-        Record::Metadata(m) => json!([["metadata", m.metadata], ["name", m.name]]),
-        Record::MetadataIndex(i) => json!([
-            ["length", i.length.to_string()],
-            ["name", i.name],
-            ["offset", i.offset.to_string()]
-        ]),
-        Record::SummaryOffset(s) => json!([
-            ["group_length", s.group_length.to_string()],
-            ["group_opcode", s.group_opcode.to_string()],
-            ["group_start", s.group_start.to_string()]
-        ]),
-        Record::DataEnd(d) => json!([["data_section_crc", d.data_section_crc.to_string()]]),
-        Record::Unknown { opcode, .. } => {
-            panic!("Unknown record in conformance test: (op {opcode})")
-        }
-    }
-}
-
-fn as_json(view: &Record<'_>) -> Value {
-    let typename = get_type(view);
-    let fields = get_fields(view);
-    json!({"type": typename, "fields": fields})
-}
+use mcap::records::Record;
+use std::env;
+use std::process;
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();
@@ -143,7 +18,7 @@ pub fn main() {
     for rec in mcap::read::ChunkFlattener::new(&file).expect("Couldn't read file") {
         let r = rec.expect("failed to read next record");
         if !matches!(r, Record::MessageIndex(_)) {
-            json_records.push(as_json(&r));
+            json_records.push(serialization::as_json(&r));
         }
     }
     let out = json!({ "records": json_records });

--- a/rust/examples/conformance_reader_async.rs
+++ b/rust/examples/conformance_reader_async.rs
@@ -1,0 +1,37 @@
+#[path = "common/serialization.rs"]
+mod serialization;
+
+use serde_json::{json, Value};
+
+use serialization::as_json;
+use std::env;
+use std::process;
+use tokio::fs::File;
+
+use tokio;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Please supply an MCAP file as argument");
+        process::exit(1);
+    }
+    let file = File::open(&args[1]).await.expect("couldn't open file");
+    let mut reader = mcap::tokio::RecordReader::new(file);
+
+    let mut json_records: Vec<Value> = vec![];
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(op) = reader
+        .next_record(&mut buf)
+        .await
+        .expect("failed to read next record")
+    {
+        if op != mcap::records::op::MESSAGE_INDEX {
+            let parsed = mcap::parse_record(op, &buf[..]).expect("failed to parse record");
+            json_records.push(as_json(&parsed));
+        }
+    }
+    let out = json!({ "records": json_records });
+    print!("{}", serde_json::to_string_pretty(&out).unwrap());
+}

--- a/rust/examples/conformance_reader_async.rs
+++ b/rust/examples/conformance_reader_async.rs
@@ -22,13 +22,10 @@ async fn main() {
 
     let mut json_records: Vec<Value> = vec![];
     let mut buf: Vec<u8> = Vec::new();
-    while let Some(op) = reader
-        .next_record(&mut buf)
-        .await
-        .expect("failed to read next record")
-    {
-        if op != mcap::records::op::MESSAGE_INDEX {
-            let parsed = mcap::parse_record(op, &buf[..]).expect("failed to parse record");
+    while let Some(opcode) = reader.next_record(&mut buf).await {
+        let opcode = opcode.expect("failed to read next record");
+        if opcode != mcap::records::op::MESSAGE_INDEX {
+            let parsed = mcap::parse_record(opcode, &buf[..]).expect("failed to parse record");
             json_records.push(as_json(&parsed));
         }
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -200,5 +200,5 @@ pub struct Attachment<'a> {
     pub data: Cow<'a, [u8]>,
 }
 
-pub use read::{MessageStream, Summary};
+pub use read::{read_record, MessageStream, Summary};
 pub use write::{WriteOptions, Writer};

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -75,6 +75,8 @@
 
 pub mod read;
 pub mod records;
+#[cfg(feature = "tokio")]
+pub mod tokio;
 pub mod write;
 
 mod io_utils;
@@ -119,6 +121,8 @@ pub enum McapError {
     UnexpectedEof,
     #[error("Chunk ended in the middle of a record")]
     UnexpectedEoc,
+    #[error("Record with opcode {opcode:02X} has length {len}, need at least {expected} to parse")]
+    RecordTooShort { opcode: u8, len: u64, expected: u64 },
     #[error("Message {0} referenced unknown channel {1}")]
     UnknownChannel(u32, u16),
     #[error("Channel `{0}` referenced unknown schema {1}")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -200,5 +200,5 @@ pub struct Attachment<'a> {
     pub data: Cow<'a, [u8]>,
 }
 
-pub use read::{read_record, MessageStream, Summary};
+pub use read::{parse_record, MessageStream, Summary};
 pub use write::{WriteOptions, Writer};

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -136,7 +136,7 @@ fn read_record_from_slice<'a>(buf: &mut &'a [u8]) -> McapResult<records::Record<
 
     let body = &buf[..len as usize];
     debug!("slice: opcode {op:02X}, length {len}");
-    let record = read_record(op, body)?;
+    let record = parse_record(op, body)?;
     trace!("       {:?}", record);
 
     *buf = &buf[len as usize..];
@@ -145,7 +145,7 @@ fn read_record_from_slice<'a>(buf: &mut &'a [u8]) -> McapResult<records::Record<
 
 /// Given a records' opcode and data, parse into a Record. The resulting Record will contain
 /// borrowed slices from `body`.
-pub fn read_record(op: u8, body: &[u8]) -> McapResult<records::Record<'_>> {
+pub fn parse_record(op: u8, body: &[u8]) -> McapResult<records::Record<'_>> {
     macro_rules! record {
         ($b:ident) => {{
             let mut cur = Cursor::new($b);

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -144,7 +144,7 @@ fn read_record_from_slice<'a>(buf: &mut &'a [u8]) -> McapResult<records::Record<
 }
 
 /// Given a record's opcode and its slice, read it into a [Record]
-fn read_record(op: u8, body: &[u8]) -> McapResult<records::Record<'_>> {
+pub(crate) fn read_record(op: u8, body: &[u8]) -> McapResult<records::Record<'_>> {
     macro_rules! record {
         ($b:ident) => {{
             let mut cur = Cursor::new($b);
@@ -278,7 +278,7 @@ impl<'a> ChunkReader<'a> {
 
             #[cfg(feature = "lz4")]
             "lz4" => ChunkDecompressor::Compressed(Some(CountingCrcReader::new(Box::new(
-                lz4_flex::frame::FrameDecoder::new(data),
+                lz4::Decoder::new(data)?,
             )))),
 
             #[cfg(not(feature = "lz4"))]

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -143,8 +143,9 @@ fn read_record_from_slice<'a>(buf: &mut &'a [u8]) -> McapResult<records::Record<
     Ok(record)
 }
 
-/// Given a record's opcode and its slice, read it into a [Record]
-pub(crate) fn read_record(op: u8, body: &[u8]) -> McapResult<records::Record<'_>> {
+/// Given a records' opcode and data, parse into a Record. The resulting Record will contain
+/// borrowed slices from `body`.
+pub fn read_record(op: u8, body: &[u8]) -> McapResult<records::Record<'_>> {
     macro_rules! record {
         ($b:ident) => {{
             let mut cur = Cursor::new($b);

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -132,7 +132,7 @@ impl Record<'_> {
             Record::SummaryOffset(offset) => Record::SummaryOffset(offset),
             Record::DataEnd(end) => Record::DataEnd(end),
             Record::Unknown { opcode, data } => Record::Unknown {
-                opcode: opcode,
+                opcode,
                 data: Cow::Owned(data.into_owned()),
             },
         }

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -99,6 +99,44 @@ impl Record<'_> {
             Record::Unknown { opcode, .. } => *opcode,
         }
     }
+
+    /// Moves this value into a fully-owned variant with no borrows. This should be free for
+    /// already-owned values.
+    pub fn into_owned(self) -> Record<'static> {
+        match self {
+            Record::Header(header) => Record::Header(header),
+            Record::Footer(footer) => Record::Footer(footer),
+            Record::Schema { header, data } => Record::Schema {
+                header,
+                data: Cow::Owned(data.into_owned()),
+            },
+            Record::Channel(channel) => Record::Channel(channel),
+            Record::Message { header, data } => Record::Message {
+                header,
+                data: Cow::Owned(data.into_owned()),
+            },
+            Record::Chunk { header, data } => Record::Chunk {
+                header,
+                data: Cow::Owned(data.into_owned()),
+            },
+            Record::MessageIndex(index) => Record::MessageIndex(index),
+            Record::ChunkIndex(index) => Record::ChunkIndex(index),
+            Record::Attachment { header, data } => Record::Attachment {
+                header,
+                data: Cow::Owned(data.into_owned()),
+            },
+            Record::AttachmentIndex(index) => Record::AttachmentIndex(index),
+            Record::Statistics(statistics) => Record::Statistics(statistics),
+            Record::Metadata(metadata) => Record::Metadata(metadata),
+            Record::MetadataIndex(index) => Record::MetadataIndex(index),
+            Record::SummaryOffset(offset) => Record::SummaryOffset(offset),
+            Record::DataEnd(end) => Record::DataEnd(end),
+            Record::Unknown { opcode, data } => Record::Unknown {
+                opcode: opcode,
+                data: Cow::Owned(data.into_owned()),
+            },
+        }
+    }
 }
 
 #[binrw]

--- a/rust/src/tokio.rs
+++ b/rust/src/tokio.rs
@@ -1,0 +1,2 @@
+mod lz4;
+pub mod read;

--- a/rust/src/tokio.rs
+++ b/rust/src/tokio.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "lz4")]
 mod lz4;
 pub mod read;
+mod read_exact_or_zero;
 
 pub use read::{RecordReader, RecordReaderOptions};
+use read_exact_or_zero::read_exact_or_zero;

--- a/rust/src/tokio.rs
+++ b/rust/src/tokio.rs
@@ -1,2 +1,4 @@
 mod lz4;
 pub mod read;
+
+pub use read::{RecordReader, RecordReaderOptions};

--- a/rust/src/tokio.rs
+++ b/rust/src/tokio.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "lz4")]
 mod lz4;
 pub mod read;
 

--- a/rust/src/tokio.rs
+++ b/rust/src/tokio.rs
@@ -1,3 +1,4 @@
+//! Read MCAP data from a stream asynchronously
 #[cfg(feature = "lz4")]
 mod lz4;
 pub mod read;

--- a/rust/src/tokio/lz4.rs
+++ b/rust/src/tokio/lz4.rs
@@ -1,0 +1,132 @@
+use lz4::liblz4::{
+    check_error, LZ4FDecompressionContext, LZ4F_createDecompressionContext, LZ4F_decompress,
+    LZ4F_freeDecompressionContext, LZ4F_VERSION,
+};
+use std::io::{Error, ErrorKind, Result};
+use std::ptr;
+use tokio::io::{AsyncRead, ReadBuf};
+
+const BUFFER_SIZE: usize = 32 * 1024;
+
+#[derive(Debug)]
+struct DecoderContext {
+    c: LZ4FDecompressionContext,
+}
+
+// An equivalent of the lz4::Decoder `std::io::Read` wrapper for `tokio::io::AsyncRead`.
+// Code below is adapted from the https://github.com/bozaro/lz4-rs crate.
+#[derive(Debug)]
+pub struct Lz4Decoder<R> {
+    c: DecoderContext,
+    r: R,
+    buf: Box<[u8]>,
+    pos: usize,
+    len: usize,
+    next: usize,
+}
+
+impl<R: AsyncRead> Lz4Decoder<R> {
+    /// Creates a new decoder which reads its input from the given
+    /// input stream. The input stream can be re-acquired by calling
+    /// `finish()`
+    pub fn new(r: R) -> Result<Lz4Decoder<R>> {
+        Ok(Lz4Decoder {
+            r,
+            c: DecoderContext::new()?,
+            buf: vec![0; BUFFER_SIZE].into_boxed_slice(),
+            pos: BUFFER_SIZE,
+            len: BUFFER_SIZE,
+            // Minimal LZ4 stream size
+            next: 11,
+        })
+    }
+
+    pub fn finish(self) -> (R, Result<()>) {
+        (
+            self.r,
+            match self.next {
+                0 => Ok(()),
+                _ => Err(Error::new(
+                    ErrorKind::Interrupted,
+                    "Finish runned before read end of compressed stream",
+                )),
+            },
+        )
+    }
+}
+
+impl<R: AsyncRead + std::marker::Unpin> AsyncRead for Lz4Decoder<R> {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        if self.next == 0 || buf.remaining() == 0 {
+            return std::task::Poll::Ready(Ok(()));
+        }
+        let mut written_len: usize = 0;
+        let mself = self.get_mut();
+        while written_len == 0 {
+            if mself.pos >= mself.len {
+                let need = if mself.buf.len() < mself.next {
+                    mself.buf.len()
+                } else {
+                    mself.next
+                };
+                {
+                    let mut comp_buf = ReadBuf::new(&mut mself.buf[..need]);
+                    let result = std::pin::pin!(&mut mself.r).poll_read(cx, &mut comp_buf);
+                    match result {
+                        std::task::Poll::Pending => return result,
+                        std::task::Poll::Ready(Err(_)) => return result,
+                        _ => {}
+                    };
+                    mself.len = comp_buf.filled().len();
+                }
+                if mself.len == 0 {
+                    break;
+                }
+                mself.pos = 0;
+                mself.next -= mself.len;
+            }
+            while (written_len < buf.remaining()) && (mself.pos < mself.len) {
+                let mut src_size = mself.len - mself.pos;
+                let mut dst_size = buf.remaining() - written_len;
+                let len = check_error(unsafe {
+                    LZ4F_decompress(
+                        mself.c.c,
+                        buf.initialize_unfilled().as_mut_ptr(),
+                        &mut dst_size,
+                        mself.buf[mself.pos..].as_ptr(),
+                        &mut src_size,
+                        ptr::null(),
+                    )
+                })?;
+                mself.pos += src_size as usize;
+                written_len += dst_size as usize;
+                buf.set_filled(written_len);
+                if len == 0 {
+                    mself.next = 0;
+                    return std::task::Poll::Ready(Ok(()));
+                } else if mself.next < len {
+                    mself.next = len;
+                }
+            }
+        }
+        return std::task::Poll::Ready(Ok(()));
+    }
+}
+
+impl DecoderContext {
+    fn new() -> Result<DecoderContext> {
+        let mut context = LZ4FDecompressionContext(ptr::null_mut());
+        check_error(unsafe { LZ4F_createDecompressionContext(&mut context, LZ4F_VERSION) })?;
+        Ok(DecoderContext { c: context })
+    }
+}
+
+impl Drop for DecoderContext {
+    fn drop(&mut self) {
+        unsafe { LZ4F_freeDecompressionContext(self.c) };
+    }
+}

--- a/rust/src/tokio/lz4.rs
+++ b/rust/src/tokio/lz4.rs
@@ -28,7 +28,7 @@ pub struct Lz4Decoder<R> {
     next: usize,
 }
 
-impl<R: AsyncRead> Lz4Decoder<R> {
+impl<R> Lz4Decoder<R> {
     /// Creates a new decoder which reads its input from the given
     /// input stream. The input stream can be re-acquired by calling
     /// `finish()`

--- a/rust/src/tokio/lz4.rs
+++ b/rust/src/tokio/lz4.rs
@@ -16,8 +16,8 @@ struct DecoderContext {
     c: LZ4FDecompressionContext,
 }
 
-// An equivalent of the lz4::Decoder `std::io::Read` wrapper for `tokio::io::AsyncRead`.
-// Code below is adapted from the https://github.com/bozaro/lz4-rs crate.
+// An adaptation of the [`lz4::Decoder`] [`std::io::Read`] impl, but for [`tokio::io::AsyncRead`].
+// Code below is adapted from the [lz4](https://github.com/bozaro/lz4-rs) crate source.
 #[derive(Debug)]
 pub struct Lz4Decoder<R> {
     c: DecoderContext,

--- a/rust/src/tokio/lz4.rs
+++ b/rust/src/tokio/lz4.rs
@@ -105,8 +105,8 @@ impl<R: AsyncRead + std::marker::Unpin> AsyncRead for Lz4Decoder<R> {
                         ptr::null(),
                     )
                 })?;
-                mself.pos += src_size as usize;
-                written_len += dst_size as usize;
+                mself.pos += src_size;
+                written_len += dst_size;
                 buf.set_filled(written_len);
                 if len == 0 {
                     mself.next = 0;
@@ -116,7 +116,7 @@ impl<R: AsyncRead + std::marker::Unpin> AsyncRead for Lz4Decoder<R> {
                 }
             }
         }
-        return Poll::Ready(Ok(()));
+        Poll::Ready(Ok(()))
     }
 }
 

--- a/rust/src/tokio/lz4.rs
+++ b/rust/src/tokio/lz4.rs
@@ -95,6 +95,7 @@ impl<R: AsyncRead + std::marker::Unpin> AsyncRead for Lz4Decoder<R> {
             while (written_len < buf.remaining()) && (mself.pos < mself.len) {
                 let mut src_size = mself.len - mself.pos;
                 let mut dst_size = buf.remaining() - written_len;
+                let prev_filled = buf.filled().len();
                 let len = check_error(unsafe {
                     LZ4F_decompress(
                         mself.c.c,
@@ -107,7 +108,7 @@ impl<R: AsyncRead + std::marker::Unpin> AsyncRead for Lz4Decoder<R> {
                 })?;
                 mself.pos += src_size;
                 written_len += dst_size;
-                buf.set_filled(written_len);
+                buf.set_filled(prev_filled + written_len);
                 if len == 0 {
                     mself.next = 0;
                     return Poll::Ready(Ok(()));

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -65,7 +65,24 @@ where
         }
     }
 }
+
 /// Reads an MCAP file record-by-record, writing the raw record data into a caller-provided Vec.
+/// ```no_run
+/// use std::fs;
+///
+/// use tokio::fs::File;
+///
+/// async fn read_it() {
+///     let file = File::open("in.mcap").await.expect("couldn't open file");
+///     let mut record_buf: Vec<u8> = Vec::new();
+///     let mut reader = mcap::tokio::RecordReader::new(file);
+///     while let Some(result) = reader.next_record(&mut record_buf).await {
+///         let opcode = result.expect("couldn't read next record");
+///         let raw_record = mcap::parse_record(opcode, &record_buf[..]).expect("couldn't parse");
+///         // do something with the record...
+///     }
+/// }
+/// ```
 pub struct RecordReader<R> {
     reader: ReaderState<R>,
     options: RecordReaderOptions,
@@ -78,12 +95,12 @@ pub struct RecordReader<R> {
 #[derive(Default, Clone)]
 pub struct RecordReaderOptions {
     /// If true, the reader will not expect the MCAP magic at the start of the stream.
-    skip_start_magic: bool,
+    pub skip_start_magic: bool,
     /// If true, the reader will not expect the MCAP magic at the end of the stream.
-    skip_end_magic: bool,
-    // If true, the reader will yield entire chunk records. Otherwise, the reader will decompress
-    // and read into the chunk, yielding the records inside.
-    emit_chunks: bool,
+    pub skip_end_magic: bool,
+    /// If true, the reader will yield entire chunk records. Otherwise, the reader will decompress
+    /// and read into the chunk, yielding the records inside.
+    pub emit_chunks: bool,
 }
 
 enum Cmd {

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -1,0 +1,438 @@
+use byteorder::ByteOrder;
+use std::future::Future;
+use tokio::io::{AsyncRead, AsyncReadExt, BufReader, Take};
+use tokio_stream::Stream;
+
+use crate::tokio::lz4::Lz4Decoder;
+use crate::{records, McapError, McapResult, MAGIC};
+use async_compression::tokio::bufread::ZstdDecoder;
+
+enum ReaderState<R> {
+    Base(R),
+    UncompressedChunk(Take<R>),
+    ZstdChunk(ZstdDecoder<BufReader<Take<R>>>),
+    Lz4Chunk(Lz4Decoder<Take<R>>),
+    Empty,
+}
+
+impl<R> AsyncRead for ReaderState<R>
+where
+    R: AsyncRead + std::marker::Unpin,
+{
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ReaderState::Base(r) => std::pin::pin!(r).poll_read(cx, buf),
+            ReaderState::UncompressedChunk(r) => std::pin::pin!(r).poll_read(cx, buf),
+            ReaderState::ZstdChunk(r) => std::pin::pin!(r).poll_read(cx, buf),
+            ReaderState::Lz4Chunk(r) => std::pin::pin!(r).poll_read(cx, buf),
+            ReaderState::Empty => {
+                panic!("invariant: reader is only set to empty while swapping with another valid variant")
+            }
+        }
+    }
+}
+impl<R> ReaderState<R>
+where
+    R: AsyncRead,
+{
+    pub fn into_inner(self) -> McapResult<R> {
+        match self {
+            ReaderState::Base(reader) => Ok(reader),
+            ReaderState::UncompressedChunk(take) => Ok(take.into_inner()),
+            ReaderState::ZstdChunk(decoder) => Ok(decoder.into_inner().into_inner().into_inner()),
+            ReaderState::Lz4Chunk(decoder) => {
+                let (output, result) = decoder.finish();
+                result?;
+                Ok(output.into_inner())
+            }
+            ReaderState::Empty => {
+                panic!("invariant: reader is only set to empty while swapping with another valid variant")
+            }
+        }
+    }
+}
+/// Reads an MCAP file record-by-record, writing the raw record data into a caller-provided Vec.
+pub struct RecordReader<R> {
+    reader: ReaderState<R>,
+    options: Options,
+    start_magic_seen: bool,
+    footer_seen: bool,
+    scratch: [u8; 9],
+}
+
+#[derive(Default, Clone)]
+pub struct Options {
+    /// If true, the reader will not expect the MCAP magic at the start of the stream.
+    skip_start_magic: bool,
+    /// If true, the reader will not expect the MCAP magic at the end of the stream.
+    skip_end_magic: bool,
+    // If true, the reader will yield entire chunk records. Otherwise, the reader will decompress
+    // and read into the chunk, yielding the records inside.
+    emit_chunks: bool,
+}
+
+enum Cmd {
+    YieldRecord(u8),
+    EnterChunk(records::ChunkHeader),
+    ExitChunk,
+    Stop,
+}
+
+impl<R> RecordReader<R>
+where
+    R: AsyncRead + std::marker::Unpin,
+{
+    pub fn new(reader: R) -> Self {
+        Self::new_with_options(reader, &Options::default())
+    }
+
+    pub fn new_with_options(reader: R, options: &Options) -> Self {
+        Self {
+            reader: ReaderState::Base(reader),
+            options: options.clone(),
+            start_magic_seen: false,
+            footer_seen: false,
+            scratch: [0; 9],
+        }
+    }
+
+    pub fn into_inner(self) -> McapResult<R> {
+        self.reader.into_inner()
+    }
+
+    /// Reads the next record from the input stream and copies the raw content into `data`.
+    /// Returns the record's opcode as a result.
+    pub async fn next_record(&mut self, data: &mut Vec<u8>) -> McapResult<Option<u8>> {
+        loop {
+            let cmd = self.next_record_inner(data).await?;
+            match cmd {
+                Cmd::Stop => return Ok(None),
+                Cmd::YieldRecord(opcode) => return Ok(Some(opcode)),
+                Cmd::EnterChunk(header) => {
+                    let mut rdr = ReaderState::Empty;
+                    std::mem::swap(&mut rdr, &mut self.reader);
+                    match header.compression.as_str() {
+                        "zstd" => {
+                            self.reader = ReaderState::ZstdChunk(ZstdDecoder::new(BufReader::new(
+                                rdr.into_inner()?.take(header.compressed_size),
+                            )));
+                        }
+                        "lz4" => {
+                            let decoder =
+                                Lz4Decoder::new(rdr.into_inner()?.take(header.compressed_size))?;
+                            self.reader = ReaderState::Lz4Chunk(decoder);
+                        }
+                        "" => {
+                            self.reader = ReaderState::UncompressedChunk(
+                                rdr.into_inner()?.take(header.compressed_size),
+                            );
+                        }
+                        _ => {
+                            std::mem::swap(&mut rdr, &mut self.reader);
+                            return Err(McapError::UnsupportedCompression(
+                                header.compression.clone(),
+                            ));
+                        }
+                    }
+                }
+                Cmd::ExitChunk => {
+                    let mut rdr = ReaderState::Empty;
+                    std::mem::swap(&mut rdr, &mut self.reader);
+                    self.reader = ReaderState::Base(rdr.into_inner()?)
+                }
+            };
+        }
+    }
+
+    async fn next_record_inner(&mut self, data: &mut Vec<u8>) -> McapResult<Cmd> {
+        if let ReaderState::Base(reader) = &mut self.reader {
+            if !self.start_magic_seen && !self.options.skip_start_magic {
+                reader.read_exact(&mut self.scratch[..MAGIC.len()]).await?;
+                if &self.scratch[..MAGIC.len()] != MAGIC {
+                    return Err(McapError::BadMagic);
+                }
+                self.start_magic_seen = true;
+            }
+            if self.footer_seen && !self.options.skip_end_magic {
+                reader.read_exact(&mut self.scratch[..MAGIC.len()]).await?;
+                if &self.scratch[..MAGIC.len()] != MAGIC {
+                    return Err(McapError::BadMagic);
+                }
+                return Ok(Cmd::Stop);
+            }
+            reader.read_exact(&mut self.scratch).await?;
+            let opcode = self.scratch[0];
+            if opcode == records::op::FOOTER {
+                self.footer_seen = true;
+            }
+            let record_len = byteorder::LittleEndian::read_u64(&self.scratch[1..]);
+            if opcode == records::op::CHUNK && !self.options.emit_chunks {
+                let chunk_header = read_chunk_header(reader, data, record_len).await?;
+                return Ok(Cmd::EnterChunk(chunk_header));
+            }
+            data.resize(record_len as usize, 0);
+            reader.read_exact(&mut data[..]).await?;
+            Ok(Cmd::YieldRecord(opcode))
+        } else {
+            let len = self.reader.read(&mut self.scratch).await?;
+            if len == 0 {
+                return Ok(Cmd::ExitChunk);
+            }
+            if len != self.scratch.len() {
+                return Err(McapError::UnexpectedEof);
+            }
+            let opcode = self.scratch[0];
+            let record_len = byteorder::LittleEndian::read_u64(&self.scratch[1..]);
+            data.resize(record_len as usize, 0);
+            self.reader.read_exact(&mut data[..]).await?;
+            Ok(Cmd::YieldRecord(opcode))
+        }
+    }
+}
+
+async fn read_chunk_header<R: AsyncRead + std::marker::Unpin>(
+    reader: &mut R,
+    scratch: &mut Vec<u8>,
+    record_len: u64,
+) -> McapResult<records::ChunkHeader> {
+    let mut header = records::ChunkHeader {
+        message_start_time: 0,
+        message_end_time: 0,
+        uncompressed_size: 0,
+        uncompressed_crc: 0,
+        compression: String::new(),
+        compressed_size: 0,
+    };
+    if record_len < 40 {
+        return Err(McapError::RecordTooShort {
+            opcode: records::op::CHUNK,
+            len: record_len,
+            expected: 40,
+        });
+    }
+    scratch.resize(32, 0);
+    reader.read_exact(&mut scratch[..]).await?;
+    header.message_start_time = byteorder::LittleEndian::read_u64(&scratch[0..8]);
+    header.message_end_time = byteorder::LittleEndian::read_u64(&scratch[8..16]);
+    header.uncompressed_size = byteorder::LittleEndian::read_u64(&scratch[16..24]);
+    header.uncompressed_crc = byteorder::LittleEndian::read_u32(&scratch[24..28]);
+    let compression_len = byteorder::LittleEndian::read_u32(&scratch[28..32]);
+    scratch.resize(compression_len as usize, 0);
+    if record_len < (40 + compression_len) as u64 {
+        return Err(McapError::RecordTooShort {
+            opcode: records::op::CHUNK,
+            len: record_len,
+            expected: (40 + compression_len) as u64,
+        });
+    }
+    reader.read_exact(&mut scratch[..]).await?;
+    header.compression = match std::str::from_utf8(&scratch[..]) {
+        Ok(val) => val.to_owned(),
+        Err(err) => {
+            return Err(McapError::Parse(binrw::error::Error::Custom {
+                pos: 32,
+                err: Box::new(err),
+            }));
+        }
+    };
+    scratch.resize(8, 0);
+    reader.read_exact(&mut scratch[..]).await?;
+    header.compressed_size = byteorder::LittleEndian::read_u64(&scratch[..]);
+    let available = record_len - (32 + compression_len as u64 + 8);
+    if available < header.compressed_size {
+        return Err(McapError::BadChunkLength {
+            header: header.compressed_size,
+            available,
+        });
+    }
+    Ok(header)
+}
+
+/// implements a Stream of owned `crate::record::Record` values.
+pub struct LinearStream<R> {
+    r: RecordReader<R>,
+    buf: Vec<u8>,
+}
+
+impl<R: AsyncRead + std::marker::Unpin> LinearStream<R> {
+    /// Creates a new stream of records from a reader.
+    pub fn new(r: R) -> Self {
+        Self {
+            r: RecordReader::new(r),
+            buf: Vec::new(),
+        }
+    }
+
+    pub fn into_inner(self) -> McapResult<R> {
+        self.r.into_inner()
+    }
+}
+
+impl<R: AsyncRead + std::marker::Unpin> Stream for LinearStream<R> {
+    type Item = McapResult<crate::records::Record<'static>>;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        // we do this swap maneuver in order to appease the borrow checker and also reuse one read
+        // buf across several records.
+        let mut buf = Vec::new();
+        std::mem::swap(&mut buf, &mut self.buf);
+        let opcode = {
+            let res = std::pin::pin!((&mut self).r.next_record(&mut buf)).poll(cx);
+            match res {
+                std::task::Poll::Pending => {
+                    std::mem::swap(&mut buf, &mut self.buf);
+                    return std::task::Poll::Pending;
+                }
+                std::task::Poll::Ready(result) => match result {
+                    Err(err) => {
+                        std::mem::swap(&mut buf, &mut self.buf);
+                        return std::task::Poll::Ready(Some(Err(err)));
+                    }
+                    Ok(None) => {
+                        std::mem::swap(&mut buf, &mut self.buf);
+                        return std::task::Poll::Ready(None);
+                    }
+                    Ok(Some(op)) => op,
+                },
+            }
+        };
+        let parse_res = crate::read::read_record(opcode, &buf[..]);
+        let result = std::task::Poll::Ready(Some(match parse_res {
+            Ok(record) => Ok(record.into_owned()),
+            Err(err) => Err(err),
+        }));
+        std::mem::swap(&mut buf, &mut self.buf);
+        return result;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use tokio_stream::StreamExt;
+
+    use super::*;
+    #[tokio::test]
+    async fn test_record_reader() -> Result<(), McapError> {
+        for compression in [
+            None,
+            Some(crate::Compression::Lz4),
+            Some(crate::Compression::Zstd),
+        ] {
+            let mut buf = std::io::Cursor::new(Vec::new());
+            {
+                let mut writer = crate::WriteOptions::new()
+                    .compression(compression)
+                    .create(&mut buf)?;
+                let channel = std::sync::Arc::new(crate::Channel {
+                    topic: "chat".to_owned(),
+                    schema: None,
+                    message_encoding: "json".to_owned(),
+                    metadata: BTreeMap::new(),
+                });
+                writer.add_channel(&channel)?;
+                writer.write(&crate::Message {
+                    channel,
+                    sequence: 0,
+                    log_time: 0,
+                    publish_time: 0,
+                    data: (&[0, 1, 2]).into(),
+                })?;
+                writer.finish()?;
+            }
+            let mut reader = RecordReader::new(std::io::Cursor::new(buf.into_inner()));
+            let mut record = Vec::new();
+            let mut opcodes: Vec<u8> = Vec::new();
+            loop {
+                let opcode = reader.next_record(&mut record).await?;
+                if let Some(opcode) = opcode {
+                    opcodes.push(opcode);
+                } else {
+                    break;
+                }
+            }
+            assert_eq!(
+                opcodes.as_slice(),
+                [
+                    records::op::HEADER,
+                    records::op::CHANNEL,
+                    records::op::MESSAGE,
+                    records::op::MESSAGE_INDEX,
+                    records::op::DATA_END,
+                    records::op::CHANNEL,
+                    records::op::CHUNK_INDEX,
+                    records::op::STATISTICS,
+                    records::op::SUMMARY_OFFSET,
+                    records::op::SUMMARY_OFFSET,
+                    records::op::SUMMARY_OFFSET,
+                    records::op::FOOTER,
+                ],
+                "reads opcodes from MCAP compressed with {:?}",
+                compression
+            );
+        }
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_linear_stream() -> Result<(), McapError> {
+        for compression in [
+            None,
+            Some(crate::Compression::Lz4),
+            Some(crate::Compression::Zstd),
+        ] {
+            let mut buf = std::io::Cursor::new(Vec::new());
+            {
+                let mut writer = crate::WriteOptions::new()
+                    .compression(compression)
+                    .create(&mut buf)?;
+                let channel = std::sync::Arc::new(crate::Channel {
+                    topic: "chat".to_owned(),
+                    schema: None,
+                    message_encoding: "json".to_owned(),
+                    metadata: BTreeMap::new(),
+                });
+                writer.add_channel(&channel)?;
+                writer.write(&crate::Message {
+                    channel,
+                    sequence: 0,
+                    log_time: 0,
+                    publish_time: 0,
+                    data: (&[0, 1, 2]).into(),
+                })?;
+                writer.finish()?;
+            }
+            let mut reader = LinearStream::new(std::io::Cursor::new(buf.into_inner()));
+            let mut opcodes: Vec<u8> = Vec::new();
+            while let Some(result) = reader.next().await {
+                let record = result?;
+                opcodes.push(record.opcode())
+            }
+            assert_eq!(
+                opcodes.as_slice(),
+                [
+                    records::op::HEADER,
+                    records::op::CHANNEL,
+                    records::op::MESSAGE,
+                    records::op::MESSAGE_INDEX,
+                    records::op::DATA_END,
+                    records::op::CHANNEL,
+                    records::op::CHUNK_INDEX,
+                    records::op::STATISTICS,
+                    records::op::SUMMARY_OFFSET,
+                    records::op::SUMMARY_OFFSET,
+                    records::op::SUMMARY_OFFSET,
+                    records::op::FOOTER,
+                ],
+                "reads records from MCAP compressed with {:?}",
+                compression
+            );
+        }
+        Ok(())
+    }
+}

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -214,7 +214,13 @@ where
                 }
                 return Ok(Cmd::Stop);
             }
-            reader.read_exact(&mut self.scratch[..9]).await?;
+            let readlen = reader.read(&mut self.scratch[..9]).await?;
+            if readlen == 0 && self.options.skip_end_magic {
+                return Ok(Cmd::Stop);
+            }
+            if readlen != 9 {
+                return Err(McapError::UnexpectedEof);
+            }
             let opcode = self.scratch[0];
             if opcode == records::op::FOOTER {
                 self.footer_seen = true;

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -423,11 +423,8 @@ mod tests {
         }
         let mut reader = RecordReader::new(std::io::Cursor::new(buf.into_inner()));
         let mut record = Vec::new();
-        let mut opcodes: Vec<u8> = Vec::new();
         while let Some(opcode) = reader.next_record(&mut record).await {
-            let opcode = opcode?;
-            opcodes.push(opcode);
-            parse_record(opcode, &record)?;
+            parse_record(opcode?, &record)?;
         }
         Ok(())
     }

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -59,7 +59,7 @@ where
 /// Reads an MCAP file record-by-record, writing the raw record data into a caller-provided Vec.
 pub struct RecordReader<R> {
     reader: ReaderState<R>,
-    options: Options,
+    options: RecordReaderOptions,
     start_magic_seen: bool,
     footer_seen: bool,
     to_discard_after_chunk: usize,
@@ -67,7 +67,7 @@ pub struct RecordReader<R> {
 }
 
 #[derive(Default, Clone)]
-pub struct Options {
+pub struct RecordReaderOptions {
     /// If true, the reader will not expect the MCAP magic at the start of the stream.
     skip_start_magic: bool,
     /// If true, the reader will not expect the MCAP magic at the end of the stream.
@@ -92,10 +92,10 @@ where
     R: AsyncRead + std::marker::Unpin,
 {
     pub fn new(reader: R) -> Self {
-        Self::new_with_options(reader, &Options::default())
+        Self::new_with_options(reader, &RecordReaderOptions::default())
     }
 
-    pub fn new_with_options(reader: R, options: &Options) -> Self {
+    pub fn new_with_options(reader: R, options: &RecordReaderOptions) -> Self {
         Self {
             reader: ReaderState::Base(reader),
             options: options.clone(),

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -274,7 +274,7 @@ async fn read_chunk_header<R: AsyncRead + std::marker::Unpin>(
 
 #[cfg(test)]
 mod tests {
-    use crate::read::read_record;
+    use crate::read::parse_record;
     use std::collections::BTreeMap;
 
     use super::*;
@@ -311,7 +311,7 @@ mod tests {
             let mut opcodes: Vec<u8> = Vec::new();
             while let Some(opcode) = reader.next_record(&mut record).await? {
                 opcodes.push(opcode);
-                read_record(opcode, &record)?;
+                parse_record(opcode, &record)?;
             }
             assert_eq!(
                 opcodes.as_slice(),

--- a/rust/src/tokio/read.rs
+++ b/rust/src/tokio/read.rs
@@ -294,7 +294,9 @@ mod tests {
     async fn test_record_reader() -> Result<(), McapError> {
         for compression in [
             None,
+            #[cfg(feature = "zstd")]
             Some(crate::Compression::Zstd),
+            #[cfg(feature = "lz4")]
             Some(crate::Compression::Lz4),
         ] {
             let mut buf = std::io::Cursor::new(Vec::new());

--- a/rust/src/tokio/read_exact_or_zero.rs
+++ b/rust/src/tokio/read_exact_or_zero.rs
@@ -82,7 +82,7 @@ mod tests {
     async fn test_repeated_read_calls() {
         let mut r = ZeroReader {
             remaining: 10,
-            max_read_len: 1,
+            max_read_len: 4,
         };
         let mut buf: Vec<u8> = vec![1; 10];
         let result = read_exact_or_zero(&mut r, &mut buf).await;

--- a/rust/src/tokio/read_exact_or_zero.rs
+++ b/rust/src/tokio/read_exact_or_zero.rs
@@ -1,6 +1,6 @@
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-/// read up to buf.len() bytes from  `r` into `buf`. This repeatedly calls read() on `r` until
+/// read up to `buf.len()` bytes from  `r` into `buf`. This repeatedly calls read() on `r` until
 /// either the buffer is full or EOF is reached. If either 0 or buf.len() bytes were read before
 /// EOF, Ok(n) is returned. If EOF is reached after 0 bytes but before buf.len(), Err(UnexpectedEOF)
 /// is returned.
@@ -23,5 +23,81 @@ pub(crate) async fn read_exact_or_zero<R: AsyncRead + std::marker::Unpin>(
         if pos == buf.len() {
             return Ok(pos);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::cmp::min;
+
+    struct ZeroReader {
+        remaining: usize,
+        max_read_len: usize,
+    }
+
+    impl AsyncRead for ZeroReader {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            let max_read_len = self.as_ref().max_read_len;
+            let remaining = self.as_ref().remaining;
+            if remaining == 0 {
+                return std::task::Poll::Ready(Ok(()));
+            }
+            let to_fill = min(min(remaining, buf.remaining()), max_read_len);
+            buf.initialize_unfilled_to(to_fill).fill(0);
+            buf.set_filled(to_fill);
+            self.as_mut().remaining -= to_fill;
+            return std::task::Poll::Ready(Ok(()));
+        }
+    }
+    #[tokio::test]
+    async fn test_full_read_is_not_error() {
+        let mut r = ZeroReader {
+            remaining: 10,
+            max_read_len: 10,
+        };
+        let mut buf: Vec<u8> = vec![1; 10];
+        let result = read_exact_or_zero(&mut r, &mut buf).await;
+        assert_eq!(result.ok(), Some(10));
+        assert_eq!(&buf[..], &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    }
+
+    #[tokio::test]
+    async fn test_eof_is_not_error() {
+        let mut r = ZeroReader {
+            remaining: 0,
+            max_read_len: 10,
+        };
+        let mut buf: Vec<u8> = vec![1; 10];
+        let result = read_exact_or_zero(&mut r, &mut buf).await;
+        assert_eq!(result.ok(), Some(0));
+        assert_eq!(&buf[..], &[1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    }
+    #[tokio::test]
+    async fn test_repeated_read_calls() {
+        let mut r = ZeroReader {
+            remaining: 10,
+            max_read_len: 1,
+        };
+        let mut buf: Vec<u8> = vec![1; 10];
+        let result = read_exact_or_zero(&mut r, &mut buf).await;
+        assert_eq!(result.ok(), Some(10));
+        assert_eq!(&buf[..], &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    }
+    #[tokio::test]
+    async fn test_partial_read_is_error() {
+        let mut r = ZeroReader {
+            remaining: 4,
+            max_read_len: 2,
+        };
+        let mut buf: Vec<u8> = vec![1; 10];
+        let result = read_exact_or_zero(&mut r, &mut buf).await;
+        assert!(!result.is_ok());
+        assert_eq!(&buf[..], &[0, 0, 0, 0, 1, 1, 1, 1, 1, 1]);
     }
 }

--- a/rust/src/tokio/read_exact_or_zero.rs
+++ b/rust/src/tokio/read_exact_or_zero.rs
@@ -1,9 +1,10 @@
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-/// read from `r` into `buf` until `buf` is completely full or EOF is reached.
-/// if R was already at EOF, this is not considered an error.
-/// If R was not at EOF, but EOF came before the end of the buffer, this is considered an error.
-/// This is useful for cases where we expect either another record full record or EOF.
+/// read up to buf.len() bytes from  `r` into `buf`. This repeatedly calls read() on `r` until
+/// either the buffer is full or EOF is reached. If either 0 or buf.len() bytes were read before
+/// EOF, Ok(n) is returned. If EOF is reached after 0 bytes but before buf.len(), Err(UnexpectedEOF)
+/// is returned.
+/// This is useful for cases where we expect either to read either a whole MCAP record or EOF.
 pub(crate) async fn read_exact_or_zero<R: AsyncRead + std::marker::Unpin>(
     r: &mut R,
     buf: &mut [u8],

--- a/rust/src/tokio/read_exact_or_zero.rs
+++ b/rust/src/tokio/read_exact_or_zero.rs
@@ -1,0 +1,26 @@
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+/// read from `r` into `buf` until `buf` is completely full or EOF is reached.
+/// if R was already at EOF, this is not considered an error.
+/// If R was not at EOF, but EOF came before the end of the buffer, this is considered an error.
+/// This is useful for cases where we expect either another record full record or EOF.
+pub(crate) async fn read_exact_or_zero<R: AsyncRead + std::marker::Unpin>(
+    r: &mut R,
+    buf: &mut [u8],
+) -> Result<usize, std::io::Error> {
+    let mut pos: usize = 0;
+    loop {
+        let readlen = r.read(&mut buf[pos..]).await?;
+        if readlen == 0 {
+            if pos != 0 {
+                return Err(std::io::ErrorKind::UnexpectedEof.into());
+            } else {
+                return Ok(0);
+            }
+        }
+        pos += readlen;
+        if pos == buf.len() {
+            return Ok(pos);
+        }
+    }
+}

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -153,10 +153,7 @@ impl WriteOptions {
     /// If `None`, chunks will not be automatically closed and the user must call `flush()` to
     /// begin a new chunk.
     pub fn chunk_size(self, chunk_size: Option<u64>) -> Self {
-        Self {
-            chunk_size: chunk_size,
-            ..self
-        }
+        Self { chunk_size, ..self }
     }
 
     /// specifies whether to use chunks for storing messages.

--- a/rust/tests/attachment.rs
+++ b/rust/tests/attachment.rs
@@ -66,7 +66,7 @@ fn round_trip() -> Result<()> {
             ..Default::default()
         }),
         attachment_indexes: vec![mcap::records::AttachmentIndex {
-            offset: 38, // Finicky - depends on the length of the library version string
+            offset: 39, // Finicky - depends on the length of the library version string
             length: 78,
             log_time: 2,
             create_time: 1,

--- a/rust/tests/attachment.rs
+++ b/rust/tests/attachment.rs
@@ -66,7 +66,8 @@ fn round_trip() -> Result<()> {
             ..Default::default()
         }),
         attachment_indexes: vec![mcap::records::AttachmentIndex {
-            offset: 39, // Finicky - depends on the length of the library version string
+            // offset depends on the length of the embedded library string, which includes the crate version
+            offset: 33 + (env!("CARGO_PKG_VERSION").len() as u64),
             length: 78,
             log_time: 2,
             create_time: 1,

--- a/rust/tests/metadata.rs
+++ b/rust/tests/metadata.rs
@@ -56,7 +56,7 @@ fn round_trip() -> Result<()> {
             ..Default::default()
         }),
         metadata_indexes: vec![mcap::records::MetadataIndex {
-            offset: 38, // Finicky - depends on the length of the library version string
+            offset: 39, // Finicky - depends on the length of the library version string
             length: 41,
             name: String::from("myMetadata"),
         }],

--- a/rust/tests/metadata.rs
+++ b/rust/tests/metadata.rs
@@ -56,7 +56,8 @@ fn round_trip() -> Result<()> {
             ..Default::default()
         }),
         metadata_indexes: vec![mcap::records::MetadataIndex {
-            offset: 39, // Finicky - depends on the length of the library version string
+            // offset depends on the length of the embedded library string, which includes the crate version
+            offset: 33 + (env!("CARGO_PKG_VERSION").len() as u64),
             length: 41,
             name: String::from("myMetadata"),
         }],

--- a/tests/conformance/scripts/run-tests/runners/RustAsyncReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/RustAsyncReaderTestRunner.ts
@@ -1,0 +1,22 @@
+import { exec } from "child_process";
+import { join } from "path";
+import { promisify } from "util";
+import { TestVariant } from "variants/types";
+
+import { StreamedReadTestRunner } from "./TestRunner";
+import { StreamedReadTestResult } from "../types";
+
+export default class RustAsyncReaderTestRunner extends StreamedReadTestRunner {
+  readonly name = "rust-async-streamed-reader";
+
+  async runReadTest(filePath: string): Promise<StreamedReadTestResult> {
+    const { stdout } = await promisify(exec)(`./conformance_reader_async ${filePath}`, {
+      cwd: join(__dirname, "../../../../../rust/target/debug/examples"),
+    });
+    return JSON.parse(stdout.trim()) as StreamedReadTestResult;
+  }
+
+  supportsVariant(_variant: TestVariant): boolean {
+    return true;
+  }
+}

--- a/tests/conformance/scripts/run-tests/runners/index.ts
+++ b/tests/conformance/scripts/run-tests/runners/index.ts
@@ -8,6 +8,7 @@ import KaitaiStructReaderTestRunner from "./KaitaiStructReaderTestRunner";
 import PythonIndexedReaderTestRunner from "./PythonIndexedReaderTestRunner";
 import PythonStreamedReaderTestRunner from "./PythonStreamedReaderTestRunner";
 import PythonWriterTestRunner from "./PythonWriterTestRunner";
+import RustAsyncReaderTestRunner from "./RustAsyncReaderTestRunner";
 import RustReaderTestRunner from "./RustReaderTestRunner";
 import RustWriterTestRunner from "./RustWriterTestRunner";
 import SwiftIndexedReaderTestRunner from "./SwiftIndexedReaderTestRunner";
@@ -31,6 +32,7 @@ const runners: readonly (IndexedReadTestRunner | StreamedReadTestRunner | WriteT
   new TypescriptIndexedReaderTestRunner(),
   new TypescriptStreamedReaderTestRunner(),
   new TypescriptWriterTestRunner(),
+  new RustAsyncReaderTestRunner(),
   new RustReaderTestRunner(),
   new RustWriterTestRunner(),
   new SwiftWriterTestRunner(),


### PR DESCRIPTION
### Changelog
- rust: switches the LZ4 compression dependency from `lz4_flex` to `lz4-rs`. This moves us from using a pure-rust lz4 implementation to C bindings. I believe this is worthwhile because `lz4_flex` does not support LZ4 "high compression mode". The practical reason for doing so in this PR is that `lz4_flex` does not expose interfaces that make it easy to build an AsyncRead adapter for it, but `lz4-rs` does.
- rust: Adds structs to read MCAP data asynchronously in a linear stream. 

### Docs

- Check generated rust docs for review.


### Description
Adds an async `RecordReader`implementation, for reading MCAP data asynchronously. This is an optional feature, named `tokio`. I chose this feature flag name and this module name because this functionality is tied heavily into the Tokio ecosystem. If at some point we rebuild this to be async-executor-agnostic, we can add that functionality under a new module and feature flag name.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

