### PR TITLE
feat: getter for message classes

### DIFF
--- a/python/mcap-protobuf-support/mcap_protobuf/decoder.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/decoder.py
@@ -26,6 +26,11 @@ class DecoderFactory(McapDecoderFactory):
     def __init__(self) -> None:
         self._types: Dict[int, Type[Any]] = {}
 
+    def pb_message_from_schema(self, schema: Schema) -> Optional[Message]:
+        if schema.encoding != SchemaEncoding.Protobuf:
+            return None
+        return self._types.get(schema.id)
+
     def decoder_for(
         self, message_encoding: str, schema: Optional[Schema]
     ) -> Optional[Callable[[bytes], Any]]:

--- a/python/mcap-protobuf-support/mcap_protobuf/decoder.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/decoder.py
@@ -27,7 +27,9 @@ class DecoderFactory(McapDecoderFactory):
     def __init__(self) -> None:
         self._types: Dict[int, Type[Any]] = {}
 
-    def pb_message_from_schema(self, schema: Schema) -> Optional[GeneratedProtocolMessageType]:
+    def pb_message_from_schema(
+        self, schema: Schema
+    ) -> Optional[GeneratedProtocolMessageType]:
         if schema.encoding != SchemaEncoding.Protobuf:
             return None
         return self._types.get(schema.id)

--- a/python/mcap-protobuf-support/mcap_protobuf/decoder.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/decoder.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional, Type
 from google.protobuf.descriptor_pb2 import FileDescriptorProto, FileDescriptorSet
 from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message_factory import GetMessageClassesForFiles, GetMessageClass
+from google.protobuf.reflection import GeneratedProtocolMessageType
 
 from mcap.decoder import DecoderFactory as McapDecoderFactory
 from mcap.exceptions import McapError
@@ -26,7 +27,7 @@ class DecoderFactory(McapDecoderFactory):
     def __init__(self) -> None:
         self._types: Dict[int, Type[Any]] = {}
 
-    def pb_message_from_schema(self, schema: Schema) -> Optional[Message]:
+    def pb_message_from_schema(self, schema: Schema) -> Optional[GeneratedProtocolMessageType]:
         if schema.encoding != SchemaEncoding.Protobuf:
             return None
         return self._types.get(schema.id)


### PR DESCRIPTION
### Changelog

Improves the reader API for accessing protobuf messages which are generated from the Schema objects within the DecoderFactory. 

### Docs

None

### Description

I am using [protarrow](https://github.com/tradewelltech/protarrow) and found myself having to search for the message class objects in the `DecoderFactory` for the example seen below. Note that, in my current project set up, I do not have the proto message classes as a submodule / dependency. Given that mcap stores the schemas themselves, that this feature adds a lot of value so that anyone can read the logs without having to include the pb messages in their project. 

```python
import protarrow

my_protos = [
    MyProto(name="foo", id=1, values=[1, 2, 4]),
    MyProto(name="bar", id=2, values=[3, 4, 5]),
]

table = protarrow.messages_to_table(my_protos, MyProto)
```

The only way to access these currently is by accessing 'private' class members. 

```python
msg = reader._decoder_factories[0]._types[schema.id]
table = protarrow.messages_to_table(my_protos, msg)
```

The change here is a quick fix but I imagine that this can be made more ergonomic with changes to the reader class itself (`python/mcap-protobuf-support/mcap_protobuf/reader.py`)

I did no tests as this is very straight forward. This PR does not have to be merged though I think it's a perfect example as to how this API can be improved. 

<table><tr><th>Before</th><th>After</th></tr><tr><td>

```python
msg_before = reader._decoder_factories[0]._types[schema.id]
```
</td><td>

```python
msg_after = reader._decoder_factories[0].pb_message_from_schema(schema)
```

</td></tr></table>

If this feature is of interest, let me know and we can discuss what methods could be of interest. It would be nice if the reader itself offered this API. That being said, for the reader base-class I am not sure if similar changes make sense. 

