### PR TITLE
mcap/cpp: control visibility with a macro

### DIFF
--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -40,7 +40,7 @@ enum struct ReadSummaryMethod {
 /**
  * @brief An abstract interface for reading MCAP data.
  */
-struct MCAP_PUBLIC IReadable {
+struct MCAP_VISIBILITY IReadable {
   virtual ~IReadable() = default;
 
   /**
@@ -72,7 +72,7 @@ struct MCAP_PUBLIC IReadable {
  * @brief IReadable implementation wrapping a FILE* pointer created by fopen()
  * and a read buffer.
  */
-class MCAP_PUBLIC FileReader final : public IReadable {
+class MCAP_VISIBILITY FileReader final : public IReadable {
 public:
   FileReader(std::FILE* file);
 
@@ -89,7 +89,7 @@ private:
 /**
  * @brief IReadable implementation wrapping a std::ifstream input file stream.
  */
-class MCAP_PUBLIC FileStreamReader final : public IReadable {
+class MCAP_VISIBILITY FileStreamReader final : public IReadable {
 public:
   FileStreamReader(std::ifstream& stream);
 
@@ -106,7 +106,7 @@ private:
 /**
  * @brief An abstract interface for compressed readers.
  */
-class MCAP_PUBLIC ICompressedReader : public IReadable {
+class MCAP_VISIBILITY ICompressedReader : public IReadable {
 public:
   virtual ~ICompressedReader() override = default;
 
@@ -132,7 +132,7 @@ public:
  * @brief A "null" compressed reader that directly passes through uncompressed
  * data. No internal buffers are allocated.
  */
-class MCAP_PUBLIC BufferReader final : public ICompressedReader {
+class MCAP_VISIBILITY BufferReader final : public ICompressedReader {
 public:
   void reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) override;
   uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
@@ -155,7 +155,7 @@ private:
  * @brief ICompressedReader implementation that decompresses Zstandard
  * (https://facebook.github.io/zstd/) data.
  */
-class MCAP_PUBLIC ZStdReader final : public ICompressedReader {
+class MCAP_VISIBILITY ZStdReader final : public ICompressedReader {
 public:
   void reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) override;
   uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
@@ -191,7 +191,7 @@ private:
  * @brief ICompressedReader implementation that decompresses LZ4
  * (https://lz4.github.io/lz4/) data.
  */
-class MCAP_PUBLIC LZ4Reader final : public ICompressedReader {
+class MCAP_VISIBILITY LZ4Reader final : public ICompressedReader {
 public:
   void reset(const std::byte* data, uint64_t size, uint64_t uncompressedSize) override;
   uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override;
@@ -232,7 +232,7 @@ struct LinearMessageView;
 /**
  * @brief Options for reading messages out of an MCAP file.
  */
-struct MCAP_PUBLIC ReadMessageOptions {
+struct MCAP_VISIBILITY ReadMessageOptions {
 public:
   /**
    * @brief Only messages with log timestamps greater or equal to startTime will be included.
@@ -272,7 +272,7 @@ public:
 /**
  * @brief Provides a read interface to an MCAP file.
  */
-class MCAP_PUBLIC McapReader final {
+class MCAP_VISIBILITY McapReader final {
 public:
   ~McapReader();
 
@@ -504,7 +504,7 @@ private:
  * @brief A low-level interface for parsing MCAP-style TLV records from a data
  * source.
  */
-struct MCAP_PUBLIC RecordReader {
+struct MCAP_VISIBILITY RecordReader {
   ByteOffset offset;
   ByteOffset endOffset;
 
@@ -524,7 +524,7 @@ private:
   Record curRecord_;
 };
 
-struct MCAP_PUBLIC TypedChunkReader {
+struct MCAP_VISIBILITY TypedChunkReader {
   std::function<void(const SchemaPtr, ByteOffset)> onSchema;
   std::function<void(const ChannelPtr, ByteOffset)> onChannel;
   std::function<void(const Message&, ByteOffset)> onMessage;
@@ -560,7 +560,7 @@ private:
  * @brief A mid-level interface for parsing and validating MCAP records from a
  * data source.
  */
-struct MCAP_PUBLIC TypedRecordReader {
+struct MCAP_VISIBILITY TypedRecordReader {
   std::function<void(const Header&, ByteOffset)> onHeader;
   std::function<void(const Footer&, ByteOffset)> onFooter;
   std::function<void(const SchemaPtr, ByteOffset, std::optional<ByteOffset>)> onSchema;
@@ -608,7 +608,7 @@ private:
  *  - noMessageIndex: false
  *  - noSummary: false
  */
-struct MCAP_PUBLIC IndexedMessageReader {
+struct MCAP_VISIBILITY IndexedMessageReader {
 public:
   IndexedMessageReader(McapReader& reader, const ReadMessageOptions& options,
                        const std::function<void(const Message&, RecordOffset)> onMessage);
@@ -653,8 +653,8 @@ private:
 /**
  * @brief An iterable view of Messages in an MCAP file.
  */
-struct MCAP_PUBLIC LinearMessageView {
-  struct MCAP_PUBLIC Iterator {
+struct MCAP_VISIBILITY LinearMessageView {
+  struct MCAP_VISIBILITY Iterator {
     using iterator_category = std::input_iterator_tag;
     using difference_type = int64_t;
     using value_type = MessageView;
@@ -665,8 +665,8 @@ struct MCAP_PUBLIC LinearMessageView {
     pointer operator->() const;
     Iterator& operator++();
     void operator++(int);
-    MCAP_PUBLIC friend bool operator==(const Iterator& a, const Iterator& b);
-    MCAP_PUBLIC friend bool operator!=(const Iterator& a, const Iterator& b);
+    MCAP_VISIBILITY friend bool operator==(const Iterator& a, const Iterator& b);
+    MCAP_VISIBILITY friend bool operator!=(const Iterator& a, const Iterator& b);
 
   private:
     friend LinearMessageView;

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -77,14 +77,14 @@ enum struct OpCode : uint8_t {
 /**
  * @brief Get the string representation of an OpCode.
  */
-MCAP_PUBLIC
+MCAP_VISIBILITY
 constexpr std::string_view OpCodeString(OpCode opcode);
 
 /**
  * @brief A generic Type-Length-Value record using a uint8 type and uint64
  * length. This is the generic form of all MCAP records.
  */
-struct MCAP_PUBLIC Record {
+struct MCAP_VISIBILITY Record {
   OpCode opcode;
   uint64_t dataSize;
   std::byte* data;
@@ -100,7 +100,7 @@ struct MCAP_PUBLIC Record {
  * <https://github.com/foxglove/mcap/tree/main/docs/specification/profiles>) and
  * a string signature of the recording library.
  */
-struct MCAP_PUBLIC Header {
+struct MCAP_VISIBILITY Header {
   std::string profile;
   std::string library;
 };
@@ -112,7 +112,7 @@ struct MCAP_PUBLIC Header {
  * Summary and Summary Offset sections. A `summaryStart` and
  * `summaryOffsetStart` of zero indicates no Summary section is available.
  */
-struct MCAP_PUBLIC Footer {
+struct MCAP_VISIBILITY Footer {
   ByteOffset summaryStart;
   ByteOffset summaryOffsetStart;
   uint32_t summaryCrc;
@@ -129,7 +129,7 @@ struct MCAP_PUBLIC Footer {
  * describing the shape of messages. One or more Channel records map to a single
  * Schema.
  */
-struct MCAP_PUBLIC Schema {
+struct MCAP_VISIBILITY Schema {
   SchemaId id;
   std::string name;
   std::string encoding;
@@ -156,7 +156,7 @@ struct MCAP_PUBLIC Schema {
  * encodings that are not self-describing (e.g. JSON) or when schema information
  * is available (e.g. JSONSchema).
  */
-struct MCAP_PUBLIC Channel {
+struct MCAP_VISIBILITY Channel {
   ChannelId id;
   std::string topic;
   std::string messageEncoding;
@@ -179,7 +179,7 @@ using ChannelPtr = std::shared_ptr<Channel>;
 /**
  * @brief A single Message published to a Channel.
  */
-struct MCAP_PUBLIC Message {
+struct MCAP_VISIBILITY Message {
   ChannelId channelId;
   /**
    * @brief An optional sequence number. If non-zero, sequence numbers should be
@@ -212,7 +212,7 @@ struct MCAP_PUBLIC Message {
  * @brief An collection of Schemas, Channels, and Messages that supports
  * compression and indexing.
  */
-struct MCAP_PUBLIC Chunk {
+struct MCAP_VISIBILITY Chunk {
   Timestamp messageStartTime;
   Timestamp messageEndTime;
   ByteOffset uncompressedSize;
@@ -226,7 +226,7 @@ struct MCAP_PUBLIC Chunk {
  * @brief A list of timestamps to byte offsets for a single Channel. This record
  * appears after each Chunk, one per Channel that appeared in that Chunk.
  */
-struct MCAP_PUBLIC MessageIndex {
+struct MCAP_VISIBILITY MessageIndex {
   ChannelId channelId;
   std::vector<std::pair<Timestamp, ByteOffset>> records;
 };
@@ -236,7 +236,7 @@ struct MCAP_PUBLIC MessageIndex {
  * summary information for a single Chunk and pointing to each Message Index
  * record associated with that Chunk.
  */
-struct MCAP_PUBLIC ChunkIndex {
+struct MCAP_VISIBILITY ChunkIndex {
   Timestamp messageStartTime;
   Timestamp messageEndTime;
   ByteOffset chunkStartOffset;
@@ -253,7 +253,7 @@ struct MCAP_PUBLIC ChunkIndex {
  * a name, media type, timestamps, and optional CRC. Attachment records are
  * written in the Data section, outside of Chunks.
  */
-struct MCAP_PUBLIC Attachment {
+struct MCAP_VISIBILITY Attachment {
   Timestamp logTime;
   Timestamp createTime;
   std::string name;
@@ -267,7 +267,7 @@ struct MCAP_PUBLIC Attachment {
  * @brief Attachment Index records are found in the Summary section, providing
  * summary information for a single Attachment.
  */
-struct MCAP_PUBLIC AttachmentIndex {
+struct MCAP_VISIBILITY AttachmentIndex {
   ByteOffset offset;
   ByteOffset length;
   Timestamp logTime;
@@ -297,7 +297,7 @@ struct MCAP_PUBLIC AttachmentIndex {
  * @brief The Statistics record is found in the Summary section, providing
  * counts and timestamp ranges for the entire file.
  */
-struct MCAP_PUBLIC Statistics {
+struct MCAP_VISIBILITY Statistics {
   uint64_t messageCount;
   uint16_t schemaCount;
   uint32_t channelCount;
@@ -313,7 +313,7 @@ struct MCAP_PUBLIC Statistics {
  * @brief Holds a named map of key/value strings containing arbitrary user data.
  * Metadata records are found in the Data section, outside of Chunks.
  */
-struct MCAP_PUBLIC Metadata {
+struct MCAP_VISIBILITY Metadata {
   std::string name;
   KeyValueMap metadata;
 };
@@ -322,7 +322,7 @@ struct MCAP_PUBLIC Metadata {
  * @brief Metadata Index records are found in the Summary section, providing
  * summary information for a single Metadata record.
  */
-struct MCAP_PUBLIC MetadataIndex {
+struct MCAP_VISIBILITY MetadataIndex {
   uint64_t offset;
   uint64_t length;
   std::string name;
@@ -337,7 +337,7 @@ struct MCAP_PUBLIC MetadataIndex {
  * found in the Summary section, a Summary Offset references the file offset and
  * length where that type of Summary record can be found.
  */
-struct MCAP_PUBLIC SummaryOffset {
+struct MCAP_VISIBILITY SummaryOffset {
   OpCode groupOpCode;
   ByteOffset groupStart;
   ByteOffset groupLength;
@@ -347,11 +347,11 @@ struct MCAP_PUBLIC SummaryOffset {
  * @brief The final record in the Data section, signaling the end of Data and
  * beginning of Summary. Optionally contains a CRC of the entire Data section.
  */
-struct MCAP_PUBLIC DataEnd {
+struct MCAP_VISIBILITY DataEnd {
   uint32_t dataSectionCrc;
 };
 
-struct MCAP_PUBLIC RecordOffset {
+struct MCAP_VISIBILITY RecordOffset {
   ByteOffset offset;
   std::optional<ByteOffset> chunkOffset;
 
@@ -385,7 +385,7 @@ struct MCAP_PUBLIC RecordOffset {
  * to that Channel's Schema. The Channel pointer is guaranteed to be valid,
  * while the Schema pointer may be null if the Channel references schema_id 0.
  */
-struct MCAP_PUBLIC MessageView {
+struct MCAP_VISIBILITY MessageView {
   const Message& message;
   const ChannelPtr channel;
   const SchemaPtr schema;

--- a/cpp/mcap/include/mcap/visibility.hpp
+++ b/cpp/mcap/include/mcap/visibility.hpp
@@ -8,6 +8,7 @@
 #    define MCAP_EXPORT __declspec(dllexport)
 #    define MCAP_IMPORT __declspec(dllimport)
 #  endif
+#  define MCAP_LOCAL
 #  ifdef MCAP_IMPLEMENTATION
 #    define MCAP_PUBLIC MCAP_EXPORT
 #  else
@@ -16,9 +17,18 @@
 #else
 #  define MCAP_EXPORT __attribute__((visibility("default")))
 #  define MCAP_IMPORT
+#  define MCAP_LOCAL __attribute__((visibility("hidden")))
 #  if __GNUC__ >= 4
 #    define MCAP_PUBLIC __attribute__((visibility("default")))
 #  else
 #    define MCAP_PUBLIC
+#  endif
+#endif
+
+#ifndef MCAP_VISIBILITY
+#  ifdef MCAP_VISIBILITY_LOCAL
+#    define MCAP_VISIBILITY MCAP_LOCAL
+#  else
+#    define MCAP_VISIBILITY MCAP_PUBLIC
 #  endif
 #endif

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -18,7 +18,7 @@ namespace mcap {
 /**
  * @brief Configuration options for McapWriter.
  */
-struct MCAP_PUBLIC McapWriterOptions {
+struct MCAP_VISIBILITY McapWriterOptions {
   /**
    * @brief Disable CRC calculations for Chunks.
    */
@@ -111,7 +111,7 @@ struct MCAP_PUBLIC McapWriterOptions {
 /**
  * @brief An abstract interface for writing MCAP data.
  */
-class MCAP_PUBLIC IWritable {
+class MCAP_VISIBILITY IWritable {
 public:
   bool crcEnabled = false;
 
@@ -163,7 +163,7 @@ private:
  * @brief Implements the IWritable interface used by McapWriter by wrapping a
  * FILE* pointer created by fopen().
  */
-class MCAP_PUBLIC FileWriter final : public IWritable {
+class MCAP_VISIBILITY FileWriter final : public IWritable {
 public:
   ~FileWriter() override;
 
@@ -183,7 +183,7 @@ private:
  * @brief Implements the IWritable interface used by McapWriter by wrapping a
  * std::ostream stream.
  */
-class MCAP_PUBLIC StreamWriter final : public IWritable {
+class MCAP_VISIBILITY StreamWriter final : public IWritable {
 public:
   StreamWriter(std::ostream& stream);
 
@@ -202,7 +202,7 @@ private:
  * in memory and written to disk as a single record, to support optimal
  * compression and calculating the final Chunk data size.
  */
-class MCAP_PUBLIC IChunkWriter : public IWritable {
+class MCAP_VISIBILITY IChunkWriter : public IWritable {
 public:
   virtual ~IChunkWriter() override = default;
 
@@ -250,7 +250,7 @@ protected:
  * @brief An in-memory IChunkWriter implementation backed by a
  * growable buffer.
  */
-class MCAP_PUBLIC BufferWriter final : public IChunkWriter {
+class MCAP_VISIBILITY BufferWriter final : public IChunkWriter {
 public:
   void handleWrite(const std::byte* data, uint64_t size) override;
   void end() override;
@@ -270,7 +270,7 @@ private:
  * @brief An in-memory IChunkWriter implementation that holds data in a
  * temporary buffer before flushing to an LZ4-compressed buffer.
  */
-class MCAP_PUBLIC LZ4Writer final : public IChunkWriter {
+class MCAP_VISIBILITY LZ4Writer final : public IChunkWriter {
 public:
   LZ4Writer(CompressionLevel compressionLevel, uint64_t chunkSize);
 
@@ -295,7 +295,7 @@ private:
  * @brief An in-memory IChunkWriter implementation that holds data in a
  * temporary buffer before flushing to an ZStandard-compressed buffer.
  */
-class MCAP_PUBLIC ZStdWriter final : public IChunkWriter {
+class MCAP_VISIBILITY ZStdWriter final : public IChunkWriter {
 public:
   ZStdWriter(CompressionLevel compressionLevel, uint64_t chunkSize);
   ~ZStdWriter() override;
@@ -319,7 +319,7 @@ private:
 /**
  * @brief Provides a write interface to an MCAP file.
  */
-class MCAP_PUBLIC McapWriter final {
+class MCAP_VISIBILITY McapWriter final {
 public:
   ~McapWriter();
 


### PR DESCRIPTION
### Changelog
Allow changing of mcap symbol visibility with a macro.

### Docs

None

### Description

When compiling a library that uses MCAP internally it is a good practice to hide MCAP api's, but the visibility attribute defines do not allow this: symbols are always public. New macro MCAP_VISIBILITY_LOCAL can be used to toggle the default. Tested in https://github.com/asherikov/intrometry.

Discussion: https://github.com/foxglove/mcap/discussions/1315
