### PR TITLE
docs: Add detailed, cited documentation for @mcap/core

### DIFF
--- a/FRONTEND_GUIDE.md
+++ b/FRONTEND_GUIDE.md
@@ -1,0 +1,94 @@
+# フロントエンドエンジニア向け開発ガイド
+
+このドキュメントは、MCAPプロジェクトに貢献するフロントエンドエンジニア向けのガイドです。
+プロジェクトの概要、技術スタック、開発の進め方について説明します。
+
+## 1. プロジェクト概要
+
+MCAPは、Pub/Sub（出版/購読型）メッセージを記録・再生するためのコンテナフォーマットです。主にロボティクスの分野で利用されますが、汎用的なフォーマットであり、Webベースの可視化ツールなどでも活用されています。
+
+フロントエンド開発者は、主に以下の2つの領域に関わることになります。
+
+1.  **TypeScriptライブラリ**: ブラウザやNode.js環境でMCAPファイルを読み書きするためのライブラリ群です。
+2.  **ドキュメンテーションサイト**: Docusaurusで構築された公式サイト（[mcap.dev](https://mcap.dev/)）の開発とメンテナンス。
+
+## 2. 技術スタック
+
+本リポジトリはYarn Workspacesを利用したモノリポ構成になっています。
+
+### TypeScriptライブラリ (`typescript/`)
+
+-   **@mcap/core**: MCAPファイルの読み書きに関する低レベルな機能を提供するコアライブラリ。
+-   **@mcap/browser**: ブラウザ環境で動作させるためのラッパー。
+-   **@mcap/nodejs**: Node.js環境で動作させるためのラッパー。
+-   **@mcap/support**: 有名な圧縮形式などをサポートするためのライブラリ。
+-   **TypeScript**: 主要な開発言語です。
+-   **Jest**: テストフレームワークとして利用します。
+
+### ドキュメンテーションサイト (`website/`)
+
+-   **Docusaurus**: 静的サイトジェネレーター。
+-   **React**: UIライブラリ。
+-   **TypeScript**: DocusaurusのコンポーネントやページはTypeScriptで記述されています。
+
+## 3. ディレクトリ構成
+
+フロントエンドエンジニアが主に関わるディレクトリは以下の通りです。
+
+```
+.
+├── typescript/      # TypeScriptライブラリのソースコード
+│   ├── core/        # @mcap/core パッケージ
+│   ├── browser/     # @mcap/browser パッケージ
+│   ├── nodejs/      # @mcap/nodejs パッケージ
+│   └── ...
+├── website/         # ドキュメンテーションサイトのソースコード
+│   ├── src/
+│   │   ├── pages/   # ページコンポーネント
+│   │   └── css/
+│   └── docs/        # Markdownで記述されたドキュメント
+└── package.json     # ルートのpackage.json (Yarn Workspacesの設定)
+```
+
+## 4. 開発環境のセットアップ
+
+### 前提条件
+
+-   Node.js
+-   Yarn
+
+### 手順
+
+1.  **リポジトリをクローンします。**
+    ```bash
+    git clone https://github.com/foxglove/mcap.git
+    cd mcap
+    ```
+
+2.  **依存関係をインストールします。**
+    リポジトリのルートで以下のコマンドを実行すると、すべてのワークスペース（TypeScriptライブラリ、Webサイトなど）の依存関係がインストールされます。
+    ```bash
+    yarn install
+    ```
+
+3.  **開発サーバーを起動します。**
+    ドキュメンテーションサイトのローカル開発サーバーを起動するには、以下のコマンドを実行します。
+    ```bash
+    yarn start
+    # もしくは yarn workspace website start
+    ```
+    ブラウザで `http://localhost:3000` が開きます。ファイルの変更はライブで反映されます。
+
+4.  **TypeScriptライブラリをビルドします。**
+    TypeScriptライブラリに変更を加えた場合は、以下のコマンドでビルドできます。
+    ```bash
+    yarn typescript:build
+    ```
+
+## 5. テスト
+
+TypeScriptライブラリのテストはJestで書かれています。以下のコマンドで、すべてのTypeScript関連のテストを実行できます。
+
+```bash
+yarn typescript:test
+```

--- a/typescript/core/MCAP_CORE_GUIDE.md
+++ b/typescript/core/MCAP_CORE_GUIDE.md
@@ -1,0 +1,246 @@
+# `@mcap/core` 詳細ガイド
+
+`@mcap/core`は、TypeScript環境でMCAPファイルを低レベルで操作するためのライブラリです。MCAPファイルの書き込み、ストリーミング読み込み、インデックスを利用した効率的な読み込みの3つの主要機能を提供します。
+
+このドキュメントでは、それぞれの機能について、その目的と具体的な使用方法を解説します。
+
+## 主な機能
+
+-   **`McapWriter`**: MCAPファイルをゼロから構築するためのクラスです。スキーマ、チャネル、メッセージなどを順次書き込み、最終的にインデックスを含んだ完全なMCAPファイルを生成します。
+-   **`McapStreamReader`**: ネットワーク経由のデータなど、データ全体が一度に利用できないストリーミング形式のMCAPを読み込むためのクラスです。受け取ったデータを逐次解析します。
+-   **`McapIndexedReader`**: ファイルシステム上のファイルなど、ランダムアクセスが可能なMCAPファイルを効率的に読み込むためのクラスです。最初にファイル末尾のインデックス情報を読み込むことで、特定のメッセージに高速にアクセスできます。
+
+---
+
+*このガイドの以降のセクションでは、各クラスの具体的な使い方をコード例と共に詳述します。*
+
+## `McapWriter` を使用したファイルの書き込み
+
+`McapWriter` は、MCAPファイルを生成するためのクラスです。`IWritable` インターフェースを満たす書き込み可能なオブジェクト（例：Node.jsの`fs.WriteStream`や自作のバッファクラス）を渡して使います。
+
+### 主なステップ
+
+1.  **`McapWriter`インスタンスの作成**: 書き込み先となる`writable`オブジェクトを指定します。
+2.  **`start()`**: ファイルのヘッダー情報を書き込み、書き込み処理を開始します。
+3.  **`registerSchema()`**: メッセージの構造を定義するスキーマを登録し、`schemaId` を取得します。
+4.  **`registerChannel()`**: メッセージが属するチャンネル（トピックやエンコーディング情報など）を登録し、`channelId` を取得します。
+5.  **`addMessage()`**: 実際のメッセージデータを、対応する`channelId`と共に書き込みます。
+6.  **`end()`**: すべてのメッセージの書き込みが終わったら、フッターやサマリー情報（各種インデックスなど）を書き込み、ファイルを完成させます。
+
+### コード例
+
+以下の例は、インメモリのバッファに簡単なMCAPファイルを書き込む方法を示しています。
+
+```typescript
+import { McapWriter } from "@mcap/core";
+import { IWritable } from "@mcap/core";
+
+// 1. IWritableインターフェースを実装した書き込み先クラスを定義
+class MemoryWriter implements IWritable {
+  buffer: Uint8Array = new Uint8Array();
+
+  position(): bigint {
+    return BigInt(this.buffer.length);
+  }
+
+  async write(data: Uint8Array): Promise<void> {
+    const newBuffer = new Uint8Array(this.buffer.length + data.length);
+    newBuffer.set(this.buffer);
+    newBuffer.set(data, this.buffer.length);
+    this.buffer = newBuffer;
+  }
+}
+
+async function writeExample() {
+  const memoryWriter = new MemoryWriter();
+
+  // 2. McapWriterのインスタンスを作成
+  const writer = new McapWriter({ writable: memoryWriter });
+
+  // 3. ヘッダーを書き込み、ライブラリ情報などを指定
+  await writer.start({
+    profile: "",
+    library: "mcap-core-example",
+  });
+
+  // 4. スキーマを登録
+  const schemaId = await writer.registerSchema({
+    name: "Example",
+    encoding: "json",
+    data: new TextEncoder().encode(JSON.stringify({ type: "object" })),
+  });
+
+  // 5. チャンネルを登録
+  const channelId = await writer.registerChannel({
+    schemaId,
+    topic: "/example",
+    messageEncoding: "json",
+    metadata: new Map(),
+  });
+
+  const textEncoder = new TextEncoder();
+
+  // 6. メッセージを追加
+  await writer.addMessage({
+    channelId,
+    sequence: 1,
+    logTime: 100n,
+    publishTime: 100n,
+    data: textEncoder.encode(JSON.stringify({ greeting: "hello" })),
+  });
+
+  await writer.addMessage({
+    channelId,
+    sequence: 2,
+    logTime: 101n,
+    publishTime: 101n,
+    data: textEncoder.encode(JSON.stringify({ greeting: "world" })),
+  });
+
+  // 7. フッターとインデックスを書き込み、ファイルを完成させる
+  await writer.end();
+
+  console.log(`MCAP file written to buffer, size: ${memoryWriter.buffer.length} bytes`);
+  // memoryWriter.buffer にMCAPファイルのバイナリデータが格納されている
+}
+
+writeExample();
+```
+
+## `McapStreamReader` を使用したストリーミング読み込み
+
+`McapStreamReader` は、データが断片的に到着するようなストリーミング環境でMCAPを読み込むためのクラスです。例えば、ネットワーク越しに受信したデータや、大きなファイルを少しずつ読み込む場合に使用します。
+
+### 主なステップ
+
+1.  **`McapStreamReader`インスタンスの作成**: 必要に応じて、解凍ハンドラなどのオプションを指定します。
+2.  **`append()`**: 新しいデータチャンク（`Uint8Array`）が到着するたびに、このメソッドを呼び出してリーダーの内部バッファに追加します。
+3.  **`nextRecord()`**: `append()`を呼び出した後、このメソッドをループで呼び出します。解析可能なレコードがバッファにあれば、それを返します。レコードがなければ `undefined` を返します。
+
+### コード例
+
+以下の例は、MCAPファイルのバイナリデータ（例えば、前の`McapWriter`の例で生成したもの）を、小さなチャンクに分割してストリームリーダーに供給する方法を示しています。
+
+```typescript
+import { McapStreamReader, McapTypes } from "@mcap/core";
+
+function readStreamExample(mcapBuffer: Uint8Array) {
+  // 1. McapStreamReaderのインスタンスを作成
+  const reader = new McapStreamReader();
+
+  let bytesRead = 0;
+  const chunkSize = 10;
+
+  // 2. データを小さなチャンクに分割して、順次リーダーに供給
+  while (bytesRead < mcapBuffer.length) {
+    const chunk = mcapBuffer.subarray(bytesRead, bytesRead + chunkSize);
+    reader.append(chunk);
+    bytesRead += chunk.length;
+
+    console.log(`Appended ${chunk.length} bytes to the stream reader.`);
+
+    // 3. レコードが解析可能になるまでnextRecord()を呼び出す
+    let record: McapTypes.TypedMcapRecord | undefined;
+    while ((record = reader.nextRecord())) {
+      console.log(`Read record: ${record.type}`);
+      if (record.type === "Message") {
+        // 必要であれば、メッセージのペイロードをデコード
+        const messageData = new TextDecoder().decode(record.data);
+        console.log(`  Message content: ${messageData}`);
+      }
+    }
+  }
+
+  console.log("Finished reading stream.");
+  // reader.done() が true になる
+}
+
+// McapWriterの例で生成したmcapBufferを渡すことを想定
+// readStreamExample(memoryWriter.buffer);
+```
+
+## `McapIndexedReader` を使用したインデックス読み込み
+
+`McapIndexedReader` は、ファイル全体にランダムアクセス可能な場合に、MCAPファイルを効率的に読み込むためのクラスです。最初にファイルのインデックス情報を読み込むため、ファイル全体をスキャンすることなく、特定のトピックや時間範囲のメッセージに高速にアクセスできます。
+
+`IReadable` インターフェース（`size()`と`read()`メソッドを持つ）を実装したオブジェクトを必要とします。
+
+### 主なステップ
+
+1.  **`McapIndexedReader.Initialize()`**: `IReadable`オブジェクトを渡して、非同期でリーダーを初期化します。この静的メソッドは、ファイルのヘッダー、フッター、そしてサマリー（インデックス）部分を読み込み、リーダーインスタンスを返します。
+2.  **`readMessages()`**: メッセージを読み込むための非同期ジェネレータメソッドを呼び出します。オプションで`topics`、`startTime`、`endTime`を指定して、結果をフィルタリングできます。
+3.  **`for-await-of`ループ**: 非同期ジェネレータからメッセージを一つずつ受け取って処理します。
+
+### コード例
+
+以下の例は、`McapWriter`の例で生成したMCAPファイルのバッファを、`IReadable`インターフェースを介してインデックスリーダーで読み込む方法を示しています。
+
+```typescript
+import { McapIndexedReader } from "@mcap/core";
+import { IReadable, McapTypes } from "@mcap/core";
+
+// 1. IReadableインターフェースを実装した読み込み元クラスを定義
+class MemoryReader implements IReadable {
+  constructor(private buffer: Uint8Array) {}
+
+  async size(): Promise<bigint> {
+    return BigInt(this.buffer.length);
+  }
+
+  async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+    return this.buffer.subarray(Number(offset), Number(offset + size));
+  }
+}
+
+
+async function readIndexedExample(mcapBuffer: Uint8Array) {
+  const memoryReader = new MemoryReader(mcapBuffer);
+
+  // 2. 静的メソッドでリーダーを初期化
+  const reader = await McapIndexedReader.Initialize({ readable: memoryReader });
+
+  // 3. 全てのメッセージを読み込んで表示
+  console.log("Reading all messages:");
+  for await (const message of reader.readMessages()) {
+    console.log(
+      `  Message on topic ${reader.channelsById.get(message.channelId)!.topic}:`,
+      JSON.parse(new TextDecoder().decode(message.data))
+    );
+  }
+
+  // 4. 特定のトピックのメッセージをフィルタリングして読み込み
+  console.log("\nReading messages on topic '/example':");
+  for await (const message of reader.readMessages({ topics: ["/example"] })) {
+     console.log(
+      `  Message on topic ${reader.channelsById.get(message.channelId)!.topic}:`,
+      JSON.parse(new TextDecoder().decode(message.data))
+    );
+  }
+}
+
+// McapWriterの例で生成したmcapBufferを渡すことを想定
+// readIndexedExample(memoryWriter.buffer);
+```
+
+## 補助的な型と定数
+
+`@mcap/core`は、主要なクラスに加えて、便利な型定義と定数をエクスポートしています。
+
+-   **`McapTypes`**:
+    `McapTypes.TypedMcapRecord` は、MCAPファイル内に存在しうるすべてのレコード（`Header`, `Channel`, `Message`, `Chunk`など）の型を含む共用体型です。また、`McapTypes.Channel` や `McapTypes.Message` のように、個別のレコード型にアクセスすることもできます。リーダーから返されるレコードの型を扱う際に便利です。
+
+-   **`McapConstants`**:
+    MCAP仕様で定義されている定数を含みます。例えば、`McapConstants.Opcode.MESSAGE` のように、各レコードタイプに対応するオペコードにアクセスできます。低レベルな処理やデバッグ時に役立ちます。
+
+```typescript
+import { McapTypes, McapConstants } from "@mcap/core";
+
+function printRecordInfo(record: McapTypes.TypedMcapRecord) {
+  if (record.type === "Message") {
+    // recordは Message 型として扱える
+    console.log(`Message record found on channel ${record.channelId}`);
+  } else if (record.type === "Header") {
+    console.log(`Header record found with profile: ${record.profile}`);
+  }
+}
+```

--- a/typescript/core/docs/McapIndexedReader.md
+++ b/typescript/core/docs/McapIndexedReader.md
@@ -1,0 +1,73 @@
+# `McapIndexedReader` 詳細ドキュメント
+
+`McapIndexedReader`は、ファイル全体にランダムアクセス可能な（シーク可能な）ソースからMCAPファイルを効率的に読み込むためのクラスです。ファイルシステム上のファイルなどが典型的なユースケースです。
+
+ストリーミングリーダーとは異なり、最初にファイルのインデックス情報を読み込むことで、ファイル全体をスキャンすることなく、特定のメッセージに高速にアクセスできます。
+
+## `Initialize()` (静的メソッド)
+
+`McapIndexedReader`のインスタンスは、コンストラクタではなく、非同期の静的メソッド `Initialize` を通じて生成します。このメソッドは、MCAPファイルのインデックスを読み取り、リーダーを完全に準備した状態で返します。
+
+```typescript
+import { McapIndexedReader, IReadable } from "@mcap/core";
+
+const readable: IReadable = ...; // IReadableを実装したオブジェクト
+const reader = await McapIndexedReader.Initialize({ readable });
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapIndexedReader.ts`, line 108](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L108)
+-   **パラメータ**:
+    -   `readable: IReadable`: 読み込み対象のソース。`size(): Promise<bigint>`と`read(offset: bigint, size: bigint): Promise<Uint8Array>`の2つのメソッドを持つ必要があります。
+    -   `decompressHandlers?: DecompressHandlers`: 圧縮チャンクの解凍ハンドラ。
+-   **処理内容**:
+    `Initialize`メソッドは、効率的なアクセスのために、ファイルのメタデータとインデックス情報を事前に読み込んで解析します。
+    1.  **ヘッダーの読み込み**: ファイルの先頭から`Header`レコードを読み込み、検証します ([lines 121-150](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L121-L150))。
+    2.  **フッターの読み込み**: ファイルの末尾から`Footer`レコードと末尾のマジックナンバーを読み込み、検証します ([lines 156-210](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L156-L210))。`Footer`には、サマリーセクションの開始位置 (`summaryStart`) が記録されています。
+    3.  **サマリーセクションの読み込み**: `Footer`の情報をもとに、`DataEnd`レコードからフッターの直前までのサマリーセクション全体を一度に読み込みます ([lines 229-233](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L229-L233))。
+    4.  **サマリーのCRC検証**: サマリーセクションのCRC（巡回冗長検査）を計算し、`Footer`に記録されている値と一致するかを検証します ([lines 234-245](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L234-L245))。
+    5.  **インデックスレコードの解析**: サマリーセクション内の各レコード（`Schema`, `Channel`, `ChunkIndex`など）を解析し、インスタンスのプロパティ（`channelsById`, `chunkIndexes`など）に格納します ([lines 254-307](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L254-L307))。
+    6.  **インスタンスの生成**: すべてのインデックス情報を解析後、それらを引数としてプライベートコンストラクタを呼び出し、準備完了状態の`McapIndexedReader`インスタンスを生成して返します ([lines 309-322](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L309-L322))。
+
+---
+
+## `readMessages()`
+
+ファイルに記録されているメッセージを非同期で読み込むためのジェネレータメソッドです。`for-await-of`構文と共に使用します。インデックス情報を活用するため、特定のトピックや時間範囲でメッセージを効率的にフィルタリングできます。
+
+```typescript
+// readerは初期化済みのMcapIndexedReaderインスタンス
+
+// すべてのメッセージを読み込む
+for await (const message of reader.readMessages()) {
+  console.log(message.data);
+}
+
+// トピックと時間範囲でフィルタリング
+for await (const message of reader.readMessages({
+  topics: ["/imu"],
+  startTime: 1640995200000000000n, // BigIntナノ秒
+  endTime: 1640995260000000000n,   // BigIntナノ秒
+})) {
+  // ...
+}
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapIndexedReader.ts`, line 325](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L325)
+-   **パラメータ**: オプションオブジェクト
+    -   `topics?: string[]`: 読み込むトピックのリスト。指定しない場合はすべてのトピックが対象。
+    -   `startTime?: bigint`: メッセージのログ時刻 (`logTime`) の下限（ナノ秒）。
+    -   `endTime?: bigint`: メッセージのログ時刻 (`logTime`) の上限（ナノ秒）。
+    -   `reverse?: boolean`: `true`にするとメッセージを降順で返す。
+-   **処理内容**:
+    1.  **チャンネルのフィルタリング**: `topics`が指定された場合、該当するトピックを持つチャンネルIDのセットを作成します ([lines 339-346](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L339-L346))。
+    2.  **チャンクの選別**: `startTime`と`endTime`の範囲に収まるメッセージを含むチャンクのみを選別します。この際、各チャンクのメタデータ（`messageStartTime`, `messageEndTime`）が利用されます ([lines 349-357](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L349-L357))。
+    3.  **ヒープ構造の利用**: 選別されたチャンクを、メッセージの開始時刻が最も早いものが頂点に来るように、最小ヒープ（min-heap）に追加します。これにより、複数のチャンクにまたがるメッセージを時系列順に効率的に処理できます ([line 348](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L348))。
+    4.  **遅延読み込みとイテレーション**:
+        -   ループのたびに、ヒープの頂点にあるチャンク（次に読み込むべきメッセージが含まれるチャンク）からメッセージを1つ取り出します ([line 371](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L371))。
+        -   そのチャンクのデータ（`Chunk`レコード）やメッセージインデックスがまだメモリに読み込まれていない場合は、このタイミングで初めて`readable`から読み込みます ([lines 364, 374](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L364-L374))。これにより、不要なデータの読み込みを最小限に抑えます。
+        -   取り出したメッセージを`yield`で返します ([line 396](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L396))。
+        -   チャンクにまだ読み込むべきメッセージが残っていれば、ヒープを再構成します。なければ、ヒープからそのチャンクを取り除きます ([lines 398-406](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapIndexedReader.ts#L398-L406))。

--- a/typescript/core/docs/McapStreamReader.md
+++ b/typescript/core/docs/McapStreamReader.md
@@ -1,0 +1,82 @@
+# `McapStreamReader` 詳細ドキュメント
+
+`McapStreamReader`は、データが断片的に到着するストリーミング環境でMCAPファイルを読み込むためのクラスです。ネットワーク経由のデータや、大きなファイルを少しずつ読み込む場合に最適です。内部にバッファを持ち、十分なデータが揃うとレコードを解析して返します。
+
+## コンストラクタ
+
+`McapStreamReader`をインスタンス化するには、オプションオブジェクトを渡します。オプションはすべて省略可能です。
+
+```typescript
+import McapStreamReader from "@mcap/core";
+
+const reader = new McapStreamReader({ validateCrcs: true });
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapStreamReader.ts`, line 81](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L81)
+-   **パラメータ**: `McapReaderOptions` 型のオブジェクトを受け取ります。このオブジェクトですべての挙動を制御します。引数を渡さない場合、すべてのオプションはデフォルト値に設定されます。
+
+---
+
+### `McapReaderOptions`
+
+コンストラクタに渡すことができるオプションです。
+
+-   **ソースコード**: [`typescript/core/src/McapStreamReader.ts`, line 9](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L9)
+
+#### 主なオプション
+
+-   `includeChunks?: boolean` (デフォルト: `false`)
+    -   `true`に設定すると、`nextRecord()`が`Chunk`レコードそのものを返すようになります。`false`の場合、`Chunk`レコードは内部で処理され、その中に含まれる`Schema`, `Channel`, `Message`レコードのみが返されます。
+    -   **根拠**: この値はコンストラクタで`this.#includeChunks`に保存されます ([line 82](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L82))。`#read`ジェネレータ内で`Chunk`レコードに遭遇した際、このフラグが`true`の場合のみ`yield record`で`Chunk`が返されます ([line 271](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L271))。
+
+-   `decompressHandlers?: DecompressHandlers` (デフォルト: `{}`)
+    -   圧縮されたチャンクを解凍（デコンプレス）するためのハンドラ関数を、圧縮形式名をキーとしたオブジェクトとして提供します。
+    -   **根拠**: `#read`ジェネレータ内で圧縮された`Chunk`に遭遇すると、`record.compression`文字列をキーとしてこのオブジェクトからハンドラを取得しようとします。ハンドラが存在しない場合、エラーがスローされます ([line 276](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L276))。
+
+-   `validateCrcs?: boolean` (デフォルト: `true`)
+    -   `true`の場合、チャンクのCRC（巡回冗長検査）を検証します。パフォーマンス向上のために`false`に設定することもできますが、データの完全性が保証されなくなります。
+    -   **根拠**: `#read`ジェネレータ内でチャンクを処理する際、このフラグが`true`で、かつチャンクのCRCが0でない場合に、CRCの計算と検証が行われます ([line 282](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L282))。
+
+-   `noMagicPrefix?: boolean` (デフォルト: `false`)
+    -   `true`の場合、リーダーはストリームの先頭にあるはずのMCAPマジックナンバーをチェックしません。MCAPファイルの一部断片を読み込む場合などに使用します。
+    -   **根拠**: `#read`ジェネレータの冒頭で、このフラグが`false`の場合にのみマジックナンバーの解析ループが実行されます ([line 241](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L241))。
+
+---
+
+## `append()` と `nextRecord()`
+
+この2つのメソッドは、`McapStreamReader`の核となるインターフェースです。`append()`でデータを供給し、`nextRecord()`で解析済みのレコードを取り出します。
+
+```typescript
+// readerはMcapStreamReaderのインスタンス
+// dataChunkはストリームから受け取ったUint8Array
+
+reader.append(dataChunk);
+
+let record;
+while ((record = reader.nextRecord())) {
+  // レコードを処理する
+  console.log(record.type);
+}
+```
+
+### `append()` の解説
+
+-   **ソースコード**: [`typescript/core/src/McapStreamReader.ts`, line 111](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L111)
+-   **処理内容**:
+    1.  リーダーが既に完了状態 (`doneReading`) でないかチェックします ([line 112](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L112))。
+    2.  `#appendOrShift`プライベートメソッドを呼び出し、新しいデータを内部バッファに追加します ([line 115](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L115))。
+    3.  `#appendOrShift` ([line 118](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L118)) は、効率的なバッファ管理を行います。既存のバッファに空きがあればデータを追記し、なければ不要なデータを破棄してバッファを詰めたり、必要であればより大きな新しいバッファを確保してデータをコピーします。
+
+### `nextRecord()` の解説
+
+-   **ソースコード**: [`typescript/core/src/McapStreamReader.ts`, line 185](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L185)
+-   **処理内容**:
+    1.  リーダーが完了状態 (`doneReading`) であれば、即座に `undefined` を返します ([line 186](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L186))。
+    2.  内部の`#generator` (`#read`メソッド) の`next()`を呼び出して、次のレコードの解析を試みます ([line 188](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L188))。
+    3.  `#read`ジェネレータは、内部バッファに完全なレコードを解析するのに十分なデータがある場合、そのレコードを`yield`します。データが不十分な場合は、何も返さずに次のデータが`append()`されるのを待ちます。
+    4.  レコードが`Channel`や`Message`の場合、一貫性チェック（例：未知のチャンネルIDを持つメッセージがないか）を行います ([lines 190-203](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L190-L203))。
+    5.  ジェネレータが完了した場合（`Footer`と末尾のマジックナンバーを読み取った場合）、`#doneReading`フラグを`true`に設定します ([line 205](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapStreamReader.ts#L205))。
+    6.  解析されたレコード、または解析できるレコードがない場合は`undefined`を返します。

--- a/typescript/core/docs/McapWriter.md
+++ b/typescript/core/docs/McapWriter.md
@@ -1,0 +1,161 @@
+# `McapWriter` 詳細ドキュメント
+
+`McapWriter`は、MCAPファイルを生成するための主要なクラスです。インスタンス化からファイルの完成まで、一連のメソッド呼び出しを通じてMCAPファイルを構築します。
+
+## コンストラクタ
+
+`McapWriter`をインスタンス化するには、コンストラクタにオプションオブジェクトを渡します。
+
+```typescript
+import { McapWriter, IWritable } from "@mcap/core";
+
+const writable: IWritable = ...; // IWritableを実装したオブジェクト
+const writer = new McapWriter({ writable });
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 105](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L105)
+-   **必須パラメータ**: `options`オブジェクトには、`writable`プロパティが必須です。これは`IWritable`インターフェースを実装したオブジェクトで、ライターが生成したバイナリデータを実際に書き込む先の抽象を提供します。
+-   **オプション**: `writable`以外にも、`McapWriterOptions` 型で定義された多数のオプションを指定することで、ライターの挙動を細かく制御できます。
+
+---
+
+### `McapWriterOptions`
+
+コンストラクタに渡すことができるオプションです。
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 32](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L32)
+
+#### 主なオプション
+
+-   `writable: IWritable` (必須)
+    -   書き込み先のオブジェクト。`position(): bigint` と `write(data: Uint8Array): Promise<void>` の2つのメソッドを持つ必要があります。
+
+-   `useChunks?: boolean` (デフォルト: `true`)
+    -   `true`の場合、メッセージはチャンクにまとめて書き込まれます。これにより、インデックスを利用した効率的な読み取りが可能になります。
+
+-   `useStatistics?: boolean` (デフォルト: `true`)
+    -   `true`の場合、ファイル全体の統計情報（メッセージ数、時間範囲など）が計算され、ファイル末尾のサマリーセクションに書き込まれます。
+
+-   `compressChunk?: (chunkData: Uint8Array) => { compression: string; compressedData: Uint8Array }`
+    -   チャンクを圧縮するためのコールバック関数を指定します。圧縮アルゴリズム名（例："zstd"）と圧縮後のデータを返す必要があります。指定しない場合、チャンクは圧縮されません。
+    -   **根拠**: コンストラクタ内で、このオプションは`this.#compressChunk`に代入されます ([line 136](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L136))。その後、`#finalizeChunk`メソッド内で、この関数が存在する場合に呼び出され、チャンクデータが圧縮されます ([line 546](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L546))。
+
+-   `chunkSize?: number` (デフォルト: `1024 * 1024`)
+    -   1チャンクあたりのおおよその最大サイズ（バイト単位）。`addMessage`メソッドの呼び出し後、チャンクのサイズがこの値を超えると、チャンクがファイルに書き込まれます。
+    -   **根拠**: `addMessage`メソッドの最後で、チャンクビルダーの現在のサイズ (`this.#chunkBuilder.byteLength`) がこの`chunkSize`と比較され、超えていれば`#finalizeChunk`が呼び出されます ([line 527](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L527))。
+
+---
+
+## `start()`
+
+MCAPファイルの書き込みを開始し、ファイルの先頭にヘッダー情報を記録します。
+
+```typescript
+await writer.start({
+  profile: "my-profile",
+  library: "my-library",
+});
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 231](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L231)
+-   **処理内容**:
+    1.  書き込みが追記モード (`appendMode`) でないことを確認します ([line 232](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L232))。
+    2.  データセクションのCRC計算を初期化します ([line 235](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L235))。
+    3.  MCAPのマジックナンバー (`\x89MCAP0\r\n`) を書き込みます ([line 236](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L236))。
+    4.  引数で渡された`Header`レコードを書き込みます ([line 237](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L237))。
+    5.  書き込んだデータを`writable`オブジェクトにフラッシュし、CRCを更新します ([lines 239-241](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L239-L241))。
+
+---
+
+## `registerSchema()` と `registerChannel()`
+
+メッセージを書き込む前に、そのメッセージの構造（スキーマ）と、どのトピックに属するか（チャンネル）を登録する必要があります。これらのメソッドは、登録したスキーマとチャンネルに一意のIDを払い出し、そのIDを返します。
+
+```typescript
+const schemaId = await writer.registerSchema({
+  name: "Example",
+  encoding: "json",
+  data: new TextEncoder().encode(JSON.stringify({ type: "object" })),
+});
+
+const channelId = await writer.registerChannel({
+  schemaId,
+  topic: "/example",
+  messageEncoding: "json",
+  metadata: new Map(),
+});
+```
+
+### `registerSchema()` の解説
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 443](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L443)
+-   **処理内容**:
+    1.  新しいスキーマIDをインクリメントして生成します (`this.#nextSchemaId++`) ([line 444](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L444))。
+    2.  引数で受け取ったスキーマ情報と生成したIDを、インスタンス内の`#schemas` Mapに保存します ([line 445](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L445))。
+    3.  統計情報が有効な場合、スキーマ数をインクリメントします ([lines 446-448](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L446-L448))。
+    4.  生成したIDを返します。
+
+### `registerChannel()` の解説
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 455](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L455)
+-   **処理内容**:
+    1.  新しいチャンネルIDをインクリメントして生成します (`this.#nextChannelId++`) ([line 456](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L456))。
+    2.  引数で受け取ったチャンネル情報と生成したIDを、インスタンス内の`#channels` Mapに保存します ([line 457](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L457))。
+    3.  統計情報が有効な場合、チャンネル数をインクリメントします ([lines 458-460](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L458-L460))。
+    4.  生成したIDを返します。
+
+---
+
+## `addMessage()`
+
+登録されたチャンネルに新しいメッセージを書き込みます。
+
+```typescript
+await writer.addMessage({
+  channelId,
+  sequence: 1,
+  logTime: 100n,
+  publishTime: 100n,
+  data: new TextEncoder().encode(JSON.stringify({ greeting: "hello" })),
+});
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 465](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L465)
+-   **処理内容**:
+    1.  **統計情報の更新**: 統計情報が有効な場合、メッセージ数、全体の開始・終了時刻、チャンネルごとのメッセージ数などを更新します ([lines 466-486](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L466-L486))。
+    2.  **スキーマとチャンネルの遅延書き込み**: このメッセージが属するチャンネル (`channelId`) の情報がまだファイルに書き込まれていない場合、このタイミングで`Channel`レコードと、必要であれば関連する`Schema`レコードを書き込みます。これにより、`registerSchema`や`registerChannel`を呼び出した順序に関わらず、必要な情報がメッセージの前に記録されることが保証されます ([lines 489-518](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L489-L518))。
+    3.  **メッセージの追加**: メッセージレコードを生成し、チャンクが有効な場合はチャンクビルダーに、無効な場合は直接レコードライターに追加します ([lines 520-525](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L520-L525))。
+    4.  **チャンクの確定**: チャンクが有効で、現在のチャンクのサイズがコンストラクタで指定された`chunkSize`を超えた場合、`#finalizeChunk()`を呼び出して現在のチャンクをファイルに書き込み、新しいチャンクを開始します ([lines 527-529](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L527-L529))。
+
+---
+
+## `end()`
+
+すべてのメッセージの書き込みが完了した後に呼び出し、MCAPファイルを完成させます。このメソッドは、ファイルの末尾にサマリーセクションとフッターを書き込みます。
+
+```typescript
+await writer.end();
+```
+
+### 解説
+
+-   **ソースコード**: [`typescript/core/src/McapWriter.ts`, line 244](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L244)
+-   **処理内容**:
+    1.  **最終チャンクの確定**: `addMessage`でまだファイルに書き込まれていない、最後のチャンクを確定して書き込みます (`#finalizeChunk()`) ([line 245](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L245))。
+    2.  **DataEndの書き込み**: データセクションの終わりを示す`DataEnd`レコードを書き込みます。これにはデータセクション全体のCRCが含まれます ([lines 252-257](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L252-L257))。
+    3.  **サマリーセクションの書き込み**: ファイルのインデックス情報を含むサマリーセクションを書き込みます。これには、オプションに応じて以下のレコードが含まれます。
+        -   `Schema` ([lines 264-274](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L264-L274))
+        -   `Channel` ([lines 276-286](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L276-L286))
+        -   `Statistics` ([lines 288-298](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L288-L298))
+        -   `MetadataIndex` ([lines 302-312](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L302-L312))
+        -   `AttachmentIndex` ([lines 314-324](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L314-L324))
+        -   `ChunkIndex` ([lines 326-336](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L326-L336))
+    4.  **SummaryOffsetの書き込み**: 各サマリーセクションの各項目へのオフセットを指す`SummaryOffset`レコードを書き込みます ([lines 342-348](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L342-L348))。
+    5.  **フッターの書き込み**: サマリーセクションの開始位置と、サマリーセクション自体のCRCを含む`Footer`レコードを書き込みます ([lines 352-368](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L352-L368))。
+    6.  **末尾のマジックナンバー**: ファイルの終端を示す、最後のマジックナンバーを書き込みます ([line 370](https://github.com/foxglove/mcap/blob/main/typescript/core/src/McapWriter.ts#L370))。


### PR DESCRIPTION
This commit adds new, highly detailed documentation for the core classes of the `@mcap/core` library. Per user request, this documentation is split into separate files for each class and includes citations to the specific source code lines that implement the described behaviors.

The new files are located in `typescript/core/docs/`:
- `McapWriter.md`: Documents the writer class, method by method.
- `McapStreamReader.md`: Documents the streaming reader class.
- `McapIndexedReader.md`: Documents the indexed reader class.

This provides an in-depth resource for developers looking to understand the internal workings of the library.

### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

