### PR TITLE
doctor: don't error on schema id 0 missing from summary section

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -567,6 +567,9 @@ func (doctor *mcapDoctor) Examine() Diagnosis {
 				// message with unknown channel, this is checked when that message is scanned
 				continue
 			}
+			if channel.SchemaID == 0 {
+				continue
+			}
 			if present := doctor.schemaIDsInSummarySection[channel.SchemaID]; !present {
 				doctor.error(
 					"Indexed chunk at offset %d contains messages referencing schema (%d) not duplicated in summary section",


### PR DESCRIPTION
### Changelog
Fixed a bug in `mcap doctor` which would raise an error for schemaless channels.

### Docs

None

### Description

Previously a schemaless channel would result in errors like:

```
Indexed chunk at offset 42 contains messages referencing schema (0) not duplicated in summary section
```