### PR TITLE
go: fix iteration edge case with overlapping chunks

### DIFF
--- a/go/mcap/indexed_message_iterator.go
+++ b/go/mcap/indexed_message_iterator.go
@@ -287,12 +287,16 @@ func (it *indexedMessageIterator) loadChunk(chunkIndex *ChunkIndex) error {
 	}
 	// produce message indexes for the newly decompressed chunk data.
 	var maxLogTime uint64
+	// Always assume we need to sort newly added message indexes unless there are no outstanding
+	// messages. Even though chunks indexes are in order of messageStartTime, the message indexes
+	// within them may overlap or be out of order (especially when time/topic filters are considered).
+	sortingRequired := true
 	// if there are no message indexes outstanding, truncate now.
 	if it.curMessageIndex == len(it.messageIndexes) {
 		it.curMessageIndex = 0
 		it.messageIndexes = it.messageIndexes[:0]
+		sortingRequired = false
 	}
-	sortingRequired := it.curMessageIndex != 0
 	startIdx := len(it.messageIndexes)
 	for offset := uint64(0); offset < bufSize; {
 		if bufSize < offset+1+8 {

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -834,7 +834,7 @@ func TestReadingMessageOrderWithOverlappingChunks(t *testing.T) {
 }
 
 // Test reading an MCAP with two overlapping chunks, with an AfterNanos filter that causes the
-// chunks to be read in reverse order
+// chunks to be read in reverse order.
 func TestReadingMessageOrderWithFilter(t *testing.T) {
 	buf := &bytes.Buffer{}
 	writer, err := NewWriter(buf, &WriterOptions{
@@ -878,7 +878,7 @@ func TestReadingMessageOrderWithFilter(t *testing.T) {
 	require.NoError(t, err)
 	info, err := reader.Info()
 	require.NoError(t, err)
-	require.Equal(t, 2, len(info.ChunkIndexes))
+	require.Len(t, info.ChunkIndexes, 2)
 
 	// We will filter out 1 message
 	expectedMsgCount := msgCount - 1

--- a/go/mcap/reader_test.go
+++ b/go/mcap/reader_test.go
@@ -839,7 +839,7 @@ func TestReadingMessageOrderWithFilter(t *testing.T) {
 	buf := &bytes.Buffer{}
 	writer, err := NewWriter(buf, &WriterOptions{
 		Chunked:     true,
-		ChunkSize:   72,
+		ChunkSize:   200,
 		Compression: CompressionLZ4,
 	})
 	require.NoError(t, err)
@@ -876,6 +876,9 @@ func TestReadingMessageOrderWithFilter(t *testing.T) {
 	// start reading the MCAP back
 	reader, err := NewReader(bytes.NewReader(buf.Bytes()))
 	require.NoError(t, err)
+	info, err := reader.Info()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(info.ChunkIndexes))
 
 	// We will filter out 1 message
 	expectedMsgCount := msgCount - 1


### PR DESCRIPTION
### Changelog
go: fixed a bug with InOrder message reading when using additional filters with overlapping chunks.

### Docs

None

### Description

Previously, during `loadChunk()`, `sortingRequired` would only be set to true if the new chunk internally had some messages out of order (or if some messages had been read already?). However, the messages also need to be sorted even if none have been read yet and each chunk is individually ordered, to properly handle overlapping chunks.

Fixed by starting with `sortingRequired = true` and only setting it to false if no message indexes are outstanding. It kinda looks like the existing logic was already supposed to work this way but I'm not totally sure.

Fixes #1374