### PR TITLE
CLI: accept RFC3339-formatted dates in relevant arguments

### DIFF
--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -14,8 +14,10 @@ import (
 
 var (
 	addAttachmentLogTime      uint64
+	addAttachmentLogDate      string
 	addAttachmentName         string
 	addAttachmentCreationTime uint64
+	addAttachmentCreationDate string
 	addAttachmentFilename     string
 	addAttachmentMediaType    string
 )
@@ -158,9 +160,23 @@ var addAttachmentCmd = &cobra.Command{
 		if addAttachmentCreationTime > 0 {
 			createTime = addAttachmentCreationTime
 		}
+		if addAttachmentCreationDate != "" {
+			date, err := parseDate(addAttachmentCreationDate)
+			if err != nil {
+				die("failed to parse creation date: %s", err)
+			}
+			createTime = date
+		}
 		logTime := uint64(time.Now().UTC().UnixNano())
 		if addAttachmentLogTime > 0 {
 			logTime = addAttachmentLogTime
+		}
+		if addAttachmentLogDate != "" {
+			date, err := parseDate(addAttachmentLogDate)
+			if err != nil {
+				die("failed to parse log date: %s", err)
+			}
+			logTime = date
 		}
 		err = utils.AmendMCAP(f, []*mcap.Attachment{
 			{
@@ -190,8 +206,14 @@ func init() {
 	addAttachmentCmd.PersistentFlags().Uint64VarP(
 		&addAttachmentLogTime, "log-time", "", 0, "attachment log time in nanoseconds (defaults to current timestamp)",
 	)
+	addAttachmentCmd.PersistentFlags().StringVarP(
+		&addAttachmentLogDate, "log-date", "", "", "RFC3339-formatted log date",
+	)
 	addAttachmentCmd.PersistentFlags().Uint64VarP(
 		&addAttachmentLogTime, "creation-time", "", 0, "attachment creation time in nanoseconds (defaults to ctime)",
+	)
+	addAttachmentCmd.PersistentFlags().StringVarP(
+		&addAttachmentCreationDate, "creation-date", "", "", "RFC3339-formatted creation date",
 	)
 	err := addAttachmentCmd.MarkPersistentFlagRequired("file")
 	if err != nil {

--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -156,7 +156,7 @@ var addAttachmentCmd = &cobra.Command{
 		}
 		createTime := uint64(fi.ModTime().UTC().UnixNano())
 		if addAttachmentCreationTime != "" {
-			date, err := parseTimestampArgs(addAttachmentCreationTime, 0, 0)
+			date, err := parseDateOrNanos(addAttachmentCreationTime)
 			if err != nil {
 				die("failed to parse creation date: %s", err)
 			}
@@ -164,7 +164,7 @@ var addAttachmentCmd = &cobra.Command{
 		}
 		logTime := uint64(time.Now().UTC().UnixNano())
 		if addAttachmentLogTime != "" {
-			date, err := parseTimestampArgs(addAttachmentCreationTime, 0, 0)
+			date, err := parseDateOrNanos(addAttachmentCreationTime)
 			if err != nil {
 				die("failed to parse log date: %s", err)
 			}

--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -13,11 +13,9 @@ import (
 )
 
 var (
-	addAttachmentLogTime      uint64
-	addAttachmentLogDate      string
+	addAttachmentLogTime      string
 	addAttachmentName         string
-	addAttachmentCreationTime uint64
-	addAttachmentCreationDate string
+	addAttachmentCreationTime string
 	addAttachmentFilename     string
 	addAttachmentMediaType    string
 )
@@ -157,22 +155,16 @@ var addAttachmentCmd = &cobra.Command{
 			die("failed to stat file %s", addAttachmentFilename)
 		}
 		createTime := uint64(fi.ModTime().UTC().UnixNano())
-		if addAttachmentCreationTime > 0 {
-			createTime = addAttachmentCreationTime
-		}
-		if addAttachmentCreationDate != "" {
-			date, err := parseDate(addAttachmentCreationDate)
+		if addAttachmentCreationTime != "" {
+			date, err := parseTimestampArgs(addAttachmentCreationTime, 0, 0)
 			if err != nil {
 				die("failed to parse creation date: %s", err)
 			}
 			createTime = date
 		}
 		logTime := uint64(time.Now().UTC().UnixNano())
-		if addAttachmentLogTime > 0 {
-			logTime = addAttachmentLogTime
-		}
-		if addAttachmentLogDate != "" {
-			date, err := parseDate(addAttachmentLogDate)
+		if addAttachmentLogTime != "" {
+			date, err := parseTimestampArgs(addAttachmentCreationTime, 0, 0)
 			if err != nil {
 				die("failed to parse log date: %s", err)
 			}
@@ -203,17 +195,11 @@ func init() {
 	addAttachmentCmd.PersistentFlags().StringVarP(
 		&addAttachmentMediaType, "content-type", "", "application/octet-stream", "content type of attachment",
 	)
-	addAttachmentCmd.PersistentFlags().Uint64VarP(
-		&addAttachmentLogTime, "log-time", "", 0, "attachment log time in nanoseconds (defaults to current timestamp)",
+	addAttachmentCmd.PersistentFlags().StringVarP(
+		&addAttachmentLogTime, "log-time", "", "", "attachment log time in nanoseconds or RFC3339 format (defaults to current timestamp)",
 	)
 	addAttachmentCmd.PersistentFlags().StringVarP(
-		&addAttachmentLogDate, "log-date", "", "", "RFC3339-formatted log date",
-	)
-	addAttachmentCmd.PersistentFlags().Uint64VarP(
-		&addAttachmentLogTime, "creation-time", "", 0, "attachment creation time in nanoseconds (defaults to ctime)",
-	)
-	addAttachmentCmd.PersistentFlags().StringVarP(
-		&addAttachmentCreationDate, "creation-date", "", "", "RFC3339-formatted creation date",
+		&addAttachmentLogTime, "creation-time", "", "", "attachment creation time in nanoseconds or RFC3339 format (defaults to ctime)",
 	)
 	err := addAttachmentCmd.MarkPersistentFlagRequired("file")
 	if err != nil {

--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -196,10 +196,18 @@ func init() {
 		&addAttachmentMediaType, "content-type", "", "application/octet-stream", "content type of attachment",
 	)
 	addAttachmentCmd.PersistentFlags().StringVarP(
-		&addAttachmentLogTime, "log-time", "", "", "attachment log time in nanoseconds or RFC3339 format (defaults to current timestamp)",
+		&addAttachmentLogTime,
+		"log-time",
+		"",
+		"",
+		"attachment log time in nanoseconds or RFC3339 format (defaults to current timestamp)",
 	)
 	addAttachmentCmd.PersistentFlags().StringVarP(
-		&addAttachmentLogTime, "creation-time", "", "", "attachment creation time in nanoseconds or RFC3339 format (defaults to ctime)",
+		&addAttachmentLogTime,
+		"creation-time",
+		"",
+		"",
+		"attachment creation time in nanoseconds or RFC3339 format (defaults to ctime)",
 	)
 	err := addAttachmentCmd.MarkPersistentFlagRequired("file")
 	if err != nil {

--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -437,7 +437,8 @@ usage:
 			"start-secs",
 			"s",
 			0,
-			"only include messages logged at or after this time. Accepts integer seconds. Ignored if `--startk` or `--start-nsecs` are used.",
+			"only include messages logged at or after this time. Accepts integer seconds."+
+				"Ignored if `--startk` or `--start-nsecs` are used.",
 		)
 		startNano := filterCmd.PersistentFlags().Uint64(
 			"start-nsecs",
@@ -454,7 +455,8 @@ usage:
 			"end-secs",
 			"e",
 			0,
-			"only include messages logged before this time. Accepts integer seconds. Ignored if `--end` or `--end-nsecs` are used.",
+			"only include messages logged before this time. Accepts integer seconds."+
+				"Ignored if `--end` or `--end-nsecs` are used.",
 		)
 		endNano := filterCmd.PersistentFlags().Uint64(
 			"end-nsecs",

--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -438,7 +438,7 @@ usage:
 			"s",
 			0,
 			"only include messages logged at or after this time. Accepts integer seconds."+
-				"Ignored if `--startk` or `--start-nsecs` are used.",
+				"Ignored if `--start` or `--start-nsecs` are used.",
 		)
 		startNano := filterCmd.PersistentFlags().Uint64(
 			"start-nsecs",

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -368,3 +368,12 @@ func TestCompileMatchers(t *testing.T) {
 	assert.True(t, matchers[0].MatchString("camera"))
 	assert.True(t, matchers[1].MatchString("lights"))
 }
+
+func TestParseDate(t *testing.T) {
+	expected := uint64(1690298850132545471)
+	zulu, err := parseDate("2023-07-25T15:27:30.132545471Z")
+	assert.Equal(t, expected, zulu)
+	withTimezone, err := parseDate("2023-07-26T01:27:30.132545471+10:00")
+	require.NoError(t, err)
+	assert.Equal(t, expected, withTimezone)
+}

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -369,12 +369,12 @@ func TestCompileMatchers(t *testing.T) {
 	assert.True(t, matchers[1].MatchString("lights"))
 }
 
-func TestParseDate(t *testing.T) {
+func TestParseDateOrNanos(t *testing.T) {
 	expected := uint64(1690298850132545471)
-	zulu, err := parseDate("2023-07-25T15:27:30.132545471Z")
+	zulu, err := parseDateOrNanos("2023-07-25T15:27:30.132545471Z")
 	require.NoError(t, err)
 	assert.Equal(t, expected, zulu)
-	withTimezone, err := parseDate("2023-07-26T01:27:30.132545471+10:00")
+	withTimezone, err := parseDateOrNanos("2023-07-26T01:27:30.132545471+10:00")
 	require.NoError(t, err)
 	assert.Equal(t, expected, withTimezone)
 }

--- a/go/cli/mcap/cmd/filter_test.go
+++ b/go/cli/mcap/cmd/filter_test.go
@@ -372,6 +372,7 @@ func TestCompileMatchers(t *testing.T) {
 func TestParseDate(t *testing.T) {
 	expected := uint64(1690298850132545471)
 	zulu, err := parseDate("2023-07-25T15:27:30.132545471Z")
+	require.NoError(t, err)
 	assert.Equal(t, expected, zulu)
 	withTimezone, err := parseDate("2023-07-26T01:27:30.132545471+10:00")
 	require.NoError(t, err)


### PR DESCRIPTION
### Changelog
#### Added
CLI: `mcap add attachment` accepts RFC3339-formatted dates to specify the log and creation times for the new attachment.
CLI: `mcap filter` accepts RFC3339-formatted dates for start and end times.
### Docs

None.

### Description

Adds the ability for users to specify a date when filtering MCAP files, or adding attachments.

I did a quick pass to see if there are any other arguments where we accept a date or date-like value, I can't see any more.