### PR TITLE
[C++] Fix typo in noMessageIndex docs

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -41,9 +41,9 @@ struct MCAP_PUBLIC McapWriterOptions {
    */
   bool noChunking = false;
   /**
-   * @brief Do not write Message Index records to the file. If `noSummary=true`
-   * and `noChunkIndex=false`, Chunk Index records will still be written to the
-   * Summary section, providing a coarse message index.
+   * @brief Do not write Message Index records to the file. If
+   * `noMessageIndex=true` and `noChunkIndex=false`, Chunk Index records will
+   * still be written to the Summary section, providing a coarse message index.
    */
   bool noMessageIndex = false;
   /**


### PR DESCRIPTION
### Changelog
Typo fix in the C++ code documentation

### Docs

None

### Description

See comment edit