### PR TITLE
Add missing tslib dependencies

### DIFF
--- a/typescript/browser/package.json
+++ b/typescript/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Support library for using MCAP in the browser",
   "license": "MIT",
   "repository": {
@@ -53,5 +53,8 @@
     "prettier": "3.1.0",
     "ts-jest": "29.1.1",
     "typescript": "5.2.2"
+  },
+  "dependencies": {
+    "tslib": "^2.5.0"
   }
 }

--- a/typescript/nodejs/package.json
+++ b/typescript/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/nodejs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Support library for using MCAP in Node.js",
   "license": "MIT",
   "repository": {
@@ -54,5 +54,8 @@
     "prettier": "3.1.0",
     "ts-jest": "29.1.1",
     "typescript": "5.2.2"
+  },
+  "dependencies": {
+    "tslib": "^2.5.0"
   }
 }

--- a/typescript/support/package.json
+++ b/typescript/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/support",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Common decompression for use with MCAP files",
   "license": "MIT",
   "repository": {
@@ -57,6 +57,7 @@
     "@foxglove/wasm-bz2": "^0.1.1",
     "@foxglove/wasm-lz4": "^1.0.2",
     "@foxglove/wasm-zstd": "^1.0.1",
-    "protobufjs": "^7.2.5"
+    "protobufjs": "^7.2.5",
+    "tslib": "^2.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3511,6 +3511,7 @@ __metadata:
     jest: 29.7.0
     prettier: 3.1.0
     ts-jest: 29.1.1
+    tslib: ^2.5.0
     typescript: 5.2.2
   languageName: unknown
   linkType: soft
@@ -3567,6 +3568,7 @@ __metadata:
     jest: 29.7.0
     prettier: 3.1.0
     ts-jest: 29.1.1
+    tslib: ^2.5.0
     typescript: 5.2.2
   languageName: unknown
   linkType: soft
@@ -3596,6 +3598,7 @@ __metadata:
     prettier: 3.1.0
     protobufjs: ^7.2.5
     ts-jest: 29.1.1
+    tslib: ^2.5.0
     typescript: 5.2.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Changelog
TypeScript: Added missing dependencies on `tslib`

### Docs

None

### Description

Fixes #1262

When `importHelpers` is true in tsconfig.json (as it is by default with `@foxglove/tsconfig`), `tslib` must be a dependency.