### PR TITLE
fix: add typings to package output

### DIFF
--- a/typescript/support/package.json
+++ b/typescript/support/package.json
@@ -23,6 +23,7 @@
   "files": [
     "dist",
     "src",
+    "typings",
     "nodejs.d.ts",
     "nodejs.js"
   ],

--- a/typescript/support/typings/protobufjs.d.ts
+++ b/typescript/support/typings/protobufjs.d.ts
@@ -8,7 +8,7 @@ declare module "protobufjs" {
       protoVersion: string,
     ): protobufjs.Message<descriptor.IFileDescriptorSet> & descriptor.IFileDescriptorSet;
   }
-  declare namespace ReflectionObject {
+  namespace ReflectionObject {
     export const fromDescriptor: (desc: protobufjs.Message) => protobufjs.Root;
   }
 }


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Getting these errors in when importing

```
node_modules/@mcap/support/dist/esm/src/protobufDescriptors.d.ts:1:22 - error TS6053: File '/home/dimitri/src/rosbags2js/node_modules/@mcap/support/typings/protobufjs.d.ts' not found.

1 /// <reference path="../../../typings/protobufjs.d.ts" />
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mcap/support/dist/esm/src/protobufDescriptors.d.ts:3:61 - error TS2339: Property 'toDescriptor' does not exist on type 'Root'.

3 export type ProtobufDescriptor = ReturnType<protobufjs.Root["toDescriptor"]>;                                       
```

PR adds `typings/protobufjs.d.ts` to package
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

