### PR TITLE
fix(readme): correct file input handling in browser example

### DIFF
--- a/typescript/browser/README.md
+++ b/typescript/browser/README.md
@@ -19,7 +19,7 @@ import { McapIndexedReader } from "@mcap/core";
  * For drag & drop, listen for "drop" events. (Note that you must also listen for "dragover" events
  * and call event.preventDefault(), to enable listening for drop events.)
  */
-async function onInputOrDrop(event: Event) {
+async function onChangeOrDrop(event: Event) {
   let file: File | undefined;
   if (event instanceof DragEvent) {
     file = event.dataTransfer?.files[0];

--- a/typescript/browser/README.md
+++ b/typescript/browser/README.md
@@ -13,22 +13,25 @@ import { loadDecompressHandlers } from "@mcap/support";
 import { BlobReadable } from "@mcap/browser";
 import { McapIndexedReader } from "@mcap/core";
 
-async function onInputOrDrop(event: InputEvent | DragEvent) {
+/**
+ * For <input type="file"/>, listen for "change" events.
+ *
+ * For drag & drop, listen for "drop" events. (Note that you must also listen for "dragover" events
+ * and call event.preventDefault(), to enable listening for drop events.)
+ */
+async function onInputOrDrop(event: Event) {
   let file: File | undefined;
-
-  if ("dataTransfer" in event && event.dataTransfer) {
-    // DragEvent
-    file = event.dataTransfer.files[0];
-  } else if ("target" in event && event.target) {
-    // InputEvent
-    file = (event.target as HTMLInputElement).files?.[0];
+  if (event instanceof DragEvent) {
+    file = event.dataTransfer?.files[0];
+    event.preventDefault();
+  } else if (event.target instanceof HTMLInputElement) {
+    file = event.target.files?.[0];
+  } else {
+    throw new Error(`Unexpected event type: ${event.type}`);
   }
-
   if (!file) {
-    console.error("No file found");
-    return;
+    throw new Error("No file selected");
   }
-
   const decompressHandlers = await loadDecompressHandlers();
   const reader = await McapIndexedReader.Initialize({
     readable: new BlobReadable(file),

--- a/typescript/browser/README.md
+++ b/typescript/browser/README.md
@@ -14,7 +14,21 @@ import { BlobReadable } from "@mcap/browser";
 import { McapIndexedReader } from "@mcap/core";
 
 async function onInputOrDrop(event: InputEvent | DragEvent) {
-  const file = event.dataTransfer.files[0];
+  let file: File | undefined;
+
+  if ("dataTransfer" in event && event.dataTransfer) {
+    // DragEvent
+    file = event.dataTransfer.files[0];
+  } else if ("target" in event && event.target) {
+    // InputEvent
+    file = (event.target as HTMLInputElement).files?.[0];
+  }
+
+  if (!file) {
+    console.error("No file found");
+    return;
+  }
+
   const decompressHandlers = await loadDecompressHandlers();
   const reader = await McapIndexedReader.Initialize({
     readable: new BlobReadable(file),

--- a/typescript/support/README.md
+++ b/typescript/support/README.md
@@ -19,7 +19,7 @@ import { McapIndexedReader } from "@mcap/core";
  * For drag & drop, listen for "drop" events. (Note that you must also listen for "dragover" events
  * and call event.preventDefault(), to enable listening for drop events.)
  */
-async function onInputOrDrop(event: Event) {
+async function onChangeOrDrop(event: Event) {
   let file: File | undefined;
   if (event instanceof DragEvent) {
     file = event.dataTransfer?.files[0];

--- a/typescript/support/README.md
+++ b/typescript/support/README.md
@@ -13,22 +13,25 @@ import { loadDecompressHandlers } from "@mcap/support";
 import { BlobReadable } from "@mcap/browser";
 import { McapIndexedReader } from "@mcap/core";
 
-async function onInputOrDrop(event: InputEvent | DragEvent) {
+/**
+ * For <input type="file"/>, listen for "change" events.
+ *
+ * For drag & drop, listen for "drop" events. (Note that you must also listen for "dragover" events
+ * and call event.preventDefault(), to enable listening for drop events.)
+ */
+async function onInputOrDrop(event: Event) {
   let file: File | undefined;
-
-  if ("dataTransfer" in event && event.dataTransfer) {
-    // DragEvent
-    file = event.dataTransfer.files[0];
-  } else if ("target" in event && event.target) {
-    // InputEvent
-    file = (event.target as HTMLInputElement).files?.[0];
+  if (event instanceof DragEvent) {
+    file = event.dataTransfer?.files[0];
+    event.preventDefault();
+  } else if (event.target instanceof HTMLInputElement) {
+    file = event.target.files?.[0];
+  } else {
+    throw new Error(`Unexpected event type: ${event.type}`);
   }
-
   if (!file) {
-    console.error("No file found");
-    return;
+    throw new Error("No file selected");
   }
-
   const decompressHandlers = await loadDecompressHandlers();
   const reader = await McapIndexedReader.Initialize({
     readable: new BlobReadable(file),

--- a/typescript/support/README.md
+++ b/typescript/support/README.md
@@ -14,7 +14,21 @@ import { BlobReadable } from "@mcap/browser";
 import { McapIndexedReader } from "@mcap/core";
 
 async function onInputOrDrop(event: InputEvent | DragEvent) {
-  const file = event.dataTransfer.files[0];
+  let file: File | undefined;
+
+  if ("dataTransfer" in event && event.dataTransfer) {
+    // DragEvent
+    file = event.dataTransfer.files[0];
+  } else if ("target" in event && event.target) {
+    // InputEvent
+    file = (event.target as HTMLInputElement).files?.[0];
+  }
+
+  if (!file) {
+    console.error("No file found");
+    return;
+  }
+
   const decompressHandlers = await loadDecompressHandlers();
   const reader = await McapIndexedReader.Initialize({
     readable: new BlobReadable(file),


### PR DESCRIPTION
### Changelog
Fix incorrect file extraction example in browser usage guide to handle InputEvent and DragEvent safely.

### Docs

This PR updates the README.md file in the `@mcap/browser` and `@mcap/support`.

### Description

The current README example under “Reading MCAP files in a browser” incorrectly uses:
```typescript
const file = event.dataTransfer.files[0];
```
while claiming to support both InputEvent and DragEvent. This will fail for InputEvent, as it does not have a dataTransfer property, leading to `undefined` or runtime errors.
This PR updates the example to correctly distinguish between DragEvent and InputEvent, ensuring safe and reliable file extraction for users following the guide.
This improves developer experience for those onboarding with `@mcap/browser` and `@mcap/support` by providing a copy-paste-safe, functional snippet in the documentation.
