### PR TITLE
chore(rust): delete unused time conversion utilities

### DIFF
--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -6,10 +6,7 @@
 //! [`Message`](crate::Message), [`Channel`](crate::Channel), and [`Schema`](crate::Schema),
 //! read from iterators like [`MesssageStream`](crate::MessageStream).
 
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use binrw::*;
 

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -9,7 +9,6 @@
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use binrw::*;
@@ -332,16 +331,6 @@ pub struct Channel {
     #[br(parse_with = parse_string_map)]
     #[bw(write_with = write_string_map)]
     pub metadata: BTreeMap<String, String>,
-}
-
-pub fn system_time_to_nanos(d: &SystemTime) -> u64 {
-    let ns = d.duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    assert!(ns <= u64::MAX as u128);
-    ns as u64
-}
-
-pub fn nanos_to_system_time(n: u64) -> SystemTime {
-    UNIX_EPOCH + Duration::from_nanos(n)
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, BinRead, BinWrite)]


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Deleted unused functions.