### PR TITLE
go: bump version to 1.7.3

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.7.2"
+var Version = "v1.7.3"


### PR DESCRIPTION
### Changelog
- #1385 

### Docs

None

### Description

Bumping version to release #1385 