### PR TITLE
ci: Add armv7 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,13 @@ jobs:
             env:
               CC: aarch64-linux-gnu-gcc
               CXX: aarch64-linux-gnu-g++
+          - os: linux
+            image: ubuntu-latest
+            arch: arm
+            setup: sudo apt-get update && sudo apt-get install -qq gcc-arm-linux-gnueabihf
+            env:
+              CC: arm-linux-gnueabihf-gcc
+              CXX: arm-linux-gnueabihf-g++
           - os: macos
             image: macos-latest
             arch: amd64


### PR DESCRIPTION
### Changelog
Added CI support for ARM 32-bit (arm-linux-gnueabihf) cross-compilation.

### Docs
None

### Description
This change extends the CI matrix to include a new build target for 32-bit ARM using `arm-linux-gnueabihf-gcc`. This is useful for testing compatibility with devices running 32-bit ARM Linux, such as Raspberry Pi models or embedded systems, and ensures build correctness across more deployment environments.

Manually validated by verifying package installation (`gcc-arm-linux-gnueabihf`) and confirming CI matrix executes successfully.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

CI did not test for 32-bit ARM targets.

</td><td>

CI includes a job with `arm-linux-gnueabihf-gcc` to build for 32-bit ARM.

</td></tr></table>

Fix #1416 
