### PR TITLE
cli: Support multiple inputs in 'cat'

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -310,8 +310,8 @@ func printMessages(
 }
 
 var catCmd = &cobra.Command{
-	Use:   "cat [file]",
-	Short: "Cat the messages in an MCAP file to stdout",
+	Use:   "cat [file]...",
+	Short: "Concatenate the messages in one or more MCAP files to stdout",
 	Run: func(_ *cobra.Command, args []string) {
 		ctx := context.Background()
 		stat, err := os.Stdin.Stat()


### PR DESCRIPTION
This adds support to the `mcap cat` command for multiple input files. Multiple files can be directly supplied, like

    mcap cat file1.mcap file2.mcap

or, the list of files may be auto-populated by your shell, enabling you to type

    mcap cat **/*.mcap