### PR TITLE
Update docs to match exclusive end_time implementation

### DIFF
--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -84,7 +84,7 @@ def _chunks_matching_topics(
     :param summary: the summary of this MCAP.
     :param topics: topics to match. If None, all chunk indices in the summary are returned.
     :param start_time: if not None, messages from before this unix timestamp are not included.
-    :param end_time: if not None, messages from this unix timestamp or after are not included.
+    :param end_time: if not None, messages at or after this unix timestamp are not included.
     """
     out: List[ChunkIndex] = []
     for chunk_index in summary.chunk_indexes:

--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -138,8 +138,8 @@ class McapReader(ABC):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
-            timestamp are not included.
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after
+            this timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
         :param reverse: if both ``log_time_order`` and ``reverse`` are True, messages will be
@@ -160,8 +160,8 @@ class McapReader(ABC):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
-            timestamp are not included.
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after
+            this timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
         :param reverse: if both ``log_time_order`` and ``reverse`` are True, messages will be
@@ -274,8 +274,8 @@ class SeekingReader(McapReader):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
-            timestamp are not included.
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after
+            this timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
         :param reverse: if both ``log_time_order`` and ``reverse`` are True, messages will be
@@ -476,8 +476,8 @@ class NonSeekingReader(McapReader):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
-            timestamp are not included.
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after
+            this timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
         :param reverse: if both ``log_time_order`` and ``reverse`` are True, messages will be

--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -84,7 +84,7 @@ def _chunks_matching_topics(
     :param summary: the summary of this MCAP.
     :param topics: topics to match. If None, all chunk indices in the summary are returned.
     :param start_time: if not None, messages from before this unix timestamp are not included.
-    :param end_time: if not None, messages from after this unix timestamp are not included.
+    :param end_time: if not None, messages from this unix timestamp or after are not included.
     """
     out: List[ChunkIndex] = []
     for chunk_index in summary.chunk_indexes:
@@ -138,7 +138,7 @@ class McapReader(ABC):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged after this
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
             timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
@@ -160,7 +160,7 @@ class McapReader(ABC):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged after this
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
             timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
@@ -274,7 +274,7 @@ class SeekingReader(McapReader):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged after this
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
             timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.
@@ -476,7 +476,7 @@ class NonSeekingReader(McapReader):
         :param topics: if not None, only messages from these topics will be returned.
         :param start_time: an integer nanosecond timestamp. if provided, messages logged before this
             timestamp are not included.
-        :param end_time: an integer nanosecond timestamp. if provided, messages logged after this
+        :param end_time: an integer nanosecond timestamp. if provided, messages logged at or after this
             timestamp are not included.
         :param log_time_order: if True, messages will be yielded in ascending log time order. If
             False, messages will be yielded in the order they appear in the MCAP file.


### PR DESCRIPTION
### Changelog

None

### Docs

* Updated the Python docstrings for the MCAP readers to label the `end_time` parameter as an exclusive bound
* The documentation on [this page](https://mcap.dev/docs/python/mcap-apidoc/mcap.reader#mcap.reader.McapReader.iter_decoded_messages) will also be updated

### Description

According to the documentation [here](https://mcap.dev/docs/python/mcap-apidoc/mcap.reader#mcap.reader.McapReader.iter_decoded_messages), the iterator should exclude messages that were logged before `start_time` or after `end_time` (i.e. both inclusive bounds). However, the implementation also excludes messages published at the same time as `end_time` (making it an exclusive bound). The documentation has been updated to match the implementation.

This discrepancy in the Python package is only happening in `python/mcap/mcap/reader.py` where `iter_message()` and `iter_decoded_message()` are defined. In all of the other files where those functions are called, `end_time` is described as an exclusive bound:
- `python/mcap-protobuf-support/mcap_protobuf/reader.py`
- `python/mcap-ros1-support/mcap_ros1/reader.py`
- `python/mcap-ros2-support/mcap_ros2/reader.py`

This motivated updating the documentation rather than modifying the implementation (which would also have been a breaking change). In addition, this follows the typical Python convention of using inclusive-start and exclusive-end bounds (`list[start:end]`, `array[start:end]`, `range(start, end)`, `numpy.arange(start, end)`, etc...).

<table>
  <tr>
    <th></th><th>Before</th><th>After</th>
  </tr><tr>
    <td>Documentation</td>
    <td><code>end_time</code> is inclusive</td><td>
    <code>end_time</code> is exclusive</td>
  </tr><tr>
    <td>Implementation</td>
    <td><code>end_time</code> is exclusive</td>
    <td><code>end_time</code> is exclusive</td>
  </tr>
</table>


Fixes: FG-9583

