### PR TITLE
cpp: add missing cstdint include (gcc15 build failure)

### DIFF
--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -3,6 +3,7 @@
 #include "errors.hpp"
 #include "visibility.hpp"
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <limits>
 #include <memory>


### PR DESCRIPTION
### Changelog
Add a missing cstdint include that causes a build error with GCC 15.1.1.

