### PR TITLE
FG-2933: Add recorder support for audio frames to MCAP recording demo

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "2.4.1",
     "@foxglove/eslint-plugin": "1.0.1",
     "@foxglove/rostime": "1.1.2",
-    "@foxglove/schemas": "1.6.2",
+    "@foxglove/schemas": "github:foxglove/schemas#e2cd86e48762e9396737a00c56e1d45ebfae24e3",
     "@foxglove/tsconfig": "2.0.0",
     "@mcap/core": "workspace:*",
     "@mdx-js/react": "1.6.22",

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "2.4.1",
     "@foxglove/eslint-plugin": "1.0.1",
     "@foxglove/rostime": "1.1.2",
-    "@foxglove/schemas": "github:foxglove/schemas#e2cd86e48762e9396737a00c56e1d45ebfae24e3",
+    "@foxglove/schemas": "github:foxglove/schemas#fbb9ccfd8d31ac6c3aa18ce7b9959eb0be9bed7c",
     "@foxglove/tsconfig": "2.0.0",
     "@mcap/core": "workspace:*",
     "@mdx-js/react": "1.6.22",

--- a/website/src/components/McapRecordingDemo/Recorder.ts
+++ b/website/src/components/McapRecordingDemo/Recorder.ts
@@ -309,13 +309,15 @@ export class Recorder extends EventEmitter<RecorderEvents> {
         sample_rate: data.sampleRate,
         number_of_channels: data.numberOfChannels,
       };
+      const encodedMsg = rootType.encode(msg).finish();
+      data.release();
       const now = this.#time();
       await this.#writer.addMessage({
         sequence,
         channelId: id,
         logTime: now,
         publishTime: now,
-        data: rootType.encode(msg).finish(),
+        data: encodedMsg,
       });
       this.messageCount++;
       this.#emit();

--- a/website/src/components/McapRecordingDemo/Recorder.ts
+++ b/website/src/components/McapRecordingDemo/Recorder.ts
@@ -1,3 +1,5 @@
+// cspell:word millis
+
 import { Time, fromMillis, fromNanoSec } from "@foxglove/rostime";
 import {
   PoseInFrame,

--- a/website/src/components/McapRecordingDemo/audioCapture.ts
+++ b/website/src/components/McapRecordingDemo/audioCapture.ts
@@ -1,0 +1,13 @@
+type CompressedAudioFormat = "opus";
+type CompressedAudioType = "key" | "delta";
+export type CompressedAudioData = {
+  format: CompressedAudioFormat;
+  type: CompressedAudioType;
+  timestamp: number;
+  data: Uint8Array;
+  sampleRate: number;
+  numberOfChannels: number;
+
+  /** Call this function to release the buffer so it can be reused for new frames */
+  release: () => void;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,13 +3056,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/schemas@github:foxglove/schemas#e2cd86e48762e9396737a00c56e1d45ebfae24e3":
+"@foxglove/schemas@github:foxglove/schemas#fbb9ccfd8d31ac6c3aa18ce7b9959eb0be9bed7c":
   version: 1.6.7
-  resolution: "@foxglove/schemas@https://github.com/foxglove/schemas.git#commit=e2cd86e48762e9396737a00c56e1d45ebfae24e3"
+  resolution: "@foxglove/schemas@https://github.com/foxglove/schemas.git#commit=fbb9ccfd8d31ac6c3aa18ce7b9959eb0be9bed7c"
   dependencies:
     "@foxglove/rosmsg-msgs-common": "npm:^3.0.0"
     tslib: "npm:^2.5.0"
-  checksum: 10c0/67b13339aa3f485e786c93ef22f45f67598db1c77c0fa062b30c22a85f3be8a655ae5c351279bccd98751dce64ba7c95ddbd0cc7ca77b3281795e195faaa042d
+  checksum: 10c0/5153e9973b5d16ae92bdd6d4c1837518adc425f78a33985cf3f364027895c792d136aa6ac9f7233d44670b4be72bd4c3946aec3c7099514054af88eaf8ffde1b
   languageName: node
   linkType: hard
 
@@ -15620,7 +15620,7 @@ __metadata:
     "@docusaurus/preset-classic": "npm:2.4.1"
     "@foxglove/eslint-plugin": "npm:1.0.1"
     "@foxglove/rostime": "npm:1.1.2"
-    "@foxglove/schemas": "github:foxglove/schemas#e2cd86e48762e9396737a00c56e1d45ebfae24e3"
+    "@foxglove/schemas": "github:foxglove/schemas#fbb9ccfd8d31ac6c3aa18ce7b9959eb0be9bed7c"
     "@foxglove/tsconfig": "npm:2.0.0"
     "@mcap/core": "workspace:*"
     "@mdx-js/react": "npm:1.6.22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,6 +3056,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/schemas@github:foxglove/schemas#e2cd86e48762e9396737a00c56e1d45ebfae24e3":
+  version: 1.6.7
+  resolution: "@foxglove/schemas@https://github.com/foxglove/schemas.git#commit=e2cd86e48762e9396737a00c56e1d45ebfae24e3"
+  dependencies:
+    "@foxglove/rosmsg-msgs-common": "npm:^3.0.0"
+    tslib: "npm:^2.5.0"
+  checksum: 10c0/67b13339aa3f485e786c93ef22f45f67598db1c77c0fa062b30c22a85f3be8a655ae5c351279bccd98751dce64ba7c95ddbd0cc7ca77b3281795e195faaa042d
+  languageName: node
+  linkType: hard
+
 "@foxglove/schemas@npm:1.3.0":
   version: 1.3.0
   resolution: "@foxglove/schemas@npm:1.3.0"
@@ -3066,7 +3076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/schemas@npm:1.6.2, @foxglove/schemas@npm:^1.0.0":
+"@foxglove/schemas@npm:^1.0.0":
   version: 1.6.2
   resolution: "@foxglove/schemas@npm:1.6.2"
   dependencies:
@@ -15610,7 +15620,7 @@ __metadata:
     "@docusaurus/preset-classic": "npm:2.4.1"
     "@foxglove/eslint-plugin": "npm:1.0.1"
     "@foxglove/rostime": "npm:1.1.2"
-    "@foxglove/schemas": "npm:1.6.2"
+    "@foxglove/schemas": "github:foxglove/schemas#e2cd86e48762e9396737a00c56e1d45ebfae24e3"
     "@foxglove/tsconfig": "npm:2.0.0"
     "@mcap/core": "workspace:*"
     "@mdx-js/react": "npm:1.6.22"


### PR DESCRIPTION
1. #1292 **<-- you are here** 
2. #1293
3. #1295

### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Foxglove does not currently support audio messages of any kind. In order to support playback of audio in Foxglove Studio, this stack of PRs adds support to record MCAP files with audio.

In this first PR, I add the ability to record audio data to the MCAP demo recorder. This does not include the user-facing controls to actually record the audio - just the plumbing to write the messages to the MCAP file.

Tested locally using the MCAP recording demo and a new Audio panel.

[FG-2933](https://linear.app/foxglove/issue/FG-2933)
