### PR TITLE
rust: add record length limit option

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 

--- a/rust/examples/conformance_reader_async.rs
+++ b/rust/examples/conformance_reader_async.rs
@@ -8,8 +8,6 @@ use std::env;
 use std::process;
 use tokio::fs::File;
 
-use tokio;
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args: Vec<String> = env::args().collect();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -139,7 +139,7 @@ pub enum McapError {
     #[error("chunk size option exceeds usize max: `{0}`")]
     ChunkBufferTooLarge(u64),
     #[error("record with opcode {opcode:02x} length exceeds limit: `{len}`")]
-    RecordTooLong { opcode: u8, len: u64 },
+    RecordTooLarge { opcode: u8, len: u64 },
     #[error("chunk (de)compressed length exceeds limit: `{0}`")]
     ChunkTooLarge(u64),
     #[error("chunk start offset is out of file range: {0}")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -136,10 +136,12 @@ pub enum McapError {
     UnsupportedCompression(String),
     #[error("Error during decompression: `{0}`")]
     DecompressionError(String),
-    #[error("chunk buffer exceeds usize max: `{0}`")]
+    #[error("chunk size option exceeds usize max: `{0}`")]
     ChunkBufferTooLarge(u64),
-    #[error("length exceeds usize max: `{0}`")]
-    TooLong(u64),
+    #[error("record with opcode {opcode:02x} length exceeds limit: `{len}`")]
+    RecordTooLong { opcode: u8, len: u64 },
+    #[error("chunk (de)compressed length exceeds limit: `{0}`")]
+    ChunkTooLarge(u64),
     #[error("cannot write more than 65536 channels to one MCAP")]
     TooManyChannels,
     #[error("cannot write more than 65535 schemas to one MCAP")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -142,6 +142,8 @@ pub enum McapError {
     RecordTooLong { opcode: u8, len: u64 },
     #[error("chunk (de)compressed length exceeds limit: `{0}`")]
     ChunkTooLarge(u64),
+    #[error("chunk start offset is out of file range: {0}")]
+    BadChunkStartOffset(u64),
     #[error("cannot write more than 65536 channels to one MCAP")]
     TooManyChannels,
     #[error("cannot write more than 65535 schemas to one MCAP")]

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -422,7 +422,7 @@ impl ChunkIndex {
         );
         match res {
             Some(n) => Ok(n),
-            None => Err(McapError::TooLong(self.chunk_start_offset)),
+            None => Err(McapError::BadChunkStartOffset(self.chunk_start_offset)),
         }
     }
 }

--- a/rust/src/sans_io.rs
+++ b/rust/src/sans_io.rs
@@ -8,8 +8,6 @@ pub use indexed_reader::{IndexedReadEvent, IndexedReader, IndexedReaderOptions};
 pub use linear_reader::{LinearReadEvent, LinearReader, LinearReaderOptions};
 pub use summary_reader::{SummaryReadEvent, SummaryReader};
 
-use crate::{McapError, McapResult};
-
 #[cfg(feature = "lz4")]
 mod lz4;
 

--- a/rust/src/sans_io.rs
+++ b/rust/src/sans_io.rs
@@ -17,8 +17,8 @@ mod zstd;
 /// Utility function for checking u64 lengths from MCAP files.
 pub(crate) fn check_len(len: u64, limit: Option<usize>) -> Option<usize> {
     let len_as_usize: usize = len.try_into().ok()?;
-    if limit.map(|l| len_as_usize > l).unwrap_or(false) {
-        return None;
+    match limit {
+        Some(limit) if len_as_usize > limit => None,
+        _ => Some(len_as_usize),
     }
-    Some(len_as_usize)
 }

--- a/rust/src/sans_io.rs
+++ b/rust/src/sans_io.rs
@@ -8,8 +8,19 @@ pub use indexed_reader::{IndexedReadEvent, IndexedReader, IndexedReaderOptions};
 pub use linear_reader::{LinearReadEvent, LinearReader, LinearReaderOptions};
 pub use summary_reader::{SummaryReadEvent, SummaryReader};
 
+use crate::{McapError, McapResult};
+
 #[cfg(feature = "lz4")]
 mod lz4;
 
 #[cfg(feature = "zstd")]
 mod zstd;
+
+/// Utility function for checking u64 lengths from MCAP files.
+pub(crate) fn check_len(len: u64, limit: Option<usize>) -> Option<usize> {
+    let len_as_usize: usize = len.try_into().ok()?;
+    if limit.map(|l| len_as_usize > l).unwrap_or(false) {
+        return None;
+    }
+    Some(len_as_usize)
+}

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -266,7 +266,7 @@ impl IndexedReader {
             let msg_len = match check_len(msg_len, self.record_length_limit) {
                 Some(len) => len,
                 None => {
-                    return Some(Err(McapError::RecordTooLong {
+                    return Some(Err(McapError::RecordTooLarge {
                         opcode,
                         len: msg_len,
                     }))
@@ -514,7 +514,7 @@ fn index_messages(
         };
         let len = u64::from_le_bytes(len_buf);
         let len =
-            check_len(len, record_length_limit).ok_or(McapError::RecordTooLong { opcode, len })?;
+            check_len(len, record_length_limit).ok_or(McapError::RecordTooLarge { opcode, len })?;
         if buf.len() < len {
             return Err(McapError::UnexpectedEoc);
         }

--- a/rust/src/sans_io/linear_reader.rs
+++ b/rust/src/sans_io/linear_reader.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use super::decompressor::Decompressor;
 use crate::{
     records::{op, ChunkHeader},
+    sans_io::check_len,
     McapError, McapResult, MAGIC,
 };
 use binrw::BinReaderExt;
@@ -132,15 +133,19 @@ pub struct LinearReaderOptions {
     /// If true, the reader will yield entire chunk records. Otherwise, the reader will decompress
     /// and read into chunks, yielding the records inside.
     pub emit_chunks: bool,
-    // Enables chunk CRC validation. Ignored if `prevalidate_chunk_crcs: true`.
+    /// Enables chunk CRC validation. Ignored if `prevalidate_chunk_crcs: true`.
     pub validate_chunk_crcs: bool,
-    // Enables chunk CRC validation before yielding any messages from the chunk. Implies
-    // `validate_chunk_crcs: true`.
+    /// Enables chunk CRC validation before yielding any messages from the chunk. Implies
+    /// `validate_chunk_crcs: true`.
     pub prevalidate_chunk_crcs: bool,
-    // Enables data section CRC validation.
+    /// Enables data section CRC validation.
     pub validate_data_section_crc: bool,
-    // Enables summary section CRC validation.
+    /// Enables summary section CRC validation.
     pub validate_summary_section_crc: bool,
+    /// If Some(limit), the reader will return an error on any non-chunk record with length > `limit`.
+    /// If used in conjunction with `prevalidate_chunk_crcs`, the reader will return an error on any
+    /// chunk record where the compressed OR decompressed length are > `limit`.
+    pub record_length_limit: Option<usize>,
 }
 
 impl LinearReaderOptions {
@@ -428,12 +433,18 @@ impl LinearReader {
                     }
                     // For all other records, load the entire record into memory and yield to the
                     // caller.
-                    let len = check!(len_as_usize(len));
+                    let len = check!(check_len(len, self.options.record_length_limit)
+                        .ok_or(McapError::RecordTooLong { opcode, len }));
                     let data = &consume!(OPCODE_LEN_SIZE + len)[OPCODE_LEN_SIZE..];
                     return Some(Ok(LinearReadEvent::Record { data, opcode }));
                 }
                 CurrentlyReading::DataEnd { len, calculated } => {
-                    let len = check!(len_as_usize(len));
+                    let len = check!(check_len(len, self.options.record_length_limit).ok_or(
+                        McapError::RecordTooLong {
+                            opcode: op::DATA_END,
+                            len
+                        }
+                    ));
                     let data = consume!(len);
                     let rec: crate::records::DataEnd = check!(std::io::Cursor::new(data).read_le());
                     let saved = rec.data_section_crc;
@@ -452,7 +463,12 @@ impl LinearReader {
                     }));
                 }
                 CurrentlyReading::Footer { len, hasher } => {
-                    let len = check!(len_as_usize(len));
+                    let len = check!(check_len(len, self.options.record_length_limit).ok_or(
+                        McapError::RecordTooLong {
+                            opcode: op::FOOTER,
+                            len
+                        }
+                    ));
                     let data = consume!(len);
                     let footer: crate::records::Footer =
                         check!(std::io::Cursor::new(data).read_le());
@@ -488,9 +504,11 @@ impl LinearReader {
                         &mut self.decompressors,
                         &header.compression
                     ));
-                    let padding_after_compressed_data = check!(len_as_usize(
-                        len - (header_len as u64) - header.compressed_size
-                    ));
+                    let padding_after_compressed_data = check!(check_len(
+                        len - (header_len as u64) - header.compressed_size,
+                        self.options.record_length_limit
+                    )
+                    .ok_or(McapError::ChunkTooLarge(len)));
 
                     let state = ChunkState {
                         decompressor,
@@ -535,7 +553,11 @@ impl LinearReader {
                         .expect("chunk state should be set");
                     match &mut state.decompressor {
                         None => {
-                            let to_load = check!(len_as_usize(state.compressed_remaining));
+                            let to_load = check!(check_len(
+                                state.compressed_remaining,
+                                self.options.record_length_limit
+                            )
+                            .ok_or(McapError::ChunkTooLarge(state.compressed_remaining)));
                             let records = load!(to_load);
                             let calculated = crc32fast::hash(records);
                             let saved = state.crc;
@@ -548,7 +570,11 @@ impl LinearReader {
                             // decompress all available compressed data until there are no compressed
                             // bytes remaining. If not all of the compressed bytes are available in
                             // file_data, decompress! will return a Read event for more data.
-                            let uncompressed_len = check!(len_as_usize(state.uncompressed_len));
+                            let uncompressed_len = check!(check_len(
+                                state.uncompressed_len,
+                                self.options.record_length_limit
+                            )
+                            .ok_or(McapError::ChunkTooLarge(state.uncompressed_len)));
                             if self.decompressed_content.len() >= uncompressed_len {
                                 let calculated =
                                     crc32fast::hash(self.decompressed_content.unread());
@@ -576,9 +602,9 @@ impl LinearReader {
                             }
                             let opcode_len_buf = load!(OPCODE_LEN_SIZE);
                             let opcode = opcode_len_buf[0];
-                            let len = check!(len_as_usize(u64::from_le_bytes(
-                                opcode_len_buf[1..].try_into().unwrap(),
-                            )));
+                            let len = u64::from_le_bytes(opcode_len_buf[1..].try_into().unwrap());
+                            let len = check!(check_len(len, self.options.record_length_limit)
+                                .ok_or(McapError::RecordTooLong { opcode, len }));
                             let opcode_len_data = consume!(OPCODE_LEN_SIZE + len);
                             let data = &opcode_len_data[OPCODE_LEN_SIZE..];
                             if let Some(hasher) = state.uncompressed_data_hasher.as_mut() {
@@ -599,8 +625,11 @@ impl LinearReader {
                                 // `self.file_data`. This can happen when a compressor adds extra
                                 // bytes after its last frame. We need to treat this as "padding
                                 // after the chunk" and skip over it before reading the next record.
-                                state.padding_after_compressed_data +=
-                                    check!(len_as_usize(state.compressed_remaining));
+                                state.padding_after_compressed_data += check!(check_len(
+                                    state.compressed_remaining,
+                                    self.options.record_length_limit
+                                )
+                                .ok_or(McapError::ChunkTooLarge(state.compressed_remaining)));
                                 state.compressed_remaining = 0;
                                 self.currently_reading = PaddingAfterChunk;
                                 continue;
@@ -612,7 +641,9 @@ impl LinearReader {
                             let Some((&len_buf, _)) = rest.split_first_chunk() else {
                                 return Some(Err(McapError::UnexpectedEoc));
                             };
-                            let len = check!(len_as_usize(u64::from_le_bytes(len_buf)));
+                            let len = u64::from_le_bytes(len_buf);
+                            let len = check!(check_len(len, self.options.record_length_limit)
+                                .ok_or(McapError::RecordTooLong { opcode, len }));
                             let _ = decompress!(OPCODE_LEN_SIZE + len, state, decompressor);
                             self.decompressed_content.mark_read(OPCODE_LEN_SIZE);
                             let (start, end) = (
@@ -677,11 +708,6 @@ pub enum LinearReadEvent<'a> {
     ReadRequest(usize),
     /// A new record from the MCAP file. Use [`crate::parse_record`] to parse the record.
     Record { data: &'a [u8], opcode: u8 },
-}
-
-/// casts a 64-bit length value from an MCAP into a [`usize`].
-fn len_as_usize(len: u64) -> McapResult<usize> {
-    len.try_into().map_err(|_| McapError::TooLong(len))
 }
 
 /// casts a 64-bit length from an MCAP into a [`usize`], saturating to [`usize::MAX`] if too large.


### PR DESCRIPTION
### Changelog
- rust: add option to raise an error if a record is above a length limit, rather than potentially allocating too much memory.
### Docs

See docstrings.

### Description

Adds an option the sans-io reader library to limit the length of record yielded from the reader. This protects the user from corrupt data that might otherwise cause the reader to try to allocate huge amounts of address space.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

