### PR TITLE
Improve releases link

### DIFF
--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -10,7 +10,7 @@ The MCAP command line tool is useful for working with MCAP files.
 
 ### Release binaries
 
-Download binaries for your platform from [the latest Github release](https://github.com/foxglove/mcap/releases/latest).
+Download binaries for your platform from [the latest GitHub release](https://github.com/foxglove/mcap/releases?q=releases%2Fmcap-cli).
 
 Then, mark it executable:
 


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This updates the CLI documentation to point to the releases page, filtered for CLI releases. The existing link (`/latest`) may or may not point to a CLI release.