### PR TITLE
Call std::fflush() and ::fsync() before std::fclose() in FileWriter::end()

### DIFF
--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -69,6 +69,20 @@ void FileWriter::flush() {
 
 void FileWriter::end() {
   if (file_) {
+    std::fflush(file_);
+#if defined(_WIN32) || defined(_WIN64)
+    // Windows platform
+    const int fd = _fileno(file_);
+    if (fd != -1) {
+      _commit(fd);
+    }
+#elif defined(__unix__) || defined(__APPLE__) || defined(__linux__)
+    // Unix/Linux/macOS platforms
+    const int fd = ::fileno(file_);
+    if (fd != -1) {
+      ::fsync(fd);
+    }
+#endif
     std::fclose(file_);
     file_ = nullptr;
   }


### PR DESCRIPTION
### Changelog
- [C++] Ensure data is flushed to physical media before `FileWriter::end()` returns

### Docs

None

### Description

I've observed periodic data loss writing MCAP files where I destroy the `McapWriter` (which triggers `FileWriter::end()` under the hood) then immediately call `std::rename()` to remove a `.active` extension from the written MCAP file. Most of the time this works, but maybe ~5% of my MCAPs are missing data at the end where the final bytes of the file are a partial Chunk record.

From my reading it looks like calling `std::fclose()` immediately followed by `std::rename()` may not be safe if there are writes that haven't flushed to disk. This change adds additional calls to `std::fflush()` and `::fsync()` to guarantee the OS has delivered all pending writes to the physical media before `FileWriter::end()` returns, and hence before my `std::rename()` call.

This change was manually tested, I am still monitoring but haven't seen any partial writes since deploying this fix locally.