### PR TITLE
rust reader: unexpected EOF in chunk is EOF

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/sans_io/read.rs
+++ b/rust/src/sans_io/read.rs
@@ -321,9 +321,6 @@ impl LinearReader {
                 {
                     return None;
                 }
-                if self.chunk_state.is_some() {
-                    return Some(Err(McapError::UnexpectedEoc));
-                }
                 return Some(Err(McapError::UnexpectedEof));
             }
             self.file_data.end += written;


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

