### PR TITLE
cpp: support linking statically on Windows

### DIFF
--- a/cpp/mcap/include/mcap/visibility.hpp
+++ b/cpp/mcap/include/mcap/visibility.hpp
@@ -1,17 +1,21 @@
 #pragma once
 
 #if defined _WIN32 || defined __CYGWIN__
-#  ifdef __GNUC__
-#    define MCAP_EXPORT __attribute__((dllexport))
-#    define MCAP_IMPORT __attribute__((dllimport))
+#  ifndef MCAP_STATIC_DEFINE
+#    ifdef __GNUC__
+#      define MCAP_EXPORT __attribute__((dllexport))
+#      define MCAP_IMPORT __attribute__((dllimport))
+#    else
+#      define MCAP_EXPORT __declspec(dllexport)
+#      define MCAP_IMPORT __declspec(dllimport)
+#    endif
+#    ifdef MCAP_IMPLEMENTATION
+#      define MCAP_PUBLIC MCAP_EXPORT
+#    else
+#      define MCAP_PUBLIC MCAP_IMPORT
+#    endif
 #  else
-#    define MCAP_EXPORT __declspec(dllexport)
-#    define MCAP_IMPORT __declspec(dllimport)
-#  endif
-#  ifdef MCAP_IMPLEMENTATION
-#    define MCAP_PUBLIC MCAP_EXPORT
-#  else
-#    define MCAP_PUBLIC MCAP_IMPORT
+#    define MCAP_PUBLIC
 #  endif
 #else
 #  define MCAP_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
### Changelog
Allows building and linking the `mcap` library statically on Windows.

### Docs

None

### Description

I'm using `mcap_builder` to use the `mcap` in my project.

Even though `mcap` is a header-only library, `mcap_builder` creates a library for the client application to link against.
`mcap_builder` currently always creates a shared library. I have a PR open to support creating a static library: https://github.com/olympus-robotics/mcap_builder/pull/4

Creating and linking against a static library on Windows causes linking issues because `visibility.hpp` implicitly assumes dynamic linking.

This PR adds a define that needs to be set when building the library statically. The PR is backwards compatible, i.e. the behavior remains the same as before if the define is not set. The define is named based on CMake convention, see https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html