### PR TITLE
rust: add sans-io indexed reader 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           toolchain: stable
           default: true
-      - run: cargo build --example=conformance_reader --example=conformance_reader_async --example=conformance_writer --features=tokio
+      - run: cargo build --example=conformance_reader --example=conformance_reader_async --example=conformance_writer --example=conformance_indexed_reader --features=tokio
         working-directory: rust
       - run: yarn install --immutable
       - run: yarn test:conformance:generate-inputs --verify

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.15.1"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/benches/reader.rs
+++ b/rust/benches/reader.rs
@@ -75,7 +75,6 @@ fn get_next_message(
             sans_io::IndexedReadEvent::Message { header, data } => {
                 into.resize(data.len(), 0);
                 into.copy_from_slice(data);
-                reader.consume_message();
                 return Some(header);
             }
             sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {

--- a/rust/benches/reader.rs
+++ b/rust/benches/reader.rs
@@ -70,7 +70,6 @@ fn get_next_message(
     into: &mut Vec<u8>,
 ) -> Option<mcap::records::MessageHeader> {
     use std::io::{Read, Seek};
-    let mut buf = Vec::new();
     while let Some(event) = reader.next_event() {
         match event.expect("next event failed") {
             sans_io::IndexedReadEvent::Message { header, data } => {
@@ -82,10 +81,10 @@ fn get_next_message(
             sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
                 file.seek(std::io::SeekFrom::Start(offset))
                     .expect("failed to seek");
-                buf.resize(length, 0);
-                file.read_exact(&mut buf).expect("failed to read");
+                into.resize(length, 0);
+                file.read_exact(into).expect("failed to read");
                 reader
-                    .insert_chunk_record_data(offset, &buf)
+                    .insert_chunk_record_data(offset, into)
                     .expect("failed to insert");
             }
         }

--- a/rust/benches/reader.rs
+++ b/rust/benches/reader.rs
@@ -52,11 +52,11 @@ fn load_summary(file: &mut std::io::Cursor<&[u8]>) -> mcap::Summary {
     let mut reader = sans_io::SummaryReader::new();
     while let Some(event) = reader.next_event() {
         match event.expect("next event failed") {
-            sans_io::SummaryReadEvent::Read(n) => {
+            sans_io::SummaryReadEvent::ReadRequest(n) => {
                 let read = file.read(reader.insert(n)).expect("read failed");
                 reader.notify_read(read);
             }
-            sans_io::SummaryReadEvent::Seek(pos) => {
+            sans_io::SummaryReadEvent::SeekRequest(pos) => {
                 reader.notify_seeked(file.seek(pos).expect("seek failed"));
             }
         }
@@ -77,10 +77,10 @@ fn get_next_message(
                 into.copy_from_slice(data);
                 return Some(header);
             }
-            sans_io::IndexedReadEvent::Seek(pos) => {
+            sans_io::IndexedReadEvent::SeekRequest(pos) => {
                 reader.notify_seeked(file.seek(pos).expect("seek failed"));
             }
-            sans_io::IndexedReadEvent::Read(n) => {
+            sans_io::IndexedReadEvent::ReadRequest(n) => {
                 let read = file.read(reader.insert(n)).expect("read failed");
                 reader.notify_read(read);
             }

--- a/rust/examples/conformance_indexed_reader.rs
+++ b/rust/examples/conformance_indexed_reader.rs
@@ -43,7 +43,7 @@ pub fn main() {
     while let Some(event) = reader.next_event() {
         match event.expect("failed to get next event") {
             IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                let chunk_data = file.split_at(offset as usize).1.split_at(length).0;
+                let chunk_data = &file[offset as usize..][..length];
                 reader
                     .insert_chunk_record_data(offset, chunk_data)
                     .expect("failed on insert");

--- a/rust/examples/conformance_indexed_reader.rs
+++ b/rust/examples/conformance_indexed_reader.rs
@@ -53,7 +53,6 @@ pub fn main() {
                     header,
                     data: std::borrow::Cow::Borrowed(data),
                 }));
-                reader.consume_message();
             }
         }
     }

--- a/rust/examples/conformance_indexed_reader.rs
+++ b/rust/examples/conformance_indexed_reader.rs
@@ -1,0 +1,98 @@
+#[path = "common/serialization.rs"]
+mod serialization;
+use std::collections::BTreeSet;
+use std::io::{Cursor, Read, Seek};
+
+use serde_json::{json, Value};
+
+use std::env;
+use std::process;
+
+pub fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Please supply an MCAP file as argument");
+        process::exit(1);
+    }
+    let file = std::fs::read(&args[1]).expect("file wouldn't open");
+    let mut messages: Vec<Value> = vec![];
+    let mut schemas: Vec<Value> = vec![];
+    let mut channels: Vec<Value> = vec![];
+    let mut statistics: Vec<Value> = vec![];
+    let mut cursor = Cursor::new(&file);
+    let summary = {
+        let mut reader = mcap::sans_io::SummaryReader::new();
+        while let Some(event) = reader.next_event() {
+            match event.expect("failed gathering summary") {
+                mcap::sans_io::SummaryReadEvent::Seek(pos) => {
+                    reader.notify_seeked(cursor.seek(pos).expect("failed to seek file"));
+                }
+                mcap::sans_io::SummaryReadEvent::Read(n) => {
+                    let read = cursor.read(reader.insert(n)).expect("failed to read file");
+                    reader.notify_read(read);
+                }
+            }
+        }
+        reader.finish().expect("file should have a summary section")
+    };
+    let mut seen_schemas = BTreeSet::new();
+    let mut seen_channels = BTreeSet::new();
+    let mut reader =
+        mcap::sans_io::IndexedReader::new(&summary).expect("failed to initialize indexed reader");
+    while let Some(event) = reader.next_event() {
+        match event.expect("failed to get next event") {
+            mcap::sans_io::IndexedReadEvent::Seek(pos) => {
+                reader.notify_seeked(cursor.seek(pos).expect("failed to seek file"));
+            }
+            mcap::sans_io::IndexedReadEvent::Read(n) => {
+                let read = cursor.read(reader.insert(n)).expect("failed to read file");
+                reader.notify_read(read);
+            }
+            mcap::sans_io::IndexedReadEvent::Message { header, data } => {
+                let channel_id = header.channel_id;
+                if !seen_channels.contains(&channel_id) {
+                    let channel = summary
+                        .channels
+                        .get(&channel_id)
+                        .expect("malformed MCAP: channel not in summary");
+                    if let Some(schema) = channel.schema.clone() {
+                        if !seen_schemas.contains(&schema.id) {
+                            schemas.push(serialization::as_json(&mcap::records::Record::Schema {
+                                header: mcap::records::SchemaHeader {
+                                    id: schema.id,
+                                    name: schema.name.clone(),
+                                    encoding: schema.encoding.clone(),
+                                },
+                                data: schema.data.clone(),
+                            }));
+                            seen_schemas.insert(schema.id);
+                        }
+                    }
+                    channels.push(serialization::as_json(&mcap::records::Record::Channel(
+                        mcap::records::Channel {
+                            id: channel.id,
+                            schema_id: channel.schema.as_ref().map(|s| s.id).unwrap_or(0),
+                            topic: channel.topic.clone(),
+                            message_encoding: channel.message_encoding.clone(),
+                            metadata: channel.metadata.clone(),
+                        },
+                    )));
+                    seen_channels.insert(channel.id);
+                }
+                messages.push(serialization::as_json(&mcap::records::Record::Message {
+                    header,
+                    data: std::borrow::Cow::Borrowed(data),
+                }));
+            }
+        }
+    }
+
+    if let Some(stats) = summary.stats {
+        statistics.push(serialization::as_json(&mcap::records::Record::Statistics(
+            stats.clone(),
+        )));
+    }
+
+    let out = json!({ "messages": messages, "schemas": schemas, "channels": channels, "statistics": statistics });
+    print!("{}", serde_json::to_string_pretty(&out).unwrap());
+}

--- a/rust/examples/conformance_indexed_reader.rs
+++ b/rust/examples/conformance_indexed_reader.rs
@@ -24,10 +24,10 @@ pub fn main() {
         let mut reader = mcap::sans_io::SummaryReader::new();
         while let Some(event) = reader.next_event() {
             match event.expect("failed gathering summary") {
-                mcap::sans_io::SummaryReadEvent::Seek(pos) => {
+                mcap::sans_io::SummaryReadEvent::SeekRequest(pos) => {
                     reader.notify_seeked(cursor.seek(pos).expect("failed to seek file"));
                 }
-                mcap::sans_io::SummaryReadEvent::Read(n) => {
+                mcap::sans_io::SummaryReadEvent::ReadRequest(n) => {
                     let read = cursor.read(reader.insert(n)).expect("failed to read file");
                     reader.notify_read(read);
                 }
@@ -41,10 +41,10 @@ pub fn main() {
         mcap::sans_io::IndexedReader::new(&summary).expect("failed to initialize indexed reader");
     while let Some(event) = reader.next_event() {
         match event.expect("failed to get next event") {
-            mcap::sans_io::IndexedReadEvent::Seek(pos) => {
+            mcap::sans_io::IndexedReadEvent::SeekRequest(pos) => {
                 reader.notify_seeked(cursor.seek(pos).expect("failed to seek file"));
             }
-            mcap::sans_io::IndexedReadEvent::Read(n) => {
+            mcap::sans_io::IndexedReadEvent::ReadRequest(n) => {
                 let read = cursor.read(reader.insert(n)).expect("failed to read file");
                 reader.notify_read(read);
             }

--- a/rust/examples/conformance_indexed_reader.rs
+++ b/rust/examples/conformance_indexed_reader.rs
@@ -3,6 +3,7 @@ mod serialization;
 use std::collections::BTreeSet;
 use std::io::{Cursor, Read, Seek};
 
+use mcap::records::SchemaHeader;
 use serde_json::{json, Value};
 
 use std::env;
@@ -16,9 +17,6 @@ pub fn main() {
     }
     let file = std::fs::read(&args[1]).expect("file wouldn't open");
     let mut messages: Vec<Value> = vec![];
-    let mut schemas: Vec<Value> = vec![];
-    let mut channels: Vec<Value> = vec![];
-    let mut statistics: Vec<Value> = vec![];
     let mut cursor = Cursor::new(&file);
     let summary = {
         let mut reader = mcap::sans_io::SummaryReader::new();
@@ -35,8 +33,7 @@ pub fn main() {
         }
         reader.finish().expect("file should have a summary section")
     };
-    let mut seen_schemas = BTreeSet::new();
-    let mut seen_channels = BTreeSet::new();
+
     let mut reader =
         mcap::sans_io::IndexedReader::new(&summary).expect("failed to initialize indexed reader");
     while let Some(event) = reader.next_event() {
@@ -49,36 +46,6 @@ pub fn main() {
                 reader.notify_read(read);
             }
             mcap::sans_io::IndexedReadEvent::Message { header, data } => {
-                let channel_id = header.channel_id;
-                if !seen_channels.contains(&channel_id) {
-                    let channel = summary
-                        .channels
-                        .get(&channel_id)
-                        .expect("malformed MCAP: channel not in summary");
-                    if let Some(schema) = channel.schema.clone() {
-                        if !seen_schemas.contains(&schema.id) {
-                            schemas.push(serialization::as_json(&mcap::records::Record::Schema {
-                                header: mcap::records::SchemaHeader {
-                                    id: schema.id,
-                                    name: schema.name.clone(),
-                                    encoding: schema.encoding.clone(),
-                                },
-                                data: schema.data.clone(),
-                            }));
-                            seen_schemas.insert(schema.id);
-                        }
-                    }
-                    channels.push(serialization::as_json(&mcap::records::Record::Channel(
-                        mcap::records::Channel {
-                            id: channel.id,
-                            schema_id: channel.schema.as_ref().map(|s| s.id).unwrap_or(0),
-                            topic: channel.topic.clone(),
-                            message_encoding: channel.message_encoding.clone(),
-                            metadata: channel.metadata.clone(),
-                        },
-                    )));
-                    seen_channels.insert(channel.id);
-                }
                 messages.push(serialization::as_json(&mcap::records::Record::Message {
                     header,
                     data: std::borrow::Cow::Borrowed(data),
@@ -87,11 +54,41 @@ pub fn main() {
         }
     }
 
+    let mut statistics: Vec<Value> = vec![];
     if let Some(stats) = summary.stats {
         statistics.push(serialization::as_json(&mcap::records::Record::Statistics(
             stats.clone(),
         )));
-    }
+    };
+
+    let schemas: Vec<_> = summary
+        .schemas
+        .values()
+        .map(|schema| {
+            serialization::as_json(&mcap::records::Record::Schema {
+                header: SchemaHeader {
+                    id: schema.id,
+                    name: schema.name.clone(),
+                    encoding: schema.encoding.clone(),
+                },
+                data: schema.data.to_owned(),
+            })
+        })
+        .collect();
+
+    let channels: Vec<_> = summary
+        .channels
+        .values()
+        .map(|channel| {
+            serialization::as_json(&mcap::records::Record::Channel(mcap::records::Channel {
+                id: channel.id,
+                schema_id: channel.schema.as_ref().map(|s| s.id).unwrap_or(0),
+                topic: channel.topic.clone(),
+                message_encoding: channel.message_encoding.clone(),
+                metadata: channel.metadata.clone(),
+            }))
+        })
+        .collect();
 
     let out = json!({ "messages": messages, "schemas": schemas, "channels": channels, "statistics": statistics });
     print!("{}", serde_json::to_string_pretty(&out).unwrap());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -144,6 +144,8 @@ pub enum McapError {
     TooManyChannels,
     #[error("cannot write more than 65535 schemas to one MCAP")]
     TooManySchemas,
+    #[error("indexed reader received chunk data with unexpected offset or length")]
+    UnexpectedChunkDataInserted,
 }
 
 pub type McapResult<T> = Result<T, McapError>;

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -502,7 +502,9 @@ impl Iterator for MessageStream<'_> {
     }
 }
 
-const FOOTER_LEN: usize = 20; // 20 bytes + 8 byte len + 1 byte opcode
+const FOOTER_LEN: usize = 8 // summary start
+ + 8 // summary offset start
+ + 4; // summary section CRC
 
 /// Read the MCAP footer.
 ///
@@ -510,7 +512,12 @@ const FOOTER_LEN: usize = 20; // 20 bytes + 8 byte len + 1 byte opcode
 /// then index into the rest of the file with
 /// [`Summary::stream_chunk`], [`attachment`], [`metadata`], etc.
 pub fn footer(mcap: &[u8]) -> McapResult<records::Footer> {
-    if mcap.len() < MAGIC.len() * 2 + (9 + 1 + FOOTER_LEN) {
+    let footer_record_len = 1 // opcode
+     + 8 // record length
+     + FOOTER_LEN;
+    // an MCAP must be at least large enough to accomodate a header magic, a footer record and a
+    // footer magic.
+    if mcap.len() < (MAGIC.len() + (footer_record_len) + MAGIC.len()) {
         return Err(McapError::UnexpectedEof);
     }
 

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -505,6 +505,9 @@ impl Iterator for MessageStream<'_> {
 const FOOTER_LEN: usize = 8 // summary start
  + 8 // summary offset start
  + 4; // summary section CRC
+const FOOTER_RECORD_LEN: usize = 1 // opcode
+     + 8 // record length
+     + FOOTER_LEN;
 
 /// Read the MCAP footer.
 ///
@@ -512,12 +515,9 @@ const FOOTER_LEN: usize = 8 // summary start
 /// then index into the rest of the file with
 /// [`Summary::stream_chunk`], [`attachment`], [`metadata`], etc.
 pub fn footer(mcap: &[u8]) -> McapResult<records::Footer> {
-    let footer_record_len = 1 // opcode
-     + 8 // record length
-     + FOOTER_LEN;
     // an MCAP must be at least large enough to accomodate a header magic, a footer record and a
     // footer magic.
-    if mcap.len() < (MAGIC.len() + (footer_record_len) + MAGIC.len()) {
+    if mcap.len() < (MAGIC.len() + FOOTER_RECORD_LEN + MAGIC.len()) {
         return Err(McapError::UnexpectedEof);
     }
 

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -563,11 +563,11 @@ impl Summary {
         let mut summary_reader = SummaryReader::new();
         while let Some(event) = summary_reader.next_event() {
             match event? {
-                SummaryReadEvent::Read(n) => {
+                SummaryReadEvent::ReadRequest(n) => {
                     let read = cursor.read(summary_reader.insert(n))?;
                     summary_reader.notify_read(read);
                 }
-                SummaryReadEvent::Seek(to) => {
+                SummaryReadEvent::SeekRequest(to) => {
                     let pos = cursor.seek(to)?;
                     summary_reader.notify_seeked(pos);
                 }

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -16,11 +16,13 @@ use binrw::prelude::*;
 use byteorder::{ReadBytesExt, LE};
 use crc32fast::hash as crc32;
 use enumset::{enum_set, EnumSet, EnumSetType};
-use log::*;
 
 use crate::{
-    records::{self, op, Record},
-    sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions},
+    records::{self, op, Footer, Record},
+    sans_io::{
+        LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions, SummaryReadEvent,
+        SummaryReader,
+    },
     Attachment, Channel, McapError, McapResult, Message, Schema, MAGIC,
 };
 
@@ -287,13 +289,17 @@ impl<'a> Iterator for ChunkFlattener<'a> {
 
 /// Parses schemas and channels and wires them together
 #[derive(Debug, Default)]
-struct ChannelAccumulator<'a> {
-    schemas: HashMap<u16, Arc<Schema<'a>>>,
-    channels: HashMap<u16, Arc<Channel<'a>>>,
+pub(crate) struct ChannelAccumulator<'a> {
+    pub(crate) schemas: HashMap<u16, Arc<Schema<'a>>>,
+    pub(crate) channels: HashMap<u16, Arc<Channel<'a>>>,
 }
 
 impl<'a> ChannelAccumulator<'a> {
-    fn add_schema(&mut self, header: records::SchemaHeader, data: Cow<'a, [u8]>) -> McapResult<()> {
+    pub(crate) fn add_schema(
+        &mut self,
+        header: records::SchemaHeader,
+        data: Cow<'a, [u8]>,
+    ) -> McapResult<()> {
         if header.id == 0 {
             return Err(McapError::InvalidSchemaId);
         }
@@ -315,7 +321,7 @@ impl<'a> ChannelAccumulator<'a> {
         Ok(())
     }
 
-    fn add_channel(&mut self, chan: records::Channel) -> McapResult<()> {
+    pub(crate) fn add_channel(&mut self, chan: records::Channel) -> McapResult<()> {
         // The schema ID can be 0 for "no schema",
         // Or must reference some previously-read schema.
         let schema = if chan.schema_id == 0 {
@@ -346,7 +352,7 @@ impl<'a> ChannelAccumulator<'a> {
         Ok(())
     }
 
-    fn get(&self, chan_id: u16) -> Option<Arc<Channel<'a>>> {
+    pub(crate) fn get(&self, chan_id: u16) -> Option<Arc<Channel<'a>>> {
         self.channels.get(&chan_id).cloned()
     }
 }
@@ -496,7 +502,7 @@ impl Iterator for MessageStream<'_> {
     }
 }
 
-const FOOTER_LEN: usize = 20 + 8 + 1; // 20 bytes + 8 byte len + 1 byte opcode
+const FOOTER_LEN: usize = 20; // 20 bytes + 8 byte len + 1 byte opcode
 
 /// Read the MCAP footer.
 ///
@@ -504,7 +510,7 @@ const FOOTER_LEN: usize = 20 + 8 + 1; // 20 bytes + 8 byte len + 1 byte opcode
 /// then index into the rest of the file with
 /// [`Summary::stream_chunk`], [`attachment`], [`metadata`], etc.
 pub fn footer(mcap: &[u8]) -> McapResult<records::Footer> {
-    if mcap.len() < MAGIC.len() * 2 + FOOTER_LEN {
+    if mcap.len() < MAGIC.len() * 2 + (9 + 1 + FOOTER_LEN) {
         return Err(McapError::UnexpectedEof);
     }
 
@@ -513,27 +519,25 @@ pub fn footer(mcap: &[u8]) -> McapResult<records::Footer> {
     }
 
     let footer_buf = &mcap[mcap.len() - MAGIC.len() - FOOTER_LEN..];
+    let mut cursor = std::io::Cursor::new(footer_buf);
 
-    match LinearReader::sans_magic(footer_buf).next() {
-        Some(Ok(Record::Footer(f))) => Ok(f),
-        _ => Err(McapError::BadFooter),
-    }
+    Ok(Footer::read_le(&mut cursor)?)
 }
 
 /// Indexes of an MCAP file parsed from its (optional) summary section
 #[derive(Default, Eq, PartialEq)]
-pub struct Summary<'a> {
+pub struct Summary {
     pub stats: Option<records::Statistics>,
     /// Maps channel IDs to their channel
-    pub channels: HashMap<u16, Arc<Channel<'a>>>,
+    pub channels: HashMap<u16, Arc<Channel<'static>>>,
     /// Maps schema IDs to their schema
-    pub schemas: HashMap<u16, Arc<Schema<'a>>>,
+    pub schemas: HashMap<u16, Arc<Schema<'static>>>,
     pub chunk_indexes: Vec<records::ChunkIndex>,
     pub attachment_indexes: Vec<records::AttachmentIndex>,
     pub metadata_indexes: Vec<records::MetadataIndex>,
 }
 
-impl fmt::Debug for Summary<'_> {
+impl fmt::Debug for Summary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Keep the actual maps as HashMaps for constant-time lookups,
         // but order everything up before debug printing it here.
@@ -551,69 +555,37 @@ impl fmt::Debug for Summary<'_> {
     }
 }
 
-impl<'a> Summary<'a> {
+impl Summary {
     /// Read the summary section of the given mapped MCAP file, if it has one.
-    pub fn read(mcap: &'a [u8]) -> McapResult<Option<Self>> {
-        let foot = footer(mcap)?;
-
-        // A summary start offset of 0 means there's no summary.
-        if foot.summary_start == 0 {
-            return Ok(None);
-        }
-
-        if foot.summary_crc != 0 {
-            // The checksum covers the entire summary _except_ itself, including other footer bytes.
-            let calculated =
-                crc32(&mcap[foot.summary_start as usize..mcap.len() - MAGIC.len() - 4]);
-            if foot.summary_crc != calculated {
-                return Err(McapError::BadSummaryCrc {
-                    saved: foot.summary_crc,
-                    calculated,
-                });
+    pub fn read(mcap: &[u8]) -> McapResult<Option<Self>> {
+        use std::io::{Read, Seek};
+        let mut cursor = std::io::Cursor::new(mcap);
+        let mut summary_reader = SummaryReader::new();
+        while let Some(event) = summary_reader.next_event() {
+            match event? {
+                SummaryReadEvent::Read(n) => {
+                    let read = cursor.read(summary_reader.insert(n))?;
+                    summary_reader.notify_read(read);
+                }
+                SummaryReadEvent::Seek(to) => {
+                    let pos = cursor.seek(to)?;
+                    summary_reader.notify_seeked(pos);
+                }
             }
         }
 
-        let mut summary = Summary::default();
-        let mut channeler = ChannelAccumulator::default();
-
-        let summary_end = match foot.summary_offset_start {
-            0 => MAGIC.len() - FOOTER_LEN,
-            sos => sos as usize,
-        };
-        let summary_buf = &mcap[foot.summary_start as usize..summary_end];
-
-        for record in LinearReader::sans_magic(summary_buf) {
-            match record? {
-                Record::Statistics(s) => {
-                    if summary.stats.is_some() {
-                        warn!("Multiple statistics records found in summary");
-                    }
-                    summary.stats = Some(s);
-                }
-                Record::Schema { header, data } => channeler.add_schema(header, data)?,
-                Record::Channel(c) => channeler.add_channel(c)?,
-                Record::ChunkIndex(c) => summary.chunk_indexes.push(c),
-                Record::AttachmentIndex(a) => summary.attachment_indexes.push(a),
-                Record::MetadataIndex(i) => summary.metadata_indexes.push(i),
-                _ => {}
-            };
-        }
-
-        summary.schemas = channeler.schemas;
-        summary.channels = channeler.channels;
-
-        Ok(Some(summary))
+        Ok(summary_reader.finish())
     }
 
     /// Stream messages from the chunk with the given index.
     ///
     /// To avoid having to read all preceding chunks first,
     /// channels and their schemas are pulled from this summary.
-    pub fn stream_chunk(
-        &self,
+    pub fn stream_chunk<'a, 'b: 'a>(
+        &'b self,
         mcap: &'a [u8],
         index: &records::ChunkIndex,
-    ) -> McapResult<impl Iterator<Item = McapResult<Message<'a>>> + '_> {
+    ) -> McapResult<impl Iterator<Item = McapResult<Message<'a>>> + 'a> {
         let end = (index.chunk_start_offset + index.chunk_length) as usize;
         if mcap.len() < end {
             return Err(McapError::BadIndex);
@@ -631,7 +603,7 @@ impl<'a> Summary<'a> {
         // Chunks from the LinearReader will always borrow from the file.
         // (Getting a normal reference to the underlying data back
         // frees us from returning things that reference this local Cow.)
-        let d: &'a [u8] = match d {
+        let d: &[u8] = match d {
             Cow::Borrowed(b) => b,
             Cow::Owned(_) => unreachable!(),
         };
@@ -734,7 +706,7 @@ impl<'a> Summary<'a> {
     /// Compressed chunks aren't random access -
     /// this decompresses everything in the chunk before
     /// [`message.offset`](records::MessageIndexEntry::offset) and throws it away.
-    pub fn seek_message(
+    pub fn seek_message<'a>(
         &self,
         mcap: &'a [u8],
         index: &records::ChunkIndex,

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -414,6 +414,23 @@ pub struct ChunkIndex {
     pub uncompressed_size: u64,
 }
 
+impl ChunkIndex {
+    /// Returns the offset in the file to the start of compressed chunk data.
+    /// This can be useful for retrieving just the compressed content of a chunk given its index.
+    pub fn compressed_data_offset(&self) -> u64 {
+        self.chunk_start_offset
+        + 1 // opcode
+        + 8 // chunk record length
+        + 8 // start time
+        + 8 // end time
+        + 8 // uncompressed size
+        + 4 // CRC
+        + 4 // compression string length
+        + (self.compression.len() as u64) // compression string
+        + 8 // compressed size
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, BinRead, BinWrite)]
 pub struct AttachmentHeader {
     pub log_time: u64,

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -14,6 +14,8 @@ use std::{
 
 use binrw::*;
 
+use crate::{McapError, McapResult};
+
 /// Opcodes for MCAP file records.
 ///
 /// "Records are identified by a single-byte opcode.
@@ -417,17 +419,23 @@ pub struct ChunkIndex {
 impl ChunkIndex {
     /// Returns the offset in the file to the start of compressed chunk data.
     /// This can be useful for retrieving just the compressed content of a chunk given its index.
-    pub fn compressed_data_offset(&self) -> u64 {
-        self.chunk_start_offset
-        + 1 // opcode
-        + 8 // chunk record length
-        + 8 // start time
-        + 8 // end time
-        + 8 // uncompressed size
-        + 4 // CRC
-        + 4 // compression string length
-        + (self.compression.len() as u64) // compression string
-        + 8 // compressed size
+    /// Returns [`McapError::TooLong`] if the resulting offset would be greater than [`u64::MAX`].
+    pub fn compressed_data_offset(&self) -> McapResult<u64> {
+        let res = self.chunk_start_offset.checked_add(
+            1 // opcode
+            + 8 // chunk record length
+            + 8 // start time
+            + 8 // end time
+            + 8 // uncompressed size
+            + 4 // CRC
+            + 4 // compression string length
+            + (self.compression.len() as u64) // 32-bit compression string length
+            + 8, // compressed size
+        );
+        match res {
+            Some(n) => Ok(n),
+            None => Err(McapError::TooLong(self.chunk_start_offset)),
+        }
     }
 }
 

--- a/rust/src/sans_io.rs
+++ b/rust/src/sans_io.rs
@@ -1,8 +1,12 @@
 //! Read MCAP files from any source of bytes
 pub mod decompressor;
+pub mod indexed_reader;
 pub mod linear_reader;
+pub mod summary_reader;
 
+pub use indexed_reader::{IndexedReadEvent, IndexedReader, IndexedReaderOptions};
 pub use linear_reader::{LinearReadEvent, LinearReader, LinearReaderOptions};
+pub use summary_reader::{SummaryReadEvent, SummaryReader};
 
 #[cfg(feature = "lz4")]
 mod lz4;

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -415,7 +415,7 @@ impl IndexedReader {
                 self.cur_compressed_chunk.len()
             };
             assert!(
-                buffer_length > self.cur_compressed_chunk_loaded_bytes + n,
+                buffer_length >= self.cur_compressed_chunk_loaded_bytes + n,
                 "notify_read called with n > last inserted length"
             );
             self.cur_compressed_chunk_loaded_bytes += n;

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -63,17 +63,18 @@ struct ChunkSlot {
 ///         reader.finish().unwrap()
 ///     };
 ///     let mut reader = mcap::sans_io::indexed_reader::IndexedReader::new(&summary).expect("could not construct reader");
+///     let mut buffer = Vec::new();
 ///     while let Some(event) = reader.next_event() {
 ///         match event? {
-///             IndexedReadEvent::ReadChunkRequest{start, length} => {
-///                 file.seek(start)?;
-///                 let mut buffer = reader.reclaim_buffer();
+///             IndexedReadEvent::ReadChunkRequest{offset, length} => {
+///                 file.seek(std::io::SeekFrom::Start(offset))?;
 ///                 buffer.resize(length, 0);
 ///                 file.read_exact(&mut buffer)?;
-///                 reader.insert_chunk_record_data(start, buffer);
+///                 reader.insert_chunk_record_data(offset, &buffer);
 ///             },
 ///             IndexedReadEvent::Message{ header, data } => {
 ///                 let channel = summary.channels.get(&header.channel_id).unwrap();
+///                 reader.consume_message();
 ///                 // do something with the message header and data
 ///             }
 ///         }

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -122,69 +122,6 @@ pub struct IndexedReader {
     filter: Filter,
     at_eof: bool,
 }
-struct Filter {
-    // inclusive log time range start
-    start: Option<u64>,
-    // exclusive log time range end
-    end: Option<u64>,
-    // If non-empty, only channels with these IDs will be yielded
-    channel_ids: BTreeSet<u16>,
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-pub enum ReadOrder {
-    /// Yield messages in order of message.log_time. For messages with equal log times, the message
-    /// earlier in the underlying file will be yielded first.
-    #[default]
-    LogTime,
-    /// Yield messages in reverse message.log_time order. For messages with equal log times, the
-    /// message later in the underlying file will be yielded first.
-    ReverseLogTime,
-    /// Yield messages in the order they are present in the file.
-    File,
-}
-
-#[derive(Default, Clone)]
-pub struct IndexedReaderOptions {
-    pub start: Option<u64>,
-    pub end: Option<u64>,
-    pub order: ReadOrder,
-    pub include_topics: Option<BTreeSet<String>>,
-}
-
-impl IndexedReaderOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Configure the reader to yield messages in the specified order (defaults to log-time order).
-    pub fn with_order(mut self, order: ReadOrder) -> Self {
-        self.order = order;
-        self
-    }
-
-    /// Configure the reader to yield only messages from topics matching this set of strings.
-    /// By default, all topics will be yielded.
-    pub fn include_topics<T: IntoIterator<Item = impl Deref<Target = str>>>(
-        mut self,
-        topics: T,
-    ) -> Self {
-        self.include_topics = Some(topics.into_iter().map(|p| p.to_owned()).collect());
-        self
-    }
-
-    /// Configure the reader to yield only messages with log time on or after this time.
-    pub fn log_time_on_or_after(mut self, start: u64) -> Self {
-        self.start = Some(start);
-        self
-    }
-
-    /// Configure the reader to yield only messages with log time before this time.
-    pub fn log_time_before(mut self, end: u64) -> Self {
-        self.end = Some(end);
-        self
-    }
-}
 
 impl IndexedReader {
     pub fn new(summary: &crate::Summary) -> McapResult<Self> {
@@ -520,6 +457,70 @@ impl IndexedReader {
         let end = start + n;
         buf.resize(end, 0);
         &mut buf[start..end]
+    }
+}
+
+struct Filter {
+    // inclusive log time range start
+    start: Option<u64>,
+    // exclusive log time range end
+    end: Option<u64>,
+    // If non-empty, only channels with these IDs will be yielded
+    channel_ids: BTreeSet<u16>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub enum ReadOrder {
+    /// Yield messages in order of message.log_time. For messages with equal log times, the message
+    /// earlier in the underlying file will be yielded first.
+    #[default]
+    LogTime,
+    /// Yield messages in reverse message.log_time order. For messages with equal log times, the
+    /// message later in the underlying file will be yielded first.
+    ReverseLogTime,
+    /// Yield messages in the order they are present in the file.
+    File,
+}
+
+#[derive(Default, Clone)]
+pub struct IndexedReaderOptions {
+    pub start: Option<u64>,
+    pub end: Option<u64>,
+    pub order: ReadOrder,
+    pub include_topics: Option<BTreeSet<String>>,
+}
+
+impl IndexedReaderOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configure the reader to yield messages in the specified order (defaults to log-time order).
+    pub fn with_order(mut self, order: ReadOrder) -> Self {
+        self.order = order;
+        self
+    }
+
+    /// Configure the reader to yield only messages from topics matching this set of strings.
+    /// By default, all topics will be yielded.
+    pub fn include_topics<T: IntoIterator<Item = impl Deref<Target = str>>>(
+        mut self,
+        topics: T,
+    ) -> Self {
+        self.include_topics = Some(topics.into_iter().map(|p| p.to_owned()).collect());
+        self
+    }
+
+    /// Configure the reader to yield only messages with log time on or after this time.
+    pub fn log_time_on_or_after(mut self, start: u64) -> Self {
+        self.start = Some(start);
+        self
+    }
+
+    /// Configure the reader to yield only messages with log time before this time.
+    pub fn log_time_before(mut self, end: u64) -> Self {
+        self.end = Some(end);
+        self
     }
 }
 

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -97,7 +97,9 @@ pub struct IndexedReader {
     // The index in `chunk_indexes` of the current chunk to be loaded. cur_chunk_index >=
     // chunk_indexes.len() means that all chunks have been loaded.
     cur_chunk_index: usize,
-    // A set of decompressed chunks. Slots are re-used when their message count reaches zero.
+    // A set of decompressed chunks. Slots are re-used when their message count reaches zero.  There
+    // may be more than one chunk slot in use at a time if we are reading in log-time or
+    // reverse-log-time order, and there are chunks that overlap in time range.
     chunk_slots: Vec<ChunkSlot>,
     // An index into the messages stored in chunk slots. Index entries are sorted in the order
     // they should be yielded.

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -488,7 +488,6 @@ fn index_messages(
             return Err(McapError::UnexpectedEoc);
         }
         let record_data = &buf[..len];
-        // 1 byte opcode + 8 byte length == 9
         let next_offset = offset
           + 1 // opcode
           + 8 // record length

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -442,10 +442,11 @@ impl IndexedReader {
                     self.chunk_slots[message_index.chunk_slot_idx].message_count -= 1;
                     let record =
                         &self.chunk_slots[message_index.chunk_slot_idx].buf[message_index.offset..];
-                    // This should not happen - we failed in the indexing process somehow.
-                    if record[0] != op::MESSAGE {
-                        panic!("invariant: message indexes should point to message records");
-                    }
+                    assert_eq!(
+                        record[0],
+                        op::MESSAGE,
+                        "invariant: message indexes should point to message records"
+                    );
                     let len = u64::from_le_bytes(record[1..9].try_into().unwrap()) as usize; // size checked when indexing
                     let mut cursor = std::io::Cursor::new(&record[9..9 + len]);
                     let header = MessageHeader::read_le(&mut cursor)?;

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -489,7 +489,10 @@ fn index_messages(
         }
         let record_data = &buf[..len];
         // 1 byte opcode + 8 byte length == 9
-        let next_offset = offset + 9 + len;
+        let next_offset = offset
+          + 1 // opcode
+          + 8 // record length
+          + len;
         if opcode != op::MESSAGE {
             offset = next_offset;
             continue;

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -414,9 +414,10 @@ impl IndexedReader {
             } else {
                 self.cur_compressed_chunk.len()
             };
-            if buffer_length < self.cur_compressed_chunk_loaded_bytes + n {
-                panic!("notify_read called with n > last inserted length");
-            }
+            assert!(
+                buffer_length > self.cur_compressed_chunk_loaded_bytes + n,
+                "notify_read called with n > last inserted length"
+            );
             self.cur_compressed_chunk_loaded_bytes += n;
         }
         self.pos += n as u64;

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -1,0 +1,788 @@
+use binrw::BinRead;
+
+use crate::{
+    records::{op, ChunkIndex, MessageHeader},
+    McapError, McapResult,
+};
+use std::{collections::BTreeSet, io::SeekFrom, ops::Deref};
+
+#[derive(Clone, Copy)]
+struct MessageIndex {
+    chunk_slot_idx: usize,
+    log_time: u64,
+    offset: usize,
+}
+
+pub enum IndexedReadEvent<'a> {
+    Read(usize),
+    Seek(SeekFrom),
+    Message {
+        header: crate::records::MessageHeader,
+        data: &'a [u8],
+    },
+}
+enum State {
+    SeekingToChunk,
+    LoadingChunkData { into_slot: usize },
+    YieldingMessages,
+    Done,
+}
+
+struct ChunkSlot {
+    buf: Vec<u8>,
+    message_count: usize,
+}
+
+pub struct IndexedReader {
+    // This MCAP's chunk indexes, pre-filtered by time range and topic and sorted in the order
+    // they should be visited.
+    chunk_indexes: Vec<ChunkIndex>,
+    // The index in `chunk_indexes` of the current chunk to be loaded. cur_chunk_index >=
+    // chunk_indexes.len() means that all chunks have been loaded.
+    cur_chunk_index: usize,
+    // A set of decompressed chunks. Slots are re-used when their message count reaches zero.
+    chunk_slots: Vec<ChunkSlot>,
+    // An index into the messages stored in chunk slots. Index entries are sorted in the order
+    // they should be yielded.
+    message_indexes: Vec<MessageIndex>,
+    // The index in `message_indexes` of the next message to yield. cur_message_index >=
+    // message_indexes.len() means that no more indexed messages are available, and more messages
+    // should be loaded from the next chunk.
+    cur_message_index: usize,
+    // A buffer to store compressed chunk data while loading a chunk from the underlying reader.
+    cur_compressed_chunk: Vec<u8>,
+    // The count of valid bytes in `cur_compressed_chunk`. This may be less than
+    // `cur_compressed_chunk.len()`, if the user has called insert(n) to read more data in but the
+    // read operation resulted in fewer successfully read bytes.
+    cur_compressed_chunk_loaded_bytes: usize,
+    // The current known position of the reader in the underlying file.
+    pos: u64,
+    // describes what the indexed reader is currently trying to do.
+    state: State,
+    // What order messages should be yielded
+    order: ReadOrder,
+    // Criteria for what messages from the MCAP should be yielded
+    filter: Filter,
+}
+struct Filter {
+    // inclusive log time range start
+    start: Option<u64>,
+    // exclusive log time range end
+    end: Option<u64>,
+    // If non-empty, only channels with these IDs will be yielded
+    channel_ids: BTreeSet<u16>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub enum ReadOrder {
+    /// Yield messages in order of message.log_time. For messages with equal log times, the message
+    /// earlier in the underlying file will be yielded first.
+    #[default]
+    LogTime,
+    /// Yield messages in reverse message.log_time order. For messages with equal log times, the
+    /// message later in the underlying file will be yielded first.
+    ReverseLogTime,
+    /// Yield messages in the order they are present in the file.
+    File,
+}
+
+#[derive(Default, Clone)]
+pub struct IndexedReaderOptions {
+    pub start: Option<u64>,
+    pub end: Option<u64>,
+    pub order: ReadOrder,
+    pub include_topics: Option<BTreeSet<String>>,
+}
+
+impl IndexedReaderOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_order(mut self, order: ReadOrder) -> Self {
+        self.order = order;
+        self
+    }
+
+    pub fn include_topics<T: IntoIterator<Item = impl Deref<Target = str>>>(
+        mut self,
+        topics: T,
+    ) -> Self {
+        self.include_topics = Some(topics.into_iter().map(|p| p.to_owned()).collect());
+        self
+    }
+
+    pub fn log_time_on_or_after(mut self, start: u64) -> Self {
+        self.start = Some(start);
+        self
+    }
+
+    pub fn log_time_before(mut self, end: u64) -> Self {
+        self.end = Some(end);
+        self
+    }
+}
+
+impl IndexedReader {
+    pub fn new(summary: &crate::Summary) -> McapResult<Self> {
+        Self::new_with_options(summary, IndexedReaderOptions::default())
+    }
+
+    pub fn new_with_options(
+        summary: &crate::Summary,
+        options: IndexedReaderOptions,
+    ) -> McapResult<Self> {
+        let channel_ids = if let Some(include_topics) = options.include_topics {
+            let mut set = BTreeSet::new();
+            for (id, channel) in summary.channels.iter() {
+                if include_topics.contains(&channel.topic) {
+                    set.insert(*id);
+                }
+            }
+            set
+        } else {
+            BTreeSet::new()
+        };
+
+        // filter out chunks that we won't use
+        let mut chunk_indexes: Vec<crate::records::ChunkIndex> = summary
+            .chunk_indexes
+            .clone()
+            .into_iter()
+            .filter(|chunk_index| {
+                if let Some(start) = options.start {
+                    if chunk_index.message_end_time < start {
+                        return false;
+                    }
+                }
+                if let Some(end) = options.end {
+                    if chunk_index.message_start_time >= end {
+                        return false;
+                    }
+                }
+                if channel_ids.is_empty() {
+                    return true;
+                }
+                // NOTE: if there are no message indexes, we can't reject this chunk because
+                // the file may not have message indexes included.
+                if chunk_index.message_index_offsets.is_empty() {
+                    return true;
+                }
+                for key in chunk_index.message_index_offsets.keys() {
+                    if channel_ids.contains(key) {
+                        return true;
+                    }
+                }
+                false
+            })
+            .collect();
+
+        // put the chunk indexes in the order that we want to read them
+        match options.order {
+            ReadOrder::File => {
+                chunk_indexes.sort_by(|a, b| a.chunk_start_offset.cmp(&b.chunk_start_offset))
+            }
+            ReadOrder::LogTime => {
+                chunk_indexes.sort_by(|a, b| {
+                    match a.message_start_time.cmp(&b.message_start_time) {
+                        std::cmp::Ordering::Equal => {
+                            a.chunk_start_offset.cmp(&b.chunk_start_offset)
+                        }
+                        other => other,
+                    }
+                });
+            }
+            ReadOrder::ReverseLogTime => {
+                chunk_indexes.sort_by(|a, b| match b.message_end_time.cmp(&a.message_end_time) {
+                    std::cmp::Ordering::Equal => b.chunk_start_offset.cmp(&a.chunk_start_offset),
+                    other => other,
+                });
+            }
+        };
+
+        // check through all chunk indexes once to ensure that we have address space for an
+        // uncompressed chunk.
+        for chunk_index in chunk_indexes.iter() {
+            if chunk_index.compressed_size > usize::MAX as u64 {
+                return Err(McapError::TooLong(chunk_index.compressed_size));
+            }
+            if chunk_index.uncompressed_size > usize::MAX as u64 {
+                return Err(McapError::TooLong(chunk_index.uncompressed_size));
+            }
+        }
+        // need to deep-clone channels and schemas here.
+        Ok(Self {
+            state: State::SeekingToChunk,
+            chunk_indexes,
+            chunk_slots: Vec::new(),
+            message_indexes: Vec::new(),
+            cur_compressed_chunk: Vec::new(),
+            cur_compressed_chunk_loaded_bytes: 0,
+            cur_message_index: 0,
+            cur_chunk_index: 0,
+            pos: 0,
+            order: options.order,
+            filter: Filter {
+                start: options.start,
+                end: options.end,
+                channel_ids,
+            },
+        })
+    }
+
+    pub fn next_event(&mut self) -> Option<McapResult<IndexedReadEvent>> {
+        self.next_event_inner().transpose()
+    }
+
+    fn next_event_inner(&mut self) -> McapResult<Option<IndexedReadEvent>> {
+        loop {
+            match &mut self.state {
+                State::SeekingToChunk => {
+                    // If there is no chunk to seek to, we're done.
+                    if self.cur_chunk_index >= self.chunk_indexes.len() {
+                        self.state = State::Done;
+                        return Ok(None);
+                    }
+                    let cur_chunk = &self.chunk_indexes[self.cur_chunk_index];
+                    // If we're not already at the start of compressed data, seek to it.
+                    let compressed_data_start = get_compressed_data_start(cur_chunk);
+                    if self.pos != compressed_data_start {
+                        return Ok(Some(IndexedReadEvent::Seek(SeekFrom::Start(
+                            compressed_data_start,
+                        ))));
+                    }
+                    // Seek is done, time to load the compressed chunk data.
+                    self.cur_compressed_chunk.clear();
+                    self.cur_compressed_chunk_loaded_bytes = 0;
+                    self.state = State::LoadingChunkData {
+                        into_slot: find_or_make_chunk_slot(
+                            &mut self.chunk_slots,
+                            cur_chunk.uncompressed_size as usize, // size checked in new()
+                        ),
+                    };
+                    continue;
+                }
+                State::LoadingChunkData { into_slot } => {
+                    // This is a defensive check - the reader should not enter this state if there
+                    // is no valid chunk to load.
+                    if self.cur_chunk_index >= self.chunk_indexes.len() {
+                        self.state = State::Done;
+                        return Ok(None);
+                    }
+                    let cur_chunk = &self.chunk_indexes[self.cur_chunk_index];
+                    let compressed_size = cur_chunk.compressed_size as usize; // size checked in new()
+                    let uncompressed_size = cur_chunk.uncompressed_size as usize; // size checked in new()
+
+                    // Keep requesting more data until we have all of the compressed chunk.
+                    if self.cur_compressed_chunk_loaded_bytes < compressed_size {
+                        let need = compressed_size - self.cur_compressed_chunk_loaded_bytes;
+                        return Ok(Some(IndexedReadEvent::Read(need)));
+                    }
+                    // decompress the chunk into the current slot. For un-compressed chunks, we do
+                    // nothing, because we already loaded the "compressed" data into the chunk slot.
+                    let slot = &mut self.chunk_slots[*into_slot];
+                    //
+                    slot.buf.resize(uncompressed_size, 0);
+                    match cur_chunk.compression.as_str() {
+                        "" => {
+                            // data is already loaded into current slot
+                        }
+                        #[cfg(feature = "zstd")]
+                        "zstd" => {
+                            // decompress zstd into current slot
+                            let n = zstd::zstd_safe::decompress(
+                                &mut slot.buf[..],
+                                &self.cur_compressed_chunk[..compressed_size],
+                            )
+                            .map_err(|err| {
+                                McapError::DecompressionError(
+                                    zstd::zstd_safe::get_error_name(err).into(),
+                                )
+                            })?;
+                            if n != uncompressed_size {
+                                return Err(McapError::DecompressionError(
+                                    format!("zstd decompression error: expected {uncompressed_size}, got {n}"),
+                                ));
+                            }
+                        }
+                        #[cfg(feature = "lz4")]
+                        "lz4" => {
+                            use std::io::Read;
+                            let mut decoder = lz4::Decoder::new(std::io::Cursor::new(
+                                &self.cur_compressed_chunk[..compressed_size],
+                            ))?;
+                            decoder.read_exact(&mut slot.buf[..])?;
+                        }
+                        other => return Err(McapError::UnsupportedCompression(other.into())),
+                    }
+                    // index the current chunk slot
+                    // before starting, check if all existing message indexes have been exhausted -
+                    // if so, clear them out now.
+                    if self.cur_message_index >= self.message_indexes.len() {
+                        self.cur_message_index = 0;
+                        self.message_indexes.clear();
+                    }
+                    // load new indexes into `self.message_indexes`
+                    let message_count = index_messages(
+                        *into_slot,
+                        &slot.buf,
+                        self.order,
+                        &self.filter,
+                        &mut self.message_indexes,
+                        self.cur_message_index,
+                    )?;
+                    slot.message_count = message_count;
+                    // If there is more dead space at the front of `self.message_indexes` than the
+                    // set of new message indexes, compact the message index array now.
+                    if message_count < (self.cur_message_index) {
+                        self.message_indexes.drain(0..self.cur_message_index);
+                        self.cur_message_index = 0;
+                    }
+                    // this chunk is finished, move on
+                    self.cur_chunk_index += 1;
+                    self.state = State::YieldingMessages;
+                    continue;
+                }
+                State::YieldingMessages => {
+                    // if we have run out of messages to yield, load the next chunk
+                    if self.cur_message_index >= self.message_indexes.len() {
+                        self.state = State::SeekingToChunk;
+                        continue;
+                    }
+                    // if the next chunk contains messages that should be yielded before the next indexed message,
+                    // load the next chunk
+                    let message_index = self.message_indexes[self.cur_message_index];
+                    if self.cur_chunk_index < self.chunk_indexes.len() {
+                        let should_load_chunk = match self.order {
+                            ReadOrder::File => false,
+                            ReadOrder::LogTime => {
+                                self.chunk_indexes[self.cur_chunk_index].message_start_time
+                                    < message_index.log_time
+                            }
+                            ReadOrder::ReverseLogTime => {
+                                self.chunk_indexes[self.cur_chunk_index].message_end_time
+                                    > message_index.log_time
+                            }
+                        };
+                        if should_load_chunk {
+                            self.state = State::SeekingToChunk;
+                            continue;
+                        }
+                    }
+                    self.cur_message_index += 1;
+                    self.chunk_slots[message_index.chunk_slot_idx].message_count -= 1;
+                    let record =
+                        &self.chunk_slots[message_index.chunk_slot_idx].buf[message_index.offset..];
+                    // This should not happen - we failed in the indexing process somehow.
+                    if record[0] != op::MESSAGE {
+                        panic!("invariant: message indexes should point to message records");
+                    }
+                    let len = u64::from_le_bytes(record[1..9].try_into().unwrap()) as usize; // size checked when indexing
+                    let mut cursor = std::io::Cursor::new(&record[9..9 + len]);
+                    let header = MessageHeader::read_le(&mut cursor)?;
+                    let header_end = cursor.position() as usize; // we can assume position <= record.len() <= usize::MAX here
+                    let msg_buf = cursor.into_inner();
+                    let data = &msg_buf[header_end..];
+                    return Ok(Some(IndexedReadEvent::Message { header, data }));
+                }
+                State::Done => {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    pub fn notify_read(&mut self, n: usize) {
+        if let State::LoadingChunkData { into_slot } = &self.state {
+            let buffer_length = if self.chunk_indexes[self.cur_chunk_index]
+                .compression
+                .is_empty()
+            {
+                self.chunk_slots[*into_slot].buf.len()
+            } else {
+                self.cur_compressed_chunk.len()
+            };
+            if buffer_length < self.cur_compressed_chunk_loaded_bytes + n {
+                panic!("notify_read called with n > last inserted length");
+            }
+            self.cur_compressed_chunk_loaded_bytes += n;
+        }
+        self.pos += n as u64;
+    }
+
+    pub fn notify_seeked(&mut self, pos: u64) {
+        // If we're currently loading data, we need to reset and start loading from the beginning.
+        if self.pos != pos && matches!(self.state, State::LoadingChunkData { .. }) {
+            let mut state = State::SeekingToChunk;
+            std::mem::swap(&mut state, &mut self.state);
+            let State::LoadingChunkData { .. } = state else {
+                unreachable!();
+            };
+        }
+        self.pos = pos;
+    }
+
+    pub fn insert(&mut self, n: usize) -> &mut [u8] {
+        let buf = match self.state {
+            State::LoadingChunkData { into_slot } => {
+                if self.chunk_indexes[self.cur_chunk_index]
+                    .compression
+                    .is_empty()
+                {
+                    &mut self.chunk_slots[into_slot].buf
+                } else {
+                    &mut self.cur_compressed_chunk
+                }
+            }
+            _ => &mut self.cur_compressed_chunk,
+        };
+        let start = self.cur_compressed_chunk_loaded_bytes;
+        let end = start + n;
+        buf.resize(end, 0);
+        &mut buf[start..end]
+    }
+}
+
+/// Insert indexes into `message_indexes` for every message in this chunk that matches the filter
+/// criteria.
+fn index_messages(
+    chunk_slot_idx: usize,
+    chunk_data: &[u8],
+    order: ReadOrder,
+    filter: &Filter,
+    message_indexes: &mut Vec<MessageIndex>,
+    cur_message_index: usize,
+) -> McapResult<usize> {
+    let mut offset = 0usize;
+    let mut sorting_required = cur_message_index != 0;
+    let mut latest_timestamp = 0;
+    let new_message_index_start = message_indexes.len();
+    while offset < chunk_data.len() {
+        let record = &chunk_data[offset..];
+        let opcode = record[0];
+        if record.len() < 9 {
+            return Err(McapError::UnexpectedEoc);
+        }
+        let len = len_as_usize(u64::from_le_bytes(record[1..9].try_into().unwrap()))?;
+        let next_offset = offset + 9 + len;
+        if opcode != op::MESSAGE {
+            offset = next_offset;
+            continue;
+        }
+        let msg = MessageHeader::read_le(&mut std::io::Cursor::new(&record[9..9 + len]))?;
+        if let Some(end) = filter.end {
+            if msg.log_time >= end {
+                offset = next_offset;
+                continue;
+            }
+        }
+        if let Some(start) = filter.start {
+            if msg.log_time < start {
+                offset = next_offset;
+                continue;
+            }
+        }
+        if !filter.channel_ids.is_empty() && !filter.channel_ids.contains(&msg.channel_id) {
+            offset = next_offset;
+            continue;
+        }
+        if !sorting_required {
+            sorting_required = msg.log_time < latest_timestamp
+        }
+        latest_timestamp = std::cmp::max(latest_timestamp, msg.log_time);
+        message_indexes.push(MessageIndex {
+            chunk_slot_idx,
+            log_time: msg.log_time,
+            offset,
+        });
+        offset = next_offset
+    }
+    match order {
+        ReadOrder::File => {
+            // in file order, message indexes do not need sorting
+        }
+        ReadOrder::LogTime => {
+            if sorting_required {
+                let unread_message_indexes = &mut message_indexes[cur_message_index..];
+                unread_message_indexes.sort_by(|a, b| a.log_time.cmp(&b.log_time));
+            }
+        }
+        ReadOrder::ReverseLogTime => {
+            // first, reverse the order of the new message indexes. This will make the sort much faster.
+            let new_message_indexes = &mut message_indexes[new_message_index_start..];
+            new_message_indexes.reverse();
+            if sorting_required {
+                let unread_message_indexes = &mut message_indexes[cur_message_index..];
+                unread_message_indexes.sort_by(|a, b| b.log_time.cmp(&a.log_time));
+            }
+        }
+    }
+    Ok(message_indexes.len() - new_message_index_start)
+}
+
+/// Finds a chunk slot with no outstanding messages in it and returns its index, or creates a new one.
+fn find_or_make_chunk_slot(chunk_slots: &mut Vec<ChunkSlot>, uncompressed_size: usize) -> usize {
+    for (i, slot) in chunk_slots.iter_mut().enumerate() {
+        if slot.message_count == 0 {
+            slot.buf.clear();
+            slot.buf.reserve(uncompressed_size);
+            return i;
+        }
+    }
+    let idx = chunk_slots.len();
+    chunk_slots.push(ChunkSlot {
+        message_count: 0,
+        buf: Vec::with_capacity(uncompressed_size),
+    });
+    idx
+}
+
+fn get_compressed_data_start(chunk_index: &ChunkIndex) -> u64 {
+    chunk_index.chunk_start_offset
+    + 1 // opcode
+    + 8 // chunk record length
+    + 8 // start time
+    + 8 // end time
+    + 8 // uncompressed size
+    + 4 // CRC
+    + 4 // compression string length
+    + (chunk_index.compression.len() as u64) // compression string
+    + 8 // compressed size
+}
+
+fn len_as_usize(len: u64) -> McapResult<usize> {
+    len.try_into().map_err(|_| McapError::TooLong(len))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        io::{Read, Seek},
+    };
+
+    use crate::sans_io::{SummaryReadEvent, SummaryReader};
+
+    use super::*;
+
+    fn make_mcap(compression: Option<crate::Compression>, chunks: &[&[(u16, u64)]]) -> Vec<u8> {
+        let mut writer = crate::WriteOptions::new()
+            .compression(compression)
+            .chunk_size(None)
+            .create(std::io::Cursor::new(Vec::new()))
+            .expect("could not make the writer");
+        let mut sequence = 0;
+        for chunk in chunks.iter() {
+            for &(id, log_time) in chunk.iter() {
+                writer
+                    .write(&crate::Message {
+                        channel: std::sync::Arc::new(crate::Channel {
+                            id,
+                            topic: if id % 2 == 0 {
+                                "even".into()
+                            } else {
+                                "odd".into()
+                            },
+                            schema: None,
+                            message_encoding: "ros1msg".into(),
+                            metadata: BTreeMap::new(),
+                        }),
+                        sequence,
+                        log_time,
+                        publish_time: log_time,
+                        data: std::borrow::Cow::Owned(vec![1, 2, 3]),
+                    })
+                    .expect("failed write");
+                sequence += 1;
+            }
+            writer.flush().expect("failed to flush chunk");
+        }
+        writer.finish().expect("failed on finish");
+        writer.into_inner().into_inner()
+    }
+
+    fn read_mcap(options: IndexedReaderOptions, mcap: &[u8]) -> Vec<(u16, u64)> {
+        let summary = crate::Summary::read(mcap)
+            .expect("summary reading should succeed")
+            .expect("there should be a summary");
+        let mut reader = IndexedReader::new_with_options(&summary, options)
+            .expect("reader construction should not fail");
+        let mut cursor = std::io::Cursor::new(&mcap);
+        let mut found = Vec::new();
+        let mut iterations = 0;
+        while let Some(event) = reader.next_event() {
+            match event.expect("indexed reader failed") {
+                IndexedReadEvent::Read(n) => {
+                    let res = cursor
+                        .read(reader.insert(n))
+                        .expect("read should not fail on cursor");
+                    reader.notify_read(res);
+                }
+                IndexedReadEvent::Seek(to) => {
+                    let pos = cursor.seek(to).expect("seek should not fail on cursor");
+                    reader.notify_seeked(pos);
+                }
+                IndexedReadEvent::Message { header, .. } => {
+                    found.push((header.channel_id, header.log_time));
+                }
+            }
+            iterations += 1;
+            if iterations > 100000 {
+                panic!("too many iterations");
+            }
+        }
+        found
+    }
+
+    fn test_read_order(chunks: &[&[(u16, u64)]]) {
+        let mcap = make_mcap(None, chunks);
+        for order in [
+            ReadOrder::LogTime,
+            ReadOrder::ReverseLogTime,
+            ReadOrder::File,
+        ] {
+            let mut expected: Vec<(u16, u64)> = chunks.iter().cloned().flatten().cloned().collect();
+            match order {
+                ReadOrder::File => {}
+                // sort in log time order (stable, so that file order is preserved) for equal values
+                ReadOrder::LogTime => expected.sort_by(|a, b| a.1.cmp(&b.1)),
+                // sort in log time order then reverse
+                ReadOrder::ReverseLogTime => {
+                    expected.sort_by(|a, b| a.1.cmp(&b.1));
+                    expected.reverse();
+                }
+            }
+            let found = read_mcap(IndexedReaderOptions::new().with_order(order), &mcap);
+            assert_eq!(&found, &expected, "order: {order:?}");
+        }
+    }
+    #[test]
+    fn test_simple_order() {
+        test_read_order(&[
+            &[(0, 1), (0, 2), (0, 3)],
+            &[(0, 4), (0, 5), (0, 6)],
+            &[(0, 7), (0, 8), (0, 9)],
+        ]);
+    }
+    #[test]
+    fn test_overlapping_chunks() {
+        test_read_order(&[
+            &[(0, 2), (0, 4), (0, 6)],
+            &[(1, 1), (1, 3), (1, 5)],
+            &[(2, 5), (2, 7), (2, 9)],
+        ]);
+    }
+
+    #[test]
+    fn test_in_chunk_disorder() {
+        test_read_order(&[
+            &[(0, 4), (0, 2), (0, 6)],
+            &[(1, 5), (1, 3), (1, 1)],
+            &[(2, 9), (2, 8), (2, 7)],
+        ]);
+    }
+    #[test]
+    fn test_continuing_overlap() {
+        test_read_order(&[
+            &[(0, 1), (0, 10)],
+            &[(1, 2), (1, 3)],
+            &[(2, 4), (2, 5)],
+            &[(3, 6), (3, 7)],
+            &[(4, 8), (4, 9)],
+        ]);
+    }
+
+    #[test]
+    fn test_time_range_filter() {
+        let mcap = make_mcap(None, &[&[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6)]]);
+        let messages = read_mcap(
+            IndexedReaderOptions::new()
+                .log_time_on_or_after(3)
+                .log_time_before(6),
+            &mcap,
+        );
+        assert_eq!(&messages, &[(0, 3), (0, 4), (0, 5)])
+    }
+    #[test]
+    fn test_compression() {
+        for compression in [
+            None,
+            Some(crate::Compression::Lz4),
+            Some(crate::Compression::Zstd),
+        ] {
+            let mcap = make_mcap(compression, &[&[(0, 1), (0, 2)], &[(0, 3), (0, 4)]]);
+            let messages = read_mcap(IndexedReaderOptions::new(), &mcap);
+            assert_eq!(
+                &messages,
+                &[(0, 1), (0, 2), (0, 3), (0, 4)],
+                "decompression with {compression:?}"
+            )
+        }
+    }
+
+    #[test]
+    fn test_channel_filter() {
+        let mcap = make_mcap(None, &[&[(0, 1), (1, 2), (2, 3), (1, 4), (0, 5), (1, 6)]]);
+        let messages = read_mcap(IndexedReaderOptions::new().include_topics(["even"]), &mcap);
+        assert_eq!(&messages, &[(0, 1), (2, 3), (0, 5)])
+    }
+
+    #[test]
+    fn test_against_fixtures() {
+        let path = "tests/data/compressed.mcap";
+        let count = 826;
+        let block_sizes = [None, Some(16 * 1024), Some(1024), Some(128)];
+        for &block_size in block_sizes.iter() {
+            let mut file = std::fs::File::open(path).expect("could not open file");
+            let summary = {
+                let mut reader = SummaryReader::new();
+                while let Some(event) = reader.next_event() {
+                    match event.expect("failed to get next summary read event") {
+                        SummaryReadEvent::Seek(pos) => {
+                            reader.notify_seeked(file.seek(pos).expect("seek failed"));
+                        }
+                        SummaryReadEvent::Read(n) => {
+                            let n = match block_size {
+                                Some(block_size) => block_size,
+                                None => n,
+                            };
+                            let read = file.read(reader.insert(n)).expect("read failed");
+                            reader.notify_read(read);
+                        }
+                    }
+                }
+                reader.finish().expect("file should contain a summary")
+            };
+            let mut reader = IndexedReader::new(&summary).expect("failed to construct summary");
+            let mut messages = Vec::new();
+            while let Some(event) = reader.next_event() {
+                match event.expect("failed to read next event") {
+                    IndexedReadEvent::Seek(pos) => {
+                        reader.notify_seeked(file.seek(pos).expect("seek failed"));
+                    }
+                    IndexedReadEvent::Read(n) => {
+                        let n = match block_size {
+                            Some(block_size) => block_size,
+                            None => n,
+                        };
+                        let read = file.read(reader.insert(n)).expect("read failed");
+                        reader.notify_read(read);
+                    }
+                    IndexedReadEvent::Message { header, .. } => {
+                        messages.push(header.log_time);
+                    }
+                }
+            }
+            assert_eq!(
+                messages.len(),
+                count,
+                "wrong message count for fixture {path}"
+            );
+            let mut last_log_time = 0u64;
+            for &log_time in messages.iter() {
+                assert!(log_time >= last_log_time, "out-of-order for fixture {path}");
+                last_log_time = log_time;
+            }
+        }
+    }
+}

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -4,7 +4,7 @@ use crate::{
     records::{op, ChunkIndex, MessageHeader},
     McapError, McapResult,
 };
-use std::{cmp::Reverse, collections::BTreeSet, ops::Deref};
+use std::{cmp::Reverse, collections::BTreeSet};
 
 #[derive(Clone, Copy)]
 struct MessageIndex {
@@ -422,11 +422,8 @@ impl IndexedReaderOptions {
 
     /// Configure the reader to yield only messages from topics matching this set of strings.
     /// By default, all topics will be yielded.
-    pub fn include_topics<T: IntoIterator<Item = impl Deref<Target = str>>>(
-        mut self,
-        topics: T,
-    ) -> Self {
-        self.include_topics = Some(topics.into_iter().map(|p| p.to_owned()).collect());
+    pub fn include_topics<T: IntoIterator<Item = impl Into<String>>>(mut self, topics: T) -> Self {
+        self.include_topics = Some(topics.into_iter().map(|p| p.into()).collect());
         self
     }
 

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -567,7 +567,7 @@ fn index_messages(
         if !sorting_required {
             sorting_required = msg.log_time < latest_timestamp
         }
-        latest_timestamp = std::cmp::max(latest_timestamp, msg.log_time);
+        latest_timestamp = latest_timestamp.max(msg.log_time);
         message_indexes.push(MessageIndex {
             chunk_slot_idx,
             log_time: msg.log_time,

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -430,11 +430,7 @@ impl IndexedReader {
         }
         // If we're currently loading data, we need to reset and start loading from the beginning.
         if self.pos != pos && matches!(self.state, State::LoadingChunkData { .. }) {
-            let mut state = State::SeekingToChunk;
-            std::mem::swap(&mut state, &mut self.state);
-            let State::LoadingChunkData { .. } = state else {
-                unreachable!();
-            };
+            self.state = State::SeekingToChunk;
         }
         self.pos = pos;
     }

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -4,7 +4,7 @@ use crate::{
     records::{op, ChunkIndex, MessageHeader},
     McapError, McapResult,
 };
-use std::{collections::BTreeSet, io::SeekFrom, ops::Deref};
+use std::{collections::BTreeSet, ops::Deref};
 
 #[derive(Clone, Copy)]
 struct MessageIndex {
@@ -15,28 +15,19 @@ struct MessageIndex {
 
 /// Events yielded by the IndexedReader.
 pub enum IndexedReadEvent<'a> {
-    /// The reader needs more data to provide the next record. Call [`IndexedReader::insert`] then
-    /// [`IndexedReader::notify_read`] to load more data. The value provided here is a hint for how
-    /// much data to insert.
-    ReadRequest(usize),
-    /// The reader needs to seek to a different position in the file. Call
-    /// [`IndexedReader::notify_seeked`] to inform the reader of the result of the seek.
-    SeekRequest(SeekFrom),
-    /// Get a new message from the reader.
+    /// The reader needs the content of a chunk record to continue yielding messages.
+    /// Read a slice out of the underlying file with the given offset and length into a buffer,
+    /// and call [`IndexedReader::insert_chunk_record_data`] with the result to get more messages.
+    ReadChunkRequest { offset: u64, length: usize },
     Message {
         header: crate::records::MessageHeader,
         data: &'a [u8],
     },
 }
-enum State {
-    SeekingToChunk,
-    LoadingChunkData { into_slot: usize },
-    YieldingMessages,
-    Done,
-}
 
 struct ChunkSlot {
     buf: Vec<u8>,
+    data_start: u64,
     message_count: usize,
 }
 
@@ -74,12 +65,12 @@ struct ChunkSlot {
 ///     let mut reader = mcap::sans_io::indexed_reader::IndexedReader::new(&summary).expect("could not construct reader");
 ///     while let Some(event) = reader.next_event() {
 ///         match event? {
-///             IndexedReadEvent::ReadRequest(need) => {
-///                 let written = file.read(reader.insert(need))?;
-///                 reader.notify_read(written);
-///             },
-///             IndexedReadEvent::SeekRequest(to) => {
-///                 reader.notify_seeked(file.seek(to)?);
+///             IndexedReadEvent::ReadChunkRequest{start, length} => {
+///                 file.seek(start)?;
+///                 let mut buffer = reader.reclaim_buffer();
+///                 buffer.resize(length, 0);
+///                 file.read_exact(&mut buffer)?;
+///                 reader.insert_chunk_record_data(start, buffer);
 ///             },
 ///             IndexedReadEvent::Message{ header, data } => {
 ///                 let channel = summary.channels.get(&header.channel_id).unwrap();
@@ -108,21 +99,21 @@ pub struct IndexedReader {
     // message_indexes.len() means that no more indexed messages are available, and more messages
     // should be loaded from the next chunk.
     cur_message_index: usize,
-    // A buffer to store compressed chunk data while loading a chunk from the underlying reader.
-    cur_compressed_chunk: Vec<u8>,
-    // The count of valid bytes in `cur_compressed_chunk`. This may be less than
-    // `cur_compressed_chunk.len()`, if the user has called insert(n) to read more data in but the
-    // read operation resulted in fewer successfully read bytes.
-    cur_compressed_chunk_loaded_bytes: usize,
-    // The current known position of the reader in the underlying file.
-    pos: u64,
-    // describes what the indexed reader is currently trying to do.
-    state: State,
     // What order messages should be yielded
     order: ReadOrder,
     // Criteria for what messages from the MCAP should be yielded
     filter: Filter,
-    at_eof: bool,
+}
+
+fn chunk_request(index: &ChunkIndex) -> Option<McapResult<IndexedReadEvent<'static>>> {
+    let length = match len_as_usize(index.compressed_size) {
+        Ok(len) => len,
+        Err(err) => return Some(Err(err)),
+    };
+    Some(Ok(IndexedReadEvent::ReadChunkRequest {
+        offset: get_compressed_data_start(index),
+        length,
+    }))
 }
 
 impl IndexedReader {
@@ -206,248 +197,163 @@ impl IndexedReader {
         }
         // need to deep-clone channels and schemas here.
         Ok(Self {
-            state: State::SeekingToChunk,
             chunk_indexes,
             chunk_slots: Vec::new(),
             message_indexes: Vec::new(),
-            cur_compressed_chunk: Vec::new(),
-            cur_compressed_chunk_loaded_bytes: 0,
             cur_message_index: 0,
             cur_chunk_index: 0,
-            pos: 0,
             order: options.order,
             filter: Filter {
                 start: options.start,
                 end: options.end,
                 channel_ids,
             },
-            at_eof: false,
         })
     }
 
     /// Returns the next event from the reader. Call this repeatedly and act on the resulting
     /// events in order to read messages from the MCAP.
-    pub fn next_event(&mut self) -> Option<McapResult<IndexedReadEvent>> {
-        self.next_event_inner().transpose()
-    }
-
-    fn next_event_inner(&mut self) -> McapResult<Option<IndexedReadEvent>> {
-        loop {
-            match &mut self.state {
-                State::SeekingToChunk => {
-                    // If there is no chunk to seek to, we're done.
-                    if self.cur_chunk_index >= self.chunk_indexes.len() {
-                        self.state = State::Done;
-                        return Ok(None);
-                    }
-                    let cur_chunk = &self.chunk_indexes[self.cur_chunk_index];
-                    // If we're not already at the start of compressed data, seek to it.
-                    let compressed_data_start = get_compressed_data_start(cur_chunk);
-                    if self.pos != compressed_data_start {
-                        return Ok(Some(IndexedReadEvent::SeekRequest(SeekFrom::Start(
-                            compressed_data_start,
-                        ))));
-                    }
-                    // Seek is done, time to load the compressed chunk data.
-                    self.cur_compressed_chunk.clear();
-                    self.cur_compressed_chunk_loaded_bytes = 0;
-                    self.state = State::LoadingChunkData {
-                        into_slot: find_or_make_chunk_slot(
-                            &mut self.chunk_slots,
-                            cur_chunk.uncompressed_size as usize, // size checked in new()
-                        ),
-                    };
-                    continue;
-                }
-                State::LoadingChunkData { into_slot } => {
-                    // This is a defensive check - the reader should not enter this state if there
-                    // is no valid chunk to load.
-                    if self.cur_chunk_index >= self.chunk_indexes.len() {
-                        self.state = State::Done;
-                        return Ok(None);
-                    }
-                    let cur_chunk = &self.chunk_indexes[self.cur_chunk_index];
-                    let compressed_size = cur_chunk.compressed_size as usize; // size checked in new()
-                    let uncompressed_size = cur_chunk.uncompressed_size as usize; // size checked in new()
-
-                    // Keep requesting more data until we have all of the compressed chunk.
-                    if self.cur_compressed_chunk_loaded_bytes < compressed_size {
-                        let need = compressed_size - self.cur_compressed_chunk_loaded_bytes;
-                        if self.at_eof {
-                            return Err(McapError::UnexpectedEof);
-                        }
-                        return Ok(Some(IndexedReadEvent::ReadRequest(need)));
-                    }
-                    // decompress the chunk into the current slot. For un-compressed chunks, we do
-                    // nothing, because we already loaded the "compressed" data into the chunk slot.
-                    let slot = &mut self.chunk_slots[*into_slot];
-                    //
-                    slot.buf.resize(uncompressed_size, 0);
-                    match cur_chunk.compression.as_str() {
-                        "" => {
-                            // data is already loaded into current slot
-                        }
-                        #[cfg(feature = "zstd")]
-                        "zstd" => {
-                            // decompress zstd into current slot
-                            let n = zstd::zstd_safe::decompress(
-                                &mut slot.buf[..],
-                                &self.cur_compressed_chunk[..compressed_size],
-                            )
-                            .map_err(|err| {
-                                McapError::DecompressionError(
-                                    zstd::zstd_safe::get_error_name(err).into(),
-                                )
-                            })?;
-                            if n != uncompressed_size {
-                                return Err(McapError::DecompressionError(
-                                    format!("zstd decompression error: expected {uncompressed_size}, got {n}"),
-                                ));
-                            }
-                        }
-                        #[cfg(feature = "lz4")]
-                        "lz4" => {
-                            use std::io::Read;
-                            let mut decoder = lz4::Decoder::new(std::io::Cursor::new(
-                                &self.cur_compressed_chunk[..compressed_size],
-                            ))?;
-                            decoder.read_exact(&mut slot.buf[..])?;
-                        }
-                        other => return Err(McapError::UnsupportedCompression(other.into())),
-                    }
-                    // index the current chunk slot
-                    // before starting, check if all existing message indexes have been exhausted -
-                    // if so, clear them out now.
-                    if self.cur_message_index >= self.message_indexes.len() {
-                        self.cur_message_index = 0;
-                        self.message_indexes.clear();
-                    }
-                    // load new indexes into `self.message_indexes`
-                    let message_count = index_messages(
-                        *into_slot,
-                        &slot.buf,
-                        self.order,
-                        &self.filter,
-                        &mut self.message_indexes,
-                        self.cur_message_index,
-                    )?;
-                    slot.message_count = message_count;
-                    // If there is more dead space at the front of `self.message_indexes` than the
-                    // set of new message indexes, compact the message index array now.
-                    if message_count < (self.cur_message_index) {
-                        self.message_indexes.drain(0..self.cur_message_index);
-                        self.cur_message_index = 0;
-                    }
-                    // this chunk is finished, move on
-                    self.cur_chunk_index += 1;
-                    self.state = State::YieldingMessages;
-                    continue;
-                }
-                State::YieldingMessages => {
-                    // if we have run out of messages to yield, load the next chunk
-                    if self.cur_message_index >= self.message_indexes.len() {
-                        self.state = State::SeekingToChunk;
-                        continue;
-                    }
-                    // if the next chunk contains messages that should be yielded before the next indexed message,
-                    // load the next chunk
-                    let message_index = self.message_indexes[self.cur_message_index];
-                    if self.cur_chunk_index < self.chunk_indexes.len() {
-                        let should_load_chunk = match self.order {
-                            ReadOrder::File => false,
-                            ReadOrder::LogTime => {
-                                self.chunk_indexes[self.cur_chunk_index].message_start_time
-                                    < message_index.log_time
-                            }
-                            ReadOrder::ReverseLogTime => {
-                                self.chunk_indexes[self.cur_chunk_index].message_end_time
-                                    > message_index.log_time
-                            }
-                        };
-                        if should_load_chunk {
-                            self.state = State::SeekingToChunk;
-                            continue;
-                        }
-                    }
-                    self.cur_message_index += 1;
-                    self.chunk_slots[message_index.chunk_slot_idx].message_count -= 1;
-                    let record =
-                        &self.chunk_slots[message_index.chunk_slot_idx].buf[message_index.offset..];
-                    assert_eq!(
-                        record[0],
-                        op::MESSAGE,
-                        "invariant: message indexes should point to message records"
-                    );
-                    let len = u64::from_le_bytes(record[1..9].try_into().unwrap()) as usize; // size checked when indexing
-                    let mut cursor = std::io::Cursor::new(&record[9..9 + len]);
-                    let header = MessageHeader::read_le(&mut cursor)?;
-                    let header_end = cursor.position() as usize; // we can assume position <= record.len() <= usize::MAX here
-                    let msg_buf = cursor.into_inner();
-                    let data = &msg_buf[header_end..];
-                    return Ok(Some(IndexedReadEvent::Message { header, data }));
-                }
-                State::Done => {
-                    return Ok(None);
+    pub fn next_event(&self) -> Option<McapResult<IndexedReadEvent>> {
+        if self.cur_message_index < self.message_indexes.len() {
+            let message_index = &self.message_indexes[self.cur_message_index];
+            // There is a message index at the top of the queue - check if we need to yield it
+            // or load another chunk first.
+            if self.cur_chunk_index < self.chunk_indexes.len() {
+                let chunk_index = &self.chunk_indexes[self.cur_chunk_index];
+                if self.yield_chunk_first(chunk_index, message_index) {
+                    return chunk_request(chunk_index);
                 }
             }
-        }
-    }
-
-    /// Inform the reader of the result of the latest read on the underlying stream. 0 implies
-    /// that the end of stream has been reached.
-    ///
-    /// Panics if `n` is greater than the last `n` provided to [`Self::insert`].
-    pub fn notify_read(&mut self, n: usize) {
-        self.at_eof = n == 0;
-        if let State::LoadingChunkData { into_slot } = &self.state {
-            let buffer_length = if self.chunk_indexes[self.cur_chunk_index]
-                .compression
-                .is_empty()
-            {
-                self.chunk_slots[*into_slot].buf.len()
-            } else {
-                self.cur_compressed_chunk.len()
-            };
-            assert!(
-                buffer_length >= self.cur_compressed_chunk_loaded_bytes + n,
-                "notify_read called with n > last inserted length"
+            // Time to yield the message.
+            let buf = &self.chunk_slots[message_index.chunk_slot_idx].buf[message_index.offset..];
+            assert_eq!(
+                buf[0],
+                op::MESSAGE,
+                "invariant: message indexes should point to message records"
             );
-            self.cur_compressed_chunk_loaded_bytes += n;
+            let msg_len = match len_as_usize(u64::from_le_bytes(buf[1..9].try_into().unwrap())) {
+                Ok(len) => len,
+                Err(err) => return Some(Err(err)),
+            };
+            let msg_data = &buf[9..9 + msg_len];
+            let mut reader = std::io::Cursor::new(msg_data);
+            let header = match MessageHeader::read_le(&mut reader) {
+                Ok(header) => header,
+                Err(err) => return Some(Err(err.into())),
+            };
+            let data_start_offset = reader.position() as usize;
+            let data = &msg_data[data_start_offset..];
+            return Some(Ok(IndexedReadEvent::Message { header, data }));
         }
-        self.pos += n as u64;
+        // we're out of message indexes, we need to load a chunk.
+        // if we're out of chunks, we're done.
+        if self.cur_chunk_index >= self.chunk_indexes.len() {
+            return None;
+        }
+        return chunk_request(&self.chunk_indexes[self.cur_chunk_index]);
     }
 
-    /// Inform the reader of the result of the latest seek of the underlying stream.
-    pub fn notify_seeked(&mut self, pos: u64) {
-        if self.at_eof && self.pos != pos {
-            self.at_eof = false;
+    /// Call to insert new compressed records into this reader. The return value indicates whether
+    /// the reader now has enough data to yield messages.
+    pub fn insert_chunk_record_data(
+        &mut self,
+        start_offset: u64,
+        compressed_data: &[u8],
+    ) -> McapResult<()> {
+        // linear search through our chunk indexes to figure out which one it is. In the common case,
+        // the first chunk index will be right.
+        let Some((i, chunk_index)) = self
+            .chunk_indexes
+            .iter()
+            .enumerate()
+            .find(|(_, chunk_index)| get_compressed_data_start(chunk_index) == start_offset)
+        else {
+            return Err(McapError::UnexpectedChunkDataInserted);
+        };
+        if compressed_data.len() != chunk_index.compressed_size as usize {
+            return Err(McapError::UnexpectedChunkDataInserted);
         }
-        // If we're currently loading data, we need to reset and start loading from the beginning.
-        if self.pos != pos && matches!(self.state, State::LoadingChunkData { .. }) {
-            self.state = State::SeekingToChunk;
-        }
-        self.pos = pos;
-    }
+        let uncompressed_size = chunk_index.uncompressed_size as usize;
+        let slot_idx =
+            find_or_make_chunk_slot(&mut self.chunk_slots, start_offset, uncompressed_size);
 
-    /// Get a mutable buffer of size `n` to read new MCAP data into from the stream.
-    pub fn insert(&mut self, n: usize) -> &mut [u8] {
-        let buf = match self.state {
-            State::LoadingChunkData { into_slot } => {
-                if self.chunk_indexes[self.cur_chunk_index]
-                    .compression
-                    .is_empty()
-                {
-                    &mut self.chunk_slots[into_slot].buf
-                } else {
-                    &mut self.cur_compressed_chunk
+        let slot = &mut self.chunk_slots[slot_idx];
+        //
+        slot.buf.resize(uncompressed_size, 0);
+        match chunk_index.compression.as_str() {
+            "" => {
+                slot.buf[..].copy_from_slice(compressed_data);
+            }
+            #[cfg(feature = "zstd")]
+            "zstd" => {
+                // decompress zstd into current slot
+                let n = zstd::zstd_safe::decompress(&mut slot.buf[..], compressed_data).map_err(
+                    |err| {
+                        McapError::DecompressionError(zstd::zstd_safe::get_error_name(err).into())
+                    },
+                )?;
+                if n != uncompressed_size {
+                    return Err(McapError::DecompressionError(format!(
+                        "zstd decompression error: expected {uncompressed_size}, got {n}"
+                    )));
                 }
             }
-            _ => &mut self.cur_compressed_chunk,
-        };
-        let start = self.cur_compressed_chunk_loaded_bytes;
-        let end = start + n;
-        buf.resize(end, 0);
-        &mut buf[start..end]
+            #[cfg(feature = "lz4")]
+            "lz4" => {
+                use std::io::Read;
+                let mut decoder = lz4::Decoder::new(std::io::Cursor::new(compressed_data))?;
+                decoder.read_exact(&mut slot.buf[..])?;
+            }
+            other => return Err(McapError::UnsupportedCompression(other.into())),
+        }
+        // index the current chunk slot
+        // before starting, check if all existing message indexes have been exhausted -
+        // if so, clear them out now.
+        if self.cur_message_index >= self.message_indexes.len() {
+            self.cur_message_index = 0;
+            self.message_indexes.clear();
+        }
+        // load new indexes into `self.message_indexes`
+        let message_count = index_messages(
+            slot_idx,
+            &slot.buf,
+            self.order,
+            &self.filter,
+            &mut self.message_indexes,
+            self.cur_message_index,
+        )?;
+        slot.message_count = message_count;
+        // If there is more dead space at the front of `self.message_indexes` than the
+        // set of new message indexes, compact the message index array now.
+        if message_count < (self.cur_message_index) {
+            self.message_indexes.drain(0..self.cur_message_index);
+            self.cur_message_index = 0;
+        }
+        // Now we need to remove the corresponding chunk index. In the common case, where
+        // the caller has inserted the next-needed chunk, we can just increment an index. In other
+        // cases, we remove the chunk index, which is O(n).
+        if i == 0 {
+            self.cur_chunk_index += 1;
+        } else {
+            self.chunk_indexes.remove(i);
+        }
+        Ok(())
+    }
+
+    /// Call to indicate to the reader that it should move on to the next message.
+    pub fn consume_message(&mut self) {
+        self.cur_message_index += 1;
+    }
+
+    fn yield_chunk_first(&self, chunk_index: &ChunkIndex, message_index: &MessageIndex) -> bool {
+        match self.order {
+            ReadOrder::File => {
+                let chunk_slot = &self.chunk_slots[message_index.chunk_slot_idx];
+                get_compressed_data_start(chunk_index) < chunk_slot.data_start
+            }
+            ReadOrder::LogTime => chunk_index.message_start_time < message_index.log_time,
+            ReadOrder::ReverseLogTime => chunk_index.message_end_time > message_index.log_time,
+        }
     }
 }
 
@@ -530,7 +436,7 @@ fn index_messages(
     // If there are any unread indexes in `message_indexes` before we begin loading
     // the new chunk, they will need to be sorted with the new messages from the new chunk.
     // If not, and we also don't detect any out-of-order messages within the chunk, we skip sorting.
-    let mut sorting_required = message_indexes.len() - cur_message_index > 0;
+    let mut sorting_required = message_indexes.len() > 0;
     let mut latest_timestamp = 0;
     let new_message_index_start = message_indexes.len();
     while offset < chunk_data.len() {
@@ -601,10 +507,15 @@ fn index_messages(
 }
 
 /// Finds a chunk slot with no outstanding messages in it and returns its index, or creates a new one.
-fn find_or_make_chunk_slot(chunk_slots: &mut Vec<ChunkSlot>, uncompressed_size: usize) -> usize {
+fn find_or_make_chunk_slot(
+    chunk_slots: &mut Vec<ChunkSlot>,
+    data_start: u64,
+    uncompressed_size: usize,
+) -> usize {
     for (i, slot) in chunk_slots.iter_mut().enumerate() {
         if slot.message_count == 0 {
             slot.buf.clear();
+            slot.data_start = data_start;
             slot.buf.reserve(uncompressed_size);
             return i;
         }
@@ -612,6 +523,7 @@ fn find_or_make_chunk_slot(chunk_slots: &mut Vec<ChunkSlot>, uncompressed_size: 
     let idx = chunk_slots.len();
     chunk_slots.push(ChunkSlot {
         message_count: 0,
+        data_start: 0,
         buf: Vec::with_capacity(uncompressed_size),
     });
     idx
@@ -690,20 +602,24 @@ mod tests {
         let mut cursor = std::io::Cursor::new(&mcap);
         let mut found = Vec::new();
         let mut iterations = 0;
+        let mut buf = Vec::new();
         while let Some(event) = reader.next_event() {
             match event.expect("indexed reader failed") {
-                IndexedReadEvent::ReadRequest(n) => {
-                    let res = cursor
-                        .read(reader.insert(n))
-                        .expect("read should not fail on cursor");
-                    reader.notify_read(res);
-                }
-                IndexedReadEvent::SeekRequest(to) => {
-                    let pos = cursor.seek(to).expect("seek should not fail on cursor");
-                    reader.notify_seeked(pos);
+                IndexedReadEvent::ReadChunkRequest { offset, length } => {
+                    cursor
+                        .seek(std::io::SeekFrom::Start(offset))
+                        .expect("should not fail to seek");
+                    buf.resize(length, 0);
+                    cursor
+                        .read_exact(&mut buf)
+                        .expect("should not fail on read");
+                    reader
+                        .insert_chunk_record_data(offset, &buf)
+                        .expect("failed to insert");
                 }
                 IndexedReadEvent::Message { header, .. } => {
                     found.push((header.channel_id, header.log_time));
+                    reader.consume_message();
                 }
             }
             iterations += 1;
@@ -812,6 +728,7 @@ mod tests {
         let path = "tests/data/compressed.mcap";
         let count = 826;
         let block_sizes = [None, Some(16 * 1024), Some(1024), Some(128)];
+        let mut buffer = Vec::new();
         for &block_size in block_sizes.iter() {
             let mut file = std::fs::File::open(path).expect("could not open file");
             let summary = {
@@ -837,19 +754,18 @@ mod tests {
             let mut messages = Vec::new();
             while let Some(event) = reader.next_event() {
                 match event.expect("failed to read next event") {
-                    IndexedReadEvent::SeekRequest(pos) => {
-                        reader.notify_seeked(file.seek(pos).expect("seek failed"));
-                    }
-                    IndexedReadEvent::ReadRequest(n) => {
-                        let n = match block_size {
-                            Some(block_size) => block_size,
-                            None => n,
-                        };
-                        let read = file.read(reader.insert(n)).expect("read failed");
-                        reader.notify_read(read);
+                    IndexedReadEvent::ReadChunkRequest { offset, length } => {
+                        file.seek(std::io::SeekFrom::Start(offset))
+                            .expect("failed seek");
+                        buffer.resize(length, 0);
+                        file.read_exact(&mut buffer).expect("failed read");
+                        reader
+                            .insert_chunk_record_data(offset, &buffer)
+                            .expect("failed on insert");
                     }
                     IndexedReadEvent::Message { header, .. } => {
                         messages.push(header.log_time);
+                        reader.consume_message();
                     }
                 }
             }

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -696,10 +696,10 @@ mod tests {
             match order {
                 ReadOrder::File => {}
                 // sort in log time order (stable, so that file order is preserved) for equal values
-                ReadOrder::LogTime => expected.sort_by(|a, b| a.1.cmp(&b.1)),
+                ReadOrder::LogTime => expected.sort_by_key(|(_, log_time)| *log_time),
                 // sort in log time order then reverse
                 ReadOrder::ReverseLogTime => {
-                    expected.sort_by(|a, b| a.1.cmp(&b.1));
+                    expected.sort_by_key(|(_, log_time)| Reverse(*log_time));
                     expected.reverse();
                 }
             }

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -286,9 +286,11 @@ impl IndexedReader {
         chunk_request(&self.chunk_indexes[self.cur_chunk_index])
     }
 
-    /// Call to insert new compressed records into this reader. `offset` should be a valid file
-    /// offset to the start of the compressed data in a chunk. `compressed_data` should be a slice
+    /// Call to insert new compressed records into this reader. `offset` must be a valid file
+    /// offset to the start of the compressed data in a chunk. `compressed_data` must be a slice
     /// containing the entire compressed data for that chunk.
+    /// Chunk contents can be inserted into this reader in a different order than they are requested
+    /// from `next_event`. Inserting the same chunk contents twice will result in an error.
     pub fn insert_chunk_record_data(
         &mut self,
         offset: u64,
@@ -376,6 +378,8 @@ impl IndexedReader {
         Ok(())
     }
 
+    // determine whether the chunk referred to by `chunk_index` should be loaded before the message
+    // referred to by `message_index` is yielded.
     fn yield_chunk_first(&self, chunk_index: &ChunkIndex, message_index: &MessageIndex) -> bool {
         match self.order {
             ReadOrder::File => {

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -537,11 +537,15 @@ fn index_messages(
     let new_message_index_start = message_indexes.len();
     while offset < chunk_data.len() {
         let record = &chunk_data[offset..];
-        let opcode = record[0];
+        // 1 byte opcode + 8 byte length == 9
         if record.len() < 9 {
             return Err(McapError::UnexpectedEoc);
         }
+        let opcode = record[0];
         let len = len_as_usize(u64::from_le_bytes(record[1..9].try_into().unwrap()))?;
+        if record.len() < (9 + len) {
+            return Err(McapError::UnexpectedEoc);
+        }
         let next_offset = offset + 9 + len;
         if opcode != op::MESSAGE {
             offset = next_offset;

--- a/rust/src/sans_io/linear_reader.rs
+++ b/rust/src/sans_io/linear_reader.rs
@@ -1048,7 +1048,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut cursor = std::io::Cursor::new(buf);
-            let data = Vec::from_iter(std::iter::repeat(0x20u8).take(1024 * 1024 * 4));
+            let data = Vec::from_iter(std::iter::repeat_n(0x20u8, 1024 * 1024 * 4));
             let mut writer = crate::WriteOptions::new()
                 .compression(None)
                 .chunk_size(None)

--- a/rust/src/sans_io/summary_reader.rs
+++ b/rust/src/sans_io/summary_reader.rs
@@ -8,7 +8,12 @@ use crate::{
 };
 use std::io::SeekFrom;
 
-const FOOTER_RECORD_AND_END_MAGIC: usize = 1 + 8 + 20 + 8;
+const FOOTER_RECORD_AND_END_MAGIC: usize = 1 // footer opcode
+    + 8 // footer length
+    + 8 // footer summary start field
+    + 8 // footer summary offset start field
+    + 4 // footer summary CRC field
+    + 8; // end magic
 
 /// Events returned by the summary reader. The summary reader yields
 pub enum SummaryReadEvent {

--- a/rust/src/sans_io/summary_reader.rs
+++ b/rust/src/sans_io/summary_reader.rs
@@ -223,9 +223,10 @@ impl SummaryReader {
         self.at_eof = n == 0;
         match &mut self.state {
             State::ReadingFooter { loaded_bytes, .. } => {
-                if self.footer_buf.len() < *loaded_bytes + n {
-                    panic!("notify_read called with n > last inserted length");
-                }
+                assert!(
+                    self.footer_buf.len() >= *loaded_bytes + n,
+                    "notify_read called with n > last inserted length",
+                );
                 *loaded_bytes += n;
             }
             State::ReadingSummary { reader, .. } => {

--- a/rust/src/sans_io/summary_reader.rs
+++ b/rust/src/sans_io/summary_reader.rs
@@ -1,0 +1,232 @@
+use binrw::BinRead;
+
+use crate::{
+    parse_record,
+    records::{Footer, Record},
+    sans_io::linear_reader::{LinearReadEvent, LinearReader, LinearReaderOptions},
+    McapResult, Summary,
+};
+use std::io::SeekFrom;
+
+pub enum SummaryReadEvent {
+    Read(usize),
+    Seek(std::io::SeekFrom),
+}
+
+#[derive(Default)]
+enum State {
+    #[default]
+    SeekingToFooter,
+    ReadingFooter {
+        loaded_bytes: usize,
+    },
+    SeekingToSummary {
+        summary_start: u64,
+    },
+    ReadingSummary {
+        summary_start: u64,
+        reader: Box<LinearReader>,
+        channeler: crate::read::ChannelAccumulator<'static>,
+    },
+}
+
+#[derive(Default)]
+pub struct SummaryReader {
+    pos: u64,
+    footer_buf: Vec<u8>,
+    file_size: Option<u64>,
+    state: State,
+    summary: crate::Summary,
+    summary_present: bool,
+}
+
+impl SummaryReader {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn next_event(&mut self) -> Option<McapResult<SummaryReadEvent>> {
+        self.next_event_inner().transpose()
+    }
+
+    pub fn next_event_inner(&mut self) -> McapResult<Option<SummaryReadEvent>> {
+        loop {
+            match &mut self.state {
+                State::SeekingToFooter => {
+                    let Some(file_size) = self.file_size else {
+                        return Ok(Some(SummaryReadEvent::Seek(SeekFrom::End(-28))));
+                    };
+                    if file_size < 28 {
+                        return Err(crate::McapError::UnexpectedEof);
+                    }
+                    let footer_start_pos = file_size - 28;
+                    if self.pos == footer_start_pos {
+                        self.state = State::ReadingFooter { loaded_bytes: 0 };
+                        continue;
+                    } else {
+                        return Ok(Some(SummaryReadEvent::Seek(SeekFrom::Start(
+                            footer_start_pos,
+                        ))));
+                    }
+                }
+                State::ReadingFooter { loaded_bytes } => {
+                    if *loaded_bytes >= 20 {
+                        let mut cursor = std::io::Cursor::new(&self.footer_buf[..*loaded_bytes]);
+                        let footer = Footer::read_le(&mut cursor)?;
+                        if footer.summary_start == 0 {
+                            // There is no summary.
+                            return Ok(None);
+                        }
+                        self.summary_present = true;
+                        self.state = State::SeekingToSummary {
+                            summary_start: footer.summary_start,
+                        };
+                        continue;
+                    } else {
+                        return Ok(Some(SummaryReadEvent::Read(20 - *loaded_bytes)));
+                    }
+                }
+                State::SeekingToSummary { summary_start } => {
+                    if self.pos == *summary_start {
+                        self.state = State::ReadingSummary {
+                            summary_start: *summary_start,
+                            reader: Box::new(LinearReader::new_with_options(
+                                LinearReaderOptions::default().with_skip_start_magic(true),
+                            )),
+                            channeler: crate::read::ChannelAccumulator::default(),
+                        };
+                        continue;
+                    } else {
+                        return Ok(Some(SummaryReadEvent::Seek(SeekFrom::Start(
+                            *summary_start,
+                        ))));
+                    }
+                }
+                State::ReadingSummary {
+                    reader, channeler, ..
+                } => match reader.next_event() {
+                    Some(Ok(LinearReadEvent::Record { data, opcode })) => {
+                        match parse_record(opcode, data)?.into_owned() {
+                            Record::AttachmentIndex(index) => {
+                                self.summary.attachment_indexes.push(index);
+                            }
+                            Record::MetadataIndex(index) => {
+                                self.summary.metadata_indexes.push(index);
+                            }
+                            Record::Statistics(statistics) => {
+                                self.summary.stats = Some(statistics);
+                            }
+                            Record::Channel(channel) => channeler.add_channel(channel)?,
+                            Record::Schema { header, data } => {
+                                channeler.add_schema(header, data)?;
+                            }
+                            Record::ChunkIndex(index) => self.summary.chunk_indexes.push(index),
+                            _ => {}
+                        };
+                        continue;
+                    }
+                    Some(Ok(LinearReadEvent::ReadRequest(n))) => {
+                        return Ok(Some(SummaryReadEvent::Read(n)));
+                    }
+                    Some(Err(err)) => {
+                        return Err(err);
+                    }
+                    None => {
+                        self.summary.schemas = channeler.schemas.clone();
+                        self.summary.channels = channeler.channels.clone();
+                        return Ok(None);
+                    }
+                },
+            }
+        }
+    }
+
+    pub fn notify_read(&mut self, n: usize) {
+        match &mut self.state {
+            State::ReadingFooter { loaded_bytes, .. } => {
+                *loaded_bytes += n;
+            }
+            State::ReadingSummary { reader, .. } => {
+                reader.notify_read(n);
+            }
+            _ => {}
+        }
+        self.pos += n as u64;
+    }
+
+    pub fn notify_seeked(&mut self, pos: u64) {
+        // potential source for bugs: we assume the first seek that occurs is a seek to the
+        // footer start. The user might seek somewhere else, we don't really have a way to tell.
+        if self.file_size.is_none() {
+            self.file_size = Some(pos + 28);
+        }
+        if self.pos != pos {
+            // if we're actively reading and got an unexpected seek, we need to reset.
+            match self.state {
+                State::ReadingFooter { .. } => {
+                    self.footer_buf.clear();
+                    self.state = State::SeekingToFooter;
+                }
+                State::ReadingSummary { summary_start, .. } => {
+                    self.state = State::SeekingToSummary { summary_start };
+                    self.summary = Summary::default();
+                }
+                _ => {}
+            }
+        }
+        self.pos = pos;
+    }
+
+    pub fn insert(&mut self, n: usize) -> &mut [u8] {
+        match &mut self.state {
+            State::ReadingFooter { loaded_bytes } => {
+                self.footer_buf.resize(*loaded_bytes + n, 0);
+                &mut self.footer_buf[*loaded_bytes..]
+            }
+            State::ReadingSummary { reader, .. } => reader.insert(n),
+            _ => {
+                // we don't need data in any other state, but just for simplicity give the user a place
+                // to put their bogus data.
+                self.footer_buf.resize(n, 0);
+                &mut self.footer_buf[..]
+            }
+        }
+    }
+
+    pub fn finish(self) -> Option<Summary> {
+        if self.summary_present {
+            Some(self.summary)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Seek};
+
+    #[test]
+    fn test_smoke() {
+        let mut f = std::fs::File::open("tests/data/compressed.mcap").expect("could not open file");
+        let mut summary_loader = SummaryReader::new();
+        while let Some(event) = summary_loader.next_event() {
+            let event = event.expect("got error instead of event");
+            match event {
+                SummaryReadEvent::Read(n) => {
+                    let read = f.read(summary_loader.insert(n)).expect("failed file read");
+                    summary_loader.notify_read(read);
+                }
+                SummaryReadEvent::Seek(to) => {
+                    let pos = f.seek(to).expect("failed file seek");
+                    summary_loader.notify_seeked(pos);
+                }
+            }
+        }
+        let Some(summary) = summary_loader.finish() else {
+            panic!("should have found a summary")
+        };
+        assert_eq!(summary.chunk_indexes.len(), 413);
+    }
+}

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -509,10 +509,10 @@ impl<W: Write + Seek> Writer<W> {
     /// Useful with subequent calls to [`write_to_known_channel()`](Self::write_to_known_channel).
     ///
     /// * `schema_id`: a schema_id returned from [`Self::add_schema`], or 0 if the channel has no
-    ///    schema.
+    ///   schema.
     /// * `topic`: The topic name.
     /// * `message_encoding`: Encoding for messages on this channel. The [well-known message
-    ///    encodings](https://mcap.dev/spec/registry#well-known-message-encodings) are preferred.
+    ///   encodings](https://mcap.dev/spec/registry#well-known-message-encodings) are preferred.
     ///  * `metadata`: Metadata about this channel.
     pub fn add_channel(
         &mut self,

--- a/tests/conformance/scripts/run-tests/runners/RustIndexedReaderTestRunner.ts
+++ b/tests/conformance/scripts/run-tests/runners/RustIndexedReaderTestRunner.ts
@@ -1,0 +1,37 @@
+import { exec } from "child_process";
+import { join } from "path";
+import { promisify } from "util";
+import { TestFeatures, TestVariant } from "variants/types";
+
+import { IndexedReadTestRunner } from "./TestRunner";
+import { IndexedReadTestResult } from "../types";
+
+export default class RustIndexedReaderTestRunner extends IndexedReadTestRunner {
+  readonly name = "rust-indexed-reader";
+
+  async runReadTest(filePath: string): Promise<IndexedReadTestResult> {
+    const { stdout } = await promisify(exec)(`./conformance_indexed_reader ${filePath}`, {
+      cwd: join(__dirname, "../../../../../rust/target/debug/examples"),
+    });
+    return JSON.parse(stdout) as IndexedReadTestResult;
+  }
+
+  supportsVariant({ records, features }: TestVariant): boolean {
+    if (!records.some((record) => record.type === "Message")) {
+      return false;
+    }
+    if (!features.has(TestFeatures.UseChunks)) {
+      return false;
+    }
+    if (!features.has(TestFeatures.UseChunkIndex)) {
+      return false;
+    }
+    if (!features.has(TestFeatures.UseRepeatedChannelInfos)) {
+      return false;
+    }
+    if (!features.has(TestFeatures.UseRepeatedSchemas)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/tests/conformance/scripts/run-tests/runners/index.ts
+++ b/tests/conformance/scripts/run-tests/runners/index.ts
@@ -9,6 +9,7 @@ import PythonIndexedReaderTestRunner from "./PythonIndexedReaderTestRunner";
 import PythonStreamedReaderTestRunner from "./PythonStreamedReaderTestRunner";
 import PythonWriterTestRunner from "./PythonWriterTestRunner";
 import RustAsyncReaderTestRunner from "./RustAsyncReaderTestRunner";
+import RustIndexedReaderTestRunner from "./RustIndexedReaderTestRunner";
 import RustReaderTestRunner from "./RustReaderTestRunner";
 import RustWriterTestRunner from "./RustWriterTestRunner";
 import SwiftIndexedReaderTestRunner from "./SwiftIndexedReaderTestRunner";
@@ -34,6 +35,7 @@ const runners: readonly (IndexedReadTestRunner | StreamedReadTestRunner | WriteT
   new TypescriptWriterTestRunner(),
   new RustAsyncReaderTestRunner(),
   new RustReaderTestRunner(),
+  new RustIndexedReaderTestRunner(),
   new RustWriterTestRunner(),
   new SwiftWriterTestRunner(),
   new SwiftStreamedReaderTestRunner(),


### PR DESCRIPTION
### Changelog
- Added: `mcap::sans_io::SummaryReader` and `mcap::sans_io::IndexedReader` structs, which can be used to a) parse out summary information and b) read messages efficiently using that summary information.

### Docs

See `cargo doc` for usage info.

### Description

Adds a sans-io indexed reading implementation, including conformance tests and benchmarks.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

### Benchmarks

The indexed reader is suspiciously faster than MessageStream by quite a bit. I suspect the major difference is that the indexed reader allows the caller to re-use the same buffer for every message yielded, rather than allocating a new one.

Raw `cargo bench` outputs (with changes removed because they compare to the previous run, which is confusing)
```
mcap_read_linear/MessageStream_1M_uncompressed
                        time:   [165.82 ms 167.64 ms 169.53 ms]
                        thrpt:  [5.8986 Melem/s 5.9653 Melem/s 6.0306 Melem/s]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
mcap_read_linear/MessageStream_1M_lz4
                        time:   [203.02 ms 204.87 ms 207.63 ms]
                        thrpt:  [4.8163 Melem/s 4.8811 Melem/s 4.9255 Melem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
mcap_read_linear/MessageStream_1M_zstd
                        time:   [213.31 ms 213.74 ms 214.26 ms]
                        thrpt:  [4.6672 Melem/s 4.6787 Melem/s 4.6881 Melem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

mcap_read_indexed/IndexedReader_1M_uncompressed
                        time:   [42.935 ms 43.215 ms 43.655 ms]
                        thrpt:  [22.907 Melem/s 23.140 Melem/s 23.291 Melem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
mcap_read_indexed/IndexedReader_1M_zstd
                        time:   [65.055 ms 65.616 ms 66.254 ms]
                        thrpt:  [15.093 Melem/s 15.240 Melem/s 15.372 Melem/s]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe
mcap_read_indexed/IndexedReader_1M_lz4
                        time:   [60.758 ms 60.977 ms 61.139 ms]
                        thrpt:  [16.356 Melem/s 16.400 Melem/s 16.459 Melem/s]