### PR TITLE
go: reject invalid utf-8 strings in MCAP

### DIFF
--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"unicode/utf8"
 )
+
+var ErrInvalidString = errors.New("string is not valid UTF-8")
 
 func getPrefixedString(data []byte, offset int) (s string, newoffset int, err error) {
 	if len(data[offset:]) < 4 {
@@ -16,7 +19,11 @@ func getPrefixedString(data []byte, offset int) (s string, newoffset int, err er
 	if len(data[offset+4:]) < length {
 		return "", 0, io.ErrShortBuffer
 	}
-	return string(data[offset+4 : offset+length+4]), offset + 4 + length, nil
+	b := data[offset+4 : offset+length+4]
+	if !utf8.Valid(b) {
+		return "", 0, fmt.Errorf("%w, hex: %x", ErrInvalidString, string(b))
+	}
+	return string(b), offset + 4 + length, nil
 }
 
 func getPrefixedBytes(data []byte, offset int) (s []byte, newoffset int, err error) {

--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -19,11 +19,11 @@ func getPrefixedString(data []byte, offset int) (s string, newoffset int, err er
 	if len(data[offset+4:]) < length {
 		return "", 0, io.ErrShortBuffer
 	}
-	b := data[offset+4 : offset+length+4]
-	if !utf8.Valid(b) {
-		return "", 0, fmt.Errorf("%w, hex: %x", ErrInvalidString, string(b))
+	asBytes := data[offset+4 : offset+length+4]
+	if !utf8.Valid(asBytes) {
+		return "", 0, fmt.Errorf("%w, hex: %x", ErrInvalidString, string(asBytes))
 	}
-	return string(b), offset + 4 + length, nil
+	return string(asBytes), offset + 4 + length, nil
 }
 
 func getPrefixedBytes(data []byte, offset int) (s []byte, newoffset int, err error) {

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -221,6 +221,17 @@ func TestReadPrefixedMap(t *testing.T) {
 			18,
 			nil,
 		},
+		{
+			"invalid utf-8",
+			flatten(
+				encodedUint32(14),
+				prefixedString("foo"),
+				[]byte{4, 0, 0, 0, 255, 255, 255, 255},
+			),
+			nil,
+			0,
+			ErrInvalidString,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {

--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.7.1"
+var Version = "v1.8.0"


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

MCAP [strings](https://mcap.dev/spec#string) should be UTF-8 formatted, we should check for this when parsing.

We've seen some users provide invalid-formatted strings in schema names or in channel metadata, and we need to catch this at import time, rather than have the invalid data in storage and be impossible to stream.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

