### PR TITLE
rust: Channel and Schema structs have IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,7 @@ jobs:
           components: "rustfmt, clippy"
       - run: rustup target add wasm32-unknown-unknown
       - run: cargo fmt --all -- --check
-      - run: cargo clippy -- --no-deps
+      - run: cargo clippy --all-targets -- --no-deps
       - run: cargo clippy --no-default-features -- --no-deps
       - run: cargo clippy --no-default-features --features lz4 -- --no-deps
       - run: cargo clippy --no-default-features --features zstd -- --no-deps

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0"
 lz4 = { version = "1.27", optional = true }
 tokio = { version = "1", features = ["io-util"] , optional = true }
 static_assertions = "1.1.0"
+bimap = "0.6.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 zstd = { version = "0.11", features = ["wasm"], optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.13.3"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/benches/reader.rs
+++ b/rust/benches/reader.rs
@@ -17,12 +17,14 @@ fn create_test_mcap(n: usize, compression: Option<mcap::Compression>) -> Vec<u8>
         const MESSAGE_DATA: &[u8] = &[42; 10];
 
         let schema = Arc::new(Schema {
+            id: 1,
             name: "TestSchema".to_string(),
             encoding: "raw".to_string(),
             data: Cow::Borrowed(b"{}"),
         });
 
         let channel = Arc::new(Channel {
+            id: 0,
             topic: "test_topic".to_string(),
             message_encoding: "raw".to_string(),
             metadata: Default::default(),
@@ -35,7 +37,7 @@ fn create_test_mcap(n: usize, compression: Option<mcap::Compression>) -> Vec<u8>
                 sequence: i as u32,
                 log_time: i as u64,
                 publish_time: i as u64,
-                data: Cow::Borrowed(&MESSAGE_DATA),
+                data: Cow::Borrowed(MESSAGE_DATA),
             };
             writer.write(&message).unwrap();
         }

--- a/rust/examples/common/conformance_writer_spec.rs
+++ b/rust/examples/common/conformance_writer_spec.rs
@@ -20,28 +20,26 @@ pub struct Record {
 }
 
 impl Record {
-    pub fn get_field(self: &Self, name: &str) -> &Value {
-        return &self
+    pub fn get_field(&self, name: &str) -> &Value {
+        &self
             .fields
             .iter()
             .find(|f| f.0 == name)
             .unwrap_or_else(|| panic!("Invalid: {}", name))
-            .1;
+            .1
     }
 
-    pub fn get_field_data(self: &Self, name: &str) -> Vec<u8> {
-        let data: Vec<u8> = self
-            .get_field(name)
+    pub fn get_field_data(&self, name: &str) -> Vec<u8> {
+        self.get_field(name)
             .as_array()
             .unwrap_or_else(|| panic!("Invalid: {}", name))
-            .into_iter()
+            .iter()
             .filter_map(|v| v.as_u64())
             .filter_map(|n| u8::try_from(n).ok())
-            .collect();
-        return data;
+            .collect()
     }
 
-    pub fn get_field_meta(self: &Self, name: &str) -> BTreeMap<String, String> {
+    pub fn get_field_meta(&self, name: &str) -> BTreeMap<String, String> {
         let data = self
             .get_field(name)
             .as_object()
@@ -50,38 +48,34 @@ impl Record {
         for (key, value) in data.iter() {
             result.insert(key.to_string(), value.as_str().unwrap().to_string());
         }
-        return result;
+        result
     }
 
-    pub fn get_field_str(self: &Self, name: &str) -> &str {
-        return self
-            .get_field(name)
+    pub fn get_field_str(&self, name: &str) -> &str {
+        self.get_field(name)
             .as_str()
-            .unwrap_or_else(|| panic!("Invalid: {}", name));
+            .unwrap_or_else(|| panic!("Invalid: {}", name))
     }
 
-    pub fn get_field_u16(self: &Self, name: &str) -> u16 {
-        return self
-            .get_field(name)
+    pub fn get_field_u16(&self, name: &str) -> u16 {
+        self.get_field(name)
             .as_str()
             .and_then(|s| s.parse::<u16>().ok())
-            .unwrap_or_else(|| panic!("Invalid: {}", name));
+            .unwrap_or_else(|| panic!("Invalid: {}", name))
     }
 
-    pub fn get_field_u32(self: &Self, name: &str) -> u32 {
-        return self
-            .get_field(name)
+    pub fn get_field_u32(&self, name: &str) -> u32 {
+        self.get_field(name)
             .as_str()
             .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or_else(|| panic!("Invalid: {}", name));
+            .unwrap_or_else(|| panic!("Invalid: {}", name))
     }
 
-    pub fn get_field_u64(self: &Self, name: &str) -> u64 {
-        return self
-            .get_field(name)
+    pub fn get_field_u64(&self, name: &str) -> u64 {
+        self.get_field(name)
             .as_str()
             .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or_else(|| panic!("Invalid: {}", name));
+            .unwrap_or_else(|| panic!("Invalid: {}", name))
     }
 }
 

--- a/rust/examples/conformance_writer.rs
+++ b/rust/examples/conformance_writer.rs
@@ -29,7 +29,7 @@ fn write_file(spec: &conformance_writer_spec::WriterSpec) {
                     media_type: record.get_field_str("media_type").to_owned(),
                 };
                 writer
-                    .attach(&attachment)
+                .attach(&attachment)
                     .expect("Couldn't write attachment");
             }
             "AttachmentIndex" => {

--- a/rust/examples/conformance_writer.rs
+++ b/rust/examples/conformance_writer.rs
@@ -29,7 +29,7 @@ fn write_file(spec: &conformance_writer_spec::WriterSpec) {
                     media_type: record.get_field_str("media_type").to_owned(),
                 };
                 writer
-                .attach(&attachment)
+                    .attach(&attachment)
                     .expect("Couldn't write attachment");
             }
             "AttachmentIndex" => {

--- a/rust/examples/conformance_writer.rs
+++ b/rust/examples/conformance_writer.rs
@@ -37,13 +37,19 @@ fn write_file(spec: &conformance_writer_spec::WriterSpec) {
             }
             "Channel" => {
                 let id = record.get_field_u16("id");
-                let schema_id = record.get_field_u64("schema_id");
+                let schema_id = record.get_field_u16("schema_id");
+                let output_schema_id = match schema_id {
+                    0 => 0,
+                    input_schema_id => {
+                        *schema_ids.get(&input_schema_id).expect("unknown schema ID")
+                    }
+                };
                 let topic = record.get_field_str("topic");
                 let message_encoding = record.get_field_str("message_encoding");
                 let returned_id = writer
-                    .add_channel(schema_id as u16, topic, message_encoding, &BTreeMap::new())
+                    .add_channel(output_schema_id, topic, message_encoding, &BTreeMap::new())
                     .expect("Couldn't write channel");
-                channel_ids.insert(returned_id, id);
+                channel_ids.insert(id, returned_id);
             }
             "ChunkIndex" => {
                 // written automatically
@@ -110,7 +116,7 @@ fn write_file(spec: &conformance_writer_spec::WriterSpec) {
                 let returned_id = writer
                     .add_schema(name, encoding, &data)
                     .expect("cannot write schema");
-                schema_ids.insert(returned_id, id);
+                schema_ids.insert(id, returned_id);
             }
             "Statistics" => {
                 // written automatically

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -169,6 +169,7 @@ pub enum Compression {
 /// or hold its own buffer if it was decompressed from a chunk.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Schema<'a> {
+    pub id: u16,
     pub name: String,
     pub encoding: String,
     pub data: Cow<'a, [u8]>,
@@ -186,6 +187,7 @@ impl fmt::Debug for Schema<'_> {
 /// Describes a channel which [Message]s are published to in an MCAP file
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Channel<'a> {
+    pub id: u16,
     pub topic: String,
     pub schema: Option<Arc<Schema<'a>>>,
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -140,6 +140,10 @@ pub enum McapError {
     ChunkBufferTooLarge(u64),
     #[error("length exceeds usize max: `{0}`")]
     TooLong(u64),
+    #[error("cannot write more than 65335 channels to one MCAP")]
+    TooManyChannels,
+    #[error("cannot write more than 65334 schemas to one MCAP")]
+    TooManySchemas,
 }
 
 pub type McapResult<T> = Result<T, McapError>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,14 +39,7 @@
 //!
 //!     // Channels and schemas are automatically assigned ID as they're serialized,
 //!     // and automatically deduplicated with `Arc` when deserialized.
-//!     let my_channel = Channel {
-//!         topic: String::from("cool stuff"),
-//!         schema: None,
-//!         message_encoding: String::from("application/octet-stream"),
-//!         metadata: BTreeMap::default()
-//!     };
-//!
-//!     let channel_id = out.add_channel(&my_channel)?;
+//!     let channel_id = out.add_channel(0, "cool stuff", "application/octet-stream", &BTreeMap::new())?;
 //!
 //!     out.write_to_known_channel(
 //!         &MessageHeader {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -140,9 +140,9 @@ pub enum McapError {
     ChunkBufferTooLarge(u64),
     #[error("length exceeds usize max: `{0}`")]
     TooLong(u64),
-    #[error("cannot write more than 65335 channels to one MCAP")]
+    #[error("cannot write more than 65536 channels to one MCAP")]
     TooManyChannels,
-    #[error("cannot write more than 65334 schemas to one MCAP")]
+    #[error("cannot write more than 65535 schemas to one MCAP")]
     TooManySchemas,
 }
 

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -299,6 +299,7 @@ impl<'a> ChannelAccumulator<'a> {
         }
 
         let schema = Arc::new(Schema {
+            id: header.id,
             name: header.name.clone(),
             encoding: header.encoding,
             data,
@@ -329,6 +330,7 @@ impl<'a> ChannelAccumulator<'a> {
         };
 
         let channel = Arc::new(Channel {
+            id: chan.id,
             topic: chan.topic.clone(),
             schema,
             message_encoding: chan.message_encoding,

--- a/rust/src/sans_io/read.rs
+++ b/rust/src/sans_io/read.rs
@@ -759,12 +759,12 @@ mod tests {
                 .chunk_size(None)
                 .create(&mut buf)?;
             let channel = std::sync::Arc::new(crate::Channel {
+                id: 0,
                 topic: "chat".to_owned(),
                 schema: None,
                 message_encoding: "json".to_owned(),
                 metadata: BTreeMap::new(),
             });
-            writer.add_channel(&channel)?;
             for n in 0..3 {
                 writer.write(&crate::Message {
                     channel: channel.clone(),
@@ -790,12 +790,12 @@ mod tests {
                 .use_chunks(false)
                 .create(&mut buf)?;
             let channel = std::sync::Arc::new(crate::Channel {
+                id: 0,
                 topic: "chat".to_owned(),
                 schema: None,
                 message_encoding: "json".to_owned(),
                 metadata: BTreeMap::new(),
             });
-            writer.add_channel(&channel)?;
             writer.write(&crate::Message {
                 channel,
                 sequence: 0,

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -269,7 +269,7 @@ impl<W: Write + Seek> Writer<W> {
         }) {
             return Ok(id);
         }
-        let next_schema_id = self.schemas.right_values().max().unwrap_or(&0) + 1;
+        let next_schema_id = self.schemas.len() as u16 + 1;
         self.write_schema(Schema {
             id: next_schema_id,
             name: name.into(),
@@ -327,12 +327,7 @@ impl<W: Write + Seek> Writer<W> {
         }) {
             return Ok(id);
         }
-        let next_channel_id = self
-            .channels
-            .right_values()
-            .max()
-            .map(|n| n + 1)
-            .unwrap_or(0);
+        let next_channel_id = self.channels.len() as u16;
         if schema_id != 0 && self.schemas.get_by_right(&schema_id).is_none() {
             return Err(McapError::UnknownSchema(topic.into(), schema_id));
         }

--- a/rust/tests/handles_time0_messages.rs
+++ b/rust/tests/handles_time0_messages.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::{collections::BTreeMap, io::Cursor};
 
 use anyhow::Result;
 
@@ -9,14 +9,7 @@ fn handles_time0_messages() -> Result<()> {
     let mut buf = Vec::new();
     let mut out = mcap::Writer::new(Cursor::new(&mut buf))?;
 
-    let my_channel = mcap::Channel {
-        topic: String::from("time"),
-        message_encoding: String::from("text/plain"),
-        metadata: Default::default(),
-        schema: None,
-    };
-
-    let channel_id = out.add_channel(&my_channel)?;
+    let channel_id = out.add_channel(0, "time", "text/plain", &BTreeMap::new())?;
 
     out.write_to_known_channel(
         &mcap::records::MessageHeader {

--- a/rust/tests/message.rs
+++ b/rust/tests/message.rs
@@ -17,7 +17,7 @@ fn smoke() -> Result<()> {
 
     let expected = mcap::Message {
         channel: Arc::new(mcap::Channel {
-            id: 0,
+            id: 1,
             schema: Some(Arc::new(mcap::Schema {
                 id: 1,
                 name: String::from("Example"),
@@ -74,7 +74,7 @@ fn run_round_trip(use_chunks: bool) -> Result<()> {
     });
 
     let channel = Arc::new(mcap::Channel {
-        id: 0,
+        id: 1,
         schema: Some(schema.clone()),
         topic: String::from("example"),
         message_encoding: String::from("a"),
@@ -89,10 +89,10 @@ fn run_round_trip(use_chunks: bool) -> Result<()> {
             chunk_count: if use_chunks { 1 } else { 0 },
             message_start_time: 2,
             message_end_time: 2,
-            channel_message_counts: [(0, 1)].into(),
+            channel_message_counts: [(1, 1)].into(),
             ..Default::default()
         }),
-        channels: [(0, channel.clone())].into(),
+        channels: [(1, channel.clone())].into(),
         schemas: [(1, schema.clone())].into(),
         ..Default::default()
     };

--- a/rust/tests/message.rs
+++ b/rust/tests/message.rs
@@ -17,7 +17,9 @@ fn smoke() -> Result<()> {
 
     let expected = mcap::Message {
         channel: Arc::new(mcap::Channel {
+            id: 0,
             schema: Some(Arc::new(mcap::Schema {
+                id: 1,
                 name: String::from("Example"),
                 encoding: String::from("c"),
                 data: Cow::Borrowed(&[4, 5, 6]),
@@ -65,12 +67,14 @@ fn run_round_trip(use_chunks: bool) -> Result<()> {
     let summary = mcap::Summary::read(&ours)?.unwrap();
 
     let schema = Arc::new(mcap::Schema {
+        id: 1,
         name: String::from("Example"),
         encoding: String::from("c"),
         data: Cow::Borrowed(&[4, 5, 6]),
     });
 
     let channel = Arc::new(mcap::Channel {
+        id: 0,
         schema: Some(schema.clone()),
         topic: String::from("example"),
         message_encoding: String::from("a"),


### PR DESCRIPTION
### Changelog

#### Breaking changes
- adds `id` members to the crate::Channel and crate::Schema structs.
- refactored and separated `Writer::add_channel` into two methods, `Writer::add_schema` and `Writer::add_channel`.

### Docs
In docstrings, please review if not clear.
### Description

When a message reader recieves schema and channel information, the schema and channel IDs in the MCAP are hidden from them.  This PR adds those so that readers can observe ID information.

Additionally, this PR updates the Writer interface in these ways:

1. The `add_channel(Channel)` method is replaced with `add_channel(schema_id, topic, message_encoding, metadata)`. This was done because the Channel struct now contains a channel ID, and to continue to use it would force the user to come up with their own channel ID before calling this function. 
2. An `add_schema(...)` method is added to register schemas ahead of channels. This is needed to allow the caller to register a new schema without coming up with an ID in advance.
3. The existing `write(Message)` method is kept, but instead of automatically assigning new IDs for the message channel and schema, it uses the IDs passed in. This means that when writing functions that transform MCAP data, the IDs from the input can be kept in the output.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

