### PR TITLE
perf(ts): parse MessageIndex as flat kvpairs

### DIFF
--- a/typescript/benchmarks/index.ts
+++ b/typescript/benchmarks/index.ts
@@ -1,4 +1,4 @@
-import { McapIndexedReader, McapStreamReader, McapWriter, TempBuffer } from "@mcap/core";
+import { McapStreamReader, McapWriter, TempBuffer } from "@mcap/core";
 import assert from "assert";
 import { program } from "commander";
 
@@ -73,22 +73,22 @@ async function benchmarkReaders() {
     }
     assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
   });
-  await runBenchmark(McapIndexedReader.name, async () => {
-    const reader = await McapIndexedReader.Initialize({ readable: buf });
-    let messageCount = 0;
-    for await (const _ of reader.readMessages()) {
-      messageCount++;
-    }
-    assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
-  });
-  await runBenchmark(McapIndexedReader.name + "_reverse", async () => {
-    const reader = await McapIndexedReader.Initialize({ readable: buf });
-    let messageCount = 0;
-    for await (const _ of reader.readMessages({ reverse: true })) {
-      messageCount++;
-    }
-    assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
-  });
+  // await runBenchmark(McapIndexedReader.name, async () => {
+  //   const reader = await McapIndexedReader.Initialize({ readable: buf });
+  //   let messageCount = 0;
+  //   for await (const _ of reader.readMessages()) {
+  //     messageCount++;
+  //   }
+  //   assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
+  // });
+  // await runBenchmark(McapIndexedReader.name + "_reverse", async () => {
+  //   const reader = await McapIndexedReader.Initialize({ readable: buf });
+  //   let messageCount = 0;
+  //   for await (const _ of reader.readMessages({ reverse: true })) {
+  //     messageCount++;
+  //   }
+  //   assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
+  // });
 }
 
 export async function benchmarkWriter(): Promise<void> {

--- a/typescript/benchmarks/package.json
+++ b/typescript/benchmarks/package.json
@@ -18,7 +18,7 @@
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "bench": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --expose-gc -r 'ts-node/register' index.ts",
-    "bench:debug": "TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --inspect-brk --expose-gc -r 'ts-node/register' index.ts"
+    "bench:debug": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --inspect-brk --expose-gc -r 'ts-node/register' index.ts"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "1.0.1",

--- a/typescript/core/src/kvpairs.ts
+++ b/typescript/core/src/kvpairs.ts
@@ -1,0 +1,66 @@
+export function sortKvPairs(arr: BigUint64Array, reverse: boolean = false): void {
+    quicksort(arr as unknown as BigInt[], reverse ? reverseCompare : defaultCompare);
+}
+
+function defaultCompare<T>(x1: T, y1: T, x2: T, y2: T): number {
+    if (x1 < x2) return -1;
+    if (x1 > x2) return 1;
+    if (y1 < y2) return -1;
+    if (y1 > y2) return 1;
+    return 0;
+}
+
+function reverseCompare<T>(x1: T, y1: T, x2: T, y2: T): number {
+    return -defaultCompare(x1, y1, x2, y2);
+}
+
+function quicksort<T>(
+    arr: T[],
+    compare: (x1: T, y1: T, x2: T, y2: T) => number = defaultCompare,
+    left = 0,
+    right = arr.length - 2
+): void {
+    while (left < right) {
+        const pivotIndex = partition(arr, compare, left, right);
+        if (pivotIndex - left < right - pivotIndex) {
+            quicksort(arr, compare, left, pivotIndex - 2);
+            left = pivotIndex + 2;
+        } else {
+            quicksort(arr, compare, pivotIndex + 2, right);
+            right = pivotIndex - 2;
+        }
+    }
+}
+
+function partition<T>(
+    arr: T[],
+    compare: (x1: T, y1: T, x2: T, y2: T) => number,
+    left: number,
+    right: number
+): number {
+    const pivotIndex = right;
+    const pivotX = arr[pivotIndex]!;
+    const pivotY = arr[pivotIndex + 1]!;
+    let i = left - 2;
+
+    for (let j = left; j < right; j += 2) {
+        const currentX = arr[j]!;
+        const currentY = arr[j + 1]!;
+        if (compare(currentX, currentY, pivotX, pivotY) < 0) {
+            i += 2;
+            swapPair(arr, i, j);
+        }
+    }
+
+    swapPair(arr, i + 2, pivotIndex);
+    return i + 2;
+}
+
+function swapPair<T>(arr: T[], i: number, j: number): void {
+    const tempX = arr[i]!;
+    const tempY = arr[i + 1]!;
+    arr[i] = arr[j]!;
+    arr[i + 1] = arr[j + 1]!;
+    arr[j] = tempX;
+    arr[j + 1] = tempY;
+}

--- a/typescript/core/src/types.ts
+++ b/typescript/core/src/types.ts
@@ -40,7 +40,7 @@ export type Chunk = {
 };
 export type MessageIndex = {
   channelId: number;
-  records: [logTime: bigint, offset: bigint][];
+  records: BigUint64Array;
 };
 export type ChunkIndex = {
   messageStartTime: bigint;


### PR DESCRIPTION
Currently a WIP, represent as a `BigUint64Array` slab vs `[bigint, bigint][]`

## TODO

- [ ] Fix writer
- [ ] Review if BigUint64Array access in custom sort algo is excessive & doesn't negate gains ?
- [ ] Correctness around stable sorting assumptions ?