### PR TITLE
go: reader: do not report full byte array for UnexpectedTokenError

### DIFF
--- a/go/mcap/reader.go
+++ b/go/mcap/reader.go
@@ -229,7 +229,7 @@ func (r *Reader) GetMetadata(offset uint64) (*Metadata, error) {
 		return nil, err
 	}
 	if token != TokenMetadata {
-		return nil, NewErrUnexpectedToken(fmt.Errorf("expected metadata record, found %v", data))
+		return nil, NewErrUnexpectedToken(fmt.Errorf("expected metadata record, found %q", token))
 	}
 	metadata, err := ParseMetadata(data)
 	if err != nil {
@@ -260,7 +260,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 		return nil, fmt.Errorf("could not read MCAP header when opening reader: %w", err)
 	}
 	if token != TokenHeader {
-		return nil, NewErrUnexpectedToken(fmt.Errorf("expected first record in MCAP to be a Header, found %v", headerData))
+		return nil, NewErrUnexpectedToken(fmt.Errorf("expected first record in MCAP to be header, found %q", token))
 	}
 	header, err := ParseHeader(headerData)
 	if err != nil {

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -954,6 +954,18 @@ func TestReadingBigTimestamps(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 }
+func TestUnexpectedTokenOnHeader(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w, err := NewWriter(buf, &WriterOptions{
+		Chunked:   true,
+		ChunkSize: 100,
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.WriteSchema(&Schema{ID: 1}))
+	require.NoError(t, w.Close())
+	_, err = NewReader(bytes.NewReader(buf.Bytes()))
+	require.ErrorContains(t, err, "expected first record in MCAP to be header, found \"chunk\"")
+}
 
 func BenchmarkReader(b *testing.B) {
 	inputParameters := []struct {

--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.7.1"
+var Version = "v1.7.2"


### PR DESCRIPTION
### Changelog
Changed: refined error message of `UnexpectedTokenError` to not include the full token byte array.
### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

This is useless - in the common case, the unexpected token is garbage, and contains garbage data. A human is not expected to read the byte array.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

