### PR TITLE
FG-2933: Add microphone capture (opus) to MCAP recording demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ["releases/**", "go/mcap/*"]
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   spellcheck:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   docs-home:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -189,3 +189,8 @@ overrides:
   - filename: "docs/**"
     words:
       - plex
+
+  - filename: "tsconfig.json"
+    words:
+      - webcodecs
+      - mediacapture

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,8 @@
     "@mcap/core": "workspace:*",
     "@mdx-js/react": "1.6.22",
     "@tsconfig/docusaurus": "1.0.7",
+    "@types/dom-mediacapture-transform": "0.1.10",
+    "@types/dom-webcodecs": "0.1.13",
     "@types/promise-queue": "2.2.0",
     "buffer": "6.0.3",
     "classnames": "2.3.2",

--- a/website/src/components/McapRecordingDemo/McapRecordingDemo.module.css
+++ b/website/src/components/McapRecordingDemo/McapRecordingDemo.module.css
@@ -106,7 +106,7 @@
   margin: 0;
 }
 
-.videoContainer {
+.mediaContainer {
   background-color: #6f3be80f;
   border: 1px solid #e0e0e0;
   font-size: 0.8rem;
@@ -120,11 +120,11 @@
   overflow: hidden;
 }
 
-[data-theme="dark"] .videoContainer {
+[data-theme="dark"] .mediaContainer {
   background-color: transparent;
 }
 
-.videoContainer video {
+.mediaContainer video {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -133,7 +133,7 @@
   z-index: 0;
 }
 
-.videoContainer .videoErrorContainer {
+.mediaContainer .mediaErrorContainer {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -143,16 +143,16 @@
   z-index: 1;
 }
 
-[data-theme="dark"] .videoContainer .videoErrorContainer {
+[data-theme="dark"] .mediaContainer .mediaErrorContainer {
   background-color: #17151ec4;
 }
 
-.videoPlaceholderText {
+.mediaPlaceholderText {
   font-weight: 600;
   cursor: pointer;
 }
 
-.videoLoadingIndicator {
+.mediaLoadingIndicator {
   position: absolute;
   top: 50%;
   left: 50%;

--- a/website/src/components/McapRecordingDemo/McapRecordingDemo.tsx
+++ b/website/src/components/McapRecordingDemo/McapRecordingDemo.tsx
@@ -16,10 +16,10 @@ import {
   toProtobufTime,
 } from "./Recorder";
 import {
-  recordAudioStream,
   startAudioStream,
   CompressedAudioData,
   startAudioCapture,
+  supportsOpusEncoding,
 } from "./audioCapture";
 import {
   CompressedVideoFrame,
@@ -164,6 +164,7 @@ export function McapRecordingDemo(): JSX.Element {
   const { data: h265Support } = useAsync(supportsH265Encoding);
   const { data: vp9Support } = useAsync(supportsVP9Encoding);
   const { data: av1Support } = useAsync(supportsAV1Encoding);
+  const { data: opusSupport } = useAsync(supportsOpusEncoding);
 
   const canStartRecording =
     recordMouse ||
@@ -294,7 +295,6 @@ export function McapRecordingDemo(): JSX.Element {
     recordH265,
     recordVP9,
     recordAV1,
-    recordVP9,
     recording,
     videoStarted,
     recordJpeg,
@@ -346,7 +346,7 @@ export function McapRecordingDemo(): JSX.Element {
     });
 
     return () => {
-      cleanup();
+      cleanup?.();
     };
   }, [addAudioData, enableMicrophone, recordOpus, audioStream, recording]);
 
@@ -488,16 +488,18 @@ export function McapRecordingDemo(): JSX.Element {
             />
             Camera (JPEG)
           </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={recordOpus}
-              onChange={(event) => {
-                setRecordOpus(event.target.checked);
-              }}
-            />
-            Microphone (Opus)
-          </label>
+          {opusSupport === true && (
+            <label>
+              <input
+                type="checkbox"
+                checked={recordOpus}
+                onChange={(event) => {
+                  setRecordOpus(event.target.checked);
+                }}
+              />
+              Microphone (Opus)
+            </label>
+          )}
           {!hasMouse && (
             <label>
               <input

--- a/website/src/components/McapRecordingDemo/audioCapture.ts
+++ b/website/src/components/McapRecordingDemo/audioCapture.ts
@@ -1,3 +1,89 @@
+type AudioStreamParams = {
+  /** Progress element to display the volume level */
+  progress: HTMLProgressElement;
+  /** Called when the audio stream is available */
+  onAudioStream: (stream: MediaStream) => void;
+  /** Called when an error is encountered */
+  onError: (error: Error) => void;
+};
+
+/**
+ * Prompts the user for microphone permission and displays audio volume in the provided <progress> element
+ * @returns A function to stop the stream and clean up resources
+ */
+export function startAudioStream({
+  progress,
+  onAudioStream,
+  onError,
+}: AudioStreamParams): () => void {
+  let canceled = false;
+  let stream: MediaStream | undefined;
+  let animationID = 0;
+
+  // Although TypeScript does not believe mediaDevices is ever undefined, it may be in practice
+  // (e.g. in Safari)
+  if (typeof navigator.mediaDevices !== "object") {
+    onError(new Error("navigator.mediaDevices is not defined"));
+  } else {
+    const update = (analyzer: AnalyserNode) => {
+      if (canceled) {
+        return;
+      }
+
+      animationID = requestAnimationFrame(() => {
+        // Update the progress bar to show the audio level
+        const fbcArray = new Uint8Array(analyzer.frequencyBinCount);
+        analyzer.getByteFrequencyData(fbcArray);
+        const level =
+          fbcArray.reduce((accum, val) => accum + val, 0) / fbcArray.length;
+        progress.value = level / 100;
+
+        update(analyzer);
+      });
+    };
+
+    const context = new AudioContext();
+    void context.resume();
+    navigator.mediaDevices
+      .getUserMedia({ audio: true })
+      .then((mediaStream) => {
+        if (canceled) {
+          return;
+        }
+        stream = mediaStream;
+        onAudioStream(stream);
+
+        // For displaying volume level
+        const source = context.createMediaStreamSource(stream);
+        const analyzer = context.createAnalyser();
+        source.connect(analyzer);
+
+        update(analyzer);
+      })
+      .catch((err) => {
+        if (canceled) {
+          return;
+        }
+
+        onError(
+          new Error(
+            `${(
+              err as Error
+            ).toString()}. Ensure microphone permissions are enabled.`,
+          ),
+        );
+      });
+  }
+
+  return () => {
+    canceled = true;
+    cancelAnimationFrame(animationID);
+    for (const track of stream?.getTracks() ?? []) {
+      track.stop();
+    }
+  };
+}
+
 type CompressedAudioFormat = "opus";
 type CompressedAudioType = "key" | "delta";
 export type CompressedAudioData = {
@@ -11,3 +97,94 @@ export type CompressedAudioData = {
   /** Call this function to release the buffer so it can be reused for new frames */
   release: () => void;
 };
+
+interface AudioCaptureParams {
+  enableOpus: boolean;
+  /** MediaStream from startAudioStream */
+  stream: MediaStream;
+  /** Called when an audio frame has been encoded */
+  onAudioData: (data: CompressedAudioData) => void;
+  onError: (error: Error) => void;
+}
+
+export function startAudioCapture({
+  enableOpus,
+  stream,
+  onAudioData,
+  onError,
+}: AudioCaptureParams): () => void {
+  const framePool: ArrayBuffer[] = [];
+
+  const track = stream.getAudioTracks()[0];
+  if (!track) {
+    onError(new Error("Invariant: expected audio track"));
+    return () => {
+      // no op
+    };
+  }
+
+  const settings = track.getSettings();
+
+  const trackProcessor = new MediaStreamTrackProcessor({
+    // TODO: Don't assert
+    track: stream.getAudioTracks()[0]!,
+  });
+
+  const encoder = new AudioEncoder({
+    output: (chunk) => {
+      console.log(chunk);
+      let buffer = framePool.pop();
+      if (!buffer || buffer.byteLength < chunk.byteLength) {
+        buffer = new ArrayBuffer(chunk.byteLength);
+      }
+      chunk.copyTo(buffer);
+      onAudioData({
+        format: "opus",
+        type: chunk.type as CompressedAudioType,
+        timestamp: chunk.timestamp,
+        data: new Uint8Array(buffer, 0, chunk.byteLength),
+        sampleRate: settings.sampleRate ?? 0,
+        numberOfChannels: settings.channelCount ?? 0,
+        release() {
+          // TODO: Don't assert
+          framePool.push(buffer!);
+        },
+      });
+    },
+    error: (error) => {
+      onError(error);
+    },
+  });
+  encoder.configure({
+    codec: "opus",
+    sampleRate: settings.sampleRate ?? 0,
+    numberOfChannels: settings.channelCount ?? 0,
+  });
+
+  const reader = trackProcessor.readable.getReader();
+  let canceled = false;
+
+  const readAndEncode = () => {
+    reader
+      .read()
+      .then((result) => {
+        if (result.done || canceled) {
+          return;
+        }
+
+        encoder.encode(result.value);
+
+        readAndEncode();
+      })
+      .catch((error) => {
+        onError(error as Error);
+      });
+  };
+
+  readAndEncode();
+
+  return () => {
+    canceled = true;
+    encoder.close();
+  };
+}

--- a/website/src/components/McapRecordingDemo/audioCapture.ts
+++ b/website/src/components/McapRecordingDemo/audioCapture.ts
@@ -35,7 +35,7 @@ export function startAudioStream({
         const fbcArray = new Uint8Array(analyzer.frequencyBinCount);
         analyzer.getByteFrequencyData(fbcArray);
         const level =
-          fbcArray.reduce((accum, val) => accum + val, 0) / fbcArray.length;
+          fbcArray.reduce((acc, val) => acc + val, 0) / fbcArray.length;
         progress.value = level / 100;
 
         update(analyzer);

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -10,6 +10,7 @@
       "@mcap/core": ["../typescript/core/src"]
     },
     "moduleResolution": "node",
+    "types": ["dom-webcodecs", "dom-mediacapture-transform"],
 
     // Settings from @foxglove/tsconfig/base
     "newLine": "lf",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4163,6 +4163,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dom-mediacapture-transform@npm:0.1.10":
+  version: 0.1.10
+  resolution: "@types/dom-mediacapture-transform@npm:0.1.10"
+  dependencies:
+    "@types/dom-webcodecs": "npm:*"
+  checksum: 10c0/cbad14e0b78bdd36dad7780d06526ab27cdc14c90035826dec0d2a1e71d5b77cc3f58feb0d9e0c08c9f6ebdb4d5a60cc507c7126115e0829d5987acc49e4dd30
+  languageName: node
+  linkType: hard
+
+"@types/dom-webcodecs@npm:*, @types/dom-webcodecs@npm:0.1.13":
+  version: 0.1.13
+  resolution: "@types/dom-webcodecs@npm:0.1.13"
+  checksum: 10c0/16683fd0330fdfbb867affec1c18fd493d88433a4ec66257579adc5d07b07e9492268b4401e9017b7388b13750722365b0392b375e39c84e74f564d5b4f634a4
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.4
   resolution: "@types/eslint-scope@npm:3.7.4"
@@ -15625,6 +15641,8 @@ __metadata:
     "@mcap/core": "workspace:*"
     "@mdx-js/react": "npm:1.6.22"
     "@tsconfig/docusaurus": "npm:1.0.7"
+    "@types/dom-mediacapture-transform": "npm:0.1.10"
+    "@types/dom-webcodecs": "npm:0.1.13"
     "@types/promise-queue": "npm:2.2.0"
     buffer: "npm:6.0.3"
     classnames: "npm:2.3.2"


### PR DESCRIPTION
1. #1292 
2. #1293 **<-- you are here**
3. #1295

### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Add microphone capture (opus) to MCAP recording demo

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Foxglove does not currently support audio messages of any kind. In order to support playback of audio in Foxglove Studio, this stack of PRs adds support to record MCAP files with audio.

This PR adds the ability for a user to select a microphone for capture.

- Show a checkbox for `Microphone (Opus)` when supported
- Show microphone volume level while microphone is enabled
- Read, encode, and record the audio track when recording is enabled
  - [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API)

Tested locally using the MCAP recording demo and a new Audio panel.

[FG-2933](https://linear.app/foxglove/issue/FG-2933)

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

https://github.com/user-attachments/assets/4a634040-4837-4b4d-afc0-0210ae19d20b

</td><td>

<!--after content goes here-->

<img width="655" alt="Screenshot 2024-12-15 at 4 41 32 PM" src="https://github.com/user-attachments/assets/5f80ff24-4d7e-4474-9871-183fd46642b0" />

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

