### PR TITLE
rust: Validate magic before footer opcode

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/sans_io/summary_reader.rs
+++ b/rust/src/sans_io/summary_reader.rs
@@ -187,11 +187,11 @@ impl SummaryReader {
                         let footer_body = &self.footer_buf[1 + 8..FOOTER_RECORD_AND_END_MAGIC - 8];
                         let end_magic =
                             &self.footer_buf[FOOTER_RECORD_AND_END_MAGIC - 8..*loaded_bytes];
-                        if opcode != crate::records::op::FOOTER {
-                            return Err(McapError::BadFooter);
-                        }
                         if end_magic != MAGIC {
                             return Err(McapError::BadMagic);
+                        }
+                        if opcode != crate::records::op::FOOTER {
+                            return Err(McapError::BadFooter);
                         }
                         let mut cursor = std::io::Cursor::new(footer_body);
                         let footer = Footer::read_le(&mut cursor)?;
@@ -405,7 +405,7 @@ mod tests {
                     summary_loader.notify_seeked(pos);
                 }
                 Err(err) => {
-                    assert!(matches!(err, McapError::BadFooter));
+                    assert!(matches!(err, McapError::BadMagic));
                     failed = true;
                     break;
                 }


### PR DESCRIPTION
### Changelog
- rust: SummaryReader validates magic before footer opcode

### Docs
None

### Description
The SummaryReader currently returns `McapError::BadFooter` for a truncated file, but `McapError::BadMagic` is far more appropriate for identifying truncated files.

This is useful for incorporating the SummaryReader into the agent. See https://github.com/foxglove/data-platform/pull/1982 and specifically https://github.com/foxglove/data-platform/pull/1982/files#diff-14f4b5ab5c91cbb2ed0875adc6fa2362858bb2984513399610f07bec3aaf6624R38-R41.