### PR TITLE
docs: specify units for `log_time` and `publish_time`

### DIFF
--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -169,10 +169,10 @@ class Writer:
 
         :param channel_id: The id of the channel to which the message should be added.
         :param sequence: Optional message counter assigned by publisher.
-        :param log_time: Time at which the message was recorded as an integer number of nanoseconds
-            since the epoch.
-        :param publish_time: Time at which the message was published as nanoseconds since epoch. If
-            not available, must be set to the log time.
+        :param log_time: Time at which the message was recorded as nanoseconds since a
+            user-understood epoch (i.e unix epoch, robot boot time, etc.).
+        :param publish_time: Time at which the message was published as nanoseconds since a
+            user-understood epoch (i.e unix epoch, robot boot time, etc.).
         :param data: Message data, to be decoded according to the schema of the channel.
         """
         message = Message(

--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -169,9 +169,10 @@ class Writer:
 
         :param channel_id: The id of the channel to which the message should be added.
         :param sequence: Optional message counter assigned by publisher.
-        :param log_time: Time at which the message was recorded.
-        :param publish_time: Time at which the message was published. If not available, must be set
-            to the log time.
+        :param log_time: Time at which the message was recorded as an integer number of nanoseconds
+            since the epoch.
+        :param publish_time: Time at which the message was published as nanoseconds since epoch. If
+            not available, must be set to the log time.
         :param data: Message data, to be decoded according to the schema of the channel.
         """
         message = Message(


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

It wasn't obvious what format `Writer.add_message` expects for `log_time` and `publish_time` argument but I've figure out that it's nanoseconds since the epoch and decided to update the docstrings so those that come after me don't have to guess.