### PR TITLE
upgrade to zstd 0.13

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,10 +28,10 @@ static_assertions = "1.1.0"
 bimap = "0.6.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-zstd = { version = "0.11", features = ["wasm"], optional = true }
+zstd = { version = "0.13", features = ["wasm"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-zstd = { version = "0.11", features = ["zstdmt"], optional = true }
+zstd = { version = "0.13", features = ["zstdmt"], optional = true }
 
 [features]
 default = ["zstd", "lz4"]

--- a/rust/src/sans_io/zstd.rs
+++ b/rust/src/sans_io/zstd.rs
@@ -2,7 +2,7 @@ use crate::{
     sans_io::decompressor::{DecompressResult, Decompressor},
     McapError, McapResult,
 };
-use zstd::zstd_safe::{get_error_name, DStream, InBuffer, OutBuffer, SafeResult};
+use zstd::zstd_safe::{get_error_name, DStream, InBuffer, OutBuffer, ResetDirective, SafeResult};
 
 pub struct ZstdDecoder {
     s: DStream<'static>,
@@ -14,7 +14,7 @@ impl ZstdDecoder {
     pub fn new() -> Self {
         let mut stream = DStream::create();
         ZstdDecoder {
-            need: stream.init(),
+            need: stream.init().expect("zstd decoder init failed"),
             s: stream,
         }
     }
@@ -42,7 +42,7 @@ impl Decompressor for ZstdDecoder {
         })
     }
     fn reset(&mut self) -> McapResult<()> {
-        handle_error(self.s.reset())?;
+        handle_error(self.s.reset(ResetDirective::SessionOnly))?;
         Ok(())
     }
 


### PR DESCRIPTION
### Changelog
Upgrade the `zstd` dependency to `0.13`.

### Docs

None

### Description

`zstd 0.11` is about 3 years out of date. Using the same major version as other projects will reduce the need for duplicate dependencies in a cargo workspace.

Notes about the change:
- `ZstdDecoder` will panic on init failure to avoid changing the return type. Note that `DStream::create` already panics on failure.
