### PR TITLE
c++: Clear writtenSchemas_ in terminate()

### DIFF
--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -477,6 +477,7 @@ void McapWriter::terminate() {
   metadataIndex_.clear();
   chunkIndex_.clear();
   statistics_ = {};
+  writtenSchemas_.clear();
   currentMessageIndex_.clear();
   currentChunkStart_ = MaxTime;
   currentChunkEnd_ = 0;


### PR DESCRIPTION
### Changelog

- C++ `McapWriter::terminate()` now clears the `writtenSchemas_` set, fixing serialization of `Schema` records after calling `close()` then `open()`. Fixes #1258
