### PR TITLE
rust: support writing private records

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -111,7 +111,7 @@ pub enum McapError {
     #[error("Schema length ({header}) exceeds space in record ({available})")]
     BadSchemaLength { header: u32, available: u32 },
     #[error("Private records must have an opcode >= 0x80, got {opcode:#04x}")]
-    BadPrivateRecordOpcode { opcode: u8 },
+    PrivateRecordOpcodeIsReserved { opcode: u8 },
     #[error("Channel `{0}` has mulitple records that don't match.")]
     ConflictingChannels(String),
     #[error("Schema `{0}` has mulitple records that don't match.")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -110,8 +110,8 @@ pub enum McapError {
     BadChunkLength { header: u64, available: u64 },
     #[error("Schema length ({header}) exceeds space in record ({available})")]
     BadSchemaLength { header: u32, available: u32 },
-    #[error("Extension records must have an opcode >= 0x80, got {opcode:#04x}")]
-    BadExtensionOpcode { opcode: u8 },
+    #[error("Private records must have an opcode >= 0x80, got {opcode:#04x}")]
+    BadPrivateRecordOpcode { opcode: u8 },
     #[error("Channel `{0}` has mulitple records that don't match.")]
     ConflictingChannels(String),
     #[error("Schema `{0}` has mulitple records that don't match.")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -110,6 +110,8 @@ pub enum McapError {
     BadChunkLength { header: u64, available: u64 },
     #[error("Schema length ({header}) exceeds space in record ({available})")]
     BadSchemaLength { header: u32, available: u32 },
+    #[error("Extension records must have an opcode >= 0x80, got {opcode:#04x}")]
+    BadExtensionOpcode { opcode: u8 },
     #[error("Channel `{0}` has mulitple records that don't match.")]
     ConflictingChannels(String),
     #[error("Schema `{0}` has mulitple records that don't match.")]

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -736,12 +736,11 @@ impl<W: Write + Seek> Writer<W> {
         Ok(())
     }
 
-    /// Write a [`CustomRecord`].
+    /// Write an unknown record. If the record can be present in chunks then the `chunkable` flag
+    /// should be set to true.
     ///
-    /// If [`CustomRecord::chunkable`] and [`WriteOptions::use_chunks`] are set then this record
-    /// will be written to a chunk.
-    ///
-    /// If the record has an invalid opcode this method will panic.
+    /// Unknown records must have a non-reserved opcode. This method will panic if provided a
+    /// method with an invalid opcode.
     pub fn write_unknown_record(
         &mut self,
         opcode: u8,

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -2136,7 +2136,7 @@ mod tests {
 
         assert_eq!(
             e.to_string(),
-            "Extension records must have an opcode >= 0x80, got 0x01"
+            "Private records must have an opcode >= 0x80, got 0x01"
         );
     }
 }

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -35,7 +35,7 @@ enum WriteMode<W: Write + Seek> {
 
 #[derive(EnumSetType, Debug)]
 pub enum PrivateRecordOptions {
-    /// The private record can appear in chunks.
+    /// If set and chunking is enabled, the private record will be written into a chunk. Otherwise, the record will be written directly to the file.
     IncludeInChunks,
 }
 

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -732,12 +732,11 @@ impl<W: Write + Seek> Writer<W> {
         Ok(())
     }
 
-    /// Write an unknown record. If the record can be present in chunks then the `chunkable` flag
+    /// Write a private record. If the record can be present in chunks then the `chunkable` flag
     /// should be set to true.
     ///
-    /// Extension records must have a non-reserved opcode. This method will panic if provided a
-    /// method with an invalid opcode.
-    pub fn write_extension_record(
+    /// Private records must have an opcode >= 0x80.
+    pub fn write_private_record(
         &mut self,
         opcode: u8,
         data: &[u8],
@@ -2085,11 +2084,11 @@ mod tests {
             .expect("failed to construct writer");
 
         writer
-            .write_extension_record(0x81, b"this is in a chunk", true)
+            .write_private_record(0x81, b"this is in a chunk", true)
             .expect("failed to write");
 
         writer
-            .write_extension_record(0x82, b"this is not in a chunk", false)
+            .write_private_record(0x82, b"this is not in a chunk", false)
             .expect("failed to write");
 
         drop(writer);
@@ -2132,7 +2131,7 @@ mod tests {
             .expect("failed to construct writer");
 
         let e = writer
-            .write_extension_record(0x1, &[1, 2, 3, 4], true)
+            .write_private_record(0x1, &[1, 2, 3, 4], true)
             .expect_err("should return err");
 
         assert_eq!(

--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -743,7 +743,7 @@ impl<W: Write + Seek> Writer<W> {
         chunkable: bool,
     ) -> McapResult<()> {
         if opcode < 0x80 {
-            return Err(McapError::BadExtensionOpcode { opcode });
+            return Err(McapError::BadPrivateRecordOpcode { opcode });
         }
 
         let record = Record::Unknown {
@@ -2074,7 +2074,7 @@ mod tests {
     }
 
     #[test]
-    fn test_writes_custom_record_to_chunk() {
+    fn test_writes_private_record_to_chunk() {
         let mut file = vec![];
 
         let mut writer = WriteOptions::new()
@@ -2121,7 +2121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_extension_opcode_fails() {
+    fn test_invalid_private_record_opcode_fails() {
         let mut file = vec![];
 
         let mut writer = WriteOptions::new()


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- rust: support writing private records

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

This change adds support for a simple `write_private_record` method for writing user-defined private records as per the spec. Since private records may also appear in chunks the method has a boolean "chunkable" flag.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

users cannot write records with custom opcodes

</td><td>

users can write private records

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

