### PR TITLE
cpp: Document the mcap vcpkg port

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ MCAP is a modular container format and logging library for pub/sub messages with
 
 MCAP libraries are provided in the following languages. For guidance on each language, see its corresponding README:
 
-| Language              | Readme                 | API docs                                                        | Package name | Version                                                                              |
-| --------------------- | ---------------------- | --------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------ |
-| C++                   | [readme](./cpp)        | [API docs](https://mcap.dev/docs/cpp)                           | `mcap`       | [![](https://shields.io/conan/v/mcap)](https://conan.io/center/mcap)                 |
-| Go                    | [readme](./go/mcap)    | [API docs](https://pkg.go.dev/github.com/foxglove/mcap/go/mcap) |              | see [releases](https://github.com/foxglove/mcap/releases)                            |
-| Python                | [readme](./python)     | [API docs](https://mcap.dev/docs/python)                        | `mcap`       | [![](https://shields.io/pypi/v/mcap)](https://pypi.org/project/mcap/)                |
-| JavaScript/TypeScript | [readme](./typescript) | [API docs](https://mcap.dev/docs/typescript)                    | `@mcap/core` | [![](https://shields.io/npm/v/@mcap/core)](https://www.npmjs.com/package/@mcap/core) |
-| Swift                 | [readme](./swift)      | [API docs](https://mcap.dev/docs/swift/documentation/mcap)      |              | see [releases](https://github.com/foxglove/mcap/releases)                            |
-| Rust                  | [readme](./rust)       | [API docs](https://mcap.dev/docs/rust/mcap)                     | `mcap`       | [![](https://shields.io/crates/v/mcap)](https://crates.io/crates/mcap)               |
+| Language              | Readme                 | API docs                                                        | Package name | Version                                                                                                                                           |
+| --------------------- | ---------------------- | --------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C++                   | [readme](./cpp)        | [API docs](https://mcap.dev/docs/cpp)                           | `mcap`       | [![](https://shields.io/conan/v/mcap)](https://conan.io/center/mcap) [![](https://img.shields.io/vcpkg/v/mcap)](https://vcpkg.io/en/package/mcap) |
+| Go                    | [readme](./go/mcap)    | [API docs](https://pkg.go.dev/github.com/foxglove/mcap/go/mcap) |              | see [releases](https://github.com/foxglove/mcap/releases)                                                                                         |
+| Python                | [readme](./python)     | [API docs](https://mcap.dev/docs/python)                        | `mcap`       | [![](https://shields.io/pypi/v/mcap)](https://pypi.org/project/mcap/)                                                                             |
+| JavaScript/TypeScript | [readme](./typescript) | [API docs](https://mcap.dev/docs/typescript)                    | `@mcap/core` | [![](https://shields.io/npm/v/@mcap/core)](https://www.npmjs.com/package/@mcap/core)                                                              |
+| Swift                 | [readme](./swift)      | [API docs](https://mcap.dev/docs/swift/documentation/mcap)      |              | see [releases](https://github.com/foxglove/mcap/releases)                                                                                         |
+| Rust                  | [readme](./rust)       | [API docs](https://mcap.dev/docs/rust/mcap)                     | `mcap`       | [![](https://shields.io/crates/v/mcap)](https://crates.io/crates/mcap)                                                                            |
 
 To run the conformance tests, you will need to use [Git LFS](https://git-lfs.github.com/),
 which is used to store the test logs under `tests/conformance/data`.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -92,6 +92,11 @@ To simplify installation of dependencies, the [Conan](https://conan.io/) package
 manager can be used with the included
 [conanfile.py](https://github.com/foxglove/mcap/blob/main/cpp/mcap/conanfile.py).
 
+### vcpkg
+
+To simplify installation of dependencies, the [vcpkg](https://vcpkg.io/en/) package
+manager can be used via the [`mcap` port](https://vcpkg.io/en/package/mcap).
+
 ### CMake
 
 For using MCAP with CMake, the third-party [olympus-robotics/mcap_builder](https://github.com/olympus-robotics/mcap_builder) repository provides a helpful wrapper.

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -104,6 +104,7 @@ words:
   - typedoc
   - unchunked
   - unindexed
+  - vcpkg
   - velodyne
   - waabi
   - Wayve


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
Add a brief blurb and badge referencing the new vcpkg port for mcap in the `README.md`.

### Docs
<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
None

### Description
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
A vcpkg port is in the works in microsoft/vcpkg#47084.  This change calls out that port in the `README.md` so that new users are aware that it exists.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

### Draft TODOs

- [x] Wait for microsoft/vcpkg#47084 to land.
