### PR TITLE
cpp: Fix bugs related to message-less chunks (#1375)

### DIFF
--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/1.4.0"
+    requires = "benchmark/1.7.0", "mcap/1.4.1"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.4.0
+conan editable add ./mcap mcap/1.4.1
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/1.4.0
+conan editable add ./mcap mcap/1.4.1
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/1.4.0"
+    requires = "mcap/1.4.1"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/1.4.0",
+        "mcap/1.4.1",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "1.4.0"
+    version = "1.4.1"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1815,7 +1815,10 @@ IndexedMessageReader::IndexedMessageReader(
     }
     chunkIndexes = mcapReader_.chunkIndexes();
   }
-  if (chunkIndexes.size() == 0 || chunkIndexes[0].messageIndexLength == 0) {
+  if (chunkIndexes.size() == 0 ||
+      std::all_of(chunkIndexes.begin(), chunkIndexes.end(), [](const ChunkIndex& ci) {
+        return ci.messageIndexLength == 0;
+      })) {
     status_ = Status(StatusCode::NoMessageIndexesAvailable,
                      "cannot read MCAP in time order with no message indexes");
     return;

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -13,7 +13,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "1.4.0"
+#define MCAP_LIBRARY_VERSION "1.4.1"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/1.4.0", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/1.4.1", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -731,6 +731,7 @@ TEST_CASE("Read Order", "[reader][writer]") {
 
     mcap::McapWriter writer;
     mcap::McapWriterOptions opts("test");
+    opts.chunkSize = 512 * 1024;
     opts.compression = mcap::Compression::None;
     opts.forceCompression = true;
     writer.open(buffer, opts);
@@ -739,8 +740,10 @@ TEST_CASE("Read Order", "[reader][writer]") {
     mcap::Channel channel("topic", "messageEncoding", schema.id);
     writer.addChannel(channel);
 
+    // Write larger-than-chunk-size messages.
     mcap::Message msg;
-    std::vector<std::byte> data = {std::byte(1), std::byte(2), std::byte(3)};
+    std::vector<std::byte> data(1024 * 1024);
+    std::fill(data.begin(), data.end(), std::byte(0x42));
     WriteMsg(writer, channel.id, 0, 0, 0, data);
     WriteMsg(writer, channel.id, 2, 2, 2, data);
     WriteMsg(writer, channel.id, 1, 1, 1, data);


### PR DESCRIPTION
- cpp: Fix a few bugs related to message-less chunks

None

PR #1291 added an optimization, which caused the behavior reported in issue #1355. The intention of that change was to close a non-empty chunk before writing a message that would overflow the chunk size. It checks whether the chunk is non-empty _after_ writing `Channel` & `Schema` records to the chunk. Therefore, it's possible to write a chunk that contains no messages.

The writer has a small bug in the metadata that it writes into the chunk index record. The `currentChunkStart_` register is initialized as `MaxTime`, and only updated when a message is added to the chunk. But when writing a message-less chunk, we need to write the message start time as 0.

The indexed message reader has a small bug in the way it detects the presence of a message index. It only looks for a message index on the first chunk index record, instead of scanning all chunk index records. This is why the test case provided in #1355 fails: the first chunk contains only `Channel` & `Schema` records without messages, and therefore the first chunk index has no message index.

Fixes: #1355

### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

