### PR TITLE
rust: configurable compression level and threads

### DIFF
--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -313,7 +313,7 @@ impl WriteOptions {
     }
 
     /// Specifies how many threads to use for compression. A value of zero
-    /// to disables multithreaded compression. The default number of threads
+    /// disables multithreaded compression. The default number of threads
     /// is equal to the number of physical CPUs.
     #[cfg(feature = "zstd")]
     pub fn compression_threads(mut self, compression_threads: u32) -> Self {

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -119,13 +119,8 @@ pub struct WriteOptions {
     calculate_data_section_crc: bool,
     calculate_summary_section_crc: bool,
     calculate_attachment_crcs: bool,
-
-    /// Compression level, or zero to use the default compression level.
     #[cfg(any(feature = "zstd", feature = "lz4"))]
     compression_level: u32,
-
-    /// Threads to use for compression, or zero to disable
-    /// multithreaded compression.
     #[cfg(feature = "zstd")]
     compression_threads: u32,
 }
@@ -306,6 +301,23 @@ impl WriteOptions {
     /// section](https://mcap.dev/spec#summary-section). This is on by default.
     pub fn repeat_schemas(mut self, repeat_schemas: bool) -> Self {
         self.repeat_schemas = repeat_schemas;
+        self
+    }
+
+    /// Specifies the compression level to use. A value of zero instructs the
+    /// compressor to use the default compression level.
+    #[cfg(any(feature = "zstd", feature = "lz4"))]
+    pub fn compression_level(mut self, compression_level: u32) -> Self {
+        self.compression_level = compression_level;
+        self
+    }
+
+    /// Specifies how many threads to use for compression. A value of zero
+    /// to disables multithreaded compression. The default number of threads
+    /// is equal to the number of physical CPUs.
+    #[cfg(feature = "zstd")]
+    pub fn compression_threads(mut self, compression_threads: u32) -> Self {
+        self.compression_threads = compression_threads;
         self
     }
 

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -126,7 +126,7 @@ pub struct WriteOptions {
 
     /// Threads to use for compression, or zero to disable
     /// multithreaded compression.
-    #[cfg(any(feature = "zstd", feature = "lz4"))]
+    #[cfg(feature = "zstd")]
     compression_threads: u32,
 }
 
@@ -156,7 +156,7 @@ impl Default for WriteOptions {
             calculate_attachment_crcs: true,
             #[cfg(any(feature = "zstd", feature = "lz4"))]
             compression_level: 0,
-            #[cfg(any(feature = "zstd", feature = "lz4"))]
+            #[cfg(feature = "zstd")]
             compression_threads: num_cpus::get_physical() as u32,
         }
     }
@@ -928,7 +928,7 @@ impl<W: Write + Seek> Writer<W> {
                     self.options.calculate_chunk_crcs,
                     #[cfg(any(feature = "zstd", feature = "lz4"))]
                     self.options.compression_level,
-                    #[cfg(any(feature = "zstd", feature = "lz4"))]
+                    #[cfg(feature = "zstd")]
                     self.options.compression_threads,
                 )?)
             }
@@ -1340,7 +1340,7 @@ impl<W: Write + Seek> ChunkWriter<W> {
         emit_message_indexes: bool,
         calculate_chunk_crcs: bool,
         #[cfg(any(feature = "zstd", feature = "lz4"))] compression_level: u32,
-        #[cfg(any(feature = "zstd", feature = "lz4"))] compression_threads: u32,
+        #[cfg(feature = "zstd")] compression_threads: u32,
     ) -> McapResult<Self> {
         // Relative to start of original stream.
         let chunk_offset = writer.stream_position()?;

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -119,10 +119,14 @@ pub struct WriteOptions {
     calculate_data_section_crc: bool,
     calculate_summary_section_crc: bool,
     calculate_attachment_crcs: bool,
+
     /// Compression level, or zero to use the default compression level.
+    #[cfg(any(feature = "zstd", feature = "lz4"))]
     compression_level: u32,
+
     /// Threads to use for compression, or zero to disable
     /// multithreaded compression.
+    #[cfg(any(feature = "zstd", feature = "lz4"))]
     compression_threads: u32,
 }
 
@@ -150,7 +154,9 @@ impl Default for WriteOptions {
             calculate_data_section_crc: true,
             calculate_summary_section_crc: true,
             calculate_attachment_crcs: true,
+            #[cfg(any(feature = "zstd", feature = "lz4"))]
             compression_level: 0,
+            #[cfg(any(feature = "zstd", feature = "lz4"))]
             compression_threads: num_cpus::get_physical() as u32,
         }
     }
@@ -920,7 +926,9 @@ impl<W: Write + Seek> Writer<W> {
                     std::mem::take(&mut self.chunk_mode),
                     self.options.emit_message_indexes,
                     self.options.calculate_chunk_crcs,
+                    #[cfg(any(feature = "zstd", feature = "lz4"))]
                     self.options.compression_level,
+                    #[cfg(any(feature = "zstd", feature = "lz4"))]
                     self.options.compression_threads,
                 )?)
             }
@@ -1331,8 +1339,8 @@ impl<W: Write + Seek> ChunkWriter<W> {
         mode: ChunkMode,
         emit_message_indexes: bool,
         calculate_chunk_crcs: bool,
-        compression_level: u32,
-        compression_threads: u32,
+        #[cfg(any(feature = "zstd", feature = "lz4"))] compression_level: u32,
+        #[cfg(any(feature = "zstd", feature = "lz4"))] compression_threads: u32,
     ) -> McapResult<Self> {
         // Relative to start of original stream.
         let chunk_offset = writer.stream_position()?;


### PR DESCRIPTION
### Changelog

This PR adds two new write options:
* `compression_level: u32` – compression level to use for zstd/lz4, or zero to use the default compression level.
* `compression_threads: u32` - number of threads to use for compression, or zero to disable multithreaded compression.

### Docs

None? Let me know if I need to update docs somewhere.

### Description

Prior to this PR, it wasn't possible to set the compression level; the default lz4 and zstd compression levels were used. Now, it's possible to set the lz4 and zstd compression levels.

Prior to this PR, non-wasm targets were forced to use multithreaded zstd compression ([reference](https://github.com/foxglove/mcap/blob/b404e42bd9ca6e9193ae994f7f3d752248ea8b06/rust/src/write.rs#L1368)). Now, it's possible to disable multithreaded compression, or to use a different number of compression threads.

lz4 supports multithreaded compression as of v1.10.0 (see [[1]](https://github.com/lz4/lz4/releases/tag/v1.10.0) and [[2]](https://github.com/lz4/lz4/pull/1336)), but this feature doesn't seem to be accessible from the [lz4](https://crates.io/crates/lz4) / [lz4-sys](https://crates.io/crates/lz4-sys) crates. For now, the `compression_level` option is ignored when using lz4 compression. Let me know if we should print a warning or fail.

I made these write options rather than parameterizing the [`Compression`](https://github.com/foxglove/mcap/blob/b404e42bd9ca6e9193ae994f7f3d752248ea8b06/rust/src/lib.rs#L158) enum variants, because these particular options are orthogonal to the compression algorithm, and because they're only applicable to writers.

