### PR TITLE
allow dependabot to update cli dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/go/cli/mcap/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/foxglove/*"


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Enables Go dependabot updates for the CLI. This should make sure that the CLI has the correct workspace dependency versions without us needing to update our pipelines to update this for us.
