### PR TITLE
Optimize LinearReader::next_record

### DIFF
--- a/rust/src/tokio/linear_reader.rs
+++ b/rust/src/tokio/linear_reader.rs
@@ -61,8 +61,8 @@ where
                     data: content,
                     opcode,
                 }) => {
-                    data.resize(content.len(), 0);
-                    data.copy_from_slice(content);
+                    data.clear();
+                    data.extend_from_slice(content);
                     return Some(Ok(opcode));
                 }
                 Err(err) => {


### PR DESCRIPTION
I just spotted that we zero the buffer with resize and then immediately overwrite it. Using clear + extend is more efficient and is a quick fix with no downside.