### PR TITLE
spec: clarify that strings are utf-8

### DIFF
--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -325,7 +325,7 @@ Multi-byte integers (`uint16`, `uint32`, `uint64`) are serialized using [little-
 
 ### String
 
-Strings are serialized using a `uint32` byte length followed by the string data, which should be valid [UTF-8](https://en.wikipedia.org/wiki/UTF-8).
+Strings are serialized using a `uint32` byte length followed by the string data, which must be valid [UTF-8](https://en.wikipedia.org/wiki/UTF-8).
 
     <byte length><utf-8 bytes>
 


### PR DESCRIPTION
### Changelog
None

### Docs

Is
### Description

Clarifies that MCAP strings must be utf-8 encoded. the "should" wording makes it unclear if readers may treat utf-8 strings as errors. Some of our implementations (python, rust) already do, others are more permissive.

I will follow up to set up `mcap doctor` to error on non-utf8 strings.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

