### PR TITLE
Updating references & links from slack to discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://robotics.stackexchange.com/questions/ask
     about: Get help from the robotics community
   - name: "💬 Live chat"
-    url: https://foxglove.dev/slack
-    about: Join the discussion in our Slack community
+    url: https://foxglove.dev/chat
+    about: Join the discussion in our Discord community

--- a/python/mcap-protobuf-support/README.md
+++ b/python/mcap-protobuf-support/README.md
@@ -35,4 +35,4 @@ pipenv run python point_cloud_example.py output.mcap
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord community](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/python/mcap-ros1-support/README.md
+++ b/python/mcap-ros1-support/README.md
@@ -36,5 +36,5 @@ ros_writer.finish()
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions,
+Join our [Discord community](https://foxglove.dev/chat) to ask questions,
 share feedback, and stay up to date on what our team is working on.

--- a/python/mcap-ros2-support/README.md
+++ b/python/mcap-ros2-support/README.md
@@ -22,5 +22,5 @@ for msg in read_ros2_messages("my_data.mcap"):
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions,
+Join our [Discord community](https://foxglove.dev/chat) to ask questions,
 share feedback, and stay up to date on what our team is working on.

--- a/typescript/browser/README.md
+++ b/typescript/browser/README.md
@@ -30,4 +30,4 @@ async function onInputOrDrop(event: InputEvent | DragEvent) {
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord community](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/typescript/core/README.md
+++ b/typescript/core/README.md
@@ -14,4 +14,4 @@ Examples of how to use the `@mcap/core` APIs can be found in the [TypeScript exa
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord community](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/typescript/nodejs/README.md
+++ b/typescript/nodejs/README.md
@@ -47,4 +47,4 @@ const writer = new McapWriter({
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord community](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/typescript/support/README.md
+++ b/typescript/support/README.md
@@ -46,4 +46,4 @@ const reader = await McapIndexedReader.Initialize({
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord community](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -115,8 +115,8 @@ const config = {
             label: "Specification",
           },
           {
-            href: "https://foxglove.dev/slack",
-            label: "Slack",
+            href: "https://foxglove.dev/chat",
+            label: "Discord",
             position: "right",
           },
           {
@@ -154,8 +154,8 @@ const config = {
                 href: "https://github.com/foxglove/mcap",
               },
               {
-                label: "Slack",
-                href: "https://foxglove.dev/slack",
+                label: "Discord",
+                href: "https://foxglove.dev/chat",
               },
               {
                 label: "Stack Overflow",


### PR DESCRIPTION
### Changelog
Updating references from community slack to community discord.

### Docs

None

### Description

* Links updated to point to https://foxglove.dev/chat
* "Slack channel" etc. references updated to "Discord community" etc.

