### PR TITLE
go: indexed message iterator: guard against bad offsets in file

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -4,15 +4,20 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/bits"
 	"slices"
 	"sort"
 
+	"math"
+
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 )
+
+var ErrBadOffset = errors.New("cannot seek to offset")
 
 const (
 	chunkBufferGrowthMultiple = 1.2
@@ -54,6 +59,7 @@ type indexedMessageIterator struct {
 	attachmentIndexes []*AttachmentIndex
 	metadataIndexes   []*MetadataIndex
 	footer            *Footer
+	fileSize          int64
 
 	curChunkIndex   int
 	messageIndexes  []messageIndexWithChunkSlot
@@ -68,14 +74,28 @@ type indexedMessageIterator struct {
 	metadataCallback func(*Metadata) error
 }
 
+func (it *indexedMessageIterator) seekTo(offset uint64) (int64, error) {
+	if offset > uint64(math.MaxInt64) {
+		return 0, fmt.Errorf("%w: %d > int64 max", ErrBadOffset, offset)
+	}
+	signedOffset := int64(offset)
+	if signedOffset >= it.fileSize {
+		return 0, fmt.Errorf("%w: %d past file end %d", ErrBadOffset, offset, it.fileSize)
+	}
+	pos, err := it.rs.Seek(signedOffset, io.SeekStart)
+	return pos, err
+}
+
 // parseIndexSection parses the index section of the file and populates the
 // related fields of the structure. It must be called prior to any of the other
 // access methods.
 func (it *indexedMessageIterator) parseSummarySection() error {
-	_, err := it.rs.Seek(-8-4-8-8, io.SeekEnd) // magic, plus 20 bytes footer
+	const footerStartOffsetFromEnd = +8 + 4 + 8 + 8 // magic, plus 20 bytes footer
+	footerStartPos, err := it.rs.Seek(-footerStartOffsetFromEnd, io.SeekEnd)
 	if err != nil {
 		return err
 	}
+	it.fileSize = footerStartPos + footerStartOffsetFromEnd
 	buf := make([]byte, 8+20)
 	_, err = io.ReadFull(it.rs, buf)
 	if err != nil {
@@ -96,7 +116,7 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 		it.hasReadSummarySection = true
 		return nil
 	}
-	_, err = it.rs.Seek(int64(footer.SummaryStart), io.SeekStart)
+	_, err = it.seekTo(footer.SummaryStart)
 	if err != nil {
 		return fmt.Errorf("failed to seek to summary start")
 	}
@@ -188,7 +208,7 @@ func (it *indexedMessageIterator) parseSummarySection() error {
 // loadChunk seeks to and decompresses a chunk into a chunk slot, then populates it.messageIndexes
 // with the offsets of messages in that chunk.
 func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
-	_, err := it.rs.Seek(int64(chunkIndex.ChunkStartOffset), io.SeekStart)
+	_, err := it.seekTo(chunkIndex.ChunkStartOffset)
 	if err != nil {
 		return err
 	}
@@ -377,7 +397,7 @@ func (it *indexedMessageIterator) NextInto(msg *Message) (*Schema, *Channel, *Me
 		// take care of the metadata here
 		if it.metadataCallback != nil {
 			for _, idx := range it.metadataIndexes {
-				_, err := it.rs.Seek(int64(idx.Offset), io.SeekStart)
+				_, err := it.seekTo(idx.Offset)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to seek to metadata: %w", err)
 				}

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -908,7 +908,6 @@ func TestOrderStableWithEquivalentTimestamps(t *testing.T) {
 		}
 		assert.Equal(t, uint64(0), msg.LogTime)
 		msgNumber := binary.LittleEndian.Uint64(msg.Data)
-		fmt.Printf("msgNumber: %d\n", msgNumber)
 		if numRead != 0 {
 			assert.Less(t, msgNumber, lastMessageNumber)
 		}
@@ -1143,7 +1142,6 @@ func TestFooterOffsetErrorDetected(t *testing.T) {
 	// break the footer summary offset field. This is 8 + 8 + 4 + 8 bytes from end of file.
 	mcapBytes := buf.Bytes()
 	end := len(mcapBytes)
-	fmt.Printf("end is %d\n", end)
 	binary.LittleEndian.PutUint64(mcapBytes[end-8-8-4-8:], 999999999)
 
 	reader, err := NewReader(bytes.NewReader(mcapBytes))


### PR DESCRIPTION
### Changelog

- if a file contains offsets that point outside of file bounds, the Go indexed reader implementation will return `mcap.ErrBadOffset` when attempting to use them.

### Docs

None.
### Description

There are files being uploaded to Foxglove that have invalid offsets inside them - these cause errors in `io.Seek`, which can't be told apart from true IO errors at the moment. This means if a read fails, we can't tell if it's because of a corrupt file or flaky I/O. This PR lets us disambiguate by returning a specific error from the library.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

