### PR TITLE
Remove unused import of 'open' from README.md example

### DIFF
--- a/typescript/browser/README.md
+++ b/typescript/browser/README.md
@@ -12,7 +12,6 @@ The `@mcap/browser` package provides utilities for working with MCAP files in br
 import { loadDecompressHandlers } from "@mcap/support";
 import { BlobReadable } from "@mcap/browser";
 import { McapIndexedReader } from "@mcap/core";
-import { open } from "fs/promises";
 
 async function onInputOrDrop(event: InputEvent | DragEvent) {
   const file = event.dataTransfer.files[0];

--- a/typescript/support/README.md
+++ b/typescript/support/README.md
@@ -12,7 +12,6 @@ The `@mcap/support` package provides utilities for working with MCAP files that 
 import { loadDecompressHandlers } from "@mcap/support";
 import { BlobReadable } from "@mcap/browser";
 import { McapIndexedReader } from "@mcap/core";
-import { open } from "fs/promises";
 
 async function onInputOrDrop(event: InputEvent | DragEvent) {
   const file = event.dataTransfer.files[0];


### PR DESCRIPTION
### Changelog
Removed unused `import { open } from "fs/promises";` from the README.md example to improve clarity and avoid confusion in the browser-based usage demonstration.



### Docs

This PR updates the README.md file in the `@mcap/browser` and `@mcap/support`.



### Description
None