### PR TITLE
rust: rename items in linear reader

### DIFF
--- a/rust/examples/conformance_reader_async.rs
+++ b/rust/examples/conformance_reader_async.rs
@@ -18,7 +18,7 @@ async fn main() {
         process::exit(1);
     }
     let file = File::open(&args[1]).await.expect("couldn't open file");
-    let mut reader = mcap::tokio::RecordReader::new(file);
+    let mut reader = mcap::tokio::LinearReader::new(file);
 
     let mut json_records: Vec<Value> = vec![];
     let mut buf: Vec<u8> = Vec::new();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -226,7 +226,7 @@ mod assertions {
 
     assert_impl_all!(Writer<Cursor<Vec<u8>>>: Send);
     assert_impl_all!(MessageStream: Send);
-    assert_impl_all!(sans_io::read::LinearReader: Send);
+    assert_impl_all!(sans_io::LinearReader: Send);
     #[cfg(feature = "tokio")]
-    assert_impl_all!(tokio::read::RecordReader<Cursor<Vec<u8>>>: Send);
+    assert_impl_all!(tokio::linear_reader::LinearReader<Cursor<Vec<u8>>>: Send);
 }

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -20,7 +20,7 @@ use log::*;
 
 use crate::{
     records::{self, op, Record},
-    sans_io::read::{LinearReader as SansIoReader, LinearReaderOptions, ReadAction},
+    sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions},
     Attachment, Channel, McapError, McapResult, Message, Schema, MAGIC,
 };
 
@@ -234,15 +234,15 @@ impl<'a> Iterator for InnerReader<'a> {
     type Item = McapResult<records::Record<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(action) = self.reader.next_action() {
-            match action {
-                Ok(ReadAction::NeedMore(need)) => {
+        while let Some(event) = self.reader.next_event() {
+            match event {
+                Ok(LinearReadEvent::Read(need)) => {
                     let len = std::cmp::min(self.buf.len(), need);
                     self.reader.insert(len).copy_from_slice(&self.buf[..len]);
-                    self.reader.set_written(len);
+                    self.reader.notify_read(len);
                     self.buf = &self.buf[len..];
                 }
-                Ok(ReadAction::GetRecord { data, opcode }) => match parse_record(opcode, data) {
+                Ok(LinearReadEvent::Record { data, opcode }) => match parse_record(opcode, data) {
                     Ok(record) => return Some(Ok(record.into_owned())),
                     Err(err) => return Some(Err(err)),
                 },
@@ -765,15 +765,15 @@ impl<'a> Summary<'a> {
         let mut reader = SansIoReader::for_chunk(h)?;
         let mut remaining = d;
         let mut uncompressed_offset: usize = 0;
-        while let Some(action) = reader.next_action() {
-            match action {
-                Ok(ReadAction::NeedMore(need)) => {
+        while let Some(event) = reader.next_event() {
+            match event {
+                Ok(LinearReadEvent::Read(need)) => {
                     let len = std::cmp::min(remaining.len(), need);
                     reader.insert(len).copy_from_slice(&remaining[..len]);
-                    reader.set_written(len);
+                    reader.notify_read(len);
                     remaining = &remaining[len..];
                 }
-                Ok(ReadAction::GetRecord { data, opcode }) => {
+                Ok(LinearReadEvent::Record { data, opcode }) => {
                     if (uncompressed_offset as u64) < message.offset {
                         uncompressed_offset += 9 + data.len();
                     } else {

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -236,7 +236,7 @@ impl<'a> Iterator for InnerReader<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(event) = self.reader.next_event() {
             match event {
-                Ok(LinearReadEvent::Read(need)) => {
+                Ok(LinearReadEvent::ReadRequest(need)) => {
                     let len = std::cmp::min(self.buf.len(), need);
                     self.reader.insert(len).copy_from_slice(&self.buf[..len]);
                     self.reader.notify_read(len);
@@ -767,7 +767,7 @@ impl<'a> Summary<'a> {
         let mut uncompressed_offset: usize = 0;
         while let Some(event) = reader.next_event() {
             match event {
-                Ok(LinearReadEvent::Read(need)) => {
+                Ok(LinearReadEvent::ReadRequest(need)) => {
                     let len = std::cmp::min(remaining.len(), need);
                     reader.insert(len).copy_from_slice(&remaining[..len]);
                     reader.notify_read(len);

--- a/rust/src/sans_io.rs
+++ b/rust/src/sans_io.rs
@@ -1,6 +1,8 @@
 //! Read MCAP files from any source of bytes
 pub mod decompressor;
-pub mod read;
+pub mod linear_reader;
+
+pub use linear_reader::{LinearReadEvent, LinearReader, LinearReaderOptions};
 
 #[cfg(feature = "lz4")]
 mod lz4;

--- a/rust/src/sans_io/linear_reader.rs
+++ b/rust/src/sans_io/linear_reader.rs
@@ -182,20 +182,20 @@ impl LinearReaderOptions {
 /// use tokio::io::AsyncReadExt;
 /// use std::io::Read;
 ///
-/// use mcap::sans_io::read::ReadAction;
+/// use mcap::sans_io::linear_reader::LinearReadEvent;
 /// use mcap::McapResult;
 ///
 /// // Asynchronously...
 /// async fn read_async() -> McapResult<()> {
 ///     let mut file = AsyncFile::open("in.mcap").await.expect("couldn't open file");
-///     let mut reader = mcap::sans_io::read::LinearReader::new();
-///     while let Some(action) = reader.next_action() {
-///         match action? {
-///             ReadAction::NeedMore(need) => {
+///     let mut reader = mcap::sans_io::linear_reader::LinearReader::new();
+///     while let Some(event) = reader.next_event() {
+///         match event? {
+///             LinearReadEvent::Read(need) => {
 ///                 let written = file.read(reader.insert(need)).await?;
-///                 reader.set_written(written);
+///                 reader.notify_read(written);
 ///             },
-///             ReadAction::GetRecord{ opcode, data } => {
+///             LinearReadEvent::Record{ opcode, data } => {
 ///                 let raw_record = mcap::parse_record(opcode, data)?;
 ///                 // do something with the record...
 ///             }
@@ -207,14 +207,14 @@ impl LinearReaderOptions {
 /// // Or synchronously.
 /// fn read_sync() -> McapResult<()> {
 ///     let mut file = fs::File::open("in.mcap")?;
-///     let mut reader = mcap::sans_io::read::LinearReader::new();
-///     while let Some(action) = reader.next_action() {
-///         match action? {
-///             ReadAction::NeedMore(need) => {
+///     let mut reader = mcap::sans_io::linear_reader::LinearReader::new();
+///     while let Some(event) = reader.next_event() {
+///         match event? {
+///             LinearReadEvent::Read(need) => {
 ///                 let written = file.read(reader.insert(need))?;
-///                 reader.set_written(written);
+///                 reader.notify_read(written);
 ///             },
-///             ReadAction::GetRecord{ opcode, data } => {
+///             LinearReadEvent::Record { opcode, data } => {
 ///                 let raw_record = mcap::parse_record(opcode, data)?;
 ///                 // do something with the record...
 ///             }
@@ -236,9 +236,9 @@ pub struct LinearReader {
     decompressed_content: RwBuf,
     // decompressor that can be re-used between chunks.
     decompressors: HashMap<String, Box<dyn Decompressor>>,
-    // Stores the number of bytes written into this reader since the last `next_action()` call.
-    last_write: Option<usize>,
+    // Stores the number of bytes written into this reader since the last `next_event()` call.
     options: LinearReaderOptions,
+    at_eof: bool,
 }
 
 impl Default for LinearReader {
@@ -266,7 +266,7 @@ impl LinearReader {
             options,
             chunk_state: None,
             decompressors: Default::default(),
-            last_write: None,
+            at_eof: false,
         }
     }
 
@@ -291,52 +291,48 @@ impl LinearReader {
         Ok(result)
     }
 
-    /// Get a mutable slice to write new MCAP data into. Call [`Self::set_written`] afterwards with
+    /// Get a mutable slice to write new MCAP data into. Call [`Self::notify_read`] afterwards with
     /// the number of bytes successfully written.
     pub fn insert(&mut self, to_write: usize) -> &mut [u8] {
         self.file_data.tail_with_size(to_write)
     }
 
-    /// Set the number of bytes successfully written into the buffer returned from [`Self::insert`]
-    /// since the last [`Self::next_action`] call. Providing 0 indicates EOF to the reader.
+    /// Notify the number of bytes read into the linear reader
+    /// since the last [`Self::next_event`] call. Providing 0 indicates EOF to the reader.
     ///
-    /// Panics if `written` is greater than the last `to_write` provided to [`Self::insert`].
-    pub fn set_written(&mut self, written: usize) {
-        if (self.file_data.data.len() - self.file_data.end) < written {
-            panic!("set_written called with written > last inserted length");
+    /// Panics if `read` is greater than the last `to_write` provided to [`Self::insert`].
+    pub fn notify_read(&mut self, written: usize) {
+        if written == 0 {
+            self.at_eof = true;
         }
-        self.last_write = Some(written);
+        if (self.file_data.data.len() - self.file_data.end) < written {
+            panic!("notify_read called with n > last inserted length");
+        }
+        self.file_data.end += written;
     }
 
-    /// Yields the next action the caller should take to progress through the file.
-    pub fn next_action(&mut self) -> Option<McapResult<ReadAction>> {
-        if let Some(written) = self.last_write.take() {
-            if written == 0 {
-                // at EOF. If the reader is not expecting end magic, and it isn't in the middle of a
-                // record or chunk, this is OK.
-                if self.options.skip_end_magic
-                    && self.file_data.len() == 0
-                    && self.decompressed_content.len() == 0
-                    && self.chunk_state.is_none()
-                {
-                    return None;
-                }
-                if self.chunk_state.is_some() {
-                    return Some(Err(McapError::UnexpectedEoc));
-                }
-                return Some(Err(McapError::UnexpectedEof));
+    /// Yields the next event the caller should take to progress through the file.
+    pub fn next_event(&mut self) -> Option<McapResult<LinearReadEvent>> {
+        if self.at_eof {
+            // at EOF. If the reader is not expecting end magic, and it isn't in the middle of a
+            // record or chunk, this is OK.
+            if self.options.skip_end_magic
+                && self.file_data.len() == 0
+                && self.decompressed_content.len() == 0
+                && self.chunk_state.is_none()
+            {
+                return None;
             }
-            self.file_data.end += written;
+            return Some(Err(McapError::UnexpectedEof));
         }
-
-        /// Macros for loading data into the reader. These return early with NeedMore(n) if
+        /// Macros for loading data into the reader. These return early with Read(n) if
         /// more data is needed.
         ///
         /// load ensures that $n bytes are available unread in self.file_data.
         macro_rules! load {
             ($n:expr) => {{
                 if self.file_data.len() < $n {
-                    return Some(Ok(ReadAction::NeedMore($n - self.file_data.len())));
+                    return Some(Ok(LinearReadEvent::Read($n - self.file_data.len())));
                 }
                 &self.file_data.data[self.file_data.start..self.file_data.start + $n]
             }};
@@ -347,7 +343,7 @@ impl LinearReader {
         macro_rules! consume {
             ($n:expr) => {{
                 if self.file_data.len() < $n {
-                    return Some(Ok(ReadAction::NeedMore($n - self.file_data.len())));
+                    return Some(Ok(LinearReadEvent::Read($n - self.file_data.len())));
                 }
                 let start = self.file_data.start;
                 self.file_data.mark_read($n);
@@ -370,7 +366,7 @@ impl LinearReader {
                         &self.decompressed_content.data
                             [self.decompressed_content.start..self.decompressed_content.start + $n]
                     }
-                    Ok(Some(n)) => return Some(Ok(ReadAction::NeedMore(n))),
+                    Ok(Some(n)) => return Some(Ok(LinearReadEvent::Read(n))),
                     Err(err) => return Some(Err(err)),
                 }
             }};
@@ -431,7 +427,7 @@ impl LinearReader {
                     // caller.
                     let len = check!(len_as_usize(len));
                     let data = &consume!(9 + len)[9..];
-                    return Some(Ok(ReadAction::GetRecord { data, opcode }));
+                    return Some(Ok(LinearReadEvent::Record { data, opcode }));
                 }
                 CurrentlyReading::DataEnd { len, calculated } => {
                     let len = check!(len_as_usize(len));
@@ -447,7 +443,7 @@ impl LinearReader {
                     if self.options.validate_summary_section_crc {
                         self.file_data.hasher = Some(crc32fast::Hasher::new());
                     }
-                    return Some(Ok(ReadAction::GetRecord {
+                    return Some(Ok(LinearReadEvent::Record {
                         data,
                         opcode: op::DATA_END,
                     }));
@@ -468,7 +464,7 @@ impl LinearReader {
                         }
                     }
                     self.currently_reading = EndMagic;
-                    return Some(Ok(ReadAction::GetRecord {
+                    return Some(Ok(LinearReadEvent::Record {
                         data,
                         opcode: op::FOOTER,
                     }));
@@ -548,7 +544,7 @@ impl LinearReader {
                         Some(decompressor) => {
                             // decompress all available compressed data until there are no compressed
                             // bytes remaining. If not all of the compressed bytes are available in
-                            // file_data, decompress! will return a NeedMore action for more data.
+                            // file_data, decompress! will return a Read event for more data.
                             let uncompressed_len = check!(len_as_usize(state.uncompressed_len));
                             if self.decompressed_content.len() >= uncompressed_len {
                                 let calculated =
@@ -586,7 +582,7 @@ impl LinearReader {
                                 hasher.update(opcode_len_data);
                             }
                             state.compressed_remaining -= (9 + len) as u64;
-                            return Some(Ok(ReadAction::GetRecord { data, opcode }));
+                            return Some(Ok(LinearReadEvent::Record { data, opcode }));
                         }
                         Some(decompressor) => {
                             if self.decompressed_content.len() == 0 {
@@ -619,7 +615,7 @@ impl LinearReader {
                             );
                             self.decompressed_content.mark_read(len);
                             let data = &self.decompressed_content.data[start..end];
-                            return Some(Ok(ReadAction::GetRecord { data, opcode }));
+                            return Some(Ok(LinearReadEvent::Record { data, opcode }));
                         }
                     }
                 }
@@ -667,15 +663,15 @@ impl LinearReader {
     }
 }
 
-/// Encapsulates the action the user should take next when reading an MCAP file.
+/// Encapsulates the event the user should take next when reading an MCAP file.
 ///
-pub enum ReadAction<'a> {
+pub enum LinearReadEvent<'a> {
     /// The reader needs more data to provide the next record. Call [`LinearReader::insert`] then
-    /// [`LinearReader::set_written`] to load more data. The value provided here is a hint for how
+    /// [`LinearReader::notify_read`] to load more data. The value provided here is a hint for how
     /// much data to insert.
-    NeedMore(usize),
+    Read(usize),
     /// Read a record out of the MCAP file. Use [`crate::parse_record`] to parse the record.
-    GetRecord { data: &'a [u8], opcode: u8 },
+    Record { data: &'a [u8], opcode: u8 },
 }
 
 /// casts a 64-bit length value from an MCAP into a [`usize`].
@@ -809,13 +805,13 @@ mod tests {
         let mut cursor = std::io::Cursor::new(buf.into_inner());
         let mut opcodes: Vec<u8> = Vec::new();
         let mut iter_count = 0;
-        while let Some(action) = reader.next_action() {
-            match action? {
-                ReadAction::NeedMore(n) => {
+        while let Some(event) = reader.next_event() {
+            match event? {
+                LinearReadEvent::Read(n) => {
                     let written = cursor.read(reader.insert(n))?;
-                    reader.set_written(written);
+                    reader.notify_read(written);
                 }
-                ReadAction::GetRecord { data, opcode } => {
+                LinearReadEvent::Record { data, opcode } => {
                     opcodes.push(opcode);
                     parse_record(opcode, data)?;
                 }
@@ -851,13 +847,13 @@ mod tests {
         let mut cursor = std::io::Cursor::new(basic_chunked_file(None)?);
         let mut opcodes: Vec<u8> = Vec::new();
         let mut iter_count = 0;
-        while let Some(action) = reader.next_action() {
-            match action? {
-                ReadAction::NeedMore(n) => {
+        while let Some(event) = reader.next_event() {
+            match event? {
+                LinearReadEvent::Read(n) => {
                     let written = cursor.read(reader.insert(n))?;
-                    reader.set_written(written);
+                    reader.notify_read(written);
                 }
-                ReadAction::GetRecord { data, opcode } => {
+                LinearReadEvent::Record { data, opcode } => {
                     opcodes.push(opcode);
                     parse_record(opcode, data)?;
                 }
@@ -877,13 +873,13 @@ mod tests {
         let mut cursor = std::io::Cursor::new(basic_chunked_file(compression)?);
         let mut opcodes: Vec<u8> = Vec::new();
         let mut iter_count = 0;
-        while let Some(action) = reader.next_action() {
-            match action? {
-                ReadAction::NeedMore(n) => {
+        while let Some(event) = reader.next_event() {
+            match event? {
+                LinearReadEvent::Read(n) => {
                     let written = cursor.read(reader.insert(n))?;
-                    reader.set_written(written);
+                    reader.notify_read(written);
                 }
-                ReadAction::GetRecord { data, opcode } => {
+                LinearReadEvent::Record { data, opcode } => {
                     opcodes.push(opcode);
                     parse_record(opcode, data)?;
                 }
@@ -961,13 +957,13 @@ mod tests {
             let mut cursor = std::io::Cursor::new(input);
             let mut opcodes: Vec<u8> = Vec::new();
             let mut iter_count = 0;
-            while let Some(action) = reader.next_action() {
-                match action? {
-                    ReadAction::NeedMore(n) => {
+            while let Some(event) = reader.next_event() {
+                match event? {
+                    LinearReadEvent::Read(n) => {
                         let written = cursor.read(reader.insert(n))?;
-                        reader.set_written(written);
+                        reader.notify_read(written);
                     }
-                    ReadAction::GetRecord { data, opcode } => {
+                    LinearReadEvent::Record { data, opcode } => {
                         opcodes.push(opcode);
                         parse_record(opcode, data)?;
                     }
@@ -1009,13 +1005,13 @@ mod tests {
         let mut cursor = std::io::Cursor::new(mcap);
         let mut opcodes: Vec<u8> = Vec::new();
         let mut iter_count = 0;
-        while let Some(action) = reader.next_action() {
-            match action? {
-                ReadAction::NeedMore(n) => {
+        while let Some(event) = reader.next_event() {
+            match event? {
+                LinearReadEvent::Read(n) => {
                     let written = cursor.read(reader.insert(n))?;
-                    reader.set_written(written);
+                    reader.notify_read(written);
                 }
-                ReadAction::GetRecord { data, opcode } => {
+                LinearReadEvent::Record { data, opcode } => {
                     opcodes.push(opcode);
                     parse_record(opcode, data)?;
                 }
@@ -1049,7 +1045,7 @@ mod tests {
     // Ensures that the internal buffer for the linear reader gets compacted regularly and does not
     // expand unbounded.
     #[test]
-    fn test_buffer_compaction() -> McapResult<()> {
+    fn test_buffer_compevent() -> McapResult<()> {
         let mut buf = Vec::new();
         {
             let mut cursor = std::io::Cursor::new(buf);
@@ -1086,14 +1082,14 @@ mod tests {
         let mut opcodes: Vec<u8> = Vec::new();
         let mut iter_count = 0;
         let mut max_needed: usize = 0;
-        while let Some(action) = reader.next_action() {
-            match action? {
-                ReadAction::NeedMore(n) => {
+        while let Some(event) = reader.next_event() {
+            match event? {
+                LinearReadEvent::Read(n) => {
                     max_needed = std::cmp::max(max_needed, n);
                     // read slightly more than requested, such that the data in the buffer does not
-                    // hit zero after the next action.
+                    // hit zero after the next event.
                     let written = cursor.read(reader.insert(n + 1))?;
-                    reader.set_written(written);
+                    reader.notify_read(written);
                     let buffer_size = reader.file_data.data.len();
                     assert!(
                         buffer_size < std::cmp::max(max_needed * 2, 4096),
@@ -1102,7 +1098,7 @@ mod tests {
                         buffer_size
                     );
                 }
-                ReadAction::GetRecord { data, opcode } => {
+                LinearReadEvent::Record { data, opcode } => {
                     opcodes.push(opcode);
                     parse_record(opcode, data)?;
                 }
@@ -1121,18 +1117,18 @@ mod tests {
         let blocksize: usize = 1024;
         let mut reader = LinearReader::new();
         let mut message_count = 0;
-        while let Some(action) = reader.next_action() {
-            match action.expect("failed to get next action") {
-                ReadAction::GetRecord { opcode, .. } => {
+        while let Some(event) = reader.next_event() {
+            match event.expect("failed to get next event") {
+                LinearReadEvent::Record { opcode, .. } => {
                     if opcode == op::MESSAGE {
                         message_count += 1;
                     }
                 }
-                ReadAction::NeedMore(_) => {
+                LinearReadEvent::Read(_) => {
                     let read = f
                         .read(reader.insert(blocksize))
                         .expect("failed to read from file");
-                    reader.set_written(read);
+                    reader.notify_read(read);
                 }
             }
         }

--- a/rust/src/tokio.rs
+++ b/rust/src/tokio.rs
@@ -1,4 +1,4 @@
 //! Read MCAP data from a stream asynchronously
-pub mod read;
+pub mod linear_reader;
 
-pub use read::{LinearReaderOptions, RecordReader};
+pub use linear_reader::{LinearReader, LinearReaderOptions};

--- a/rust/src/tokio/linear_reader.rs
+++ b/rust/src/tokio/linear_reader.rs
@@ -1,7 +1,7 @@
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-pub use crate::sans_io::read::LinearReaderOptions;
-use crate::sans_io::read::{LinearReader as SansIoReader, ReadAction};
+pub use crate::sans_io::linear_reader::LinearReaderOptions;
+use crate::sans_io::{LinearReadEvent, LinearReader as SansIoReader};
 use crate::McapResult;
 
 /// Reads an MCAP file record-by-record, writing the raw record data into a caller-provided Vec.
@@ -13,7 +13,7 @@ use crate::McapResult;
 /// async fn read_it() {
 ///     let file = File::open("in.mcap").await.expect("couldn't open file");
 ///     let mut record_buf: Vec<u8> = Vec::new();
-///     let mut reader = mcap::tokio::RecordReader::new(file);
+///     let mut reader = mcap::tokio::LinearReader::new(file);
 ///     while let Some(result) = reader.next_record(&mut record_buf).await {
 ///         let opcode = result.expect("couldn't read next record");
 ///         let raw_record = mcap::parse_record(opcode, &record_buf[..]).expect("couldn't parse");
@@ -21,12 +21,12 @@ use crate::McapResult;
 ///     }
 /// }
 /// ```
-pub struct RecordReader<R> {
+pub struct LinearReader<R> {
     source: R,
     reader: SansIoReader,
 }
 
-impl<R> RecordReader<R>
+impl<R> LinearReader<R>
 where
     R: AsyncRead + std::marker::Unpin,
 {
@@ -48,16 +48,16 @@ where
     /// Reads the next record from the input stream and copies the raw content into `data`.
     /// Returns the record's opcode as a result.
     pub async fn next_record(&mut self, data: &mut Vec<u8>) -> Option<McapResult<u8>> {
-        while let Some(action) = self.reader.next_action() {
-            match action {
-                Ok(ReadAction::NeedMore(n)) => {
+        while let Some(event) = self.reader.next_event() {
+            match event {
+                Ok(LinearReadEvent::Read(n)) => {
                     let written = match self.source.read(self.reader.insert(n)).await {
                         Ok(n) => n,
                         Err(err) => return Some(Err(err.into())),
                     };
-                    self.reader.set_written(written);
+                    self.reader.notify_read(written);
                 }
-                Ok(ReadAction::GetRecord {
+                Ok(LinearReadEvent::Record {
                     data: content,
                     opcode,
                 }) => {

--- a/rust/src/tokio/linear_reader.rs
+++ b/rust/src/tokio/linear_reader.rs
@@ -50,7 +50,7 @@ where
     pub async fn next_record(&mut self, data: &mut Vec<u8>) -> Option<McapResult<u8>> {
         while let Some(event) = self.reader.next_event() {
             match event {
-                Ok(LinearReadEvent::Read(n)) => {
+                Ok(LinearReadEvent::ReadRequest(n)) => {
                     let written = match self.source.read(self.reader.insert(n)).await {
                         Ok(n) => n,
                         Err(err) => return Some(Err(err.into())),


### PR DESCRIPTION
### Changelog
- Breaking: renamed `mcap::sans_io::read` to `mcap::sans_io::linear_reader`.
- Breaking: renamed `mcap::sans_io::read::ReadAction` to `mcap::sans_io::linear_reader::LinearReadEvent`
- Breaking: renamed `LinearReader::next_action()` to `LinearReader::next_event()`.
- Breaking: renamed `LinearReader::set_written()` to `LinearReader::notify_read()`.
- Breaking: renamed `mcap::tokio::read::RecordReader` to `mcap::tokio::linear_reader::LinearReader`
### Docs

Changes are reflected in `cargo doc`.

### Description

This PR revises the names of functions and structs exposed from the `sans_io` module, because they're badly named as-is and we need to fix this now before we add more to this module.
Specifically:
1. `ReadAction` gets renamed to `LinearReadEvent`. This is because there's no definition of "action" in this context that makes sense - NeedMore is not an action. NeedMore is requesting the caller take some action, but then GetMessage is not requesting the caller to do anything. "events" are a term more commonly used in other parsers such as [SAX](http://www.saxproject.org/event.html), and can be interpreted more generally.
2. `set_written()` is renamed to `notify_read()`. This better reflects what it's for (notifying the reader of the result of a read), and I found the term `written` confusing on a struct meant to be used for reading.
3. the `tokio::RecordReader` is renamed to LinearReader for consistency.
4. The `sans_io::read` module is renamed to `linear_reader` - This better reflects its contents. When we add more readers to the sans_io module, I don't intend to add them all to the `sans_io::read` module, it doesn't help anyone to nest so deeply.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

