### PR TITLE
Use smaller testdata files

### DIFF
--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -445,7 +445,7 @@ func TestReaderCounting(t *testing.T) {
 				require.NoError(t, err)
 				c++
 			}
-			assert.Equal(t, 1606, c)
+			assert.Equal(t, 3, c)
 		})
 	}
 }
@@ -673,7 +673,7 @@ func TestReadingDiagnostics(t *testing.T) {
 		require.NoError(t, err)
 		c++
 	}
-	assert.Equal(t, 52, c)
+	assert.Equal(t, 1, c)
 }
 
 func TestReadingMetadata(t *testing.T) {

--- a/python/mcap/tests/test_reader.py
+++ b/python/mcap/tests/test_reader.py
@@ -67,7 +67,7 @@ def test_all_messages(reader_cls: AnyReaderSubclass):
             assert isinstance(message, Message)
             count += 1
 
-        assert count == 1606
+        assert count == 3
 
 
 @pytest.mark.parametrize("reader_cls", READER_SUBCLASSES)
@@ -76,8 +76,8 @@ def test_time_range(reader_cls: AnyReaderSubclass):
     with open(DEMO_MCAP, "rb") as f:
         reader: McapReader = reader_cls(f)
         count = 0
-        start = int(1490149582 * 1e9)
-        end = int(1490149586 * 1e9)
+        start = int(40)
+        end = int(43)
         for schema, channel, message in reader.iter_messages(
             start_time=start, end_time=end
         ):
@@ -88,7 +88,7 @@ def test_time_range(reader_cls: AnyReaderSubclass):
             assert message.log_time >= start
             count += 1
 
-        assert count == 825
+        assert count == 1
 
 
 @pytest.mark.parametrize("reader_cls", READER_SUBCLASSES)
@@ -104,7 +104,7 @@ def test_only_diagnostics(reader_cls: AnyReaderSubclass):
             assert isinstance(message, Message)
             count += 1
 
-        assert count == 52
+        assert count == 1
 
 
 def write_json_mcap(filepath: Path):

--- a/testdata/bags/demo.bag
+++ b/testdata/bags/demo.bag
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e6e0049cc2567afe437da3f019debfcf1d96bd33f8c12d3680353a0329b6510
-size 70311473
+oid sha256:7792eacb1f0e8f7b7123ce127a1115c818f1826244cd7239f538da6133f65568
+size 5295

--- a/testdata/mcap/demo.mcap
+++ b/testdata/mcap/demo.mcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f878642b6fc15d2e771ce530252e6454de296e6d99b18748e6cd7d09eaa80598
-size 61497068
+oid sha256:b90a0af442bfc6aaf31d7ae0a361f04d2a4eecca7168f9917391b74697af5c8c
+size 990


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Use smaller and simpler `demo.bag` and `demo.mcap` files.

Fixes: FG-9552
