### PR TITLE
perf(rust): prealloc decompression buffers

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -368,7 +368,7 @@ fn read_record_from_chunk_stream<'a, R: Read>(r: &mut R) -> McapResult<records::
     debug!("chunk: opcode {op:02X}, length {len}");
     let record = match op {
         op::SCHEMA => {
-            let mut record = Vec::new();
+            let mut record = Vec::with_capacity(len as usize);
             r.take(len).read_to_end(&mut record)?;
             if len as usize != record.len() {
                 return Err(McapError::UnexpectedEoc);
@@ -396,7 +396,7 @@ fn read_record_from_chunk_stream<'a, R: Read>(r: &mut R) -> McapResult<records::
             }
         }
         op::CHANNEL => {
-            let mut record = Vec::new();
+            let mut record = Vec::with_capacity(len as usize);
             r.take(len).read_to_end(&mut record)?;
             if len as usize != record.len() {
                 return Err(McapError::UnexpectedEoc);
@@ -421,14 +421,14 @@ fn read_record_from_chunk_stream<'a, R: Read>(r: &mut R) -> McapResult<records::
             // Fortunately, message headers are fixed length.
             const HEADER_LEN: u64 = 22;
 
-            let mut header_buf = Vec::new();
+            let mut header_buf = Vec::with_capacity(HEADER_LEN as usize);
             r.take(HEADER_LEN).read_to_end(&mut header_buf)?;
             if header_buf.len() as u64 != HEADER_LEN {
                 return Err(McapError::UnexpectedEoc);
             }
             let header: records::MessageHeader = Cursor::new(header_buf).read_le()?;
 
-            let mut data = Vec::new();
+            let mut data = Vec::with_capacity((len - HEADER_LEN) as usize);
             r.take(len - HEADER_LEN).read_to_end(&mut data)?;
             if data.len() as u64 != len - HEADER_LEN {
                 return Err(McapError::UnexpectedEoc);


### PR DESCRIPTION
To avoid reallocs as decompressors write into them. Simple 4-line change that boosts decompressed throughput by +40-50%

### Bench delta

```
mcap_read/MessageStream_1M_uncompressed
                        time:   [66.406 ms 66.638 ms 66.810 ms]
                        thrpt:  [14.968 Melem/s 15.006 Melem/s 15.059 Melem/s]
                 change:
                        time:   [-4.2425% -3.4304% -2.6572%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7297% +3.5523% +4.4305%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
mcap_read/MessageStream_1M_lz4
                        time:   [223.21 ms 224.45 ms 225.67 ms]
                        thrpt:  [4.4313 Melem/s 4.4554 Melem/s 4.4801 Melem/s]
                 change:
                        time:   [-36.047% -34.784% -33.497%] (p = 0.00 < 0.05)
                        thrpt:  [+50.370% +53.337% +56.364%]
                        Performance has improved.
mcap_read/MessageStream_1M_zstd
                        time:   [274.52 ms 276.51 ms 278.58 ms]
                        thrpt:  [3.5896 Melem/s 3.6165 Melem/s 3.6427 Melem/s]
                 change:
                        time:   [-28.976% -28.093% -27.277%] (p = 0.00 < 0.05)
                        thrpt:  [+37.508% +39.069% +40.797%]
                        Performance has improved.
```