### PR TITLE
fix(python): use deque for insert-order message queue

### DIFF
--- a/python/mcap/mcap/_message_queue.py
+++ b/python/mcap/mcap/_message_queue.py
@@ -104,16 +104,14 @@ class LogTimeOrderQueue(_MessageQueue):
 
 
 class InsertOrderQueue(_MessageQueue):
-    def __init__(self, reverse: bool = False):
-        self._q: Deque[_Orderable] = deque()
-        self._reverse = reverse
+    def __init__(self):
+        self._q: Deque[QueueItem] = deque()
 
     def push(self, item: QueueItem):
-        orderable = _make_orderable(item, self._reverse)
-        self._q.append(orderable)
+        self._q.append(item)
 
     def pop(self) -> QueueItem:
-        return self._q.popleft().item  # cspell:disable-line
+        return self._q.popleft()  # cspell:disable-line
 
     def __len__(self) -> int:
         return len(self._q)
@@ -127,7 +125,10 @@ def make_message_queue(
     :param log_time_order: if True, this queue acts as a priority queue, ordered by log time.
         if False, ``pop()`` returns elements in insert order.
     :param reverse: if True, order elements in descending log time order rather than ascending.
+        only valid if ``log_time_order`` is True, otherwise throws a ValueError.
     """
     if log_time_order:
         return LogTimeOrderQueue(reverse)
-    return InsertOrderQueue(reverse)
+    if reverse:
+        raise ValueError("reverse is only valid with log_time_order=True")
+    return InsertOrderQueue()

--- a/python/mcap/mcap/_message_queue.py
+++ b/python/mcap/mcap/_message_queue.py
@@ -74,7 +74,6 @@ def _make_orderable(item: QueueItem, reverse: bool) -> _Orderable:
 
 
 class _MessageQueue(ABC):
-
     @abstractmethod
     def push(self, item: QueueItem):
         raise NotImplementedError()
@@ -120,7 +119,9 @@ class InsertOrderQueue(_MessageQueue):
         return len(self._q)
 
 
-def make_message_queue(log_time_order: bool = True, reverse: bool = False) -> _MessageQueue:
+def make_message_queue(
+    log_time_order: bool = True, reverse: bool = False
+) -> _MessageQueue:
     """Create a queue of MCAP messages and chunk indices.
 
     :param log_time_order: if True, this queue acts as a priority queue, ordered by log time.

--- a/python/mcap/mcap/_message_queue.py
+++ b/python/mcap/mcap/_message_queue.py
@@ -114,7 +114,7 @@ class InsertOrderQueue(_MessageQueue):
         self._q.append(orderable)
 
     def pop(self) -> QueueItem:
-        return self._q.popleft().item
+        return self._q.popleft().item  # cspell:disable-line
 
     def __len__(self) -> int:
         return len(self._q)

--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -292,7 +292,9 @@ class SeekingReader(McapReader):
             )
             return
 
-        message_queue = make_message_queue(log_time_order=log_time_order, reverse=reverse)
+        message_queue = make_message_queue(
+            log_time_order=log_time_order, reverse=reverse
+        )
         for chunk_index in _chunks_matching_topics(
             summary, topics, start_time, end_time
         ):

--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -15,7 +15,7 @@ from typing import (
     Tuple,
 )
 
-from ._message_queue import MessageQueue
+from ._message_queue import make_message_queue
 from .data_stream import ReadDataStream, RecordBuilder
 from .decoder import DecoderFactory
 from .exceptions import DecoderNotFoundError, McapError
@@ -292,7 +292,7 @@ class SeekingReader(McapReader):
             )
             return
 
-        message_queue = MessageQueue(log_time_order=log_time_order, reverse=reverse)
+        message_queue = make_message_queue(log_time_order=log_time_order, reverse=reverse)
         for chunk_index in _chunks_matching_topics(
             summary, topics, start_time, end_time
         ):

--- a/python/mcap/tests/test_message_queue.py
+++ b/python/mcap/tests/test_message_queue.py
@@ -61,7 +61,7 @@ def push_elements(mq: _MessageQueue):
 
 def push_messages_reverse_order(mq: _MessageQueue, n: int = 10_000):
     for i in range(n):
-        mq.push(dummy_message_tuple(n-i, 0, i))
+        mq.push(dummy_message_tuple(n - i, 0, i))
 
 
 def test_chunk_message_ordering():

--- a/python/mcap/tests/test_message_queue.py
+++ b/python/mcap/tests/test_message_queue.py
@@ -129,6 +129,7 @@ def test_insert_ordering():
     assert isinstance(results[5], tuple)
     assert results[5][2] == 30
 
+
 def test_insert_order_is_faster():
     log_time_order_mq = make_message_queue(log_time_order=True)
     push_messages_reverse_order(log_time_order_mq)

--- a/python/mcap/tests/test_message_queue.py
+++ b/python/mcap/tests/test_message_queue.py
@@ -1,7 +1,7 @@
 import time
 from typing import List
 
-from mcap._message_queue import make_message_queue, _MessageQueue, QueueItem
+from mcap._message_queue import QueueItem, _MessageQueue, make_message_queue
 from mcap.records import Channel, ChunkIndex, Message, Schema
 
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Significantly increases the performance of iterating through an MCAP file in insertion order.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None. (internal only)

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

I used `iter_messages(log_time_order=False)` since my application doesn't care about message order, expecting it to perform better than `log_time_order=True` (the default). However I noticed that my application took _17 minutes_ to iterate through 3.5 million MCAP messages. It took 32 seconds with `log_time_order=True`. 

The previous message queue implementation used a `list` as a FIFO queue, which has poor performance as `pop(0)` will copy the list every time an item is evicted. After changing the implementation to use a `deque`, `log_time_order=False` took 15 seconds.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

Here's code for a minimal performance test. Note that the mcap file has ~3.5 million messages.

```python
import time
from collections import deque
from mcap.reader import make_reader

with open("example.mcap", "rb") as f:
    reader = make_reader(f)
    start = time.time()
    deque(reader.iter_messages(log_time_order=False), maxlen=0)
    end = time.time()
    print(end - start)
```

Note that `deque(iterable, maxlen=0)` will consume the iterable in C, so basically as fast as possible (see the `itertools` [recipe](https://docs.python.org/3/library/itertools.html#itertools-recipes) for `consume()`).

I ran this three times after the fix, but just once before because I didn't have the patience 😄 

<table><tr><th>Before</th><th>After</th></tr><tr><td>
1125.6354639530182
</td><td>
11.093337059020996</br>
10.840037822723389</br>
10.490556001663208
</td></tr></table>

Over 100x faster! If you're curious, `log_time_order=True` was ~17 seconds (both before and after the changeset).

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

I also updated the code to have two separate impls rather than a bifurcated implementation.

I added a unit test to assert that `log_time_order=False` is faster than `True` (purposely adding messages in reverse log time order so that the heap should perform worse). As with most perf unit tests, it is potentially flakey with smaller inputs so I put 10k messages in it, but feel free to discuss if there's a different way you want to run through that.

