### PR TITLE
docs: clarify extension record wording

### DIFF
--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -105,7 +105,7 @@ The summary offset section aids random access reading.
 
 MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for private records. 0x00 is not a valid opcode.
 
-Private records are application-specific and not defined within the MCAP spec. Tools without explicit support for certain private records should skip them.
+Private records are application-specific and not defined within the MCAP spec.
 
 All MCAP records are serialized as follows:
 

--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -105,6 +105,8 @@ The summary offset section aids random access reading.
 
 MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for private records. 0x00 is not a valid opcode.
 
+Private records are application-specific and not defined within the MCAP spec. Tools without explicit support for certain private records should skip them.
+
 All MCAP records are serialized as follows:
 
     <record type><record content length><record content>

--- a/website/docs/spec/index.md
+++ b/website/docs/spec/index.md
@@ -103,7 +103,7 @@ The summary offset section aids random access reading.
 
 ## Records
 
-MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for application extensions and user proposals. 0x00 is not a valid opcode.
+MCAP files may contain a variety of records. Records are identified by a single-byte **opcode**. Record opcodes in the range 0x01-0x7F are reserved for future MCAP format usage. 0x80-0xFF are reserved for private records. 0x00 is not a valid opcode.
 
 All MCAP records are serialized as follows:
 
@@ -181,7 +181,7 @@ The message encoding and schema must match that of the Channel record correspond
 
 ### Chunk (op=0x06)
 
-A Chunk contains a batch of records. Readers should expect Schema, Channel, and Message records to be present in chunks, but future spec changes or user extensions may include others. The batch of records contained in a chunk may be compressed or uncompressed.
+A Chunk contains a batch of records. Readers should expect Schema, Channel, and Message records to be present in chunks, but future spec changes may include others. Private records may also be included. The batch of records contained in a chunk may be compressed or uncompressed.
 
 All messages in the chunk must reference channels recorded earlier in the file (in a previous chunk, earlier in the current chunk, or earlier in the data section).
 


### PR DESCRIPTION
### Description

The docs aren't super clear about what "user proposals", "user extensions" or "application extensions" are, and why the opcodes from 0x80 are reserved for this purpose.

I propose we change this to simply say "private records". There is some precedent for this around; PNG defines "private chunks", MP4 defines "private streams" or "private extensions", TIFF defines "private tags". Other formats mention "application" or "custom" data or extensions.
