### PR TITLE
python: remove unused buffer

### DIFF
--- a/python/mcap/mcap/_chunk_builder.py
+++ b/python/mcap/mcap/_chunk_builder.py
@@ -48,6 +48,5 @@ class ChunkBuilder:
         self.message_end_time = 0
         self.message_indices.clear()
         self.message_start_time = 0
-        self.buffer = BytesIO()
         self.record_writer.end()
         self.num_messages = 0

--- a/python/mcap/mcap/_chunk_builder.py
+++ b/python/mcap/mcap/_chunk_builder.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 from typing import Dict
 
 from .data_stream import RecordBuilder


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description

In the Python implementation of `ChunkBuilder.reset()`, the `self.buffer` object is recreated but never actually referenced. This PR removes the unused `self.buffer` variable to simplify the code.

I manually ran the following examples without encountering any errors:
```
python3 python/examples/jsonschema/pointcloud_csv_to_mcap.py python/examples/jsonschema/bus.csv
python3 python/examples/protobuf/image_example.py ptoro_image.mcap
python3 python/examples/protobuf/writer.py proto.mcap
python3 python/examples/raw/writer.py raw.mcap
```

Additionally, I ran:
```
mcap doctor out.mcap
mcap doctor ptoro_image.mcap
mcap doctor proto.mcap
mcap doctor raw.mcap
```
All checks passed without issues.