### PR TITLE
typescript: support chunk indexes with empty message index

### DIFF
--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -103,6 +103,17 @@ export class ChunkCursor {
     const reverse = this.#reverse;
     let messageIndexStartOffset: bigint | undefined;
     let relevantMessageIndexStartOffset: bigint | undefined;
+
+    if (this.chunkIndex.messageIndexLength === 0n) {
+      // Chunk has no message indexes.
+      // We only allow that if the chunk has no messages and the start and end times are 0.
+      if (this.chunkIndex.messageStartTime !== 0n || this.chunkIndex.messageEndTime !== 0n) {
+        throw new Error(
+          `Encountered a chunk index without message indexes and non-zero start and end times`,
+        );
+      }
+    }
+
     for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
       if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {
         messageIndexStartOffset = offset;

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -38,6 +38,16 @@ export class ChunkCursor {
     this.#startTime = params.startTime;
     this.#endTime = params.endTime;
     this.#reverse = params.reverse;
+
+    if (this.chunkIndex.messageIndexLength === 0n) {
+      // Chunk has no message indexes.
+      // We only allow that if the chunk has no messages and the start and end times are 0.
+      if (this.chunkIndex.messageStartTime !== 0n || this.chunkIndex.messageEndTime !== 0n) {
+        throw new Error(
+          `Encountered a chunk index without message indexes and non-zero start and end times`,
+        );
+      }
+    }
   }
 
   /**
@@ -103,16 +113,6 @@ export class ChunkCursor {
     const reverse = this.#reverse;
     let messageIndexStartOffset: bigint | undefined;
     let relevantMessageIndexStartOffset: bigint | undefined;
-
-    if (this.chunkIndex.messageIndexLength === 0n) {
-      // Chunk has no message indexes.
-      // We only allow that if the chunk has no messages and the start and end times are 0.
-      if (this.chunkIndex.messageStartTime !== 0n || this.chunkIndex.messageEndTime !== 0n) {
-        throw new Error(
-          `Encountered a chunk index without message indexes and non-zero start and end times`,
-        );
-      }
-    }
 
     for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
       if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -38,10 +38,6 @@ export class ChunkCursor {
     this.#startTime = params.startTime;
     this.#endTime = params.endTime;
     this.#reverse = params.reverse;
-
-    if (this.chunkIndex.messageIndexLength === 0n) {
-      throw new Error(`Chunks without message indexes are not currently supported`);
-    }
   }
 
   /**


### PR DESCRIPTION
### Changelog
typescript: support chunk indexes with empty message index

### Docs
None

### Description
When a chunk contains no messages, the corresponding [ChunkIndex](https://mcap.dev/spec#chunk-index-op0x08)'s message index is empty. Prior to this PR, the typescript lib threw an exception when a chunk index with an empty message index was encountered. 
This PR changes this to no longer throw when such a chunk index is encountered. If the message index is empty, the internal method `#getSortTime` will fallback to the chunk index' start time which is `0n` and everything works as expected.

https://github.com/foxglove/mcap/blob/e5c9da312727063194e52e84e2b71a7cfaa66f6d/typescript/core/src/ChunkCursor.ts#L228-L229

Note: We could change the `McapIndexedReader` to exclude such chunk indexes from its internal heap, but I believe that it's not worth adding additional code for improving performance of such a corner case


