### PR TITLE
Update reader.py to remove argparse dependency

### DIFF
--- a/python/examples/ros2/py_mcap_demo/py_mcap_demo/reader.py
+++ b/python/examples/ros2/py_mcap_demo/py_mcap_demo/reader.py
@@ -1,5 +1,4 @@
 """script that reads ROS2 messages from an MCAP bag using the rosbag2_py API."""
-import argparse
 
 import rosbag2_py
 from rclpy.serialization import deserialize_message
@@ -32,13 +31,7 @@ def read_messages(input_bag: str):
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "input", help="input bag path (folder or filepath) to read from"
-    )
-
-    args = parser.parse_args()
-    for topic, msg, timestamp in read_messages(args.input):
+    for topic, msg, timestamp in read_messages(input("Enter the path to your .mcap file here:"):
         print(f"{topic} ({type(msg).__name__}) [{timestamp}]: '{msg.data}'")
 
 


### PR DESCRIPTION
reader.py currently uses an unnecessary module and needlessly complicated and confusing syntax to get the path to the .mcap file. I have removed this dependency and made the code significantly more readable and user-friendly by using a simple input() command which tells the user what it wants and waits for an input, rather than using argparse and expecting the end user to understand what parameters should be passed where. The updated version is also significantly more compact.

### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

