### PR TITLE
typescript: bump core to 2.1.7

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bump the Typescript core package with the `McapStreamReader` unknown record fixes.