### PR TITLE
cli: add more chunk info to "mcap info"

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -197,7 +197,6 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		fmt.Fprintf(buf, "chunks:\n")
 		fmt.Fprintf(buf, "\tmax uncompressed size: %s\n", humanBytes(largestChunkUncompressedSize))
 		fmt.Fprintf(buf, "\tmax compressed size: %s\n", humanBytes(largestChunkCompressedSize))
-			humanBytes(largestChunkUncompressedSize), humanBytes(largestChunkCompressedSize))
 		if hasOverlaps {
 			fmt.Fprintf(buf, "\toverlaps: [max concurrent: %d, decompressed: %s]\n",
 				maxActiveChunks, humanBytes(maxTotalUncompressedSize))

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -195,7 +195,8 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 			fmt.Fprintf(buf, "\n")
 		}
 		fmt.Fprintf(buf, "chunks:\n")
-		fmt.Fprintf(buf, "\tmax size: %s / %s\n",
+		fmt.Fprintf(buf, "\tmax uncompressed size: %s\n", humanBytes(largestChunkUncompressedSize))
+		fmt.Fprintf(buf, "\tmax compressed size: %s\n", humanBytes(largestChunkCompressedSize))
 			humanBytes(largestChunkUncompressedSize), humanBytes(largestChunkCompressedSize))
 		if hasOverlaps {
 			fmt.Fprintf(buf, "\toverlaps: [max concurrent: %d, decompressed: %s]\n",

--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -198,7 +198,7 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 		fmt.Fprintf(buf, "\tmax size: %s / %s\n",
 			humanBytes(largestChunkUncompressedSize), humanBytes(largestChunkCompressedSize))
 		if hasOverlaps {
-			fmt.Fprintf(buf, "\toverlaps: yes [max overlapping: %d, decompressed: %s]\n",
+			fmt.Fprintf(buf, "\toverlaps: [max concurrent: %d, decompressed: %s]\n",
 				maxActiveChunks, humanBytes(maxTotalUncompressedSize))
 		} else {
 			fmt.Fprintf(buf, "\toverlaps: no\n")


### PR DESCRIPTION
This adds information about max chunk size and presence of chunk overlaps to the mcap info output under a new "chunks" entry. When a file is unchunked, this information is omitted.

Also adds a --unchunked switch to `mcap compress`, which is useful for creating unchunked files for testing.