### PR TITLE
rust: do not panic on next write if chunk closure fails

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 license = "MIT"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -152,6 +152,8 @@ pub enum McapError {
     TooManySchemas,
     #[error("indexed reader received chunk data with unexpected offset or length")]
     UnexpectedChunkDataInserted,
+    #[error("attempted another write after a write method failed")]
+    AttemptedWriteAfterFailure,
 }
 
 pub type McapResult<T> = Result<T, McapError>;


### PR DESCRIPTION
### Changelog
- rust: removed the condition for a panic if a subsequent write failed.
### Docs

None.
<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Previously, if we attempted to close a chunk and this failed, the writer would be left in an invalid state, with `self.writer = None`. This is no longer the case. Instead we return an explicit error value for cases where we can no longer write because the underlying file is invalid in an (unknown) state.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

