### PR TITLE
mcap CLI: Allow pulling latched topics to the start of the filtered segment

### DIFF
--- a/go/cli/mcap/cmd/filter.go
+++ b/go/cli/mcap/cmd/filter.go
@@ -20,6 +20,7 @@ type filterFlags struct {
 	output             string
 	includeTopics      []string
 	excludeTopics      []string
+	latchedTopics      []string
 	startSec           uint64
 	endSec             uint64
 	startNano          uint64
@@ -37,6 +38,7 @@ type filterOpts struct {
 	output             string
 	includeTopics      []regexp.Regexp
 	excludeTopics      []regexp.Regexp
+	latchedTopics      []regexp.Regexp
 	start              uint64
 	end                uint64
 	includeMetadata    bool
@@ -123,6 +125,13 @@ func buildFilterOptions(flags *filterFlags) (*filterOpts, error) {
 		return nil, err
 	}
 	opts.excludeTopics = excludeTopics
+
+	latchedTopics, err := compileMatchers(flags.latchedTopics)
+	if err != nil {
+		return nil, err
+	}
+	opts.latchedTopics = latchedTopics
+
 	opts.chunkSize = flags.chunkSize
 	return opts, nil
 }
@@ -274,6 +283,8 @@ func filter(
 	buf := make([]byte, 1024)
 	schemas := make(map[uint16]markableSchema)
 	channels := make(map[uint16]markableChannel)
+	mostRecentLatched := make(map[uint16]*mcap.Message)
+	handledLatched := false
 
 	for {
 		token, data, err := lexer.Next(buf)
@@ -317,6 +328,12 @@ func filter(
 			if err != nil {
 				return err
 			}
+			for i := range opts.latchedTopics {
+				matcher := opts.latchedTopics[i]
+				if matcher.MatchString(channel.Topic) {
+					mostRecentLatched[channel.ID] = nil
+				}
+			}
 			// if any topics match an includeTopic, add it.
 			for i := range opts.includeTopics {
 				matcher := opts.includeTopics[i]
@@ -346,11 +363,59 @@ func filter(
 			if err != nil {
 				return err
 			}
+			most_recent, ok := mostRecentLatched[message.ChannelID]
 			if message.LogTime < opts.start {
+
+				if ok {
+					if most_recent == nil || most_recent.LogTime < message.LogTime {
+						mostRecentLatched[message.ChannelID] = message
+						oldData := message.Data
+						mostRecentLatched[message.ChannelID].Data = make([]byte, len(message.Data))
+						copy(mostRecentLatched[message.ChannelID].Data, oldData)
+					}
+				}
 				continue
 			}
 			if message.LogTime >= opts.end {
 				continue
+			}
+			if !handledLatched {
+				handledLatched = true
+				// We have reached the start of the record, so here we need to add the latched topics
+				for _, mostRecent := range mostRecentLatched {
+					if mostRecent == nil {
+						continue
+					}
+					// We might still need to write the channel
+					channel, ok := channels[mostRecent.ChannelID]
+					if !ok {
+						continue
+					}
+					if !channel.written {
+						if channel.SchemaID != 0 {
+							schema, ok := schemas[channel.SchemaID]
+							if !ok {
+								return fmt.Errorf("encountered channel with topic %s with unknown schema ID %d", channel.Topic, channel.SchemaID)
+							}
+							if !schema.written {
+								if err := mcapWriter.WriteSchema(schema.Schema); err != nil {
+									return err
+								}
+								schemas[channel.SchemaID] = markableSchema{schema.Schema, true}
+							}
+						}
+						if err := mcapWriter.WriteChannel(channel.Channel); err != nil {
+							return err
+						}
+						channels[mostRecent.ChannelID] = markableChannel{channel.Channel, true}
+					}
+					mostRecent.LogTime = opts.start
+					mostRecent.PublishTime = opts.start
+					if err := mcapWriter.WriteMessage(mostRecent); err != nil {
+						return err
+					}
+					numMessages++
+				}
 			}
 			channel, ok := channels[message.ChannelID]
 			if !ok {
@@ -425,6 +490,12 @@ usage:
 			[]string{},
 			"messages with topic names matching this regex will be excluded, can be supplied multiple times",
 		)
+		latchedTopics := filterCmd.PersistentFlags().StringArrayP(
+			"latched-topic-regex",
+			"l",
+			[]string{},
+			"For included topics matching this regex, the most recent message previous to the start time will still be included, with its time adjusted to the start time of the output",
+		)
 		start := filterCmd.PersistentFlags().StringP(
 			"start",
 			"S",
@@ -485,6 +556,7 @@ usage:
 				output:             *output,
 				includeTopics:      *includeTopics,
 				excludeTopics:      *excludeTopics,
+				latchedTopics:      *latchedTopics,
 				start:              *start,
 				startSec:           *startSec,
 				startNano:          *startNano,


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
Add `--latched-topic-regex` option to `mcap filter`, which pulls the most recent message of each matching topic to the beginning of the filtered timespan.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
Description is added through the command line parser and available with `mcap filter -h`

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

In ROS and similar systems, it is common for certain topics like `/tf_static` to be latched, where they are published once (or infrequently) and expected to be available to subscribers that come later.  rosbags/mcaps without these messages without these messages can often be difficult to analyze or visualize due to the lack of critical messages.  For this reason, ROS1 had [a flag for rosbag recorder](https://github.com/ros/ros_comm/pull/1850) to repeat such messages when the rosbag recorder split the rosbag, and [a similar feature may be planned for ROS2](https://github.com/ros2/rosbag2/issues/1159).  It is convenient to also have such a feature when snipping a small time segment of a large mcap, to ensure that the filtered mcap still has the necessary information for analysis and visualization.

Other notes:
- I have not tried to optimize too much, as the assumption is that messages on latched topics are not too frequent. Performance may be quite bad if someone uses this flag on a large high volume topic.
- DDS and other communication systems may support things like higher depth queues of latched topics (transient_local) or latched topics from multiple publishers on the same topic.  Handling these cases is I believe not feasible in this tool, and the case of depth=1, single publisher is by far the most prevalent.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->
Tested with --start-secs specified and -l flag on:
- Nonexistent topic (no effect on final result)
- Topic with multiple messages (Only the most recent message before start time was pulled to the beginning of the filtered mcap, as expected
- /tf_static -> Pulled to beginning of the filtered mcap


