### PR TITLE
mcap recover: print status message to stderr instead of stdout

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -257,11 +257,12 @@ func filter(
 	defer func() {
 		err := mcapWriter.Close()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "failed to close mcap writer: %w", err)
+			fmt.Fprintf(os.Stderr, "failed to close mcap writer: %w\n", err)
 			return
 		}
 		if opts.recover {
-			fmt.Printf(
+			fmt.Fprintf(
+				os.Stderr,
 				"Recovered %d messages, %d attachments, and %d metadata records.\n",
 				numMessages,
 				numAttachments,

--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -257,7 +257,7 @@ func filter(
 	defer func() {
 		err := mcapWriter.Close()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close mcap writer: %w\n", err)
+			fmt.Fprintf(os.Stderr, "failed to close mcap writer: %v\n", err)
 			return
 		}
 		if opts.recover {


### PR DESCRIPTION
### Changelog
Fixed a bug in `mcap recover` which would produce an invalid file when redirecting stdout to a file.

### Docs

None

### Description

Status message now goes to stderr instead of stdout.

Also fixed another nearby line which looked wrong, it was using Fprintln with `%w` but Fprintln doesn't accept format strings. https://pkg.go.dev/fmt#Fprintln