### PR TITLE
replace `memmap` with `memmap2`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,7 +46,7 @@ camino = "1.0"
 clap = { version = "3.2", features = ["derive"]}
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 itertools = "0.10"
-memmap = "0.7"
+memmap2 = "0.9.5"
 rayon = "1.5"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1"

--- a/rust/examples/mcapcat.rs
+++ b/rust/examples/mcapcat.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use log::*;
-use memmap::Mmap;
+use memmap2::Mmap;
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/rust/examples/mcapcopy.rs
+++ b/rust/examples/mcapcopy.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use log::*;
-use memmap::Mmap;
+use memmap2::Mmap;
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/rust/examples/recover.rs
+++ b/rust/examples/recover.rs
@@ -8,7 +8,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use enumset::enum_set;
 use log::*;
-use memmap::Mmap;
+use memmap2::Mmap;
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! use anyhow::{Context, Result};
 //! use camino::Utf8Path;
-//! use memmap::Mmap;
+//! use memmap2::Mmap;
 //!
 //! fn map_mcap<P: AsRef<Utf8Path>>(p: P) -> Result<Mmap> {
 //!     let fd = fs::File::open(p.as_ref()).context("Couldn't open MCAP file")?;

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -1,7 +1,7 @@
 //! Read MCAP data from a memory-mapped file.
 //!
 //! MCAPs are read from a byte slice instead of a [`std::io::Read`] trait object.
-//! Consider [memory-mapping](https://docs.rs/memmap/0.7.0/memmap/struct.Mmap.html)
+//! Consider [memory-mapping](https://docs.rs/memmap2/0.9.5/memmap2/struct.Mmap.html)
 //! the file - the OS will load (and cache!) it on-demand, without any
 //! further system calls.
 use std::{

--- a/rust/tests/attachment.rs
+++ b/rust/tests/attachment.rs
@@ -6,7 +6,7 @@ use mcap::records::AttachmentHeader;
 use std::{borrow::Cow, io::BufWriter};
 
 use anyhow::Result;
-use memmap::Mmap;
+use memmap2::Mmap;
 use tempfile::tempfile;
 
 #[test]

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use anyhow::{Context, Result};
 use camino::Utf8Path;
-use memmap::Mmap;
+use memmap2::Mmap;
 
 pub fn map_mcap<P: AsRef<Utf8Path>>(p: P) -> Result<Mmap> {
     let p = p.as_ref();

--- a/rust/tests/compression.rs
+++ b/rust/tests/compression.rs
@@ -6,7 +6,7 @@ use std::io::BufWriter;
 
 use anyhow::Result;
 use itertools::Itertools;
-use memmap::Mmap;
+use memmap2::Mmap;
 use tempfile::tempfile;
 
 fn round_trip(comp: Option<mcap::Compression>) -> Result<()> {

--- a/rust/tests/message.rs
+++ b/rust/tests/message.rs
@@ -5,7 +5,7 @@ use common::*;
 use std::{borrow::Cow, io::BufWriter, sync::Arc};
 
 use anyhow::Result;
-use memmap::Mmap;
+use memmap2::Mmap;
 use tempfile::tempfile;
 
 #[test]

--- a/rust/tests/metadata.rs
+++ b/rust/tests/metadata.rs
@@ -5,7 +5,7 @@ use common::*;
 use std::io::BufWriter;
 
 use anyhow::Result;
-use memmap::Mmap;
+use memmap2::Mmap;
 use tempfile::tempfile;
 
 #[test]

--- a/rust/tests/round_trip.rs
+++ b/rust/tests/round_trip.rs
@@ -7,7 +7,7 @@ use std::io::BufWriter;
 
 use anyhow::Result;
 use itertools::Itertools;
-use memmap::Mmap;
+use memmap2::Mmap;
 use rayon::prelude::*;
 use tempfile::tempfile;
 


### PR DESCRIPTION
### Changelog
Replace (unmaintained) `memmap` dev-dependency with `memmap2`.

### Docs

None, other than the corresponding doc-comment change in `lib.rs`.

### Description

`memmap` has been unmaintained for many years; there has been a RustSec [advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077.html) about this for 4 years. As a dev-dependency this isn't critical, but it seems likely that users of this library will copy/paste example code. Setting a good example for them seems worthwhile.