### PR TITLE
Fix issue with re-using McapWriter

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -22,5 +22,8 @@ target_link_libraries(bag2mcap ${CONAN_LIBS})
 add_executable(mcapdump mcapdump.cpp)
 target_link_libraries(mcapdump ${CONAN_LIBS})
 
+add_executable(rotatemcap rotatemcap.cpp)
+target_link_libraries(rotatemcap ${CONAN_LIBS})
+
 add_subdirectory(protobuf)
 add_subdirectory(jsonschema)

--- a/cpp/examples/rotatemcap.cpp
+++ b/cpp/examples/rotatemcap.cpp
@@ -1,0 +1,86 @@
+#define MCAP_IMPLEMENTATION
+#include <mcap/writer.hpp>
+
+#include <array>
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+constexpr char StringSchema[] = "string data";
+constexpr char NumberSchema[] = "number data";
+
+mcap::Timestamp now() {
+  return mcap::Timestamp(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count());
+}
+
+int main() {
+  mcap::McapWriter writer;
+
+  auto options = mcap::McapWriterOptions("ros1");
+  options.compression = mcap::Compression::Zstd;
+
+  std::ofstream out("output.mcap", std::ios::binary);
+  writer.open(out, options);
+
+  // Here we add both all the schemas and channels up front, but we
+  // could have also added stdMsgsNumber and topic2 before we used
+  // them in the second file below.
+
+  mcap::Schema stdMsgsString("std_msgs/String", "ros1msg", StringSchema);
+  writer.addSchema(stdMsgsString);
+  mcap::Schema stdMsgsNumber("std_msgs/Number", "ros1msg", NumberSchema);
+  writer.addSchema(stdMsgsNumber);
+
+  mcap::Channel topic("/chatter", "ros1", stdMsgsString.id);
+  writer.addChannel(topic);
+  mcap::Channel topic2("/chatter2", "ros1", stdMsgsNumber.id);
+  writer.addChannel(topic2);
+
+  std::array<std::byte, 4 + 13> payload{};
+  constexpr uint32_t length = 13;
+  std::memcpy(payload.data(), &length, 4);
+  std::memcpy(payload.data() + 4, "Hello, world!", 13);
+
+  mcap::Message msg;
+  msg.channelId = topic.id;
+  msg.sequence = 0;
+  msg.publishTime = now();
+  msg.logTime = msg.publishTime;
+  msg.data = payload.data();
+  msg.dataSize = payload.size();
+
+  auto res = writer.write(msg);
+  if (!res.ok()) {
+    std::cerr << "Failed to write message: " << res.message << "\n";
+    writer.terminate();
+    std::ignore = std::remove("output.mcap");
+    return 1;
+  }
+
+  // Rotate the mcap file to a new file, no need to call close()
+  std::ofstream out2("output2.mcap", std::ios::binary);
+  writer.open(out2, options);
+
+  mcap::Message msg2;
+  msg2.channelId = topic2.id;
+  msg2.sequence = 0;
+  msg2.publishTime = now();
+  msg2.logTime = msg2.publishTime;
+  msg2.data = reinterpret_cast<const std::byte*>("1234");
+  msg2.dataSize = 4;
+
+  res = writer.write(msg2);
+  if (!res.ok()) {
+    std::cerr << "Failed to write message: " << res.message << "\n";
+    writer.terminate();
+    std::ignore = std::remove("output2.mcap");
+    return 1;
+  }
+
+  writer.close();
+
+  return 0;
+}

--- a/cpp/examples/rotatemcap.cpp
+++ b/cpp/examples/rotatemcap.cpp
@@ -16,6 +16,9 @@ mcap::Timestamp now() {
                            .count());
 }
 
+// Use a single McapWriter to manage a "rotating" series of mcap files.
+// Wrtie some data to one mcap file, then switch to a new mcap file,
+// while using the same set of schemas and channels.
 int main() {
   mcap::McapWriter writer;
 

--- a/cpp/examples/rotatemcap.cpp
+++ b/cpp/examples/rotatemcap.cpp
@@ -17,7 +17,7 @@ mcap::Timestamp now() {
 }
 
 // Use a single McapWriter to manage a "rotating" series of mcap files.
-// Wrtie some data to one mcap file, then switch to a new mcap file,
+// Write some data to one mcap file, then switch to a new mcap file,
 // while using the same set of schemas and channels.
 int main() {
   mcap::McapWriter writer;

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -326,6 +326,9 @@ public:
   /**
    * @brief Open a new MCAP file for writing and write the header.
    *
+   * If the writer was already opened, this calls `close`() first to reset the state.
+   * A writer may be re-used after being reset via `close`() or `terminate`().
+   *
    * @param filename Filename of the MCAP file to write.
    * @param options Options for MCAP writing. `profile` is required.
    * @return A non-success status if the file could not be opened for writing.
@@ -334,6 +337,9 @@ public:
 
   /**
    * @brief Open a new MCAP file for writing and write the header.
+   *
+   * If the writer was already opened, this calls `close`() first to reset the state.
+   * A writer may be re-used after being reset via `close`() or `terminate`().
    *
    * @param writer An implementation of the IWritable interface. Output bytes
    *   will be written to this object.
@@ -351,20 +357,26 @@ public:
 
   /**
    * @brief Write the MCAP footer, flush pending writes to the output stream,
-   * and reset internal state.
+   * and reset internal state. The writer may be re-used with another call to open afterwards.
    */
   void close();
 
   /**
    * @brief Reset internal state without writing the MCAP footer or flushing
    * pending writes. This should only be used in error cases as the output MCAP
-   * file will be truncated.
+   * file will be truncated. The writer may be re-used with another call to open afterwards.
    */
   void terminate();
 
   /**
    * @brief Add a new schema to the MCAP file and set `schema.id` to a generated
    * schema id. The schema id is used when adding channels to the file.
+   *
+   * Schemas are not cleared when the state is reset via `close`() or `terminate`().
+   * If you're re-using a writer for multiple files in a row, the schemas only need
+   * to be added once, before first use.
+   *
+   * This method does not de-duplicate schemas.
    *
    * @param schema Description of the schema to register. The `id` field is
    *   ignored and will be set to a generated schema id.
@@ -375,6 +387,12 @@ public:
    * @brief Add a new channel to the MCAP file and set `channel.id` to a
    * generated channel id. The channel id is used when adding messages to the
    * file.
+   *
+   * Channels are not cleared when the state is reset via `close`() or `terminate`().
+   * If you're re-using a writer for multiple files in a row, the channels only need
+   * to be added once, before first use.
+   *
+   * This method does not de-duplicate channels.
    *
    * @param channel Description of the channel to register. The `id` value is
    *   ignored and will be set to a generated channel id.

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -304,6 +304,8 @@ McapWriter::~McapWriter() {
 }
 
 void McapWriter::open(IWritable& writer, const McapWriterOptions& options) {
+  // If the writer was opened, close it first
+  close();
   options_ = options;
   opened_ = true;
   chunkSize_ = options.noChunking ? 0 : options.chunkSize;
@@ -338,6 +340,8 @@ void McapWriter::open(IWritable& writer, const McapWriterOptions& options) {
 }
 
 Status McapWriter::open(const std::string_view filename, const McapWriterOptions& options) {
+  // If the writer was opened, close it first
+  close();
   fileOutput_ = std::make_unique<FileWriter>();
   const auto status = fileOutput_->open(filename);
   if (!status.ok()) {
@@ -349,6 +353,8 @@ Status McapWriter::open(const std::string_view filename, const McapWriterOptions
 }
 
 void McapWriter::open(std::ostream& stream, const McapWriterOptions& options) {
+  // If the writer was opened, close it first
+  close();
   streamOutput_ = std::make_unique<StreamWriter>(stream);
   open(*streamOutput_, options);
 }

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -1068,11 +1068,11 @@ TEST_CASE("Schema isolation between files with noRepeatedSchemas=false", "[write
 
   mcap::Schema schema1("Schema1", "encoding1", "schema1_data");
   writer.addSchema(schema1);
-  mcap::Channel channel1("topic1", "msgencoding1", schema1.id);
+  mcap::Channel channel1("topic1", "msg_encoding1", schema1.id);
   writer.addChannel(channel1);
   mcap::Schema schema2("Schema2", "encoding2", "schema2_data");
   writer.addSchema(schema2);
-  mcap::Channel channel2("topic2", "msgencoding2", schema2.id);
+  mcap::Channel channel2("topic2", "msg_encoding2", schema2.id);
   writer.addChannel(channel2);
 
   {


### PR DESCRIPTION
### Changelog

Fix an issue where re-using a writer leads to schemas appearing in mcap files where they were not used. Documented how to re-use a writer correctly and added an example.

### Docs

I made changes to the doc comments, how do I deploy those?

### Description

There were some issues in terminate() not clearing all the state it needs to, as well as in writing the summary where schemas and channels that don't appear in the file can be written out.

I fixed those issues, added a test for them, added docs for how to re-use a McapWriter safely, and added an example.

Linear ticket: FG-10773
