### PR TITLE
rust: make Wrtier::with_options pub

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -390,11 +390,13 @@ pub struct Writer<W: Write + Seek> {
 }
 
 impl<W: Write + Seek> Writer<W> {
+    /// Create a new MCAP [`Writer`] using the provided seeking writer.
     pub fn new(writer: W) -> McapResult<Self> {
         Self::with_options(writer, WriteOptions::default())
     }
 
-    fn with_options(writer: W, opts: WriteOptions) -> McapResult<Self> {
+    /// Create a new MCAP [`Writer`] using the provided seeking writer and [`WriteOptions`].
+    pub fn with_options(writer: W, opts: WriteOptions) -> McapResult<Self> {
         let mut writer = CountingCrcWriter::new(writer, opts.calculate_data_section_crc);
         writer.write_all(MAGIC)?;
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Make `Writher::with_options` public

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Makes the `Writer::with_options` method in the Rust library public to easier support setting options.

This also bumps the version to 0.16.0 in preparation to release this and the breaking changes from #1341.

Fixes #1348.
