### PR TITLE
FG-2933: Add mp4a.40.2 capture to MCAP recording demo

### DIFF
--- a/website/src/components/McapRecordingDemo/McapRecordingDemo.tsx
+++ b/website/src/components/McapRecordingDemo/McapRecordingDemo.tsx
@@ -20,6 +20,7 @@ import {
   CompressedAudioData,
   startAudioCapture,
   supportsOpusEncoding,
+  supportsMP4AEncoding,
 } from "./audioCapture";
 import {
   CompressedVideoFrame,
@@ -144,6 +145,7 @@ export function McapRecordingDemo(): JSX.Element {
   const [recordH265, setRecordH265] = useState(false);
   const [recordVP9, setRecordVP9] = useState(false);
   const [recordAV1, setRecordAV1] = useState(false);
+  const [recordMP4A, setRecordMP4A] = useState(false);
   const [recordOpus, setRecordOpus] = useState(false);
   const [recordMouse, setRecordMouse] = useState(true);
   const [recordOrientation, setRecordOrientation] = useState(true);
@@ -164,6 +166,7 @@ export function McapRecordingDemo(): JSX.Element {
   const { data: h265Support } = useAsync(supportsH265Encoding);
   const { data: vp9Support } = useAsync(supportsVP9Encoding);
   const { data: av1Support } = useAsync(supportsAV1Encoding);
+  const { data: mp4aSupport } = useAsync(supportsMP4AEncoding);
   const { data: opusSupport } = useAsync(supportsOpusEncoding);
 
   const canStartRecording =
@@ -174,6 +177,7 @@ export function McapRecordingDemo(): JSX.Element {
     (recordH265 && !videoError) ||
     (recordH264 && !videoError) ||
     (recordJpeg && !videoError) ||
+    (recordMP4A && !audioError) ||
     (recordOpus && !audioError);
 
   // Automatically pause recording after 30 seconds to avoid unbounded growth
@@ -304,7 +308,7 @@ export function McapRecordingDemo(): JSX.Element {
     undefined,
   );
 
-  const enableMicrophone = recordOpus;
+  const enableMicrophone = recordMP4A || recordOpus;
   useEffect(() => {
     const progress = audioProgressRef.current;
     if (!progress || !enableMicrophone) {
@@ -327,7 +331,7 @@ export function McapRecordingDemo(): JSX.Element {
       setAudioStream(undefined);
       setAudioError(undefined);
     };
-  }, [enableMicrophone, recordOpus]);
+  }, [enableMicrophone]);
 
   useEffect(() => {
     if (!enableMicrophone || !recording || !audioStream) {
@@ -335,6 +339,7 @@ export function McapRecordingDemo(): JSX.Element {
     }
 
     const cleanup = startAudioCapture({
+      enableMP4A: recordMP4A,
       enableOpus: recordOpus,
       stream: audioStream,
       onAudioData: (data) => {
@@ -348,7 +353,14 @@ export function McapRecordingDemo(): JSX.Element {
     return () => {
       cleanup?.();
     };
-  }, [addAudioData, enableMicrophone, recordOpus, audioStream, recording]);
+  }, [
+    addAudioData,
+    enableMicrophone,
+    recordMP4A,
+    recordOpus,
+    audioStream,
+    recording,
+  ]);
 
   const onRecordClick = useCallback(
     (event: React.MouseEvent) => {
@@ -488,6 +500,18 @@ export function McapRecordingDemo(): JSX.Element {
             />
             Camera (JPEG)
           </label>
+          {mp4aSupport === true && (
+            <label>
+              <input
+                type="checkbox"
+                checked={recordMP4A}
+                onChange={(event) => {
+                  setRecordMP4A(event.target.checked);
+                }}
+              />
+              Microphone (mp4a.40.2)
+            </label>
+          )}
           {opusSupport === true && (
             <label>
               <input

--- a/website/src/components/McapRecordingDemo/Recorder.ts
+++ b/website/src/components/McapRecordingDemo/Recorder.ts
@@ -64,6 +64,8 @@ export class Recorder extends EventEmitter<RecorderEvents> {
   #vp9ChannelSeq = 0;
   #av1Channel?: ProtobufChannelInfo;
   #av1ChannelSeq = 0;
+  #mp4aChannel?: ProtobufChannelInfo;
+  #mp4aChannelSeq = 0;
   #opusChannel?: ProtobufChannelInfo;
   #opusChannelSeq = 0;
 
@@ -118,6 +120,8 @@ export class Recorder extends EventEmitter<RecorderEvents> {
     this.#h265ChannelSeq = 0;
     this.#av1Channel = undefined;
     this.#av1ChannelSeq = 0;
+    this.#mp4aChannel = undefined;
+    this.#mp4aChannelSeq = 0;
     this.#opusChannel = undefined;
     this.#opusChannelSeq = 0;
   }
@@ -293,6 +297,14 @@ export class Recorder extends EventEmitter<RecorderEvents> {
       let channel: ProtobufChannelInfo;
       let sequence: number;
       switch (data.format) {
+        case "mp4a.40.2":
+          channel = this.#mp4aChannel ??= await addProtobufChannel(
+            this.#writer,
+            "microphone_mp4a",
+            foxgloveMessageSchemas.CompressedAudio,
+          );
+          sequence = this.#mp4aChannelSeq++;
+          break;
         case "opus":
           channel = this.#opusChannel ??= await addProtobufChannel(
             this.#writer,


### PR DESCRIPTION
1. #1292 
2. #1293
3. #1295 **<-- you are here**

### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Add microphone capture (mp4a.40.2) to MCAP recording demo

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Foxglove does not currently support audio messages of any kind. In order to support playback of audio in Foxglove Studio, this stack of PRs adds support to record MCAP files with audio.

This PR adds the ability for a user to select a microphone for capture with the `mp4a.40.2` encoding.

- Show a checkbox for `Microphone (mp4a.40.2)` when supported
- Configure multiple encoders for use
  - [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API)
- Record `mp4a` channel in the Recorder

Tested locally using the MCAP recording demo and a new Audio panel.

[FG-2933](https://linear.app/foxglove/issue/FG-2933)

Supported `AudioEncoder` and `AudioDecoder` configs in Chrome:

<img width="823" alt="chrome-encoder-decoder-support" src="https://github.com/user-attachments/assets/f781c518-afd0-40c6-bae3-98303e4e8c00" />
