### PR TITLE
C++: flush underlying writer after every chunk write

### DIFF
--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/1.4.1"
+    requires = "benchmark/1.7.0", "mcap/1.5.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.4.1
+conan editable add ./mcap mcap/1.5.0
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.4.1
+conan editable add ./mcap mcap/1.5.0
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/1.4.1"
+    requires = "mcap/1.5.0"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/1.4.1",
+        "mcap/1.5.0",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conan import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "1.4.1"
+    version = "1.5.0"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -1,5 +1,4 @@
-from conan import ConanFile, tools
-
+from conan import ConanFile
 
 class McapConan(ConanFile):
     name = "mcap"
@@ -13,9 +12,6 @@ class McapConan(ConanFile):
     settings = ("os", "compiler", "build_type", "arch")
     requires = ("lz4/1.9.4", "zstd/1.5.2")
     generators = "cmake"
-
-    def validate(self):
-        tools.check_min_cppstd(self, "17")
 
     def configure(self):
         pass

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools
+from conan import ConanFile, tools
 
 
 class McapConan(ConanFile):

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -1,4 +1,5 @@
-from conan import ConanFile
+from conans import ConanFile, tools
+
 
 class McapConan(ConanFile):
     name = "mcap"
@@ -12,6 +13,9 @@ class McapConan(ConanFile):
     settings = ("os", "compiler", "build_type", "arch")
     requires = ("lz4/1.9.4", "zstd/1.5.2")
     generators = "cmake"
+
+    def validate(self):
+        tools.check_min_cppstd(self, "17")
 
     def configure(self):
         pass

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "1.4.1"
+#define MCAP_LIBRARY_VERSION "1.5.0"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -148,7 +148,7 @@ public:
    * completed chunk. Callers may also retain a reference to the writer and call flush() at their
    * own cadence. Defaults to a no-op.
    */
-  virtual void flush(){};
+  virtual void flush() {}
 
 protected:
   virtual void handleWrite(const std::byte* data, uint64_t size) = 0;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -144,9 +144,11 @@ public:
   void resetCrc();
 
   /**
-   * @brief flushes any buffered data to the output. Defaults to a no-op.
+   * @brief flushes any buffered data to the output. This is called by McapWriter after every
+   * completed chunk. Callers may also retain a reference to the writer and call flush() at their
+   * own cadence. Defaults to a no-op.
    */
-  virtual void flush() = 0;
+  virtual void flush() {};
 
 protected:
   virtual void handleWrite(const std::byte* data, uint64_t size) = 0;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -240,10 +240,6 @@ public:
    */
   virtual const std::byte* compressedData() const = 0;
 
-  // No-op IWritable::flush() implementation. Chunk writers have no concept of an "underlying
-  // stream" to flush to.
-  void flush() override {}
-
 protected:
   virtual void handleClear() = 0;
 };

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -148,7 +148,7 @@ public:
    * completed chunk. Callers may also retain a reference to the writer and call flush() at their
    * own cadence. Defaults to a no-op.
    */
-  virtual void flush() {};
+  virtual void flush(){};
 
 protected:
   virtual void handleWrite(const std::byte* data, uint64_t size) = 0;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -143,6 +143,11 @@ public:
    */
   void resetCrc();
 
+  /**
+   * @brief flushes any buffered data to the output. Defaults to a no-op.
+   */
+  virtual void flush() = 0;
+
 protected:
   virtual void handleWrite(const std::byte* data, uint64_t size) = 0;
 
@@ -162,6 +167,7 @@ public:
 
   void handleWrite(const std::byte* data, uint64_t size) override;
   void end() override;
+  void flush() override;
   uint64_t size() const override;
 
 private:
@@ -179,6 +185,7 @@ public:
 
   void handleWrite(const std::byte* data, uint64_t size) override;
   void end() override;
+  void flush() override;
   uint64_t size() const override;
 
 private:
@@ -205,6 +212,7 @@ public:
    * @brief Returns the size in bytes of the uncompressed data.
    */
   virtual uint64_t size() const override = 0;
+
   /**
    * @brief Returns the size in bytes of the compressed data. This will only be
    * called after `end()`.
@@ -229,6 +237,10 @@ public:
    * after `end()`.
    */
   virtual const std::byte* compressedData() const = 0;
+
+  // No-op IWritable::flush() implementation. Chunk writers have no concept of an "underlying
+  // stream" to flush to.
+  void flush() override {}
 
 protected:
   virtual void handleClear() = 0;

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -61,6 +61,12 @@ void FileWriter::handleWrite(const std::byte* data, uint64_t size) {
   size_ += size;
 }
 
+void FileWriter::flush() {
+  if (file_) {
+    std::fflush(file_);
+  }
+}
+
 void FileWriter::end() {
   if (file_) {
     std::fclose(file_);
@@ -84,8 +90,12 @@ void StreamWriter::handleWrite(const std::byte* data, uint64_t size) {
   size_ += size;
 }
 
-void StreamWriter::end() {
+void StreamWriter::flush() {
   stream_.flush();
+}
+
+void StreamWriter::end() {
+  flush();
 }
 
 uint64_t StreamWriter::size() const {
@@ -921,6 +931,7 @@ uint64_t McapWriter::write(IWritable& output, const Chunk& chunk) {
   write(output, chunk.compression);
   write(output, chunk.compressedSize);
   write(output, chunk.records, chunk.compressedSize);
+  output.flush();
 
   return 9 + recordSize;
 }

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/1.4.1", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/1.5.0", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
### Changelog

#### C++
- Added: added a `flush()` method to `IWritable` to flush any buffered bytes to the underlying writer. This is optional for any external implementations to implement, and defaults to a no-op.
- Changed: After writing a chunk, the McapWriter will call `flush()` on the underlying writer. This ensures that any completed chunk does not get held up in an internal buffer while the next chunk is being constructed.

### Docs

See new docstring on `flush()`.
### Description

Adds a virtual function to the `IWritable` interface to flush it, with a default no-op implementation. I don't really know the right policy for un-chunked files, but my current opinion is that we can leave that to the caller - they might call flush every few seconds, or every few messages.

I don't consider this a breaking change. This is almost certainly ABI-breaking, but we don't support that as a public interface, and I can't see a way that this change would cause existing code to fail to compile.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<!--before content goes here-->

C++ writers using `FileWriter` might not see a chunk flushed to disk even after it has been fully finalized
<!--after content goes here-->
</td><td>

C++ writers using `FileWriter` will see a  chunk flushed to disk as soon as it is finished.

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
Fixes: #1254 

