### PR TITLE
docs: unused import in python protobuf.md example

### DIFF
--- a/website/docs/guides/python/protobuf.md
+++ b/website/docs/guides/python/protobuf.md
@@ -11,8 +11,6 @@ To start writing Python code that reads and writes Protobuf data in MCAP, instal
 To read in Protobuf data from an MCAP file (`my_data.mcap`), use the high-level `reader` interface.
 
 ```python
-import sys
-
 from mcap_protobuf.reader import read_protobuf_messages
 
 def main():


### PR DESCRIPTION
### Changelog
None
### Docs
Diff

### Description
Title.

I got "unused import" when i copy-pasted the example, I assume it's not there for a reason? Feel free to close if deemed noise.


