### PR TITLE
Add information regarding rosbag2 conversion compression

### DIFF
--- a/website/docs/guides/getting-started/ros-2.md
+++ b/website/docs/guides/getting-started/ros-2.md
@@ -39,10 +39,15 @@ $ cat << EOF > convert.yaml
 output_bags:
   - uri: ros2_output
     storage_id: mcap
+    storage_config_uri: my_storage_config.yaml
     all: true
 EOF
+$ cat << EOF > my_storage_config.yaml
+compression: Zstd
 $ ros2 bag convert -i ros2_input.db3 -o convert.yaml
 ```
+
+If you want to use compression when converting, specify a storage config file. Specifying `compression_mode` and `compression_format` directly in the `convert.yaml` file will result in an unplayable rosbag2 (https://github.com/ros2/rosbag2/issues/1920).
 
 ### Using the `mcap` CLI tool
 

--- a/website/docs/guides/getting-started/ros-2.md
+++ b/website/docs/guides/getting-started/ros-2.md
@@ -44,6 +44,7 @@ output_bags:
 EOF
 $ cat << EOF > my_storage_config.yaml
 compression: Zstd
+EOF
 $ ros2 bag convert -i ros2_input.db3 -o convert.yaml
 ```
 


### PR DESCRIPTION
### Changelog
Added documentation for using rosbag2 convert with mcap compression.

### Docs
None

### Description
When creating a rosbag with `ros2 bag convert` and this configuration:
```yaml
output_bags:
- uri: out
  storage_id: mcap
  compression_mode: file
  compression_format: zstd
  all_topics: true
```

A `out_0.mcap.zstd` file is created, which is unreadable by `ros2 play` -- the file must be first be fully inflated (taking up 4x the original space and long time) and can then be read.

Thanks to a contributor at rosbag2 (https://github.com/ros2/rosbag2/issues/1920) I was able to figure out a working configuration for converting to a compressed rosbag, which involves two separate configuration files:
```yaml
output_bags:
- uri: out
  storage_id: mcap
  storage_config_uri: mcap_config.yaml
  all_topics: true
```
and `mcap_config.yaml` as used by `ros2 bag record -s mcap --all --storage-config-file mcap_config.yaml`.

I think it would be nice to also have this feature documented in the mcap docs.