### PR TITLE
Rust: Avoid panicking in Drop impl in writer

### DIFF
--- a/rust/src/write.rs
+++ b/rust/src/write.rs
@@ -1130,7 +1130,7 @@ impl<W: Write + Seek> Writer<W> {
 
 impl<W: Write + Seek> Drop for Writer<W> {
     fn drop(&mut self) {
-        self.finish().unwrap();
+        let _ = self.finish();
     }
 }
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- Avoids unwrapping / panicking in the `Drop` impl of the `Writer<W>` type and instead swallows the error. 

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Hey all, Jeremy Steward from https://tangramvision.com here.

Panicking on an unwrap is generally bad — it prevents users from being able to handle errors gracefully or print their own messaging around the errors themselves. `.unwrap` can be fine if panicking is better than the alternative (e.g. doing something unsafe), but from a library maintainers perspective you really don't want to unwrap ever. From an application perspective, you might choose to unwrap, but it's annoying if a library unwraps for you, because you might have been able to handle that error by using the library differently.

The above is what I would describe as a very broad and general principle, and of course there are exceptions. This MR focuses on that principle but in particular around the `Writer`'s `Drop` impl. Panicking on `Drop` is the worst, because you can't do anything about it and it is not always clear when that code gets called (pinning down the exact scope exit for `Drop` to execute especially across threads / async are a special hell 🙃). Panicking on this Writer specifically is the worst, because this panic is always forced. For example, if you called:

```
if let Err(err) = writer.finish() { 
    // handle error
}

std::mem::drop(writer);
```

The implementation of `finish` could throw that error multiple times, especially if there was some problem with writing the last chunk ([line 1029](https://docs.rs/mcap/latest/src/mcap/write.rs.html#1022-1050)). So you handle the error, but then the code immediately panics on you despite your best efforts. ☠️ 

The suggested change is just to swallow the error in the `Drop` call. There is maybe a larger change that would suggest that `finish` should have a signature of `fn finish(self) -> Result<(Summary, W), (Self, mcap::McapError)>` instead, so that you always finish writing the MCAP and immediately drop it, returning the writer as well. However, that would be an API breaking change, and would be packing a lot more into the semantics of that `Result` type, since on failure you would probably want to get `Self` back to try and fix the issue.

The compromise then is to not make any breaking changes and just avoid panicking on `Drop`. If an error is detected when you drop the type, you obviously didn't care to handle it independently, and so the natural thing is to just ignore that error. Yes this would lead to silent failures in writing out MCAPs that you drop, but you have the tools to avoid that if you choose to do so (`finish` and `into_inner` are publicly exported).

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

There isn't really any testing to be done, since the fix is to just swallow the error. I can imagine a scenario where you want to test this, you probably want to write to a `std::io::Cursor<&mut [u8]>`, to simulate running out of space in the buffer (which seems like the most reasonable way to trigger this in practice). You would have to leave just enough space in that slice to start writing, but then fail on `finish`. I didn't do this because it seems excessive for the scope of the fix.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

