### PR TITLE
cpp: Fix for undefined behavior in mcap::ParseByteArray(..)

### DIFF
--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -138,6 +138,8 @@ inline Status ParseByteArray(const std::byte* data, uint64_t maxSize, ByteArray*
     return Status(StatusCode::InvalidRecord, msg);
   }
   output->resize(size);
+  //  output->data() may return nullptr if 'output' is empty, but memcpy() does not accept nullptr.
+  // 'output' will be empty only if the 'size' is equal to 0.
   if (size > 0) {
     std::memcpy(output->data(), data + 4, size);
   }

--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -138,7 +138,9 @@ inline Status ParseByteArray(const std::byte* data, uint64_t maxSize, ByteArray*
     return Status(StatusCode::InvalidRecord, msg);
   }
   output->resize(size);
-  std::memcpy(output->data(), data + 4, size);
+  if (size > 0) {
+    std::memcpy(output->data(), data + 4, size);
+  }
   return StatusCode::Success;
 }
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
Fix for possible undefined behavior in the cpp mcap reader.

### Docs
<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
- We discovered undefined behavior in the `mcap::ParseByteArray(..)` when was running `Rosbag2` tests with `UBSAN` (Undefined Behavior Sanitizer). In particular tests from the https://github.com/ros2/rosbag2/blob/rolling/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
UBSAN was pointing ou to the `std::memcpy(output->data(), data + 4, size);` 
- According to the https://en.cppreference.com/w/cpp/string/byte/memcpy If either dest or src is an invalid or null pointer, the behavior is undefined, even if count is zero.
After a comprehensive analysis, we found that we have a null pointer in dest, and the count is zero in std::memcpy(..) when the message definition was not found and was recorded with empty strings.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->
Undefined behavior when reading empty message definitions
</td><td>

<!--after content goes here-->
No undefined behavior when reading empty message definitions
</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

