### PR TITLE
bump minimum go version for dependabot

### DIFF
--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -1,6 +1,6 @@
 module github.com/foxglove/mcap/go/cli/mcap
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/storage v1.23.0

--- a/go/mcap/go.mod
+++ b/go/mcap/go.mod
@@ -1,6 +1,6 @@
 module github.com/foxglove/mcap/go/mcap
 
-go 1.18
+go 1.21
 
 require (
 	github.com/klauspost/compress v1.16.7


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Bumps the minimum go versions so that dependabot can update the mcap cli version. It has currently been struggling to do this because the "slices" package is not available in the standard library (it was released in 1.21). https://github.com/foxglove/mcap/network/updates/1002878288

This change sets the minimum version to 1.21 to support it. The workspace version is currently 1.22.5.
