### PR TITLE
rust: fix removal of identical channel data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,13 +497,13 @@ jobs:
           components: "rustfmt, clippy"
       - run: rustup target add wasm32-unknown-unknown
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets -- --no-deps
-      - run: cargo clippy --no-default-features -- --no-deps
-      - run: cargo clippy --no-default-features --features lz4 -- --no-deps
-      - run: cargo clippy --no-default-features --features zstd -- --no-deps
-      - run: cargo clippy --no-default-features --features tokio -- --no-deps
-      - run: cargo clippy --no-default-features --features tokio,lz4 -- --no-deps
-      - run: cargo clippy --no-default-features --features tokio,zstd -- --no-deps
+      - run: cargo clippy --all-targets -- --no-deps -D warnings
+      - run: cargo clippy --no-default-features -- --no-deps -D warnings
+      - run: cargo clippy --no-default-features --features lz4 -- --no-deps -D warnings
+      - run: cargo clippy --no-default-features --features zstd -- --no-deps -D warnings
+      - run: cargo clippy --no-default-features --features tokio -- --no-deps -D warnings
+      - run: cargo clippy --no-default-features --features tokio,lz4 -- --no-deps -D warnings
+      - run: cargo clippy --no-default-features --features tokio,zstd -- --no-deps -D warnings
       - run: cargo build --all-features
       - run: cargo test --all-features
       - run: cargo build --all-features --target wasm32-unknown-unknown

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT"
 

--- a/rust/examples/conformance_writer.rs
+++ b/rust/examples/conformance_writer.rs
@@ -12,6 +12,7 @@ const USE_ATTACHMENT_INDEX: &str = "ax";
 const USE_METADATA_INDEX: &str = "mdx";
 const USE_CHUNK_INDEX: &str = "chx";
 const USE_SUMMARY_OFFSET: &str = "sum";
+#[allow(dead_code)]
 const ADD_EXTRA_DATA_TO_RECORDS: &str = "pad";
 
 fn write_file(spec: &conformance_writer_spec::WriterSpec) {

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -464,7 +464,7 @@ impl<'a> MessageStream<'a> {
     }
 }
 
-impl<'a> Iterator for MessageStream<'a> {
+impl Iterator for MessageStream<'_> {
     type Item = McapResult<Message<'static>>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -448,17 +448,16 @@ impl<W: Write + Seek> Writer<W> {
         }
         let id = self.next_schema_id;
         self.next_schema_id += 1;
-        assert!(!self
-            .canonical_schemas
-            .insert(
+        self.canonical_schemas
+            .insert_no_overwrite(
                 SchemaContent {
                     name: Cow::Owned(name.to_owned()),
                     encoding: Cow::Owned(encoding.to_owned()),
                     data: Cow::Owned(data.to_owned().into()),
                 },
-                id
+                id,
             )
-            .did_overwrite());
+            .expect("neither schema ID or content should be present in canonical_schemas");
         assert!(self.all_schema_ids.insert(id, id).is_none());
         self.write_schema(Schema {
             id,

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -332,7 +332,7 @@ struct ChannelContent<'a> {
     metadata: Cow<'a, BTreeMap<String, String>>,
 }
 
-impl<'a> ChannelContent<'a> {
+impl ChannelContent<'_> {
     fn into_owned(self) -> ChannelContent<'static> {
         ChannelContent {
             topic: Cow::Owned(self.topic.into_owned()),
@@ -350,7 +350,7 @@ struct SchemaContent<'a> {
     data: Cow<'a, [u8]>,
 }
 
-impl<'a> SchemaContent<'a> {
+impl SchemaContent<'_> {
     fn into_owned(self) -> SchemaContent<'static> {
         SchemaContent {
             name: Cow::Owned(self.name.into_owned()),
@@ -608,7 +608,7 @@ impl<W: Write + Seek> Writer<W> {
         };
         let channel_content = ChannelContent {
             topic: Cow::Borrowed(&message.channel.topic),
-            schema_id: schema_id,
+            schema_id,
             message_encoding: Cow::Borrowed(&message.channel.message_encoding),
             metadata: Cow::Borrowed(&message.channel.metadata),
         };


### PR DESCRIPTION
### Changelog
- Fixed: fixed a bug where when writing messages using `mcap::Writer::write(&Message{...})`, introduced in #1297 . Writing messages on separate channels with identical channel data would cause channel data for some channels not to be written to the MCAP, resulting in an invalid MCAP.
### Docs

None.

### Description

MCAP as specified allows a 1:N relationship between channel content and channel IDs. This is intentional - there may be multiple sources publishing the exact same topic, and the output MCAP can and should contain one channel per publisher, not per topic.

#1297 introduced the use of a bimap to track the relationship between channel / schema IDs and their content. however, I overlooked at the time a key constraint of the bimap implementation, in that all values on the left and right side are unique.
 This means it could not track multiple identical channels or schemas with the same ID. This PR introduces an additional (u16, u16) map for channels and schemas which tracks the mapping of all IDs to their "canonical" IDs in the bimap. This allows us to track the presence of multiple records with the same content but different IDs, while also preserving the quick lookups that the bimap was introduced for.


<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

