### PR TITLE
rust: bump crate version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
### Changelog

This PR bumps the Rust crate version from `0.18.0` to `0.19.0`

### Docs

None

### Description

Changes since 0.18.0:
* https://github.com/foxglove/mcap/pull/1394
* https://github.com/foxglove/mcap/pull/1391

For context, see https://github.com/foxglove/mcap/pull/1394#issuecomment-2968400124