### PR TITLE
rust: writer: return summary from finish()

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -534,7 +534,7 @@ pub fn footer(mcap: &[u8]) -> McapResult<records::Footer> {
 }
 
 /// Indexes of an MCAP file parsed from its (optional) summary section
-#[derive(Default, Eq, PartialEq)]
+#[derive(Default, Eq, PartialEq, Clone)]
 pub struct Summary {
     pub stats: Option<records::Statistics>,
     /// Maps channel IDs to their channel


### PR DESCRIPTION
### Changelog
- Changed: the `mcap::writer::Writer::finish()` method now returns a summary of the files' content.

### Docs

None.

### Description

We have a few cases internally where we want to write out an MCAP to some destination, then also track the summary information for that MCAP somewhere else. Cases include:
- log rotation, where we want to track schemas and channels written and would rather not do that externally
- maintaining an external index of MCAP chunks, which we do at Foxglove
- Writing then immediately reading back chunk data without needing to re-parse the just-written summary

This PR enables that by returning a summary from `finish()`.

Note: similar functionality is available from the Go writer, which exposes statistics and indexes as public fields from the Writer struct, see here: https://pkg.go.dev/github.com/foxglove/mcap/go/mcap#Writer
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

