### PR TITLE
rust: Bump version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
### Changelog
- Use buffer size as record length limit

### Docs
None

### Description
Forgot to bump cargo version in #1427 