### PR TITLE
remove myself from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,11 +17,11 @@
 # Sanity check changes to the owners file for syntax and ordering
 /.github/CODEOWNERS @defunctzombie @jtbandes @james-rms
 
-/cpp @jtbandes @james-rms @indirectlylit
+/cpp @jtbandes @james-rms
 
 /go @james-rms
 
-/python @jtbandes @james-rms @indirectlylit
+/python @jtbandes @james-rms
 
 /rust @james-rms @bennetthardwick
 


### PR DESCRIPTION
### Changelog

none

### Docs

none

### Description

I haven't worked on this repo in a while. Happy to still lend a hand if someone wants to pull me in especially on Python, but removing myself from CODEOWNERS so I don't get automatically added as a reviewer anymore.


