### PR TITLE
rust: make interfaces Send

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,6 +24,7 @@ paste = "1.0"
 thiserror = "1.0"
 lz4 = { version = "1.27", optional = true }
 tokio = { version = "1", features = ["io-util"] , optional = true }
+static_assertions = "1.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 zstd = { version = "0.11", features = ["wasm"], optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -210,3 +210,16 @@ pub struct Attachment<'a> {
 
 pub use read::{parse_record, MessageStream, Summary};
 pub use write::{WriteOptions, Writer};
+
+// The following assertions ensure that the MCAP components can be sent between threads.
+mod assertions {
+    use super::*;
+    use static_assertions::assert_impl_all;
+    use std::io::Cursor;
+
+    assert_impl_all!(Writer<Cursor<Vec<u8>>>: Send);
+    assert_impl_all!(MessageStream: Send);
+    assert_impl_all!(sans_io::read::LinearReader: Send);
+    #[cfg(feature = "tokio")]
+    assert_impl_all!(tokio::read::RecordReader<Cursor<Vec<u8>>>: Send);
+}

--- a/rust/src/sans_io/decompressor.rs
+++ b/rust/src/sans_io/decompressor.rs
@@ -8,7 +8,7 @@ pub struct DecompressResult {
 }
 
 /// A trait for streaming decompression.
-pub trait Decompressor {
+pub trait Decompressor: Send {
     /// Returns the recommended size of input to pass into `decompress()`.
     fn next_read_size(&self) -> usize;
     /// Decompresses up to `dst.len()` bytes, consuming up to `src.len()` bytes from `src`.


### PR DESCRIPTION
### Changelog

<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

rust: make sure structs are Send

### Docs

None

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

This PR makes sure that all MCAP readers and writers can be sent between threads. This is mainly just adding `Send` to the `Decompressor` trait, but it also adds compile time assertions to make sure we don't regress.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

readers are not `Send`

</td><td>

<!--after content goes here-->

readers are now `Send`

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
