### PR TITLE
typescript: support yielding unknown records from stream reader

### DIFF
--- a/typescript/core/src/McapStreamReader.test.ts
+++ b/typescript/core/src/McapStreamReader.test.ts
@@ -715,4 +715,69 @@ describe("McapStreamReader", () => {
     expect(streamReader.nextRecord()).toEqual({ ...makeMessage(5), type: "Message" });
     expect(streamReader.bytesRemaining()).toBe(0);
   });
+
+  describe("unknown records", () => {
+    const chunkedUnknownRecord = record(0x81 as Opcode, [5, 6, 7, 8]);
+
+    const fullMcap = new Uint8Array([
+      ...MCAP_MAGIC,
+      // custom op code
+      ...record(0x80 as Opcode, [1, 2, 3, 4]),
+      ...record(Opcode.CHUNK, [
+        ...uint64LE(0n), // start_time
+        ...uint64LE(0n), // end_time
+        ...uint64LE(BigInt(chunkedUnknownRecord.byteLength)), // decompressed size
+        ...uint32LE(crc32(chunkedUnknownRecord)), // decompressed crc32
+        ...string(""), // compression
+        ...uint64LE(BigInt(chunkedUnknownRecord.byteLength)),
+        ...chunkedUnknownRecord,
+      ]),
+      ...record(Opcode.FOOTER, [
+        ...uint64LE(0n), // summary start
+        ...uint64LE(0n), // summary offset start
+        ...uint32LE(0), // summary crc
+      ]),
+      ...MCAP_MAGIC,
+    ]);
+
+    it("skips unknown opcodes", () => {
+      const reader = new McapStreamReader();
+      reader.append(fullMcap);
+
+      expect(reader.nextRecord()).toEqual({
+        type: "Footer",
+        summaryStart: 0n,
+        summaryOffsetStart: 0n,
+        summaryCrc: 0,
+      });
+
+      expect(reader.nextRecord()).toBeUndefined();
+    });
+
+    it("yields unknown opcodes", () => {
+      const reader = new McapStreamReader({ includeUnknownRecords: true });
+      reader.append(fullMcap);
+
+      expect(reader.nextRecord()).toEqual({
+        type: "Unknown",
+        opcode: 0x80,
+        data: new Uint8Array([1, 2, 3, 4]),
+      });
+
+      expect(reader.nextRecord()).toEqual({
+        type: "Unknown",
+        opcode: 0x81,
+        data: new Uint8Array([5, 6, 7, 8]),
+      });
+
+      expect(reader.nextRecord()).toEqual({
+        type: "Footer",
+        summaryStart: 0n,
+        summaryOffsetStart: 0n,
+        summaryCrc: 0,
+      });
+
+      expect(reader.nextRecord()).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- typescript: add option to include unknown records in stream reader output, instead of skipping

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

We're currently skipping unknown records in the Typescript `McapStreamReader`. It would be great to be able to get access to those unknown records in order to implement the application extensions / user proposals section of the spec.

I'm not sure whether the default behaviour should be skipping (since Typescript makes you handle the `Unknown` record anyway), but I've left it as is for backwards compatibility.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

`McapStreamReader.nextRecord()` wouldn't yield unknown records
<!--before content goes here-->

</td><td>

Setting `includeUnknownRecords` as a reader arg will yield them
<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

