### PR TITLE
rust: LinearReader: reclaim dead space when possible

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/sans_io/read.rs
+++ b/rust/src/sans_io/read.rs
@@ -96,11 +96,11 @@ impl RwBuf {
     // returns a mutable view of the un-written part of the buffer, resizing as needed to ensure
     // N bytes are available to write into.
     fn tail_with_size(&mut self, n: usize) -> &mut [u8] {
-        let unread_len = self.unread().len();
-        if self.start > unread_len {
-            let (before, after) = self.data.split_at_mut(unread_len);
-            before.copy_from_slice(&mut after[self.start - unread_len..self.end - unread_len]);
-            self.data.truncate(unread_len);
+        let unread_len = self.end - self.start;
+        // Compact the output buffer if there is sufficient free space and there is more free
+        // than used.
+        if self.start > 4096 && self.start > unread_len {
+            self.data.copy_within(self.start..self.end, 0);
             self.start = 0;
             self.end = unread_len;
         }

--- a/rust/src/sans_io/read.rs
+++ b/rust/src/sans_io/read.rs
@@ -326,10 +326,6 @@ impl LinearReader {
             self.file_data.end += written;
         }
 
-        if self.file_data.len() == 0 {
-            self.file_data.clear();
-        }
-
         /// Macros for loading data into the reader. These return early with NeedMore(n) if
         /// more data is needed.
         ///

--- a/rust/src/sans_io/read.rs
+++ b/rust/src/sans_io/read.rs
@@ -96,6 +96,14 @@ impl RwBuf {
     // returns a mutable view of the un-written part of the buffer, resizing as needed to ensure
     // N bytes are available to write into.
     fn tail_with_size(&mut self, n: usize) -> &mut [u8] {
+        let unread_len = self.unread().len();
+        if self.start > unread_len {
+            let (before, after) = self.data.split_at_mut(unread_len);
+            before.copy_from_slice(&mut after[self.start - unread_len..self.end - unread_len]);
+            self.data.truncate(unread_len);
+            self.start = 0;
+            self.end = unread_len;
+        }
         let desired_end = self.end + n;
         self.data.resize(desired_end, 0);
         &mut self.data[self.end..]


### PR DESCRIPTION
### Changelog
- Rust: fixed a bug where a reader not reading the exact amount required into the LinearReader might cause the internal buffer to grow unbounded.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

