### PR TITLE
fix pypi publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,7 @@ jobs:
           packages_dir: python/mcap/dist
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap-protobuf-support to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -326,6 +327,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
           packages_dir: python/mcap-protobuf-support/dist
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap-ros1-support to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -334,6 +336,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
           packages_dir: python/mcap-ros1-support/dist
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap-ros2-support to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -342,6 +345,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
           packages_dir: python/mcap-ros2-support/dist
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap to PyPI
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,36 +315,36 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
-          packages_dir: python/mcap/dist
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          packages-dir: python/mcap/dist
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
           attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap-protobuf-support to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
-          packages_dir: python/mcap-protobuf-support/dist
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: python/mcap-protobuf-support/dist
           attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap-ros1-support to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
-          packages_dir: python/mcap-ros1-support/dist
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: python/mcap-ros1-support/dist
           attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap-ros2-support to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
-          packages_dir: python/mcap-ros2-support/dist
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: python/mcap-ros2-support/dist
           attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap to PyPI
@@ -353,7 +353,7 @@ jobs:
           startsWith(github.ref, 'refs/tags/releases/python/mcap/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: python/mcap/dist
+          packages-dir: python/mcap/dist
 
       - name: Publish mcap-protobuf-support to PyPI
         if: |
@@ -361,7 +361,7 @@ jobs:
           startsWith(github.ref, 'refs/tags/releases/python/mcap-protobuf-support/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: python/mcap-protobuf-support/dist
+          packages-dir: python/mcap-protobuf-support/dist
 
       - name: Publish mcap-ros1-support to PyPI
         if: |
@@ -369,7 +369,7 @@ jobs:
           startsWith(github.ref, 'refs/tags/releases/python/mcap-ros1-support/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: python/mcap-ros1-support/dist
+          packages-dir: python/mcap-ros1-support/dist
 
       - name: Publish mcap-ros2-support to PyPI
         if: |
@@ -377,7 +377,7 @@ jobs:
           startsWith(github.ref, 'refs/tags/releases/python/mcap-ros2-support/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: python/mcap-ros2-support/dist
+          packages-dir: python/mcap-ros2-support/dist
 
   go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changelog
None
### Docs

None

### Description

See also https://github.com/foxglove/schemas/pull/158.

> Running a publish to TestPyPI immediately followed by a publish to the "real" PyPI triggered an error due to a file already existing. The workaround recommended in https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440 is to set `attestations: false` on the TestPyPI publish.