### PR TITLE
rust: fix clippy warnings

### DIFF
--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -664,7 +664,7 @@ impl Summary {
         &self,
         mcap: &[u8],
         index: &records::ChunkIndex,
-    ) -> McapResult<HashMap<Arc<Channel>, Vec<records::MessageIndexEntry>>> {
+    ) -> McapResult<HashMap<Arc<Channel<'_>>, Vec<records::MessageIndexEntry>>> {
         if index.message_index_offsets.is_empty() {
             // Message indexing is optional... should we be more descriptive here?
             return Err(McapError::BadIndex);
@@ -724,7 +724,7 @@ impl Summary {
         mcap: &'a [u8],
         index: &records::ChunkIndex,
         message: &records::MessageIndexEntry,
-    ) -> McapResult<Message> {
+    ) -> McapResult<Message<'_>> {
         // Get the chunk (as a header and its data) out of the file at the given offset.
         let end = (index.chunk_start_offset + index.chunk_length) as usize;
         if mcap.len() < end {

--- a/rust/src/sans_io/indexed_reader.rs
+++ b/rust/src/sans_io/indexed_reader.rs
@@ -238,7 +238,7 @@ impl IndexedReader {
 
     /// Returns the next event from the reader. Call this repeatedly and act on the resulting
     /// events in order to read messages from the MCAP.
-    pub fn next_event(&mut self) -> Option<McapResult<IndexedReadEvent>> {
+    pub fn next_event(&mut self) -> Option<McapResult<IndexedReadEvent<'_>>> {
         // If this reader is aware of messages that haven't been yielded yet, try to yield them.
         if self.cur_message_index < self.message_indexes.len() {
             let message_index = &self.message_indexes[self.cur_message_index];

--- a/rust/src/sans_io/linear_reader.rs
+++ b/rust/src/sans_io/linear_reader.rs
@@ -325,7 +325,7 @@ impl LinearReader {
     }
 
     /// Yields the next event the caller should take to progress through the file.
-    pub fn next_event(&mut self) -> Option<McapResult<LinearReadEvent>> {
+    pub fn next_event(&mut self) -> Option<McapResult<LinearReadEvent<'_>>> {
         if self.at_eof {
             // at EOF. If the reader is not expecting end magic, and it isn't in the middle of a
             // record or chunk, this is OK.


### PR DESCRIPTION
Fixes some clippy warnings for the new 1.89 release.