### PR TITLE
cpp: Fix bugs related to message-less chunks

### DIFF
--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1813,7 +1813,10 @@ IndexedMessageReader::IndexedMessageReader(
     }
     chunkIndexes = mcapReader_.chunkIndexes();
   }
-  if (chunkIndexes.size() == 0 || chunkIndexes[0].messageIndexLength == 0) {
+  if (chunkIndexes.size() == 0 ||
+      std::all_of(chunkIndexes.begin(), chunkIndexes.end(), [](const ChunkIndex& ci) {
+        return ci.messageIndexLength == 0;
+      })) {
     status_ = Status(StatusCode::NoMessageIndexesAvailable,
                      "cannot read MCAP in time order with no message indexes");
     return;

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -552,8 +552,8 @@ Status McapWriter::write(const Message& message) {
   if (chunkWriter != nullptr && /* Chunked? */
       uncompressedSize_ != 0 && /* Current chunk is not empty/new? */
       9 + getRecordSize(message) + uncompressedSize_ >= chunkSize_ /* Overflowing? */) {
-      auto& fileOutput = *output_;
-      writeChunk(fileOutput, *chunkWriter);
+    auto& fileOutput = *output_;
+    writeChunk(fileOutput, *chunkWriter);
   }
 
   // For the chunk-local message index.
@@ -780,8 +780,10 @@ void McapWriter::writeChunk(IWritable& output, IChunkWriter& chunkData) {
     const uint64_t messageIndexLength = output.size() - messageIndexOffset;
 
     // Fill in the newly created chunk index record. This will be written into
-    // the summary section when close() is called
-    chunkIndexRecord.messageStartTime = currentChunkStart_;
+    // the summary section when close() is called. Note that currentChunkStart_
+    // may still be initialized to MaxTime if this chunk does not contain any
+    // messages.
+    chunkIndexRecord.messageStartTime = currentChunkStart_ == MaxTime ? 0 : currentChunkStart_;
     chunkIndexRecord.messageEndTime = currentChunkEnd_;
     chunkIndexRecord.chunkStartOffset = chunkStartOffset;
     chunkIndexRecord.chunkLength = chunkLength;

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -733,6 +733,7 @@ TEST_CASE("Read Order", "[reader][writer]") {
 
     mcap::McapWriter writer;
     mcap::McapWriterOptions opts("test");
+    opts.chunkSize = 512 * 1024;
     opts.compression = mcap::Compression::None;
     opts.forceCompression = true;
     writer.open(buffer, opts);
@@ -741,8 +742,10 @@ TEST_CASE("Read Order", "[reader][writer]") {
     mcap::Channel channel("topic", "messageEncoding", schema.id);
     writer.addChannel(channel);
 
+    // Write larger-than-chunk-size messages.
     mcap::Message msg;
-    std::vector<std::byte> data = {std::byte(1), std::byte(2), std::byte(3)};
+    std::vector<std::byte> data(1024 * 1024);
+    std::fill(data.begin(), data.end(), std::byte(0x42));
     WriteMsg(writer, channel.id, 0, 0, 0, data);
     WriteMsg(writer, channel.id, 2, 2, 2, data);
     WriteMsg(writer, channel.id, 1, 1, 1, data);


### PR DESCRIPTION
### Changelog
- cpp: Fix a few bugs related to message-less chunks

### Docs
None

### Description
PR #1291 added an optimization, which caused the behavior reported in issue #1355. The intention of that change was to close a non-empty chunk before writing a message that would overflow the chunk size. It checks whether the chunk is non-empty _after_ writing `Channel` & `Schema` records to the chunk (see: [writer.inl](https://github.com/foxglove/mcap/blob/ba0d926f112ec7fa207c7a7c6d2a4809570db850/cpp/mcap/include/mcap/writer.inl#L550-L557)). Therefore, it's possible to write a chunk that contains no messages.

The writer has a small bug in the metadata that it writes into the chunk index record. The `currentChunkStart_` register is initialized as `MaxTime`, and only updated when a message is added to the chunk. But when writing a message-less chunk, we need to write the message start time as 0.

The indexed message reader has a small bug in the way it detects the presence of a message index. It only looks for a message index on the first chunk index record, instead of scanning all chunk index records. This is why the test case provided in #1355 fails: the first chunk contains only `Channel` & `Schema` records without messages, and therefore the first chunk index has no message index.

Fixes: #1355 