### PR TITLE
experiment(ts): perf

### DIFF
--- a/typescript/benchmarks/index.ts
+++ b/typescript/benchmarks/index.ts
@@ -1,4 +1,4 @@
-import { McapStreamReader, McapWriter, TempBuffer } from "@mcap/core";
+import { McapIndexedReader, McapStreamDispatch, McapStreamReader, McapWriter, TempBuffer } from "@mcap/core";
 import assert from "assert";
 import { program } from "commander";
 
@@ -57,20 +57,30 @@ async function benchmarkReaders() {
     });
   }
   await writer.end();
-  await runBenchmark(McapStreamReader.name, async () => {
-    const reader = new McapStreamReader();
-    reader.append(buf.get());
+  // await runBenchmark(McapStreamReader.name, async () => {
+  //   const reader = new McapStreamReader();
+  //   reader.append(buf.get());
+  //   let messageCount = 0;
+  //   for (;;) {
+  //     const rec = reader.nextRecord();
+  //     if (rec != undefined) {
+  //       if (rec.type === "Message") {
+  //         messageCount++;
+  //       }
+  //     } else {
+  //       break;
+  //     }
+  //   }
+  //   assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
+  // });
+  await runBenchmark(McapStreamDispatch.name, async () => {
     let messageCount = 0;
-    for (;;) {
-      const rec = reader.nextRecord();
-      if (rec != undefined) {
-        if (rec.type === "Message") {
-          messageCount++;
-        }
-      } else {
-        break;
-      }
-    }
+    const dispatch = new McapStreamDispatch({
+      onMessage: (_msg) => {
+        messageCount++;
+      },
+    });
+    dispatch.append(buf.get());
     assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
   });
   // await runBenchmark(McapIndexedReader.name, async () => {

--- a/typescript/benchmarks/index.ts
+++ b/typescript/benchmarks/index.ts
@@ -1,4 +1,4 @@
-import { McapIndexedReader, McapStreamReader, McapWriter, TempBuffer } from "@mcap/core";
+import { McapStreamReader, McapWriter, TempBuffer } from "@mcap/core";
 import assert from "assert";
 import { program } from "commander";
 
@@ -73,22 +73,22 @@ async function benchmarkReaders() {
     }
     assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
   });
-  await runBenchmark(McapIndexedReader.name, async () => {
-    const reader = await McapIndexedReader.Initialize({ readable: buf });
-    let messageCount = 0;
-    for await (const _ of reader.readMessages()) {
-      messageCount++;
-    }
-    assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
-  });
-  await runBenchmark(McapIndexedReader.name + "_reverse", async () => {
-    const reader = await McapIndexedReader.Initialize({ readable: buf });
-    let messageCount = 0;
-    for await (const _ of reader.readMessages({ reverse: true })) {
-      messageCount++;
-    }
-    assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
-  });
+  // await runBenchmark(McapIndexedReader.name, async () => {
+  //   const reader = await McapIndexedReader.Initialize({ readable: buf });
+  //   let messageCount = 0;
+  //   for await (const _ of reader.readMessages()) {
+  //     messageCount++;
+  //   }
+  //   assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
+  // });
+  // await runBenchmark(McapIndexedReader.name + "_reverse", async () => {
+  //   const reader = await McapIndexedReader.Initialize({ readable: buf });
+  //   let messageCount = 0;
+  //   for await (const _ of reader.readMessages({ reverse: true })) {
+  //     messageCount++;
+  //   }
+  //   assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
+  // });
 }
 
 export async function benchmarkWriter(): Promise<void> {

--- a/typescript/benchmarks/index.ts
+++ b/typescript/benchmarks/index.ts
@@ -57,22 +57,23 @@ async function benchmarkReaders() {
     });
   }
   await writer.end();
-  // await runBenchmark(McapStreamReader.name, async () => {
-  //   const reader = new McapStreamReader();
-  //   reader.append(buf.get());
-  //   let messageCount = 0;
-  //   for (;;) {
-  //     const rec = reader.nextRecord();
-  //     if (rec != undefined) {
-  //       if (rec.type === "Message") {
-  //         messageCount++;
-  //       }
-  //     } else {
-  //       break;
-  //     }
-  //   }
-  //   assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
-  // });
+  console.log("Buf size", buf.get().byteLength);
+  await runBenchmark(McapStreamReader.name, async () => {
+    const reader = new McapStreamReader({ validateCrcs: true });
+    reader.append(buf.get());
+    let messageCount = 0;
+    for (;;) {
+      const rec = reader.nextRecord();
+      if (rec != undefined) {
+        if (rec.type === "Message") {
+          messageCount++;
+        }
+      } else {
+        break;
+      }
+    }
+    assert(messageCount === numMessages, `expected ${numMessages} messages, got ${messageCount}`);
+  });
   await runBenchmark(McapStreamDispatch.name, async () => {
     let messageCount = 0;
     const dispatch = new McapStreamDispatch({

--- a/typescript/benchmarks/index.ts
+++ b/typescript/benchmarks/index.ts
@@ -20,7 +20,7 @@ class FakeMemoryWritable {
     this.#size = 0;
   }
   position() {
-    return BigInt(this.#size);
+    return this.#size;
   }
   async write(data: Uint8Array) {
     if (data.byteLength > this.#lastWrittenData.byteLength) {
@@ -51,8 +51,8 @@ async function benchmarkReaders() {
     await writer.addMessage({
       channelId,
       sequence: i,
-      logTime: BigInt(i),
-      publishTime: BigInt(i),
+      logTime: i,
+      publishTime: i,
       data: messageData,
     });
   }
@@ -133,8 +133,8 @@ async function runWriteBenchmark({
         await writer.addMessage({
           channelId,
           sequence: i,
-          logTime: BigInt(i),
-          publishTime: BigInt(i),
+          logTime: i,
+          publishTime: i,
           data: messageData,
         });
       }

--- a/typescript/benchmarks/package.json
+++ b/typescript/benchmarks/package.json
@@ -18,7 +18,7 @@
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "bench": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --expose-gc -r 'ts-node/register' index.ts",
-    "bench:debug": "TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --inspect-brk --expose-gc -r 'ts-node/register' index.ts"
+    "bench:debug": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --inspect-brk --expose-gc -r 'ts-node/register' index.ts"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "1.0.1",

--- a/typescript/benchmarks/package.json
+++ b/typescript/benchmarks/package.json
@@ -18,6 +18,7 @@
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "bench": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --expose-gc -r 'ts-node/register' index.ts",
+    "bench:trace": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --trace-opt --trace-deopt --huge-max-old-generation-size --expose-gc -r 'ts-node/register' index.ts",
     "bench:debug": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.cjs.json node --huge-max-old-generation-size --inspect-brk --expose-gc -r 'ts-node/register' index.ts"
   },
   "devDependencies": {

--- a/typescript/browser/src/BlobReadable.ts
+++ b/typescript/browser/src/BlobReadable.ts
@@ -10,11 +10,11 @@ export class BlobReadable implements McapTypes.IReadable {
     this.#blob = blob;
   }
 
-  public async size(): Promise<bigint> {
-    return BigInt(this.#blob.size);
+  public async size(): Promise<number> {
+    return this.#blob.size;
   }
 
-  public async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+  public async read(offset: number, size: number): Promise<Uint8Array> {
     if (offset + size > this.#blob.size) {
       throw new Error(
         `Read of ${size} bytes at offset ${offset} exceeds file size ${this.#blob.size}`,

--- a/typescript/browser/src/index.test.ts
+++ b/typescript/browser/src/index.test.ts
@@ -28,8 +28,8 @@ describe("BlobReadable", () => {
     const message = {
       channelId,
       sequence: 1,
-      logTime: 1n,
-      publishTime: 2n,
+      logTime: 1,
+      publishTime: 2,
       data: new Uint8Array([1, 2, 3]),
     };
     await writer.addMessage(message);

--- a/typescript/core/src/BufferBuilder.ts
+++ b/typescript/core/src/BufferBuilder.ts
@@ -73,15 +73,17 @@ export class BufferBuilder {
     this.#offset += 4;
     return this;
   }
-  int64(value: bigint): this {
+  int64(value: number | bigint): this {
+    const bigIntValue = typeof value === "number" ? BigInt(value) : value;
     this.#ensureAdditionalCapacity(8);
-    this.#view.setBigInt64(this.#offset, value, LITTLE_ENDIAN);
+    this.#view.setBigInt64(this.#offset, bigIntValue, LITTLE_ENDIAN);
     this.#offset += 8;
     return this;
   }
-  uint64(value: bigint): this {
+  uint64(value: number | bigint): this {
+    const bigIntValue = typeof value === "number" ? BigInt(value) : value;
     this.#ensureAdditionalCapacity(8);
-    this.#view.setBigUint64(this.#offset, value, LITTLE_ENDIAN);
+    this.#view.setBigUint64(this.#offset, bigIntValue, LITTLE_ENDIAN);
     this.#offset += 8;
     return this;
   }

--- a/typescript/core/src/ChunkBuilder.test.ts
+++ b/typescript/core/src/ChunkBuilder.test.ts
@@ -8,17 +8,17 @@ describe("ChunkBuilder", () => {
       channelId: 0,
       data: new Uint8Array(),
       sequence: 0,
-      logTime: 0n,
-      publishTime: 0n,
+      logTime: 0,
+      publishTime: 0,
     });
     builder.addMessage({
       channelId: 0,
       data: new Uint8Array(),
       sequence: 1,
-      logTime: 1n,
-      publishTime: 1n,
+      logTime: 1,
+      publishTime: 1,
     });
-    expect(builder.messageStartTime).toBe(0n);
-    expect(builder.messageEndTime).toBe(1n);
+    expect(builder.messageStartTime).toBe(0);
+    expect(builder.messageEndTime).toBe(1);
   });
 });

--- a/typescript/core/src/ChunkBuilder.ts
+++ b/typescript/core/src/ChunkBuilder.ts
@@ -9,8 +9,8 @@ class ChunkBuilder {
   #messageIndices: Map<number, MessageIndex> | undefined;
   #totalMessageCount = 0;
 
-  messageStartTime = 0n;
-  messageEndTime = 0n;
+  messageStartTime = 0;
+  messageEndTime = 0;
 
   constructor({ useMessageIndex = true }: ChunkBuilderOptions) {
     if (useMessageIndex) {
@@ -68,7 +68,7 @@ class ChunkBuilder {
         };
         this.#messageIndices.set(message.channelId, messageIndex);
       }
-      messageIndex.records.push([message.logTime, BigInt(this.#recordWriter.length)]);
+      messageIndex.records.push([message.logTime, this.#recordWriter.length]);
     }
 
     this.#totalMessageCount += 1;
@@ -76,8 +76,8 @@ class ChunkBuilder {
   }
 
   reset(): void {
-    this.messageStartTime = 0n;
-    this.messageEndTime = 0n;
+    this.messageStartTime = 0;
+    this.messageEndTime = 0;
     this.#totalMessageCount = 0;
     this.#messageIndices?.clear();
     this.#recordWriter.reset();

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -1,7 +1,8 @@
 import Reader from "./Reader";
+import { sortKvPairs } from "./kvpairs";
 import { parseRecord } from "./parse";
-import { sortedIndexBy } from "./sortedIndexBy";
-import { sortedLastIndexBy } from "./sortedLastIndex";
+// import { sortedIndexBy } from "./sortedIndexBy";
+// import { sortedLastIndexBy } from "./sortedLastIndex";
 import { IReadable, TypedMcapRecords } from "./types";
 
 type ChunkCursorParams = {
@@ -28,7 +29,7 @@ export class ChunkCursor {
   #reverse: boolean;
 
   // List of message offsets (across all channels) sorted by logTime.
-  #orderedMessageOffsets?: [logTime: number, offset: number][];
+  #orderedMessageOffsets?: BigUint64Array;
   // Index for the next message offset. Gets incremented for every popMessage() call.
   #nextMessageOffsetIndex = 0;
 
@@ -92,7 +93,10 @@ export class ChunkCursor {
       );
     }
 
-    return this.#orderedMessageOffsets[this.#nextMessageOffsetIndex++]!;
+    const logTime = this.#orderedMessageOffsets[this.#nextMessageOffsetIndex]!;
+    const offset = this.#orderedMessageOffsets[this.#nextMessageOffsetIndex + 1]!;
+    this.#nextMessageOffsetIndex += 2;
+    return [logTime, offset];
   }
 
   /**
@@ -121,7 +125,7 @@ export class ChunkCursor {
       }
     }
     if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
-      this.#orderedMessageOffsets = [];
+      this.#orderedMessageOffsets = new BigUint64Array(0);
       return;
     }
 
@@ -138,7 +142,7 @@ export class ChunkCursor {
     );
 
     const reader = new Reader(messageIndexesView);
-    const arrayOfMessageOffsets: [logTime: number, offset: number][][] = [];
+    let arrayOfMessageOffsets: BigUint64Array = new BigUint64Array(0);
     let record;
     while ((record = parseRecord(reader, true))) {
       if (record.type !== "MessageIndex") {
@@ -150,47 +154,28 @@ export class ChunkCursor {
       ) {
         continue;
       }
-
-      arrayOfMessageOffsets.push(record.records);
+      arrayOfMessageOffsets = BigUint64ArrayConcat(arrayOfMessageOffsets, record.records);
     }
 
     if (reader.bytesRemaining() !== 0) {
       throw new Error(`${reader.bytesRemaining()} bytes remaining in message index section`);
     }
 
-    this.#orderedMessageOffsets = arrayOfMessageOffsets
-      .flat()
-      .sort(([logTimeA, offsetA], [logTimeB, offsetB]) => {
-        let diff = Number(logTimeA - logTimeB);
-
-        // Break ties by message offset in the file
-        if (diff === 0) {
-          diff = Number(offsetA - offsetB);
-        }
-
-        return diff;
-      });
-
-    if (reverse) {
-      // If we used `logTimeB - logTimeA` as the comparator for reverse iteration, messages with
-      // the same timestamp would not be in reverse order. To avoid this problem we use reverse()
-      // instead.
-      this.#orderedMessageOffsets.reverse();
-    }
-
+    this.#orderedMessageOffsets = arrayOfMessageOffsets;
     if (this.#orderedMessageOffsets.length === 0) {
       return;
     }
+    // Sort the message offsets
+    sortKvPairs(this.#orderedMessageOffsets, reverse);
 
-    const [logTimeFirstMessage] = this.#orderedMessageOffsets[0]!;
+    const logTimeFirstMessage = this.#orderedMessageOffsets[0]!;
     if (logTimeFirstMessage < this.chunkIndex.messageStartTime) {
       throw new Error(
         `Chunk at offset ${this.chunkIndex.chunkStartOffset} contains a message with logTime (${logTimeFirstMessage}) earlier than chunk messageStartTime (${this.chunkIndex.messageStartTime})`,
       );
     }
 
-    const [logTimeLastMessage] =
-      this.#orderedMessageOffsets[this.#orderedMessageOffsets.length - 1]!;
+    const logTimeLastMessage = this.#orderedMessageOffsets[this.#orderedMessageOffsets.length - 2]!;
     if (logTimeLastMessage > this.chunkIndex.messageEndTime) {
       throw new Error(
         `Chunk at offset ${this.chunkIndex.chunkStartOffset} contains a message with logTime with logTime (${logTimeLastMessage}) later than chunk messageEndTime (${this.chunkIndex.messageEndTime})`,
@@ -205,16 +190,20 @@ export class ChunkCursor {
     let endIndex: number | undefined;
 
     if (startTime != undefined) {
-      startIndex = sortedIndexBy(this.#orderedMessageOffsets, startTime, iteratee);
+      startIndex = sortedIndexBy(this.#orderedMessageOffsets, startTime, iteratee) * 2;
     }
     if (endTime != undefined) {
-      endIndex = sortedLastIndexBy(this.#orderedMessageOffsets, endTime, iteratee);
+      endIndex = sortedLastIndexBy(this.#orderedMessageOffsets, endTime, iteratee) * 2;
     }
 
     // Remove offsets whose log time is outside of the range [startTime, endTime] which
     // avoids having to do additional book-keep of additional array start & stop indexes.
     if (startIndex != undefined || endIndex != undefined) {
-      this.#orderedMessageOffsets = this.#orderedMessageOffsets.slice(startIndex, endIndex);
+      startIndex = startIndex ? Math.max(0, startIndex) : 0;
+      endIndex = endIndex ? Math.min(this.#orderedMessageOffsets.length, endIndex) : this.#orderedMessageOffsets.length;
+      if (startIndex !== 0 || endIndex !== this.#orderedMessageOffsets.length) {
+        this.#orderedMessageOffsets = this.#orderedMessageOffsets.subarray(startIndex, endIndex);
+      }
     }
   }
 
@@ -226,10 +215,85 @@ export class ChunkCursor {
       this.#orderedMessageOffsets.length > 0 &&
       this.#nextMessageOffsetIndex < this.#orderedMessageOffsets.length
     ) {
-      return this.#orderedMessageOffsets[this.#nextMessageOffsetIndex]![0];
+      return this.#orderedMessageOffsets[this.#nextMessageOffsetIndex]!;
     }
 
     // Fall back to the chunk index' start time or end time.
     return this.#reverse ? this.chunkIndex.messageEndTime : this.chunkIndex.messageStartTime;
   }
+}
+
+function BigUint64ArrayConcat(a: BigUint64Array, b: BigUint64Array) {
+  if (a.length === 0) {
+    return b;
+  }
+  if (b.length === 0) {
+    return a;
+  }
+  const c = new BigUint64Array(a.length + b.length);
+  c.set(a);
+  c.set(b, a.length);
+  return c;
+}
+
+/**
+ * Return the lowest index of `array` where an element can be inserted and maintain its sorted
+ * order. This is a specialization of lodash's sortedIndexBy() for flat key-value pairs.
+ */
+function sortedIndexBy(
+  array: BigUint64Array,
+  value: bigint,
+  iteratee: (value: bigint) => bigint,
+): number {
+  let low = 0;
+  let high = array.length / 2;
+
+  if (high === 0) {
+    return 0;
+  }
+
+  const computedValue = iteratee(value);
+
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    const computed = iteratee(array[mid * 2]!);
+
+    if (computed < computedValue) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}
+
+/**
+ * Return the lowest index of `array` where an element can be inserted and maintain its sorted
+ * order. This is a specialization of lodash's sortedLastIndexBy() for flat key-value pairs.
+ */
+function sortedLastIndexBy(
+  array: BigUint64Array,
+  value: bigint,
+  iteratee: (value: bigint) => bigint,
+): number {
+  let low = 0;
+  let high = array.length / 2;
+
+  if (high === 0) {
+    return 0;
+  }
+
+  const computedValue = iteratee(value);
+
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    const computed = iteratee(array[mid * 2]!);
+
+    if (computed <= computedValue) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return high;
 }

--- a/typescript/core/src/ISeekableWriter.ts
+++ b/typescript/core/src/ISeekableWriter.ts
@@ -5,7 +5,7 @@ import { IWritable } from "./IWritable";
  */
 export interface ISeekableWriter extends IWritable {
   /** Move the cursor to the given position */
-  seek(position: bigint): Promise<void>;
+  seek(position: number): Promise<void>;
   /** Remove data after the current write position */
   truncate(): Promise<void>;
 }

--- a/typescript/core/src/IWritable.ts
+++ b/typescript/core/src/IWritable.ts
@@ -6,5 +6,5 @@ export interface IWritable {
   write(buffer: Uint8Array): Promise<unknown>;
 
   // The current position in bytes from the start of the output
-  position(): bigint;
+  position(): number;
 }

--- a/typescript/core/src/McapRecordBuilder.test.ts
+++ b/typescript/core/src/McapRecordBuilder.test.ts
@@ -20,29 +20,29 @@ describe("McapRecordBuilder", () => {
     const buffer = new BufferBuilder();
     buffer
       .uint8(1) // opcode
-      .uint64(BigInt(14)) // record content byte length
+      .uint64(14) // record content byte length
       .string("foo")
       .string("bar");
 
     expect(writer.buffer).toEqual(buffer.buffer);
-    expect(written).toEqual(BigInt(buffer.length));
+    expect(written).toEqual(buffer.length);
   });
 
   it("writes footer", () => {
     const writer = new McapRecordBuilder();
 
     writer.writeFooter({
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
 
     const buffer = new BufferBuilder();
     buffer
       .uint8(2) // opcode
-      .uint64(BigInt(20)) // record content byte length
-      .uint64(0n)
-      .uint64(0n)
+      .uint64(20) // record content byte length
+      .uint64(0)
+      .uint64(0)
       .uint32(0);
 
     expect(writer.buffer).toEqual(buffer.buffer);
@@ -61,7 +61,7 @@ describe("McapRecordBuilder", () => {
     const buffer = new BufferBuilder();
     buffer
       .uint8(3) // opcode
-      .uint64(BigInt(42)) // record content byte length
+      .uint64(42) // record content byte length
       .uint16(1)
       .string("schema name")
       .string("some format")
@@ -69,7 +69,7 @@ describe("McapRecordBuilder", () => {
       .bytes(new TextEncoder().encode("schema"));
 
     expect(writer.buffer).toEqual(buffer.buffer);
-    expect(written).toEqual(BigInt(buffer.length));
+    expect(written).toEqual(buffer.length);
   });
 
   it("writes channel", () => {
@@ -86,7 +86,7 @@ describe("McapRecordBuilder", () => {
     const buffer = new BufferBuilder();
     buffer
       .uint8(4) // opcode
-      .uint64(BigInt(30)) // record content byte length
+      .uint64(30) // record content byte length
       .uint16(1)
       .uint16(2)
       .string("/topic")
@@ -94,7 +94,7 @@ describe("McapRecordBuilder", () => {
       .uint32(0); // user data length
 
     expect(writer.buffer).toEqual(buffer.buffer);
-    expect(written).toEqual(BigInt(buffer.length));
+    expect(written).toEqual(buffer.length);
   });
 
   it("writes messages", () => {
@@ -102,8 +102,8 @@ describe("McapRecordBuilder", () => {
 
     writer.writeMessage({
       channelId: 1,
-      logTime: 5n,
-      publishTime: 3n,
+      logTime: 5,
+      publishTime: 3,
       sequence: 7,
       data: new Uint8Array(),
     });
@@ -111,11 +111,11 @@ describe("McapRecordBuilder", () => {
     const buffer = new BufferBuilder();
     buffer
       .uint8(5) // opcode
-      .uint64(BigInt(22)) // record content byte length
+      .uint64(22) // record content byte length
       .uint16(1)
       .uint32(7)
-      .uint64(5n)
-      .uint64(3n);
+      .uint64(5)
+      .uint64(3);
 
     expect(buffer.length).toEqual(22 + 9);
     expect(writer.buffer).toEqual(buffer.buffer);
@@ -132,13 +132,13 @@ describe("McapRecordBuilder", () => {
     const buffer = new BufferBuilder();
     buffer
       .uint8(0x0c) // opcode
-      .uint64(BigInt(36)) // record content byte length
+      .uint64(36) // record content byte length
       .string("name")
       .uint32(24) // metadata byte length
       .string("something")
       .string("magical");
 
     expect(writer.buffer).toEqual(buffer.buffer);
-    expect(written).toEqual(BigInt(buffer.length));
+    expect(written).toEqual(buffer.length);
   });
 });

--- a/typescript/core/src/McapRecordBuilder.ts
+++ b/typescript/core/src/McapRecordBuilder.ts
@@ -55,12 +55,12 @@ export class McapRecordBuilder {
     this.#bufferBuilder.bytes(new Uint8Array(MCAP_MAGIC));
   }
 
-  writeHeader(header: Header): bigint {
+  writeHeader(header: Header): number {
     this.#bufferBuilder.uint8(Opcode.HEADER);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder size
+      .uint64(0) // placeholder size
       .string(header.profile)
       .string(header.library);
 
@@ -71,29 +71,29 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeFooter(footer: Footer): bigint {
+  writeFooter(footer: Footer): number {
     this.#bufferBuilder
       .uint8(Opcode.FOOTER)
-      .uint64(20n) // footer is fixed length
+      .uint64(20) // footer is fixed length
       .uint64(footer.summaryStart)
       .uint64(footer.summaryOffsetStart)
       .uint32(footer.summaryCrc);
     // footer record cannot be padded
-    return 20n;
+    return 20;
   }
 
-  writeSchema(schema: Schema): bigint {
+  writeSchema(schema: Schema): number {
     this.#bufferBuilder.uint8(Opcode.SCHEMA);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint16(schema.id)
       .string(schema.name)
       .string(schema.encoding)
@@ -106,18 +106,18 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeChannel(info: Channel): bigint {
+  writeChannel(info: Channel): number {
     this.#bufferBuilder.uint8(Opcode.CHANNEL);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint16(info.id)
       .uint16(info.schemaId)
       .string(info.topic)
@@ -133,17 +133,17 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
   writeMessage(message: Message): void {
     this.#bufferBuilder.uint8(Opcode.MESSAGE);
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint16(message.channelId)
       .uint32(message.sequence)
       .uint64(message.logTime)
@@ -153,22 +153,22 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
   }
 
-  writeAttachment(attachment: Attachment): bigint {
+  writeAttachment(attachment: Attachment): number {
     this.#bufferBuilder.uint8(Opcode.ATTACHMENT);
 
     const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder.uint64(0n); // placeholder
+    this.#bufferBuilder.uint64(0); // placeholder
     const crcStartPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .uint64(attachment.logTime)
       .uint64(attachment.createTime)
       .string(attachment.name)
       .string(attachment.mediaType)
-      .uint64(BigInt(attachment.data.byteLength))
+      .uint64(attachment.data.byteLength)
       .bytes(attachment.data);
     this.#bufferBuilder.uint32(
       crc32(
@@ -185,18 +185,18 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeAttachmentIndex(attachmentIndex: AttachmentIndex): bigint {
+  writeAttachmentIndex(attachmentIndex: AttachmentIndex): number {
     this.#bufferBuilder.uint8(Opcode.ATTACHMENT_INDEX);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint64(attachmentIndex.offset)
       .uint64(attachmentIndex.length)
       .uint64(attachmentIndex.logTime)
@@ -211,41 +211,41 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeChunk(chunk: Chunk): bigint {
+  writeChunk(chunk: Chunk): number {
     this.#bufferBuilder.uint8(Opcode.CHUNK);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint64(chunk.messageStartTime)
       .uint64(chunk.messageEndTime)
       .uint64(chunk.uncompressedSize)
       .uint32(chunk.uncompressedCrc)
       .string(chunk.compression)
-      .uint64(BigInt(chunk.records.byteLength))
+      .uint64(chunk.records.byteLength)
       .bytes(chunk.records);
     // chunk record cannot be padded
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeChunkIndex(chunkIndex: ChunkIndex): bigint {
+  writeChunkIndex(chunkIndex: ChunkIndex): number {
     this.#bufferBuilder.uint8(Opcode.CHUNK_INDEX);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint64(chunkIndex.messageStartTime)
       .uint64(chunkIndex.messageEndTime)
       .uint64(chunkIndex.chunkStartOffset)
@@ -268,13 +268,13 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeMessageIndex(messageIndex: MessageIndex): bigint {
+  writeMessageIndex(messageIndex: MessageIndex): number {
     this.#bufferBuilder.uint8(Opcode.MESSAGE_INDEX);
     const startPosition = this.#bufferBuilder.length;
 
@@ -282,7 +282,7 @@ export class McapRecordBuilder {
     const messageIndexRecordsByteLength = messageIndex.records.length * 16;
 
     this.#bufferBuilder
-      .uint64(0n) // placeholder
+      .uint64(0) // placeholder
       .uint16(messageIndex.channelId)
       .uint32(messageIndexRecordsByteLength);
 
@@ -296,17 +296,17 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeMetadata(metadata: Metadata): bigint {
+  writeMetadata(metadata: Metadata): number {
     this.#bufferBuilder.uint8(Opcode.METADATA);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder size
+      .uint64(0) // placeholder size
       .string(metadata.name)
       .tupleArray(
         (key) => this.#bufferBuilder.string(key),
@@ -320,18 +320,18 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeMetadataIndex(metadataIndex: MetadataIndex): bigint {
+  writeMetadataIndex(metadataIndex: MetadataIndex): number {
     this.#bufferBuilder.uint8(Opcode.METADATA_INDEX);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder size
+      .uint64(0) // placeholder size
       .uint64(metadataIndex.offset)
       .uint64(metadataIndex.length)
       .string(metadataIndex.name);
@@ -342,18 +342,18 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeSummaryOffset(summaryOffset: SummaryOffset): bigint {
+  writeSummaryOffset(summaryOffset: SummaryOffset): number {
     this.#bufferBuilder.uint8(Opcode.SUMMARY_OFFSET);
 
     const startPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
-      .uint64(0n) // placeholder size
+      .uint64(0) // placeholder size
       .uint8(summaryOffset.groupOpcode)
       .uint64(summaryOffset.groupStart)
       .uint64(summaryOffset.groupLength);
@@ -364,19 +364,19 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeStatistics(statistics: Statistics): bigint {
+  writeStatistics(statistics: Statistics): number {
     this.#bufferBuilder.uint8(Opcode.STATISTICS);
 
     const startPosition = this.#bufferBuilder.length;
 
     this.#bufferBuilder
-      .uint64(0n) // placeholder size
+      .uint64(0) // placeholder size
       .uint64(statistics.messageCount)
       .uint16(statistics.schemaCount)
       .uint32(statistics.channelCount)
@@ -397,18 +397,18 @@ export class McapRecordBuilder {
     const endPosition = this.#bufferBuilder.length;
     this.#bufferBuilder
       .seek(startPosition)
-      .uint64(BigInt(endPosition - startPosition - 8))
+      .uint64(endPosition - startPosition - 8)
       .seek(endPosition);
 
-    return BigInt(endPosition - startPosition + 1);
+    return endPosition - startPosition + 1;
   }
 
-  writeDataEnd(dataEnd: DataEnd): bigint {
+  writeDataEnd(dataEnd: DataEnd): number {
     this.#bufferBuilder
       .uint8(Opcode.DATA_END)
-      .uint64(4n) // data end is fixed length
+      .uint64(4) // data end is fixed length
       .uint32(dataEnd.dataSectionCrc);
     // data end record cannot be padded
-    return 4n;
+    return 4;
   }
 }

--- a/typescript/core/src/McapStreamDispatch.ts
+++ b/typescript/core/src/McapStreamDispatch.ts
@@ -1,0 +1,251 @@
+import { crc32 } from "@foxglove/crc";
+
+import Reader from "./Reader";
+import { MCAP_MAGIC } from "./constants";
+import { monoParseMessage, parseMagic, parseRecord } from "./parse";
+import { Channel, DecompressHandlers, McapMagic, TypedMcapRecord, TypedMcapRecords } from "./types";
+
+type McapDispatchOptions = {
+  includeChunks?: boolean;
+  decompressHandlers?: DecompressHandlers;
+  validateCrcs?: boolean;
+  noMagicPrefix?: boolean;
+};
+
+type McapDispatchHandlers = {
+  onHeader?: (record: TypedMcapRecords["Header"]) => void;
+  onSchema?: (record: TypedMcapRecords["Schema"]) => void;
+  onChannel?: (record: TypedMcapRecords["Channel"]) => void;
+  onMessage?: (record: TypedMcapRecords["Message"]) => void;
+  onChunk?: (record: TypedMcapRecords["Chunk"]) => void;
+  onMessageIndex?: (record: TypedMcapRecords["MessageIndex"]) => void;
+  onChunkIndex?: (record: TypedMcapRecords["ChunkIndex"]) => void;
+  onAttachment?: (record: TypedMcapRecords["Attachment"]) => void;
+  onAttachmentIndex?: (record: TypedMcapRecords["AttachmentIndex"]) => void;
+  onStatistics?: (record: TypedMcapRecords["Statistics"]) => void;
+  onMetadata?: (record: TypedMcapRecords["Metadata"]) => void;
+  onMetadataIndex?: (record: TypedMcapRecords["MetadataIndex"]) => void;
+  onSummaryOffset?: (record: TypedMcapRecords["SummaryOffset"]) => void;
+  onDataEnd?: (record: TypedMcapRecords["DataEnd"]) => void;
+  onFooter?: (record: TypedMcapRecords["Footer"]) => void;
+  onError?: (error: Error) => void;
+};
+
+export default class McapStreamDispatch {
+  #buffer = new ArrayBuffer(MCAP_MAGIC.length * 2);
+  #view = new DataView(this.#buffer);
+  #reader = new Reader(this.#view, MCAP_MAGIC.length * 2);
+  #decompressHandlers: DecompressHandlers;
+  #includeChunks: boolean;
+  #validateCrcs: boolean;
+  #noMagicPrefix: boolean;
+  #doneReading = false;
+  #channelsById = new Map<number, TypedMcapRecords["Channel"]>();
+  #handlers: McapDispatchHandlers;
+  #header: TypedMcapRecords["Header"] | undefined;
+
+  constructor(handlers: McapDispatchHandlers, options: McapDispatchOptions = {}) {
+    this.#handlers = handlers;
+    this.#includeChunks = options.includeChunks ?? false;
+    this.#decompressHandlers = options.decompressHandlers ?? {};
+    this.#validateCrcs = options.validateCrcs ?? true;
+    this.#noMagicPrefix = options.noMagicPrefix ?? false;
+  }
+
+  append(data: Uint8Array): void {
+    if (this.#doneReading) {
+      throw new Error("Already done reading");
+    }
+    this.#appendOrShift(data);
+    this.#reader.reset(this.#view);
+    this.#processRecords();
+  }
+
+  #appendOrShift(data: Uint8Array): void {
+    const remainingBytes = this.#reader.bytesRemaining();
+    const totalNeededBytes = remainingBytes + data.byteLength;
+
+    if (totalNeededBytes <= this.#buffer.byteLength) {
+      if (this.#view.byteOffset + totalNeededBytes <= this.#buffer.byteLength) {
+        const array = new Uint8Array(this.#buffer, this.#view.byteOffset);
+        array.set(data, remainingBytes);
+        this.#view = new DataView(this.#buffer, this.#view.byteOffset, totalNeededBytes);
+      } else {
+        const existingData = new Uint8Array(this.#buffer, this.#view.byteOffset, remainingBytes);
+        const array = new Uint8Array(this.#buffer);
+        array.set(existingData, 0);
+        array.set(data, existingData.byteLength);
+        this.#view = new DataView(this.#buffer, 0, totalNeededBytes);
+      }
+    } else {
+      this.#buffer = new ArrayBuffer(totalNeededBytes * 2);
+      const array = new Uint8Array(this.#buffer);
+      const existingData = new Uint8Array(this.#view.buffer, this.#view.byteOffset, remainingBytes);
+      array.set(existingData, 0);
+      array.set(data, existingData.byteLength);
+      this.#view = new DataView(this.#buffer, 0, totalNeededBytes);
+    }
+  }
+
+  #processRecords(): void {
+    if (!this.#noMagicPrefix) {
+      let magic: McapMagic | undefined;
+      while ((magic = parseMagic(this.#reader)) === undefined) {
+        if (this.#reader.bytesRemaining() === 0) return;
+      }
+    }
+
+    while (!this.#doneReading) {
+      const record = parseRecord(this.#reader, this.#validateCrcs);
+      if (!record) break;
+
+      this.#handleRecord(record);
+    }
+  }
+
+  #handleRecord(record: TypedMcapRecord): void {
+    switch (record.type) {
+      case "Header":
+        if (this.#header) {
+          this.#handleError(new Error(`Duplicate Header record`));
+          return;
+        }
+        this.#header = record;
+        this.#handlers.onHeader?.(record);
+        break;
+      case "Footer":
+        this.#handlers.onFooter?.(record);
+        this.#doneReading = true;
+        break;
+      case "Schema":
+        this.#handlers.onSchema?.(record);
+        break;
+      case "Channel":
+        this.#handleChannel(record);
+        break;
+      case "Message":
+        this.#handleMessage(record);
+        break;
+      case "Chunk":
+        this.#handleChunk(record);
+        break;
+      case "MessageIndex":
+        this.#handlers.onMessageIndex?.(record);
+        break;
+      case "ChunkIndex":
+        this.#handlers.onChunkIndex?.(record);
+        break;
+      case "Attachment":
+        this.#handlers.onAttachment?.(record);
+        break;
+      case "AttachmentIndex":
+        this.#handlers.onAttachmentIndex?.(record);
+        break;
+      case "Statistics":
+        this.#handlers.onStatistics?.(record);
+        break;
+      case "Metadata":
+        this.#handlers.onMetadata?.(record);
+        break;
+      case "MetadataIndex":
+        this.#handlers.onMetadataIndex?.(record);
+        break;
+      case "SummaryOffset":
+        this.#handlers.onSummaryOffset?.(record);
+        break;
+      case "DataEnd":
+        this.#handlers.onDataEnd?.(record);
+        break;
+    }
+  }
+
+  #handleChannel(record: TypedMcapRecords["Channel"]): void {
+    const existing = this.#channelsById.get(record.id);
+    this.#channelsById.set(record.id, record);
+    if (existing && !this.#isChannelEqual(existing, record)) {
+      this.#handleError(
+        new Error(`Channel record for id ${record.id} (topic: ${record.topic}) differs from previous channel record of the same id.`)
+      );
+      return;
+    }
+    this.#handlers.onChannel?.(record);
+  }
+
+  #handleMessage(record: TypedMcapRecords["Message"]): void {
+    const channelId = record.channelId;
+    const existing = this.#channelsById.get(channelId);
+    if (!existing) {
+      this.#handleError(new Error(`Encountered message on channel ${channelId} without prior channel record`));
+      return;
+    }
+    this.#handlers.onMessage?.(record);
+  }
+
+  #handleChunk(record: TypedMcapRecords["Chunk"]): void {
+    if (this.#includeChunks) {
+      this.#handlers.onChunk?.(record);
+    }
+
+    let buffer = record.records;
+    if (record.compression !== "" && buffer.byteLength > 0) {
+      const decompress = this.#decompressHandlers[record.compression];
+      if (!decompress) {
+        this.#handleError(new Error(`Unsupported compression ${record.compression}`));
+        return;
+      }
+      buffer = decompress(buffer, record.uncompressedSize);
+    }
+
+    if (this.#validateCrcs && record.uncompressedCrc !== 0) {
+      const chunkCrc = crc32(buffer);
+      if (chunkCrc !== record.uncompressedCrc) {
+        this.#handleError(new Error(`Incorrect chunk CRC ${chunkCrc} (expected ${record.uncompressedCrc})`));
+        return;
+      }
+    }
+
+    const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    const chunkReader = new Reader(view);
+
+    while (chunkReader.bytesRemaining() > 0) {
+      const chunkRecord = monoParseMessage(chunkReader) ?? parseRecord(chunkReader, this.#validateCrcs);
+      if (!chunkRecord) break;
+
+      if (chunkRecord.type === "Schema" || chunkRecord.type === "Channel" || chunkRecord.type === "Message") {
+        this.#handleRecord(chunkRecord);
+      } else if (chunkRecord.type !== "Unknown") {
+        this.#handleError(new Error(`${chunkRecord.type} record not allowed inside a chunk`));
+        return;
+      }
+    }
+
+    if (chunkReader.bytesRemaining() !== 0) {
+      this.#handleError(new Error(`${chunkReader.bytesRemaining()} bytes remaining in chunk`));
+    }
+  }
+
+  #isChannelEqual(a: Channel, b: Channel): boolean {
+    if (
+      !(
+        a.id === b.id &&
+        a.messageEncoding === b.messageEncoding &&
+        a.schemaId === b.schemaId &&
+        a.topic === b.topic &&
+        a.metadata.size === b.metadata.size
+      )
+    ) {
+      return false;
+    }
+    for (const [keyA, valueA] of a.metadata.entries()) {
+      const valueB = b.metadata.get(keyA);
+      if (valueA !== valueB) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  #handleError(error: Error): void {
+    this.#handlers.onError?.(error);
+  }
+}

--- a/typescript/core/src/McapStreamReader.test.ts
+++ b/typescript/core/src/McapStreamReader.test.ts
@@ -31,8 +31,8 @@ describe("McapStreamReader", () => {
       new Uint8Array([
         ...MCAP_MAGIC,
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0x0123456789abcdefn), // summary start
-          ...uint64LE(0x0123456789abcdefn), // summary offset start
+          ...uint64LE(0x0123456789abcdef), // summary start
+          ...uint64LE(0x0123456789abcdef), // summary offset start
           ...uint32LE(0x01234567), // summary crc
         ]),
         ...MCAP_MAGIC.slice(0, MCAP_MAGIC.length - 1),
@@ -49,8 +49,8 @@ describe("McapStreamReader", () => {
         ...MCAP_MAGIC,
         ...record(Opcode.HEADER, [...string("prof"), ...string("lib")]),
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0x0123456789abcdefn), // summary start
-          ...uint64LE(0x0123456789abcdefn), // summary offset start
+          ...uint64LE(0x0123456789abcdef), // summary start
+          ...uint64LE(0x0123456789abcdef), // summary offset start
           ...uint32LE(0x01234567), // summary crc
         ]),
         ...[0, 0, 0, 0, 0, 0, 0, 0],
@@ -66,8 +66,8 @@ describe("McapStreamReader", () => {
       new Uint8Array([
         ...MCAP_MAGIC,
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0x0123456789abcdefn), // summary start
-          ...uint64LE(0x0123456789abcdefn), // summary offset start
+          ...uint64LE(0x0123456789abcdef), // summary start
+          ...uint64LE(0x0123456789abcdef), // summary offset start
           ...uint32LE(0x01234567), // summary crc
         ]),
         ...[0, 0, 0, 0, 0, 0, 0, 0],
@@ -82,8 +82,8 @@ describe("McapStreamReader", () => {
       new Uint8Array([
         ...MCAP_MAGIC,
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0x0123456789abcdefn), // summary start
-          ...uint64LE(0x0123456789abcdefn), // summary offset start
+          ...uint64LE(0x0123456789abcdef), // summary start
+          ...uint64LE(0x0123456789abcdef), // summary offset start
           ...uint32LE(0x01234567), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -91,8 +91,8 @@ describe("McapStreamReader", () => {
     );
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0x0123456789abcdefn,
-      summaryOffsetStart: 0x0123456789abcdefn,
+      summaryStart: 0x0123456789abcdef,
+      summaryOffsetStart: 0x0123456789abcdef,
       summaryCrc: 0x01234567,
     });
     expect(reader.done()).toBe(true);
@@ -104,20 +104,20 @@ describe("McapStreamReader", () => {
       new Uint8Array([
         ...MCAP_MAGIC,
         ...record(Opcode.CHUNK, [
-          ...uint64LE(0n), // start_time
-          ...uint64LE(0n), // end_time
-          ...uint64LE(0n), // decompressed size
+          ...uint64LE(0), // start_time
+          ...uint64LE(0), // end_time
+          ...uint64LE(0), // decompressed size
           ...uint32LE(0), // decompressed crc32
           ...string("lz4"), // compression
-          ...uint64LE(BigInt(0n)),
+          ...uint64LE(0),
           // no chunk data
         ]),
         ...record(Opcode.DATA_END, [
           ...uint32LE(0), // data section crc
         ]),
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -129,8 +129,8 @@ describe("McapStreamReader", () => {
     });
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
     expect(reader.done()).toBe(true);
@@ -141,8 +141,8 @@ describe("McapStreamReader", () => {
     const data = new Uint8Array([
       ...MCAP_MAGIC,
       ...record(Opcode.FOOTER, [
-        ...uint64LE(0x0123456789abcdefn), // summary start
-        ...uint64LE(0x0123456789abcdefn), // summary offset start
+        ...uint64LE(0x0123456789abcdef), // summary start
+        ...uint64LE(0x0123456789abcdef), // summary offset start
         ...uint32LE(0x01234567), // summary crc
       ]),
       ...MCAP_MAGIC,
@@ -155,8 +155,8 @@ describe("McapStreamReader", () => {
     reader.append(new Uint8Array(data.buffer, data.length - 1, 1));
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0x0123456789abcdefn,
-      summaryOffsetStart: 0x0123456789abcdefn,
+      summaryStart: 0x0123456789abcdef,
+      summaryOffsetStart: 0x0123456789abcdef,
       summaryCrc: 0x01234567,
     });
     expect(reader.done()).toBe(true);
@@ -171,8 +171,8 @@ describe("McapStreamReader", () => {
       new Uint8Array([
         ...MCAP_MAGIC,
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0x0123456789abcdefn), // summary start
-          ...uint64LE(0x0123456789abcdefn), // summary offset start
+          ...uint64LE(0x0123456789abcdef), // summary start
+          ...uint64LE(0x0123456789abcdef), // summary offset start
           ...uint32LE(0x01234567), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -189,18 +189,18 @@ describe("McapStreamReader", () => {
         ...MCAP_MAGIC,
 
         ...record(Opcode.CHUNK, [
-          ...uint64LE(0n), // start_time
-          ...uint64LE(0n), // end_time
-          ...uint64LE(0n), // decompressed size
+          ...uint64LE(0), // start_time
+          ...uint64LE(0), // end_time
+          ...uint64LE(0), // decompressed size
           ...uint32LE(0), // decompressed crc32
           ...string(""), // compression
-          ...uint64LE(BigInt(0n)),
+          ...uint64LE(0),
           // (no chunk data)
         ]),
 
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -208,8 +208,8 @@ describe("McapStreamReader", () => {
     );
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
     expect(reader.done()).toBe(true);
@@ -222,18 +222,18 @@ describe("McapStreamReader", () => {
         ...MCAP_MAGIC,
 
         ...record(Opcode.CHUNK, [
-          ...uint64LE(0n), // start_time
-          ...uint64LE(0n), // end_time
-          ...uint64LE(1n), // decompressed size
+          ...uint64LE(0), // start_time
+          ...uint64LE(0), // end_time
+          ...uint64LE(1), // decompressed size
           ...uint32LE(crc32(new Uint8Array([Opcode.CHANNEL]))), // decompressed crc32
           ...string(""), // compression
-          ...uint64LE(BigInt(1n)),
+          ...uint64LE(1),
           Opcode.CHANNEL, // truncated record
         ]),
 
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -251,13 +251,13 @@ describe("McapStreamReader", () => {
         ...record(Opcode.MESSAGE, [
           ...uint16LE(42), // channel id
           ...uint32LE(0), // sequence
-          ...uint64LE(0n), // log time
-          ...uint64LE(0n), // publish time
+          ...uint64LE(0), // log time
+          ...uint64LE(0), // publish time
         ]),
 
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -272,8 +272,8 @@ describe("McapStreamReader", () => {
     const message = record(Opcode.MESSAGE, [
       ...uint16LE(42), // channel id
       ...uint32LE(0), // sequence
-      ...uint64LE(0n), // log time
-      ...uint64LE(0n), // publish time
+      ...uint64LE(0), // log time
+      ...uint64LE(0), // publish time
     ]);
     const reader = new McapStreamReader();
     reader.append(
@@ -281,18 +281,18 @@ describe("McapStreamReader", () => {
         ...MCAP_MAGIC,
 
         ...record(Opcode.CHUNK, [
-          ...uint64LE(0n), // start_time
-          ...uint64LE(0n), // end_time
-          ...uint64LE(0n), // decompressed size
+          ...uint64LE(0), // start_time
+          ...uint64LE(0), // end_time
+          ...uint64LE(0), // decompressed size
           ...uint32LE(crc32(message)), // decompressed crc32
           ...string(""), // compression
-          ...uint64LE(BigInt(message.byteLength)),
+          ...uint64LE(message.byteLength),
           ...message,
         ]),
 
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -317,8 +317,8 @@ describe("McapStreamReader", () => {
           11,
         ]),
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -335,18 +335,18 @@ describe("McapStreamReader", () => {
         ...record(
           Opcode.ATTACHMENT,
           crcSuffix([
-            ...uint64LE(2n), // log time
-            ...uint64LE(1n), // create time
+            ...uint64LE(2), // log time
+            ...uint64LE(1), // create time
             ...string("myFile"), // name
             ...string("text/plain"), // media type
-            ...uint64LE(3n), // data length
+            ...uint64LE(3), // data length
             10,
             11,
           ]),
         ),
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -370,8 +370,8 @@ describe("McapStreamReader", () => {
         ]),
 
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -387,8 +387,8 @@ describe("McapStreamReader", () => {
     } as TypedMcapRecords["Channel"]);
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
     expect(reader.done()).toBe(true);
@@ -411,18 +411,18 @@ describe("McapStreamReader", () => {
         ...MCAP_MAGIC,
 
         ...record(Opcode.CHUNK, [
-          ...uint64LE(0n), // start_time
-          ...uint64LE(0n), // end_time
-          ...uint64LE(0n), // decompressed size
+          ...uint64LE(0), // start_time
+          ...uint64LE(0), // end_time
+          ...uint64LE(0), // decompressed size
           ...uint32LE(crc32(channel)), // decompressed crc32
           ...string(compressed ? "xyz" : ""), // compression
-          ...uint64LE(BigInt(payload.byteLength)),
+          ...uint64LE(payload.byteLength),
           ...payload,
         ]),
 
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -438,8 +438,8 @@ describe("McapStreamReader", () => {
     } as TypedMcapRecords["Channel"]);
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
     expect(reader.done()).toBe(true);
@@ -496,39 +496,39 @@ describe("McapStreamReader", () => {
               ? [...channel, ...channel2]
               : testType === "same chunk"
                 ? record(Opcode.CHUNK, [
-                    ...uint64LE(0n), // start_time
-                    ...uint64LE(0n), // end_time
-                    ...uint64LE(0n), // decompressed size
+                    ...uint64LE(0), // start_time
+                    ...uint64LE(0), // end_time
+                    ...uint64LE(0), // decompressed size
                     ...uint32LE(crc32(new Uint8Array([...channel, ...channel2]))), // decompressed crc32
                     ...string(""), // compression
-                    ...uint64LE(BigInt(channel.byteLength + channel2.byteLength)),
+                    ...uint64LE(channel.byteLength + channel2.byteLength),
                     ...channel,
                     ...channel2,
                   ])
                 : [
                     ...record(Opcode.CHUNK, [
-                      ...uint64LE(0n), // start_time
-                      ...uint64LE(0n), // end_time
-                      ...uint64LE(0n), // decompressed size
+                      ...uint64LE(0), // start_time
+                      ...uint64LE(0), // end_time
+                      ...uint64LE(0), // decompressed size
                       ...uint32LE(crc32(new Uint8Array(channel))), // decompressed crc32
                       ...string(""), // compression
-                      ...uint64LE(BigInt(channel.byteLength)),
+                      ...uint64LE(channel.byteLength),
                       ...channel,
                     ]),
                     ...record(Opcode.CHUNK, [
-                      ...uint64LE(0n), // start_time
-                      ...uint64LE(0n), // end_time
-                      ...uint64LE(0n), // decompressed size
+                      ...uint64LE(0), // start_time
+                      ...uint64LE(0), // end_time
+                      ...uint64LE(0), // decompressed size
                       ...uint32LE(crc32(new Uint8Array(channel2))), // decompressed crc32
                       ...string(""), // compression
-                      ...uint64LE(BigInt(channel2.byteLength)),
+                      ...uint64LE(channel2.byteLength),
                       ...channel2,
                     ]),
                   ]),
 
             ...record(Opcode.FOOTER, [
-              ...uint64LE(0n), // summary start
-              ...uint64LE(0n), // summary offset start
+              ...uint64LE(0), // summary start
+              ...uint64LE(0), // summary offset start
               ...uint32LE(0), // summary crc
             ]),
             ...MCAP_MAGIC,
@@ -557,16 +557,16 @@ describe("McapStreamReader", () => {
         ...record(
           Opcode.ATTACHMENT,
           crcSuffix([
-            ...uint64LE(2n), // log time
-            ...uint64LE(1n), // create time
+            ...uint64LE(2), // log time
+            ...uint64LE(1), // create time
             ...string("myFile"), // name
             ...string("text/plain"), // media type
             ...uint64PrefixedBytes(new TextEncoder().encode("hello")), // data
           ]),
         ),
         ...record(Opcode.FOOTER, [
-          ...uint64LE(0n), // summary start
-          ...uint64LE(0n), // summary offset start
+          ...uint64LE(0), // summary start
+          ...uint64LE(0), // summary offset start
           ...uint32LE(0), // summary crc
         ]),
         ...MCAP_MAGIC,
@@ -575,15 +575,15 @@ describe("McapStreamReader", () => {
     expect(reader.nextRecord()).toEqual({
       type: "Attachment",
       name: "myFile",
-      logTime: 2n,
-      createTime: 1n,
+      logTime: 2,
+      createTime: 1,
       mediaType: "text/plain",
       data: new TextEncoder().encode("hello"),
     } as TypedMcapRecords["Attachment"]);
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
     expect(reader.done()).toBe(true);
@@ -600,20 +600,20 @@ describe("McapStreamReader", () => {
     const fullMcap = new Uint8Array([
       ...MCAP_MAGIC,
       ...record(Opcode.CHUNK, [
-        ...uint64LE(0n), // start_time
-        ...uint64LE(0n), // end_time
-        ...uint64LE(BigInt(channel.byteLength)), // decompressed size
+        ...uint64LE(0), // start_time
+        ...uint64LE(0), // end_time
+        ...uint64LE(channel.byteLength), // decompressed size
         ...uint32LE(0), // decompressed crc32
         ...string(""), // compression
-        ...uint64LE(BigInt(channel.byteLength)),
+        ...uint64LE(channel.byteLength),
         ...channel,
       ]),
       ...record(Opcode.DATA_END, [
         ...uint32LE(0), // data section crc
       ]),
       ...record(Opcode.FOOTER, [
-        ...uint64LE(0n), // summary start
-        ...uint64LE(0n), // summary offset start
+        ...uint64LE(0), // summary start
+        ...uint64LE(0), // summary offset start
         ...uint32LE(0), // summary crc
       ]),
       ...MCAP_MAGIC,
@@ -627,9 +627,9 @@ describe("McapStreamReader", () => {
     reader.append(fullMcap.slice(MCAP_MAGIC.length));
     expect(reader.nextRecord()).toEqual({
       type: "Chunk",
-      messageStartTime: 0n,
-      messageEndTime: 0n,
-      uncompressedSize: BigInt(channel.byteLength),
+      messageStartTime: 0,
+      messageEndTime: 0,
+      uncompressedSize: channel.byteLength,
       uncompressedCrc: 0,
       compression: "",
       records: channel,
@@ -648,8 +648,8 @@ describe("McapStreamReader", () => {
     });
     expect(reader.nextRecord()).toEqual({
       type: "Footer",
-      summaryStart: 0n,
-      summaryOffsetStart: 0n,
+      summaryStart: 0,
+      summaryOffsetStart: 0,
       summaryCrc: 0,
     });
     expect(reader.done()).toBe(true);

--- a/typescript/core/src/McapWriter.test.ts
+++ b/typescript/core/src/McapWriter.test.ts
@@ -37,21 +37,21 @@ describe("McapWriter", () => {
       channelId,
       data: new Uint8Array(),
       sequence: 0,
-      logTime: 0n,
-      publishTime: 0n,
+      logTime: 0,
+      publishTime: 0,
     });
     await writer.addMessage({
       channelId,
       data: new Uint8Array(),
       sequence: 1,
-      logTime: 1n,
-      publishTime: 1n,
+      logTime: 1,
+      publishTime: 1,
     });
     await writer.end();
 
     const reader = await McapIndexedReader.Initialize({ readable: tempBuffer });
 
-    expect(reader.chunkIndexes).toMatchObject([{ messageStartTime: 0n, messageEndTime: 1n }]);
+    expect(reader.chunkIndexes).toMatchObject([{ messageStartTime: 0, messageEndTime: 1 }]);
 
     await expect(collect(reader.readMessages())).resolves.toEqual([
       {
@@ -59,36 +59,36 @@ describe("McapWriter", () => {
         channelId,
         data: new Uint8Array(),
         sequence: 0,
-        logTime: 0n,
-        publishTime: 0n,
+        logTime: 0,
+        publishTime: 0,
       },
       {
         type: "Message",
         channelId,
         data: new Uint8Array(),
         sequence: 1,
-        logTime: 1n,
-        publishTime: 1n,
+        logTime: 1,
+        publishTime: 1,
       },
     ]);
-    await expect(collect(reader.readMessages({ endTime: 0n }))).resolves.toEqual([
+    await expect(collect(reader.readMessages({ endTime: 0 }))).resolves.toEqual([
       {
         type: "Message",
         channelId,
         data: new Uint8Array(),
         sequence: 0,
-        logTime: 0n,
-        publishTime: 0n,
+        logTime: 0,
+        publishTime: 0,
       },
     ]);
-    await expect(collect(reader.readMessages({ startTime: 1n }))).resolves.toEqual([
+    await expect(collect(reader.readMessages({ startTime: 1 }))).resolves.toEqual([
       {
         type: "Message",
         channelId,
         data: new Uint8Array(),
         sequence: 1,
-        logTime: 1n,
-        publishTime: 1n,
+        logTime: 1,
+        publishTime: 1,
       },
     ]);
   });
@@ -108,15 +108,15 @@ describe("McapWriter", () => {
       channelId,
       data: new Uint8Array(),
       sequence: 0,
-      logTime: 0n,
-      publishTime: 0n,
+      logTime: 0,
+      publishTime: 0,
     });
     await writer.addMessage({
       channelId,
       data: new Uint8Array(),
       sequence: 1,
-      logTime: 1n,
-      publishTime: 1n,
+      logTime: 1,
+      publishTime: 1,
     });
     await writer.end();
 
@@ -145,27 +145,27 @@ describe("McapWriter", () => {
         type: "Message",
         channelId: 0,
         data: new Uint8Array(),
-        logTime: 0n,
-        publishTime: 0n,
+        logTime: 0,
+        publishTime: 0,
         sequence: 0,
       },
       {
         type: "MessageIndex",
         channelId: 0,
-        records: [[0n, 33n]],
+        records: [[0, 33]],
       },
       {
         type: "Message",
         channelId: 0,
         data: new Uint8Array(),
-        logTime: 1n,
-        publishTime: 1n,
+        logTime: 1,
+        publishTime: 1,
         sequence: 1,
       },
       {
         type: "MessageIndex",
         channelId: 0,
-        records: [[1n, 0n]],
+        records: [[1, 0]],
       },
       {
         type: "DataEnd",
@@ -183,61 +183,61 @@ describe("McapWriter", () => {
         type: "Statistics",
         attachmentCount: 0,
         channelCount: 1,
-        channelMessageCounts: new Map([[0, 2n]]),
+        channelMessageCounts: new Map([[0, 2]]),
         chunkCount: 2,
-        messageCount: 2n,
-        messageEndTime: 1n,
-        messageStartTime: 0n,
+        messageCount: 2,
+        messageEndTime: 1,
+        messageStartTime: 0,
         metadataCount: 0,
         schemaCount: 0,
       },
       {
         type: "ChunkIndex",
-        chunkLength: 113n,
-        chunkStartOffset: 25n,
-        compressedSize: 64n,
+        chunkLength: 113,
+        chunkStartOffset: 25,
+        compressedSize: 64,
         compression: "",
-        messageEndTime: 0n,
-        messageIndexLength: 31n,
-        messageIndexOffsets: new Map([[0, 138n]]),
-        messageStartTime: 0n,
-        uncompressedSize: 64n,
+        messageEndTime: 0,
+        messageIndexLength: 31,
+        messageIndexOffsets: new Map([[0, 138]]),
+        messageStartTime: 0,
+        uncompressedSize: 64,
       },
       {
         type: "ChunkIndex",
-        chunkLength: 80n,
-        chunkStartOffset: 169n,
-        compressedSize: 31n,
+        chunkLength: 80,
+        chunkStartOffset: 169,
+        compressedSize: 31,
         compression: "",
-        messageEndTime: 1n,
-        messageIndexLength: 31n,
-        messageIndexOffsets: new Map([[0, 249n]]),
-        messageStartTime: 1n,
-        uncompressedSize: 31n,
+        messageEndTime: 1,
+        messageIndexLength: 31,
+        messageIndexOffsets: new Map([[0, 249]]),
+        messageStartTime: 1,
+        uncompressedSize: 31,
       },
       {
         type: "SummaryOffset",
-        groupLength: 33n,
+        groupLength: 33,
         groupOpcode: Opcode.CHANNEL,
-        groupStart: 293n,
+        groupStart: 293,
       },
       {
         type: "SummaryOffset",
-        groupLength: 65n,
+        groupLength: 65,
         groupOpcode: Opcode.STATISTICS,
-        groupStart: 326n,
+        groupStart: 326,
       },
       {
         type: "SummaryOffset",
-        groupLength: 166n,
+        groupLength: 166,
         groupOpcode: Opcode.CHUNK_INDEX,
-        groupStart: 391n,
+        groupStart: 391,
       },
       {
         type: "Footer",
         summaryCrc: 3779440972,
-        summaryOffsetStart: 557n,
-        summaryStart: 293n,
+        summaryOffsetStart: 557,
+        summaryStart: 293,
       },
     ]);
   });
@@ -272,8 +272,8 @@ describe("McapWriter", () => {
       channelId,
       data: new Uint8Array(),
       sequence: 0,
-      logTime: 0n,
-      publishTime: 0n,
+      logTime: 0,
+      publishTime: 0,
     });
     await writer.end();
 
@@ -298,8 +298,8 @@ describe("McapWriter", () => {
       ...record(Opcode.MESSAGE, [
         ...uint16LE(channelId), // channel id
         ...uint32LE(0), // sequence
-        ...uint64LE(0n), // log time
-        ...uint64LE(0n), // publish time
+        ...uint64LE(0), // log time
+        ...uint64LE(0), // publish time
       ]),
     ]);
 
@@ -312,16 +312,16 @@ describe("McapWriter", () => {
       {
         type: "Chunk",
         compression: "reverse double",
-        messageStartTime: 0n,
-        messageEndTime: 0n,
+        messageStartTime: 0,
+        messageEndTime: 0,
         uncompressedCrc: crc32(expectedChunkData),
-        uncompressedSize: BigInt(expectedChunkData.byteLength),
+        uncompressedSize: expectedChunkData.byteLength,
         records: reverseDouble(expectedChunkData),
       },
       {
         type: "MessageIndex",
         channelId: 0,
-        records: [[0n, 33n]],
+        records: [[0, 33]],
       },
       {
         type: "DataEnd",
@@ -337,21 +337,21 @@ describe("McapWriter", () => {
       },
       {
         type: "ChunkIndex",
-        chunkLength: expect.any(BigInt) as bigint,
-        chunkStartOffset: 25n,
-        compressedSize: BigInt(2 * expectedChunkData.byteLength),
+        chunkLength: expect.any(Number) as number,
+        chunkStartOffset: 25,
+        compressedSize: 2 * expectedChunkData.byteLength,
         compression: "reverse double",
-        messageEndTime: 0n,
-        messageIndexLength: 31n,
-        messageIndexOffsets: new Map([[0, expect.any(BigInt) as bigint]]),
-        messageStartTime: 0n,
-        uncompressedSize: BigInt(expectedChunkData.byteLength),
+        messageEndTime: 0,
+        messageIndexLength: 31,
+        messageIndexOffsets: new Map([[0, expect.any(Number) as number]]),
+        messageStartTime: 0,
+        uncompressedSize: expectedChunkData.byteLength,
       },
       {
         type: "Footer",
         summaryCrc: expect.any(Number) as number,
-        summaryOffsetStart: expect.any(BigInt) as bigint,
-        summaryStart: expect.any(BigInt) as bigint,
+        summaryOffsetStart: expect.any(Number) as number,
+        summaryStart: expect.any(Number) as number,
       },
     ]);
   });
@@ -377,8 +377,8 @@ describe("McapWriter", () => {
       channelId: channelId1,
       data: new Uint8Array(),
       sequence: 0,
-      logTime: 0n,
-      publishTime: 0n,
+      logTime: 0,
+      publishTime: 0,
     });
     await writer.end();
 
@@ -408,14 +408,14 @@ describe("McapWriter", () => {
         type: "Message",
         channelId: 0,
         data: new Uint8Array(),
-        logTime: 0n,
-        publishTime: 0n,
+        logTime: 0,
+        publishTime: 0,
         sequence: 0,
       },
       {
         type: "MessageIndex",
         channelId: 0,
-        records: [[0n, 71n]],
+        records: [[0, 71]],
       },
     ];
 
@@ -445,55 +445,55 @@ describe("McapWriter", () => {
         type: "Statistics",
         attachmentCount: 0,
         channelCount: 1,
-        channelMessageCounts: new Map([[0, 1n]]),
+        channelMessageCounts: new Map([[0, 1]]),
         chunkCount: 1,
-        messageCount: 1n,
-        messageEndTime: 0n,
-        messageStartTime: 0n,
+        messageCount: 1,
+        messageEndTime: 0,
+        messageStartTime: 0,
         metadataCount: 0,
         schemaCount: 1,
       },
       {
         type: "ChunkIndex",
-        chunkLength: 151n,
-        chunkStartOffset: 25n,
-        compressedSize: 102n,
+        chunkLength: 151,
+        chunkStartOffset: 25,
+        compressedSize: 102,
         compression: "",
-        messageEndTime: 0n,
-        messageIndexLength: 31n,
-        messageIndexOffsets: new Map([[0, 176n]]),
-        messageStartTime: 0n,
-        uncompressedSize: 102n,
+        messageEndTime: 0,
+        messageIndexLength: 31,
+        messageIndexOffsets: new Map([[0, 176]]),
+        messageStartTime: 0,
+        uncompressedSize: 102,
       },
       {
         type: "SummaryOffset",
-        groupLength: 34n,
+        groupLength: 34,
         groupOpcode: Opcode.SCHEMA,
-        groupStart: 220n,
+        groupStart: 220,
       },
       {
         type: "SummaryOffset",
-        groupLength: 37n,
+        groupLength: 37,
         groupOpcode: Opcode.CHANNEL,
-        groupStart: 254n,
+        groupStart: 254,
       },
       {
         type: "SummaryOffset",
-        groupLength: 65n,
+        groupLength: 65,
         groupOpcode: Opcode.STATISTICS,
-        groupStart: 291n,
+        groupStart: 291,
       },
       {
         type: "SummaryOffset",
-        groupLength: 83n,
+        groupLength: 83,
         groupOpcode: Opcode.CHUNK_INDEX,
-        groupStart: 356n,
+        groupStart: 356,
       },
       {
         type: "Footer",
         summaryCrc: 2739614603,
-        summaryOffsetStart: 439n,
-        summaryStart: 220n,
+        summaryOffsetStart: 439,
+        summaryStart: 220,
       },
     ]);
 
@@ -501,8 +501,8 @@ describe("McapWriter", () => {
 
     await appendWriter.addAttachment({
       name: "attachment1",
-      logTime: 0n,
-      createTime: 0n,
+      logTime: 0,
+      createTime: 0,
       mediaType: "text/plain",
       data: new TextEncoder().encode("foo"),
     });
@@ -514,8 +514,8 @@ describe("McapWriter", () => {
       channelId: channelId1,
       data: new Uint8Array(),
       sequence: 1,
-      logTime: 1n,
-      publishTime: 1n,
+      logTime: 1,
+      publishTime: 1,
     });
     const channelId2 = await appendWriter.registerChannel({
       topic: "channel2",
@@ -527,15 +527,15 @@ describe("McapWriter", () => {
       channelId: channelId2,
       data: new Uint8Array(),
       sequence: 2,
-      logTime: 2n,
-      publishTime: 2n,
+      logTime: 2,
+      publishTime: 2,
     });
     await appendWriter.end();
 
     const appendedRecords = readAsMcapStream(tempBuffer.get());
 
-    const newSummaryStart = 546n;
-    const dataEndLength = 1n + 8n + 4n;
+    const newSummaryStart = 546;
+    const dataEndLength = 1 + 8 + 4;
     const expectedDataCrc = crc32(
       tempBuffer.get().slice(0, Number(newSummaryStart - dataEndLength)),
     );
@@ -545,8 +545,8 @@ describe("McapWriter", () => {
       {
         type: "Attachment",
         name: "attachment1",
-        logTime: 0n,
-        createTime: 0n,
+        logTime: 0,
+        createTime: 0,
         mediaType: "text/plain",
         data: new TextEncoder().encode("foo"),
       },
@@ -559,8 +559,8 @@ describe("McapWriter", () => {
         type: "Message",
         channelId: 0,
         data: new Uint8Array(),
-        logTime: 1n,
-        publishTime: 1n,
+        logTime: 1,
+        publishTime: 1,
         sequence: 1,
       },
       {
@@ -575,19 +575,19 @@ describe("McapWriter", () => {
         type: "Message",
         channelId: 1,
         data: new Uint8Array(),
-        logTime: 2n,
-        publishTime: 2n,
+        logTime: 2,
+        publishTime: 2,
         sequence: 2,
       },
       {
         type: "MessageIndex",
         channelId: 0,
-        records: [[1n, 0n]],
+        records: [[1, 0]],
       },
       {
         type: "MessageIndex",
         channelId: 1,
-        records: [[2n, 68n]],
+        records: [[2, 68]],
       },
       {
         type: "DataEnd",
@@ -621,99 +621,99 @@ describe("McapWriter", () => {
         attachmentCount: 1,
         channelCount: 2,
         channelMessageCounts: new Map([
-          [0, 2n],
-          [1, 1n],
+          [0, 2],
+          [1, 1],
         ]),
         chunkCount: 2,
-        messageCount: 3n,
-        messageEndTime: 2n,
-        messageStartTime: 0n,
+        messageCount: 3,
+        messageEndTime: 2,
+        messageStartTime: 0,
         metadataCount: 1,
         schemaCount: 1,
       },
       {
         type: "MetadataIndex",
-        offset: 276n,
-        length: 47n,
+        offset: 276,
+        length: 47,
         name: "metadata1",
       },
       {
         type: "AttachmentIndex",
-        offset: 207n,
-        length: 69n,
-        logTime: 0n,
-        createTime: 0n,
-        dataSize: 3n,
+        offset: 207,
+        length: 69,
+        logTime: 0,
+        createTime: 0,
+        dataSize: 3,
         name: "attachment1",
         mediaType: "text/plain",
       },
       {
         type: "ChunkIndex",
-        chunkLength: 151n,
-        chunkStartOffset: 25n,
-        compressedSize: 102n,
+        chunkLength: 151,
+        chunkStartOffset: 25,
+        compressedSize: 102,
         compression: "",
-        messageEndTime: 0n,
-        messageIndexLength: 31n,
-        messageIndexOffsets: new Map([[0, 176n]]),
-        messageStartTime: 0n,
-        uncompressedSize: 102n,
+        messageEndTime: 0,
+        messageIndexLength: 31,
+        messageIndexOffsets: new Map([[0, 176]]),
+        messageStartTime: 0,
+        uncompressedSize: 102,
       },
       {
         type: "ChunkIndex",
-        chunkLength: 148n,
-        chunkStartOffset: 323n,
-        compressedSize: 99n,
+        chunkLength: 148,
+        chunkStartOffset: 323,
+        compressedSize: 99,
         compression: "",
-        messageEndTime: 2n,
-        messageIndexLength: 62n,
+        messageEndTime: 2,
+        messageIndexLength: 62,
         messageIndexOffsets: new Map([
-          [0, 471n],
-          [1, 502n],
+          [0, 471],
+          [1, 502],
         ]),
-        messageStartTime: 1n,
-        uncompressedSize: 99n,
+        messageStartTime: 1,
+        uncompressedSize: 99,
       },
       {
         type: "SummaryOffset",
-        groupLength: 34n,
+        groupLength: 34,
         groupOpcode: Opcode.SCHEMA,
-        groupStart: 546n,
+        groupStart: 546,
       },
       {
         type: "SummaryOffset",
-        groupLength: 74n,
+        groupLength: 74,
         groupOpcode: Opcode.CHANNEL,
-        groupStart: 580n,
+        groupStart: 580,
       },
       {
         type: "SummaryOffset",
-        groupLength: 75n,
+        groupLength: 75,
         groupOpcode: Opcode.STATISTICS,
-        groupStart: 654n,
+        groupStart: 654,
       },
       {
         type: "SummaryOffset",
-        groupLength: 38n,
+        groupLength: 38,
         groupOpcode: Opcode.METADATA_INDEX,
-        groupStart: 729n,
+        groupStart: 729,
       },
       {
         type: "SummaryOffset",
-        groupLength: 78n,
+        groupLength: 78,
         groupOpcode: Opcode.ATTACHMENT_INDEX,
-        groupStart: 767n,
+        groupStart: 767,
       },
       {
         type: "SummaryOffset",
-        groupLength: 176n,
+        groupLength: 176,
         groupOpcode: Opcode.CHUNK_INDEX,
-        groupStart: 845n,
+        groupStart: 845,
       },
       {
         type: "Footer",
         summaryCrc: 758669511,
-        summaryOffsetStart: 1021n,
+        summaryOffsetStart: 1021,
         summaryStart: newSummaryStart,
       },
     ]);
@@ -737,19 +737,19 @@ describe("McapWriter", () => {
             ...uint32LE(useDataSectionCrc ? crc32(originalDataSection) : 0), // data crc
           ]),
           ...record(Opcode.STATISTICS, [
-            ...uint64LE(0n), // message count
+            ...uint64LE(0), // message count
             ...uint16LE(0), // schema count
             ...uint32LE(0), // channel count
             ...uint32LE(0), // attachment count
             ...uint32LE(0), // metadata count
             ...uint32LE(0), // chunk count
-            ...uint64LE(0n), // message start time
-            ...uint64LE(0n), // message end time
+            ...uint64LE(0), // message start time
+            ...uint64LE(0), // message end time
             ...uint32LE(0), // channel message counts length
           ]),
           ...record(Opcode.FOOTER, [
-            ...uint64LE(BigInt(originalDataSection.length + dataEndLength)), // summary start
-            ...uint64LE(0n), // summary offset start
+            ...uint64LE(originalDataSection.length + dataEndLength), // summary start
+            ...uint64LE(0), // summary offset start
             ...uint32LE(0), // summary crc
           ]),
           ...MCAP_MAGIC,
@@ -768,8 +768,8 @@ describe("McapWriter", () => {
       });
       await appendWriter.addMessage({
         channelId: chanId,
-        logTime: 0n,
-        publishTime: 0n,
+        logTime: 0,
+        publishTime: 0,
         sequence: 0,
         data: new Uint8Array([]),
       });
@@ -777,15 +777,15 @@ describe("McapWriter", () => {
 
       const summarySection = new Uint8Array([
         ...record(Opcode.STATISTICS, [
-          ...uint64LE(1n), // message count
+          ...uint64LE(1), // message count
           ...uint16LE(0), // schema count
           ...uint32LE(1), // channel count
           ...uint32LE(0), // attachment count
           ...uint32LE(0), // metadata count
           ...uint32LE(0), // chunk count
-          ...uint64LE(0n), // message start time
-          ...uint64LE(0n), // message end time
-          ...keyValues(uint16LE, uint64LE, [[0, 1n]]), // channel message counts length
+          ...uint64LE(0), // message start time
+          ...uint64LE(0), // message end time
+          ...keyValues(uint16LE, uint64LE, [[0, 1]]), // channel message counts length
         ]),
       ]);
 
@@ -801,8 +801,8 @@ describe("McapWriter", () => {
         ...record(Opcode.MESSAGE, [
           ...uint16LE(chanId),
           ...uint32LE(0), // sequence
-          ...uint64LE(0n), // log time
-          ...uint64LE(0n), // publish time
+          ...uint64LE(0), // log time
+          ...uint64LE(0), // publish time
         ]),
       ]);
 
@@ -814,17 +814,17 @@ describe("McapWriter", () => {
           ]),
           ...summarySection,
           ...record(Opcode.FOOTER, [
-            ...uint64LE(BigInt(newDataSection.length + dataEndLength)), // summary start
-            ...uint64LE(0n), // summary offset start
+            ...uint64LE(newDataSection.length + dataEndLength), // summary start
+            ...uint64LE(0), // summary offset start
             ...uint32LE(
               // summary crc
               crc32(
                 new Uint8Array([
                   ...summarySection,
                   Opcode.FOOTER,
-                  ...uint64LE(8n + 8n + 4n), // footer record length
-                  ...uint64LE(BigInt(newDataSection.length + dataEndLength)), // summary start
-                  ...uint64LE(0n), // summary offset start
+                  ...uint64LE(8 + 8 + 4), // footer record length
+                  ...uint64LE(newDataSection.length + dataEndLength), // summary start
+                  ...uint64LE(0), // summary offset start
                 ]),
               ),
             ),

--- a/typescript/core/src/McapWriter.ts
+++ b/typescript/core/src/McapWriter.ts
@@ -99,14 +99,14 @@ export class McapWriter {
     this.#useSummaryOffsets = useSummaryOffsets;
     if (useStatistics) {
       this.statistics = {
-        messageCount: 0n,
+        messageCount: 0,
         schemaCount: 0,
         channelCount: 0,
         attachmentCount: 0,
         metadataCount: 0,
         chunkCount: 0,
-        messageStartTime: 0n,
-        messageEndTime: 0n,
+        messageStartTime: 0,
+        messageEndTime: 0,
         channelMessageCounts: new Map(),
       };
     }
@@ -217,7 +217,7 @@ export class McapWriter {
 
     if (this.#repeatSchemas) {
       const schemaStart = this.#writable.position();
-      let schemaLength = 0n;
+      let schemaLength = 0;
       for (const schema of this.#schemas.values()) {
         schemaLength += this.#recordWriter.writeSchema(schema);
       }
@@ -233,7 +233,7 @@ export class McapWriter {
       await this.#writable.write(this.#recordWriter.buffer);
       this.#recordWriter.reset();
       const channelStart = this.#writable.position();
-      let channelLength = 0n;
+      let channelLength = 0;
       for (const channel of this.#channels.values()) {
         channelLength += this.#recordWriter.writeChannel(channel);
       }
@@ -266,7 +266,7 @@ export class McapWriter {
       await this.#writable.write(this.#recordWriter.buffer);
       this.#recordWriter.reset();
       const metadataIndexStart = this.#writable.position();
-      let metadataIndexLength = 0n;
+      let metadataIndexLength = 0;
       for (const metadataIndex of this.#metadataIndices) {
         metadataIndexLength += this.#recordWriter.writeMetadataIndex(metadataIndex);
       }
@@ -282,7 +282,7 @@ export class McapWriter {
       await this.#writable.write(this.#recordWriter.buffer);
       this.#recordWriter.reset();
       const attachmentIndexStart = this.#writable.position();
-      let attachmentIndexLength = 0n;
+      let attachmentIndexLength = 0;
       for (const attachmentIndex of this.#attachmentIndices) {
         attachmentIndexLength += this.#recordWriter.writeAttachmentIndex(attachmentIndex);
       }
@@ -298,7 +298,7 @@ export class McapWriter {
       await this.#writable.write(this.#recordWriter.buffer);
       this.#recordWriter.reset();
       const chunkIndexStart = this.#writable.position();
-      let chunkIndexLength = 0n;
+      let chunkIndexLength = 0;
       for (const chunkIndex of this.#chunkIndices) {
         chunkIndexLength += this.#recordWriter.writeChunkIndex(chunkIndex);
       }
@@ -318,7 +318,7 @@ export class McapWriter {
 
     if (this.#useSummaryOffsets) {
       for (const summaryOffset of summaryOffsets) {
-        if (summaryOffset.groupLength !== 0n) {
+        if (summaryOffset.groupLength !== 0) {
           this.#recordWriter.writeSummaryOffset(summaryOffset);
         }
       }
@@ -327,15 +327,15 @@ export class McapWriter {
     summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
 
     const footer: Footer = {
-      summaryStart: summaryLength === 0n ? 0n : summaryStart,
-      summaryOffsetStart: this.#useSummaryOffsets ? summaryOffsetStart : 0n,
+      summaryStart: summaryLength === 0 ? 0 : summaryStart,
+      summaryOffsetStart: this.#useSummaryOffsets ? summaryOffsetStart : 0,
       summaryCrc: 0,
     };
     const tempBuffer = new DataView(new ArrayBuffer(1 + 8 + 8 + 8));
     tempBuffer.setUint8(0, Opcode.FOOTER);
-    tempBuffer.setBigUint64(1, 8n + 8n + 4n, true);
-    tempBuffer.setBigUint64(1 + 8, footer.summaryStart, true);
-    tempBuffer.setBigUint64(1 + 8 + 8, footer.summaryOffsetStart, true);
+    tempBuffer.setBigUint64(1, BigInt(8 + 8 + 4), true);
+    tempBuffer.setBigUint64(1 + 8, BigInt(footer.summaryStart), true);
+    tempBuffer.setBigUint64(1 + 8 + 8, BigInt(footer.summaryOffsetStart), true);
     summaryCrc = crc32Update(summaryCrc, tempBuffer);
     footer.summaryCrc = crc32Final(summaryCrc);
 
@@ -373,7 +373,7 @@ export class McapWriter {
 
   async addMessage(message: Message): Promise<void> {
     if (this.statistics) {
-      if (this.statistics.messageCount === 0n) {
+      if (this.statistics.messageCount === 0) {
         this.statistics.messageStartTime = message.logTime;
         this.statistics.messageEndTime = message.logTime;
       } else {
@@ -386,7 +386,7 @@ export class McapWriter {
       }
       this.statistics.channelMessageCounts.set(
         message.channelId,
-        (this.statistics.channelMessageCounts.get(message.channelId) ?? 0n) + 1n,
+        (this.statistics.channelMessageCounts.get(message.channelId) ?? 0) + 1,
       );
       ++this.statistics.messageCount;
     }
@@ -448,7 +448,7 @@ export class McapWriter {
         name: attachment.name,
         mediaType: attachment.mediaType,
         offset,
-        dataSize: BigInt(attachment.data.byteLength),
+        dataSize: attachment.data.byteLength,
         length,
       });
     }
@@ -491,7 +491,7 @@ export class McapWriter {
     }
 
     const chunkData = this.#chunkBuilder.buffer;
-    const uncompressedSize = BigInt(chunkData.length);
+    const uncompressedSize = chunkData.length;
     const uncompressedCrc = crc32(chunkData);
     let compression = "";
     let compressedData = chunkData;
@@ -512,7 +512,7 @@ export class McapWriter {
 
     const chunkLength = this.#recordWriter.writeChunk(chunkRecord);
 
-    const messageIndexOffsets = this.#chunkIndices ? new Map<number, bigint>() : undefined;
+    const messageIndexOffsets = this.#chunkIndices ? new Map<number, number>() : undefined;
 
     if (this.#dataSectionCrc != undefined) {
       this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
@@ -521,7 +521,7 @@ export class McapWriter {
     this.#recordWriter.reset();
 
     const messageIndexStart = this.#writable.position();
-    let messageIndexLength = 0n;
+    let messageIndexLength = 0;
     for (const messageIndex of this.#chunkBuilder.indices) {
       messageIndexOffsets?.set(messageIndex.channelId, messageIndexStart + messageIndexLength);
       messageIndexLength += this.#recordWriter.writeMessageIndex(messageIndex);
@@ -536,7 +536,7 @@ export class McapWriter {
         messageIndexOffsets: messageIndexOffsets!,
         messageIndexLength,
         compression: chunkRecord.compression,
-        compressedSize: BigInt(chunkRecord.records.byteLength),
+        compressedSize: chunkRecord.records.byteLength,
         uncompressedSize: chunkRecord.uncompressedSize,
       });
     }

--- a/typescript/core/src/Reader.ts
+++ b/typescript/core/src/Reader.ts
@@ -46,8 +46,8 @@ export default class Reader {
     return value;
   }
 
-  uint64(): bigint {
-    const value = getBigUint64.call(this.#view, this.offset, true);
+  uint64(): number {
+    const value = getBigUint64(this.#view, this.offset, true);
     this.offset += 8;
     return value;
   }

--- a/typescript/core/src/Reader.ts
+++ b/typescript/core/src/Reader.ts
@@ -125,8 +125,11 @@ export default class Reader {
 
   // Read a borrowed Uint8Array, useful temp references or borrow semantics
   u8ArrayBorrow(length: number): Uint8Array {
-    const result = this.#viewU8.subarray(this.offset, this.offset + length);
-    this.offset += length;
+    const begin = this.offset;
+    const end = begin + length;
+    // const result = this.#viewU8.subarray(begin, end);
+    const result = new Uint8Array(this.#view.buffer, this.#view.byteOffset + begin, length);
+    this.offset = end;
     return result;
   }
 

--- a/typescript/core/src/TempBuffer.ts
+++ b/typescript/core/src/TempBuffer.ts
@@ -27,12 +27,12 @@ export class TempBuffer implements IReadable, IWritable, ISeekableWriter {
     }
   }
 
-  position(): bigint {
-    return BigInt(this.#position);
+  position(): number {
+    return this.#position;
   }
 
-  async seek(position: bigint): Promise<void> {
-    if (position < 0n) {
+  async seek(position: number): Promise<void> {
+    if (position < 0) {
       throw new Error(`Attempted to seek to negative position ${position}`);
     } else if (position > this.#buffer.byteLength) {
       this.#setCapacity(Number(position));
@@ -54,12 +54,12 @@ export class TempBuffer implements IReadable, IWritable, ISeekableWriter {
     this.#position += data.byteLength;
   }
 
-  async size(): Promise<bigint> {
-    return BigInt(this.#buffer.byteLength);
+  async size(): Promise<number> {
+    return this.#buffer.byteLength;
   }
 
-  async read(offset: bigint, size: bigint): Promise<Uint8Array> {
-    if (offset < 0n || offset + size > BigInt(this.#buffer.byteLength)) {
+  async read(offset: number, size: number): Promise<Uint8Array> {
+    if (offset < 0 || offset + size > this.#buffer.byteLength) {
       throw new Error("read out of range");
     }
     return new Uint8Array(this.#buffer, Number(offset), Number(size));

--- a/typescript/core/src/crc32.ts
+++ b/typescript/core/src/crc32.ts
@@ -1,0 +1,99 @@
+/**
+ * Compute CRC32 lookup tables as described at:
+ * https://github.com/komrad36/CRC#option-6-1-byte-tabular
+ *
+ * An iteration of CRC computation can be performed on 8 bits of input at once. By pre-computing a
+ * table of the values of CRC(?) for all 2^8 = 256 possible byte values, during the final
+ * computation we can replace a loop over 8 bits with a single lookup in the table.
+ *
+ * For further speedup, we can also pre-compute the values of CRC(?0) for all possible bytes when a
+ * zero byte is appended. Then we can process two bytes of input at once by computing CRC(AB) =
+ * CRC(A0) ^ CRC(B), using one lookup in the CRC(?0) table and one lookup in the CRC(?) table.
+ *
+ * The same technique applies for any number of bytes to be processed at once, although the speed
+ * improvements diminish.
+ *
+ * @param polynomial The binary representation of the polynomial to use (reversed, i.e. most
+ * significant bit represents x^0).
+ * @param numTables The number of bytes of input that will be processed at once.
+ */
+export function crc32GenerateTables({ polynomial, numTables }: { polynomial: number; numTables: number }): Uint32Array {
+    const table = new Uint32Array(256 * numTables);
+    for (let i = 0; i < 256; i++) {
+        let r = i;
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        r = ((r & 1) * polynomial) ^ (r >>> 1);
+        table[i] = r;
+    }
+    for (let i = 256; i < table.length; i++) {
+        const value = table[i - 256]!;
+        table[i] = table[value & 0xff]! ^ (value >>> 8);
+    }
+    return table;
+}
+
+const CRC32_TABLE = crc32GenerateTables({ polynomial: 0xedb88320, numTables: 8 });
+
+/**
+ * Initialize a CRC32 to all 1 bits.
+ */
+export function crc32Init(): number {
+    return ~0;
+}
+
+/**
+ * Update a streaming CRC32 calculation.
+ *
+ * For performance, this implementation processes the data 8 bytes at a time, using the algorithm
+ * presented at: https://github.com/komrad36/CRC#option-9-8-byte-tabular
+ */
+export function crc32Update(prev: number, data: ArrayBufferView): number {
+    const byteLength = data.byteLength;
+    const view = new DataView(data.buffer, data.byteOffset, byteLength);
+    let r = prev;
+    // Process 8 bytes (2 uint32s) at a time.
+    const endOffset = byteLength - 8;
+    let offset = 0;
+    while (offset < endOffset) {
+        r ^= view.getUint32(offset, true);
+        offset += 4;
+        const r2 = view.getUint32(offset, true);
+        offset += 4;
+        r =
+            (CRC32_TABLE[((r2 >>> 24) & 0xff)]! | 0) ^
+            (CRC32_TABLE[256 + ((r2 >>> 16) & 0xff)]! | 0) ^
+            (CRC32_TABLE[512 + ((r2 >>> 8) & 0xff)]! | 0) ^
+            (CRC32_TABLE[768 + (r2 & 0xff)]! | 0) ^
+            (CRC32_TABLE[1024 + ((r >>> 24) & 0xff)]! | 0) ^
+            (CRC32_TABLE[1280 + ((r >>> 16) & 0xff)]! | 0) ^
+            (CRC32_TABLE[1536 + ((r >>> 8) & 0xff)]! | 0) ^
+            (CRC32_TABLE[1792 + (r & 0xff)]! | 0);
+    }
+    // Process any remaining bytes one by one. (Perf note: inexplicably, using a temporary variable
+    // `i` rather than reusing `offset` here is faster in V8.)
+    for (let i = offset; i < byteLength; i++) {
+        r = CRC32_TABLE[(r ^ view.getUint8(i)) & 0xff]! ^ (r >>> 8);
+    }
+    return r;
+}
+
+/**
+ * Finalize a CRC32 by inverting the output value. An unsigned right-shift of 0 is used to ensure the result is a positive number.
+ */
+export function crc32Final(prev: number): number {
+    return (prev ^ ~0) >>> 0;
+}
+
+/**
+ * Calculate a one-shot CRC32. If the data is being accumulated incrementally, use the functions
+ * `crc32Init`, `crc32Update`, and `crc32Final` instead.
+ */
+export function crc32(data: ArrayBufferView): number {
+    return crc32Final(crc32Update(crc32Init(), data));
+}

--- a/typescript/core/src/getBigUint64.ts
+++ b/typescript/core/src/getBigUint64.ts
@@ -1,18 +1,16 @@
+const N32 = 2 ** 32;
 // DataView.getBigUint64 was added to relatively recent versions of Safari. It's pretty easy to
 // maintain this fallback code.
 //
 // eslint-disable-next-line @foxglove/no-boolean-parameters
-export const getBigUint64: (this: DataView, offset: number, littleEndian?: boolean) => bigint =
-  typeof DataView.prototype.getBigUint64 === "function"
-    ? DataView.prototype.getBigUint64 // eslint-disable-line @typescript-eslint/unbound-method
-    : function (this: DataView, offset, littleEndian): bigint {
-        const lo =
-          littleEndian === true
-            ? this.getUint32(offset, littleEndian)
-            : this.getUint32(offset + 4, littleEndian);
-        const hi =
-          littleEndian === true
-            ? this.getUint32(offset + 4, littleEndian)
-            : this.getUint32(offset, littleEndian);
-        return (BigInt(hi) << 32n) | BigInt(lo);
-      };
+export function getBigUint64(view: DataView, offset: number, littleEndian?: boolean): number {
+  const lo =
+    littleEndian === true
+      ? view.getUint32(offset, littleEndian)
+      : view.getUint32(offset + 4, littleEndian);
+  const hi =
+    littleEndian === true
+      ? view.getUint32(offset + 4, littleEndian)
+      : view.getUint32(offset, littleEndian);
+  return hi * N32 + lo;
+}

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -1,5 +1,6 @@
 export { McapIndexedReader } from "./McapIndexedReader";
 export { default as McapStreamReader } from "./McapStreamReader";
+export { default as McapStreamDispatch } from "./McapStreamDispatch";
 export { McapWriter } from "./McapWriter";
 export type { McapWriterOptions } from "./McapWriter";
 export { McapRecordBuilder } from "./McapRecordBuilder";

--- a/typescript/core/src/kvpairs.ts
+++ b/typescript/core/src/kvpairs.ts
@@ -1,0 +1,66 @@
+export function sortKvPairs(arr: BigUint64Array, reverse: boolean = false): void {
+    quicksort(arr as unknown as BigInt[], reverse ? reverseCompare : defaultCompare);
+}
+
+function defaultCompare<T>(x1: T, y1: T, x2: T, y2: T): number {
+    if (x1 < x2) return -1;
+    if (x1 > x2) return 1;
+    if (y1 < y2) return -1;
+    if (y1 > y2) return 1;
+    return 0;
+}
+
+function reverseCompare<T>(x1: T, y1: T, x2: T, y2: T): number {
+    return -defaultCompare(x1, y1, x2, y2);
+}
+
+function quicksort<T>(
+    arr: T[],
+    compare: (x1: T, y1: T, x2: T, y2: T) => number = defaultCompare,
+    left = 0,
+    right = arr.length - 2
+): void {
+    while (left < right) {
+        const pivotIndex = partition(arr, compare, left, right);
+        if (pivotIndex - left < right - pivotIndex) {
+            quicksort(arr, compare, left, pivotIndex - 2);
+            left = pivotIndex + 2;
+        } else {
+            quicksort(arr, compare, pivotIndex + 2, right);
+            right = pivotIndex - 2;
+        }
+    }
+}
+
+function partition<T>(
+    arr: T[],
+    compare: (x1: T, y1: T, x2: T, y2: T) => number,
+    left: number,
+    right: number
+): number {
+    const pivotIndex = right;
+    const pivotX = arr[pivotIndex]!;
+    const pivotY = arr[pivotIndex + 1]!;
+    let i = left - 2;
+
+    for (let j = left; j < right; j += 2) {
+        const currentX = arr[j]!;
+        const currentY = arr[j + 1]!;
+        if (compare(currentX, currentY, pivotX, pivotY) < 0) {
+            i += 2;
+            swapPair(arr, i, j);
+        }
+    }
+
+    swapPair(arr, i + 2, pivotIndex);
+    return i + 2;
+}
+
+function swapPair<T>(arr: T[], i: number, j: number): void {
+    const tempX = arr[i]!;
+    const tempY = arr[i + 1]!;
+    arr[i] = arr[j]!;
+    arr[i + 1] = arr[j + 1]!;
+    arr[j] = tempX;
+    arr[j + 1] = tempY;
+}

--- a/typescript/core/src/parse.ts
+++ b/typescript/core/src/parse.ts
@@ -439,3 +439,29 @@ export function monoParseMessage(reader: Reader): TypedMcapRecord | undefined | 
 
   return parseMessage(reader, recordLengthNum);
 }
+
+
+export function monoParseMessage2(reader: Reader, end: number): TypedMcapRecord | undefined | null {
+  const RECORD_HEADER_SIZE = 1 /*opcode*/ + 8; /*record content length*/
+  if (reader.offset + RECORD_HEADER_SIZE > end) {
+    return undefined;
+  }
+  const start = reader.offset;
+  const opcode = reader.uint8() as Opcode;
+  const recordLength = reader.uint64();
+
+  if (opcode !== Opcode.MESSAGE) {
+    reader.offset = start; // Rewind to the start of the record
+    return null;
+  }
+
+  const recordLengthNum = Number(recordLength);
+
+  if (reader.offset + recordLengthNum > end) {
+    reader.offset = start; // Rewind to the start of the record
+    throw new Error("Message record length exceeds bounds of record");
+    return undefined;
+  }
+
+  return parseMessage(reader, recordLengthNum);
+}

--- a/typescript/core/src/parse.ts
+++ b/typescript/core/src/parse.ts
@@ -284,7 +284,7 @@ function parseAttachment(
   const mediaType = reader.string();
   const dataLen = reader.uint64();
   // NOTE: probably not necessary, but just in case
-  if (BigInt(reader.offset) + dataLen > Number.MAX_SAFE_INTEGER) {
+  if (reader.offset + dataLen > Number.MAX_SAFE_INTEGER) {
     throw new Error(`Attachment too large: ${dataLen}`);
   }
   if (reader.offset + Number(dataLen) + 4 /*crc*/ > startOffset + recordLength) {

--- a/typescript/core/src/parse.ts
+++ b/typescript/core/src/parse.ts
@@ -229,10 +229,7 @@ function parseChunk(reader: Reader, recordLength: number): TypedMcapRecord {
 function parseMessageIndex(reader: Reader, recordLength: number): TypedMcapRecord {
   const startOffset = reader.offset;
   const channelId = reader.uint16();
-  const records = reader.keyValuePairs(
-    (r) => r.uint64(),
-    (r) => r.uint64(),
-  );
+  const records = reader.kvPairsU64Fast();
   reader.offset = startOffset + recordLength;
   return {
     type: "MessageIndex",

--- a/typescript/core/src/parse.ts
+++ b/typescript/core/src/parse.ts
@@ -414,3 +414,27 @@ function parseDataEnd(reader: Reader, recordLength: number): TypedMcapRecord {
     dataSectionCrc,
   };
 }
+
+export function monoParseMessage(reader: Reader): TypedMcapRecord | undefined | null {
+  const RECORD_HEADER_SIZE = 1 /*opcode*/ + 8; /*record content length*/
+  if (reader.bytesRemaining() < RECORD_HEADER_SIZE) {
+    return undefined;
+  }
+  const start = reader.offset;
+  const opcode = reader.uint8() as Opcode;
+  const recordLength = reader.uint64();
+
+  if (opcode !== Opcode.MESSAGE) {
+    reader.offset = start; // Rewind to the start of the record
+    return null;
+  }
+
+  const recordLengthNum = Number(recordLength);
+
+  if (reader.bytesRemaining() < recordLengthNum) {
+    reader.offset = start; // Rewind to the start of the record
+    return undefined;
+  }
+
+  return parseMessage(reader, recordLengthNum);
+}

--- a/typescript/core/src/sortedIndexBy.test.ts
+++ b/typescript/core/src/sortedIndexBy.test.ts
@@ -2,52 +2,52 @@ import { sortedIndexBy } from "./sortedIndexBy";
 
 describe("sortedIndexBy", () => {
   it("handles an empty array", () => {
-    const array: [bigint, bigint][] = [];
+    const array: [number, number][] = [];
 
-    expect(sortedIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedIndexBy(array, 42n, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 42, (x) => x)).toEqual(0);
   });
 
   it("handles a contiguous array", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [2n, 42n],
-      [3n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [2, 42],
+      [3, 42],
     ];
 
-    expect(sortedIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedIndexBy(array, 1n, (x) => x)).toEqual(0);
-    expect(sortedIndexBy(array, 2n, (x) => x)).toEqual(1);
-    expect(sortedIndexBy(array, 3n, (x) => x)).toEqual(2);
-    expect(sortedIndexBy(array, 4n, (x) => x)).toEqual(3);
+    expect(sortedIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 1, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 2, (x) => x)).toEqual(1);
+    expect(sortedIndexBy(array, 3, (x) => x)).toEqual(2);
+    expect(sortedIndexBy(array, 4, (x) => x)).toEqual(3);
   });
 
   it("handles a sparse array", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [3n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [3, 42],
     ];
 
-    expect(sortedIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedIndexBy(array, 1n, (x) => x)).toEqual(0);
-    expect(sortedIndexBy(array, 2n, (x) => x)).toEqual(1);
-    expect(sortedIndexBy(array, 3n, (x) => x)).toEqual(1);
-    expect(sortedIndexBy(array, 4n, (x) => x)).toEqual(2);
+    expect(sortedIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 1, (x) => x)).toEqual(0);
+    expect(sortedIndexBy(array, 2, (x) => x)).toEqual(1);
+    expect(sortedIndexBy(array, 3, (x) => x)).toEqual(1);
+    expect(sortedIndexBy(array, 4, (x) => x)).toEqual(2);
   });
 
   it("handles negation", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [2n, 42n],
-      [3n, 42n],
-      [4n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [2, 42],
+      [3, 42],
+      [4, 42],
     ];
 
-    expect(sortedIndexBy(array, 0n, (x) => -x)).toEqual(4);
-    expect(sortedIndexBy(array, 1n, (x) => -x)).toEqual(4);
-    expect(sortedIndexBy(array, 2n, (x) => -x)).toEqual(4);
-    expect(sortedIndexBy(array, 3n, (x) => -x)).toEqual(0);
-    expect(sortedIndexBy(array, 4n, (x) => -x)).toEqual(0);
-    expect(sortedIndexBy(array, 5n, (x) => -x)).toEqual(0);
+    expect(sortedIndexBy(array, 0, (x) => -x)).toEqual(4);
+    expect(sortedIndexBy(array, 1, (x) => -x)).toEqual(4);
+    expect(sortedIndexBy(array, 2, (x) => -x)).toEqual(4);
+    expect(sortedIndexBy(array, 3, (x) => -x)).toEqual(0);
+    expect(sortedIndexBy(array, 4, (x) => -x)).toEqual(0);
+    expect(sortedIndexBy(array, 5, (x) => -x)).toEqual(0);
   });
 });

--- a/typescript/core/src/sortedIndexBy.ts
+++ b/typescript/core/src/sortedIndexBy.ts
@@ -3,9 +3,9 @@
  * order. This is a specialization of lodash's sortedIndexBy().
  */
 export function sortedIndexBy(
-  array: [bigint, bigint][],
-  value: bigint,
-  iteratee: (value: bigint) => bigint,
+  array: [number, number][],
+  value: number,
+  iteratee: (value: number) => number,
 ): number {
   let low = 0;
   let high = array.length;

--- a/typescript/core/src/sortedLastIndex.ts
+++ b/typescript/core/src/sortedLastIndex.ts
@@ -3,9 +3,9 @@
  * order. This is a specialization of lodash's sortedIndexBy().
  */
 export function sortedLastIndexBy(
-  array: [bigint, bigint][],
-  value: bigint,
-  iteratee: (value: bigint) => bigint,
+  array: [number, number][],
+  value: number,
+  iteratee: (value: number) => number,
 ): number {
   let low = 0;
   let high = array.length;

--- a/typescript/core/src/sortedLastIndexBy.test.ts
+++ b/typescript/core/src/sortedLastIndexBy.test.ts
@@ -2,68 +2,68 @@ import { sortedLastIndexBy } from "./sortedLastIndex";
 
 describe("sortedLastIndexBy", () => {
   it("handles an empty array", () => {
-    const array: [bigint, bigint][] = [];
+    const array: [number, number][] = [];
 
-    expect(sortedLastIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedLastIndexBy(array, 42n, (x) => x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 42, (x) => x)).toEqual(0);
   });
 
   it("handles a contiguous array", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [2n, 42n],
-      [3n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [2, 42],
+      [3, 42],
     ];
 
-    expect(sortedLastIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedLastIndexBy(array, 1n, (x) => x)).toEqual(1);
-    expect(sortedLastIndexBy(array, 2n, (x) => x)).toEqual(2);
-    expect(sortedLastIndexBy(array, 3n, (x) => x)).toEqual(3);
-    expect(sortedLastIndexBy(array, 4n, (x) => x)).toEqual(3);
+    expect(sortedLastIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 1, (x) => x)).toEqual(1);
+    expect(sortedLastIndexBy(array, 2, (x) => x)).toEqual(2);
+    expect(sortedLastIndexBy(array, 3, (x) => x)).toEqual(3);
+    expect(sortedLastIndexBy(array, 4, (x) => x)).toEqual(3);
   });
 
   it("handles a sparse array", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [3n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [3, 42],
     ];
 
-    expect(sortedLastIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedLastIndexBy(array, 1n, (x) => x)).toEqual(1);
-    expect(sortedLastIndexBy(array, 2n, (x) => x)).toEqual(1);
-    expect(sortedLastIndexBy(array, 3n, (x) => x)).toEqual(2);
-    expect(sortedLastIndexBy(array, 4n, (x) => x)).toEqual(2);
+    expect(sortedLastIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 1, (x) => x)).toEqual(1);
+    expect(sortedLastIndexBy(array, 2, (x) => x)).toEqual(1);
+    expect(sortedLastIndexBy(array, 3, (x) => x)).toEqual(2);
+    expect(sortedLastIndexBy(array, 4, (x) => x)).toEqual(2);
   });
 
   it("handles negation", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [2n, 42n],
-      [3n, 42n],
-      [4n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [2, 42],
+      [3, 42],
+      [4, 42],
     ];
 
-    expect(sortedLastIndexBy(array, 0n, (x) => -x)).toEqual(4);
-    expect(sortedLastIndexBy(array, 1n, (x) => -x)).toEqual(4);
-    expect(sortedLastIndexBy(array, 2n, (x) => -x)).toEqual(4);
-    expect(sortedLastIndexBy(array, 3n, (x) => -x)).toEqual(4);
-    expect(sortedLastIndexBy(array, 4n, (x) => -x)).toEqual(0);
-    expect(sortedLastIndexBy(array, 5n, (x) => -x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 0, (x) => -x)).toEqual(4);
+    expect(sortedLastIndexBy(array, 1, (x) => -x)).toEqual(4);
+    expect(sortedLastIndexBy(array, 2, (x) => -x)).toEqual(4);
+    expect(sortedLastIndexBy(array, 3, (x) => -x)).toEqual(4);
+    expect(sortedLastIndexBy(array, 4, (x) => -x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 5, (x) => -x)).toEqual(0);
   });
 
   it("handles a contiguous array with duplicate times", () => {
-    const array: [bigint, bigint][] = [
-      [1n, 42n],
-      [2n, 42n],
-      [2n, 42n],
-      [2n, 42n],
-      [3n, 42n],
-      [3n, 42n],
+    const array: [number, number][] = [
+      [1, 42],
+      [2, 42],
+      [2, 42],
+      [2, 42],
+      [3, 42],
+      [3, 42],
     ];
 
-    expect(sortedLastIndexBy(array, 0n, (x) => x)).toEqual(0);
-    expect(sortedLastIndexBy(array, 1n, (x) => x)).toEqual(1);
-    expect(sortedLastIndexBy(array, 2n, (x) => x)).toEqual(4);
-    expect(sortedLastIndexBy(array, 3n, (x) => x)).toEqual(6);
+    expect(sortedLastIndexBy(array, 0, (x) => x)).toEqual(0);
+    expect(sortedLastIndexBy(array, 1, (x) => x)).toEqual(1);
+    expect(sortedLastIndexBy(array, 2, (x) => x)).toEqual(4);
+    expect(sortedLastIndexBy(array, 3, (x) => x)).toEqual(6);
   });
 });

--- a/typescript/core/src/testUtils.ts
+++ b/typescript/core/src/testUtils.ts
@@ -14,9 +14,9 @@ export function uint32LE(n: number): Uint8Array {
   return result;
 }
 
-export function uint64LE(n: bigint): Uint8Array {
+export function uint64LE(n: number | bigint): Uint8Array {
   const result = new Uint8Array(8);
-  new DataView(result.buffer).setBigUint64(0, n, true);
+  new DataView(result.buffer).setBigUint64(0, BigInt(n), true);
   return result;
 }
 

--- a/typescript/core/src/types.ts
+++ b/typescript/core/src/types.ts
@@ -40,7 +40,7 @@ export type Chunk = {
 };
 export type MessageIndex = {
   channelId: number;
-  records: [logTime: number, offset: number][];
+  records: BigUint64Array;
 };
 export type ChunkIndex = {
   messageStartTime: number;

--- a/typescript/core/src/types.ts
+++ b/typescript/core/src/types.ts
@@ -6,8 +6,8 @@ export type Header = {
   library: string;
 };
 export type Footer = {
-  summaryStart: bigint;
-  summaryOffsetStart: bigint;
+  summaryStart: number;
+  summaryOffsetStart: number;
   summaryCrc: number;
 };
 export type Schema = {
@@ -26,73 +26,73 @@ export type Channel = {
 export type Message = {
   channelId: number;
   sequence: number;
-  logTime: bigint;
-  publishTime: bigint;
+  logTime: number;
+  publishTime: number;
   data: Uint8Array;
 };
 export type Chunk = {
-  messageStartTime: bigint;
-  messageEndTime: bigint;
-  uncompressedSize: bigint;
+  messageStartTime: number;
+  messageEndTime: number;
+  uncompressedSize: number;
   uncompressedCrc: number;
   compression: string;
   records: Uint8Array;
 };
 export type MessageIndex = {
   channelId: number;
-  records: [logTime: bigint, offset: bigint][];
+  records: [logTime: number, offset: number][];
 };
 export type ChunkIndex = {
-  messageStartTime: bigint;
-  messageEndTime: bigint;
-  chunkStartOffset: bigint;
-  chunkLength: bigint;
-  messageIndexOffsets: Map<number, bigint>;
-  messageIndexLength: bigint;
+  messageStartTime: number;
+  messageEndTime: number;
+  chunkStartOffset: number;
+  chunkLength: number;
+  messageIndexOffsets: Map<number, number>;
+  messageIndexLength: number;
   compression: string;
-  compressedSize: bigint;
-  uncompressedSize: bigint;
+  compressedSize: number;
+  uncompressedSize: number;
 };
 export type Attachment = {
   name: string;
-  logTime: bigint;
-  createTime: bigint;
+  logTime: number;
+  createTime: number;
   mediaType: string;
   data: Uint8Array;
 };
 export type AttachmentIndex = {
-  offset: bigint;
-  length: bigint;
-  logTime: bigint;
-  createTime: bigint;
-  dataSize: bigint;
+  offset: number;
+  length: number;
+  logTime: number;
+  createTime: number;
+  dataSize: number;
   name: string;
   mediaType: string;
 };
 export type Statistics = {
-  messageCount: bigint;
+  messageCount: number;
   schemaCount: number;
   channelCount: number;
   attachmentCount: number;
   metadataCount: number;
   chunkCount: number;
-  messageStartTime: bigint;
-  messageEndTime: bigint;
-  channelMessageCounts: Map<number, bigint>;
+  messageStartTime: number;
+  messageEndTime: number;
+  channelMessageCounts: Map<number, number>;
 };
 export type Metadata = {
   name: string;
   metadata: Map<string, string>;
 };
 export type MetadataIndex = {
-  offset: bigint;
-  length: bigint;
+  offset: number;
+  length: number;
   name: string;
 };
 export type SummaryOffset = {
   groupOpcode: number;
-  groupStart: bigint;
-  groupLength: bigint;
+  groupStart: number;
+  groupLength: number;
 };
 export type DataEnd = {
   dataSectionCrc: number;
@@ -130,13 +130,13 @@ export type TypedMcapRecord = Values<TypedMcapRecords>;
 export type McapRecord = Values<McapRecords>;
 
 export type DecompressHandlers = {
-  [compression: string]: (buffer: Uint8Array, decompressedSize: bigint) => Uint8Array;
+  [compression: string]: (buffer: Uint8Array, decompressedSize: number) => Uint8Array;
 };
 
 /**
  * IReadable describes a random-access reader interface.
  */
 export interface IReadable {
-  size(): Promise<bigint>;
-  read(offset: bigint, size: bigint): Promise<Uint8Array>;
+  size(): Promise<number>;
+  read(offset: number, size: number): Promise<Uint8Array>;
 }

--- a/typescript/examples/basicwriter/scripts/main.ts
+++ b/typescript/examples/basicwriter/scripts/main.ts
@@ -51,8 +51,8 @@ async function main() {
   await mcapFile.addMessage({
     channelId,
     sequence: 0,
-    publishTime: 0n,
-    logTime: BigInt(Date.now()) * 1_000_000n,
+    publishTime: 0,
+    logTime: Date.now() * 1_000_000,
     data: msgData,
   });
 

--- a/typescript/examples/flatbuffer/output/foxglove/time.ts
+++ b/typescript/examples/flatbuffer/output/foxglove/time.ts
@@ -29,7 +29,7 @@ static sizeOf():number {
   return 16;
 }
 
-static createTime(builder:flatbuffers.Builder, sec: bigint, nsec: number):flatbuffers.Offset {
+static createTime(builder:flatbuffers.Builder, sec: number, nsec: number):flatbuffers.Offset {
   builder.prep(8, 16);
   builder.pad(4);
   builder.writeInt32(nsec);

--- a/typescript/examples/flatbufferswriter/scripts/flatbufferUtils.ts
+++ b/typescript/examples/flatbufferswriter/scripts/flatbufferUtils.ts
@@ -70,7 +70,7 @@ export function buildTfMessage(builder: Builder, tfJson: FrameTransform): number
   FbFrameTransform.addRotation(builder, quat);
   FbFrameTransform.addTimestamp(
     builder,
-    FbTime.createTime(builder, BigInt(tfJson.timestamp.sec), tfJson.timestamp.nsec),
+    FbTime.createTime(builder, tfJson.timestamp.sec, tfJson.timestamp.nsec),
   );
 
   const tf = FbFrameTransform.endFrameTransform(builder);
@@ -103,7 +103,7 @@ export function buildGridMessage(builder: Builder, json: Grid): number {
   FbGrid.startGrid(builder);
   FbGrid.addTimestamp(
     builder,
-    FbTime.createTime(builder, BigInt(json.timestamp.sec), json.timestamp.nsec),
+    FbTime.createTime(builder, json.timestamp.sec, json.timestamp.nsec),
   );
   FbGrid.addFrameId(builder, frameId);
   FbGrid.addPose(builder, pose);

--- a/typescript/examples/flatbufferswriter/scripts/main.ts
+++ b/typescript/examples/flatbufferswriter/scripts/main.ts
@@ -173,8 +173,8 @@ async function main() {
   await mcapFile.addMessage({
     channelId: tfChannelId,
     sequence: 0,
-    publishTime: 0n,
-    logTime: 0n,
+    publishTime: 0,
+    logTime: 0,
     data: tfBuilder.asUint8Array(),
   });
 
@@ -211,7 +211,7 @@ async function main() {
   let count = 0;
   while (currTime <= mcapTimeLength) {
     console.log(`Adding grid ${count}`);
-    const nsTime = BigInt(currTime) * 1_000_000n;
+    const nsTime = currTime * 1_000_000;
     const message = getGridMessageData(currTime);
     await mcapFile.addMessage({
       channelId: gridChannelId,

--- a/typescript/examples/text-annotation-demo/scripts/main.ts
+++ b/typescript/examples/text-annotation-demo/scripts/main.ts
@@ -86,27 +86,27 @@ async function main() {
   ) {
     scene.renderScene();
 
-    const bigTime = BigInt(Math.floor(currentTimeSeconds * 1_000_000_000));
+    const bigTime = Math.floor(currentTimeSeconds * 1_000_000_000);
     const rosTime = fromNanoSec(bigTime);
 
     await mcapFile.addMessage({
       channelId: calibrationChannelId,
       sequence: 0,
-      publishTime: 0n,
+      publishTime: 0,
       logTime: bigTime,
       data: Buffer.from(JSON.stringify(scene.getCameraCalibration(rosTime))),
     });
     await mcapFile.addMessage({
       channelId: imageChannelId,
       sequence: 0,
-      publishTime: 0n,
+      publishTime: 0,
       logTime: bigTime,
       data: Buffer.from(JSON.stringify(scene.getRawImage(rosTime))),
     });
     await mcapFile.addMessage({
       channelId: annotationsChannelId,
       sequence: 0,
-      publishTime: 0n,
+      publishTime: 0,
       logTime: bigTime,
       data: Buffer.from(JSON.stringify(scene.getImageAnnotations(rosTime))),
     });
@@ -120,12 +120,12 @@ async function main() {
  * @param nsec Nanoseconds integer
  * @returns Time object
  */
-function fromNanoSec(nsec: bigint): Time {
+function fromNanoSec(nsec: number): Time {
   // From https://github.com/ros/roscpp_core/blob/86720717c0e1200234cc0a3545a255b60fb541ec/rostime/include/ros/impl/time.h#L63
   // and https://github.com/ros/roscpp_core/blob/7583b7d38c6e1c2e8623f6d98559c483f7a64c83/rostime/src/time.cpp#L536
   //
-  // Note: BigInt(1e9) is slower than writing out the number
-  return { sec: Number(nsec / 1_000_000_000n), nsec: Number(nsec % 1_000_000_000n) };
+  // Note: 1e9 is slower than writing out the number
+  return { sec: Number(nsec / 1_000_000_000), nsec: Number(nsec % 1_000_000_000) };
 }
 
 void main();

--- a/typescript/examples/validate/scripts/validate.ts
+++ b/typescript/examples/validate/scripts/validate.ts
@@ -42,7 +42,7 @@ async function readStream(
   processRecord: (record: TypedMcapRecord) => void,
 ) {
   const startTime = performance.now();
-  let readBytes = 0n;
+  let readBytes = 0;
 
   let lastRecordType: TypedMcapRecord["type"] | undefined;
   await new Promise<void>((resolve, reject) => {
@@ -52,7 +52,7 @@ async function readStream(
         if (typeof data === "string") {
           throw new Error("expected buffer");
         }
-        readBytes += BigInt(data.byteLength);
+        readBytes += data.byteLength;
         reader.append(data);
         for (let record; (record = reader.nextRecord()); ) {
           lastRecordType = record.type;

--- a/typescript/nodejs/src/FileHandleReadable.ts
+++ b/typescript/nodejs/src/FileHandleReadable.ts
@@ -12,16 +12,16 @@ export class FileHandleReadable implements McapTypes.IReadable {
     this.#handle = handle;
   }
 
-  async size(): Promise<bigint> {
-    return BigInt((await this.#handle.stat()).size);
+  async size(): Promise<number> {
+    return (await this.#handle.stat()).size;
   }
 
-  async read(offset: bigint, length: bigint): Promise<Uint8Array> {
+  async read(offset: number, length: number): Promise<Uint8Array> {
     if (offset > Number.MAX_SAFE_INTEGER || length > Number.MAX_SAFE_INTEGER) {
       throw new Error(`Read too large: offset ${offset}, length ${length}`);
     }
     if (length > this.#buffer.byteLength) {
-      this.#buffer = new ArrayBuffer(Number(length * 2n));
+      this.#buffer = new ArrayBuffer(Number(length * 2));
     }
     const result = await this.#handle.read({
       buffer: new DataView(this.#buffer, 0, Number(length)),

--- a/typescript/nodejs/src/FileHandleWritable.ts
+++ b/typescript/nodejs/src/FileHandleWritable.ts
@@ -17,7 +17,7 @@ export class FileHandleWritable implements IWritable {
     this.#totalBytesWritten += written.bytesWritten;
   }
 
-  position(): bigint {
-    return BigInt(this.#totalBytesWritten);
+  position(): number {
+    return this.#totalBytesWritten;
   }
 }

--- a/typescript/nodejs/src/index.test.ts
+++ b/typescript/nodejs/src/index.test.ts
@@ -33,8 +33,8 @@ describe("FileHandleReadable & FileHandleWritable", () => {
       const message = {
         channelId,
         sequence: 1,
-        logTime: 1n,
-        publishTime: 2n,
+        logTime: 1,
+        publishTime: 2,
         data: new Uint8Array([1, 2, 3]),
       };
       await writer.addMessage(message);


### PR DESCRIPTION
Contains a bunch of perf experiments:

```
McapStreamReader
        9.20±0.31 op/s  Heap Used: 9.08±0.06 MB/op      Heap Total: 0.05±0.05 MB/op     ArrayBuffers: 44.70±26.63 MB/op
McapStreamDispatch
        26.30±0.22 op/s Heap Used: 2.15±0.01 MB/op      Heap Total: 0.00±0.00 MB/op     ArrayBuffers: 1.21±0.00 MB/op
```

BigInt => Number & faster crc32 are hard to land generally for browsers etc...