### PR TITLE
Add into_inner() on Rust writer

### DIFF
--- a/rust/src/io_utils.rs
+++ b/rust/src/io_utils.rs
@@ -37,6 +37,10 @@ impl<W> CountingCrcWriter<W> {
     pub fn finalize(self) -> (W, Hasher) {
         (self.inner, self.hasher)
     }
+
+    pub fn current_checksum(&self) -> u32 {
+        self.hasher.clone().finalize()
+    }
 }
 
 impl<W: Write> Write for CountingCrcWriter<W> {


### PR DESCRIPTION
### Changelog
Add an `into_inner()` method on the Rust writer to get back the underlying stream.

### Docs

https://linear.app/foxglove/issue/FG-9969/[rust-sdk]-cant-close-mcap-writer

### Description

Some I/O errors only show up when the output file is closed. This change allows users to check for such errors.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

Fixes: FG-9969