### PR TITLE
Document MessagePack (msgpack) encoding

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -69,6 +69,7 @@ words:
   - matplotlib
   - mcap
   - msgdef
+  - msgpack
   - nanos
   - nanosec
   - noenv

--- a/website/docs/spec/registry.md
+++ b/website/docs/spec/registry.md
@@ -38,6 +38,10 @@ The Channel `message_encoding` field describes the encoding for all messages wit
 
 - `message_encoding`: [`cbor`](https://cbor.io/)
 
+### msgpack
+
+- `message_encoding`: [`msgpack`](https://msgpack.org/)
+
 ### json
 
 - `message_encoding`: [`json`](https://www.json.org/json-en.html)


### PR DESCRIPTION
[MessagePack](https://msgpack.org/) is a binary encoding similar to CBOR.

Add to the registry how to encode this in MCAP files.