### PR TITLE
cpp: enable & fix -Wshadow for GCC

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,9 +1,11 @@
+.PHONY: default
 default: build
 
 .PHONY: dev-image
 dev-image:
 	docker build -t mcap_cpp_dev -f dev.Dockerfile .
 
+.PHONY: dev-shell
 dev-shell: dev-image
 	docker run --rm -v $(CURDIR):/src -it mcap_cpp_dev /bin/bash
 
@@ -15,6 +17,7 @@ build: dev-image
 build-host:
 	./build.sh
 
+.PHONY: clean
 clean:
 	docker rm -f hdoc
 	docker rmi -f mcap_cpp_dev

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -3,7 +3,6 @@ project(McapBenchmarks CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CONAN_SYSTEM_INCLUDES ON)
 
 if (MSVC)
   add_compile_options(/W4 /WX

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends --no-install-suggests \
+  build-essential \
   ca-certificates \
   curl \
   cmake \

--- a/cpp/docs/CMakeLists.txt
+++ b/cpp/docs/CMakeLists.txt
@@ -3,7 +3,6 @@ project(McapDocs CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CONAN_SYSTEM_INCLUDES ON)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ project(McapExamples CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CONAN_SYSTEM_INCLUDES ON)
+set(CONAN_SYSTEM_INCLUDES ON) # avoid warnings in protobuf headers
 
 if (MSVC)
   add_compile_options(/W4 /WX

--- a/cpp/mcap/include/mcap/errors.hpp
+++ b/cpp/mcap/include/mcap/errors.hpp
@@ -40,8 +40,8 @@ struct [[nodiscard]] Status {
   Status()
       : code(StatusCode::Success) {}
 
-  Status(StatusCode code)
-      : code(code) {
+  Status(StatusCode _code)
+      : code(_code) {
     switch (code) {
       case StatusCode::Success:
         break;
@@ -108,9 +108,9 @@ struct [[nodiscard]] Status {
     }
   }
 
-  Status(StatusCode code, const std::string& message)
-      : code(code)
-      , message(message) {}
+  Status(StatusCode _code, const std::string& _message)
+      : code(_code)
+      , message(_message) {}
 
   bool ok() const {
     return code == StatusCode::Success;

--- a/cpp/mcap/include/mcap/intervaltree.hpp
+++ b/cpp/mcap/include/mcap/intervaltree.hpp
@@ -122,15 +122,15 @@ public:
       interval_vector rights;
 
       for (typename interval_vector::const_iterator i = ivals.begin(); i != ivals.end(); ++i) {
-        const interval& interval = *i;
-        if (interval.stop < center) {
-          lefts.push_back(interval);
-        } else if (interval.start > center) {
-          rights.push_back(interval);
+        const interval& cur = *i;
+        if (cur.stop < center) {
+          lefts.push_back(cur);
+        } else if (cur.start > center) {
+          rights.push_back(cur);
         } else {
-          assert(interval.start <= center);
-          assert(center <= interval.stop);
-          intervals.push_back(interval);
+          assert(cur.start <= center);
+          assert(center <= cur.stop);
+          intervals.push_back(cur);
         }
       }
 
@@ -170,10 +170,10 @@ public:
   // Call f on all intervals overlapping [start, stop]
   template <class UnaryFunction>
   void visit_overlapping(const Scalar& start, const Scalar& stop, UnaryFunction f) const {
-    auto filterF = [&](const interval& interval) {
-      if (interval.stop >= start && interval.start <= stop) {
+    auto filterF = [&](const interval& cur) {
+      if (cur.stop >= start && cur.start <= stop) {
         // Only apply f if overlapping
-        f(interval);
+        f(cur);
       }
     };
     visit_near(start, stop, filterF);
@@ -182,9 +182,9 @@ public:
   // Call f on all intervals contained within [start, stop]
   template <class UnaryFunction>
   void visit_contained(const Scalar& start, const Scalar& stop, UnaryFunction f) const {
-    auto filterF = [&](const interval& interval) {
-      if (start <= interval.start && interval.stop <= stop) {
-        f(interval);
+    auto filterF = [&](const interval& cur) {
+      if (start <= cur.start && cur.stop <= stop) {
+        f(cur);
       }
     };
     visit_near(start, stop, filterF);
@@ -192,16 +192,16 @@ public:
 
   interval_vector find_overlapping(const Scalar& start, const Scalar& stop) const {
     interval_vector result;
-    visit_overlapping(start, stop, [&](const interval& interval) {
-      result.emplace_back(interval);
+    visit_overlapping(start, stop, [&](const interval& cur) {
+      result.emplace_back(cur);
     });
     return result;
   }
 
   interval_vector find_contained(const Scalar& start, const Scalar& stop) const {
     interval_vector result;
-    visit_contained(start, stop, [&](const interval& interval) {
-      result.push_back(interval);
+    visit_contained(start, stop, [&](const interval& cur) {
+      result.push_back(cur);
     });
     return result;
   }
@@ -234,15 +234,15 @@ public:
     struct Extent {
       std::pair<Scalar, Scalar> x{std::numeric_limits<Scalar>::max(),
                                   std::numeric_limits<Scalar>::min()};
-      void operator()(const interval& interval) {
-        x.first = std::min(x.first, interval.start);
-        x.second = std::max(x.second, interval.stop);
+      void operator()(const interval& cur) {
+        x.first = std::min(x.first, cur.start);
+        x.second = std::max(x.second, cur.stop);
       }
     };
     Extent extent;
 
-    visit_all([&](const interval& interval) {
-      extent(interval);
+    visit_all([&](const interval& cur) {
+      extent(cur);
     });
     return extent.x;
   }

--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -1218,9 +1218,9 @@ std::optional<Compression> McapReader::ParseCompression(const std::string_view c
 
 // RecordReader ////////////////////////////////////////////////////////////////
 
-RecordReader::RecordReader(IReadable& dataSource, ByteOffset startOffset, ByteOffset endOffset)
+RecordReader::RecordReader(IReadable& dataSource, ByteOffset startOffset, ByteOffset _endOffset)
     : offset(startOffset)
-    , endOffset(endOffset)
+    , endOffset(_endOffset)
     , dataSource_(&dataSource)
     , status_(StatusCode::Success)
     , curRecord_{} {}

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -118,9 +118,9 @@ struct MCAP_PUBLIC Footer {
   uint32_t summaryCrc;
 
   Footer() = default;
-  Footer(ByteOffset summaryStart, ByteOffset summaryOffsetStart)
-      : summaryStart(summaryStart)
-      , summaryOffsetStart(summaryOffsetStart)
+  Footer(ByteOffset _summaryStart, ByteOffset _summaryOffsetStart)
+      : summaryStart(_summaryStart)
+      , summaryOffsetStart(_summaryOffsetStart)
       , summaryCrc(0) {}
 };
 
@@ -137,16 +137,17 @@ struct MCAP_PUBLIC Schema {
 
   Schema() = default;
 
-  Schema(const std::string_view name, const std::string_view encoding, const std::string_view data)
-      : name(name)
-      , encoding(encoding)
-      , data{reinterpret_cast<const std::byte*>(data.data()),
-             reinterpret_cast<const std::byte*>(data.data() + data.size())} {}
+  Schema(const std::string_view _name, const std::string_view _encoding,
+         const std::string_view _data)
+      : name(_name)
+      , encoding(_encoding)
+      , data{reinterpret_cast<const std::byte*>(_data.data()),
+             reinterpret_cast<const std::byte*>(_data.data() + _data.size())} {}
 
-  Schema(const std::string_view name, const std::string_view encoding, const ByteArray& data)
-      : name(name)
-      , encoding(encoding)
-      , data{data} {}
+  Schema(const std::string_view _name, const std::string_view _encoding, const ByteArray& _data)
+      : name(_name)
+      , encoding(_encoding)
+      , data{_data} {}
 };
 
 /**
@@ -165,12 +166,12 @@ struct MCAP_PUBLIC Channel {
 
   Channel() = default;
 
-  Channel(const std::string_view topic, const std::string_view messageEncoding, SchemaId schemaId,
-          const KeyValueMap& metadata = {})
-      : topic(topic)
-      , messageEncoding(messageEncoding)
-      , schemaId(schemaId)
-      , metadata(metadata) {}
+  Channel(const std::string_view _topic, const std::string_view _messageEncoding,
+          SchemaId _schemaId, const KeyValueMap& _metadata = {})
+      : topic(_topic)
+      , messageEncoding(_messageEncoding)
+      , schemaId(_schemaId)
+      , metadata(_metadata) {}
 };
 
 using SchemaPtr = std::shared_ptr<Schema>;
@@ -391,11 +392,11 @@ struct MCAP_PUBLIC MessageView {
   const SchemaPtr schema;
   const RecordOffset messageOffset;
 
-  MessageView(const Message& message, const ChannelPtr channel, const SchemaPtr schema,
+  MessageView(const Message& _message, const ChannelPtr _channel, const SchemaPtr _schema,
               RecordOffset offset)
-      : message(message)
-      , channel(channel)
-      , schema(schema)
+      : message(_message)
+      , channel(_channel)
+      , schema(_schema)
       , messageOffset(offset) {}
 };
 

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -104,8 +104,8 @@ struct MCAP_PUBLIC McapWriterOptions {
   bool noStatistics = false;
   bool noSummaryOffsets = false;
 
-  McapWriterOptions(const std::string_view profile)
-      : profile(profile) {}
+  McapWriterOptions(const std::string_view _profile)
+      : profile(_profile) {}
 };
 
 /**

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -3,7 +3,6 @@ project(McapTest CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CONAN_SYSTEM_INCLUDES ON)
 
 if (MSVC)
   add_compile_options(/W4 /WX

--- a/cpp/test/streamed_writer_conformance.cpp
+++ b/cpp/test/streamed_writer_conformance.cpp
@@ -78,8 +78,8 @@ mcap::McapWriterOptions ReadOptions(const json& featuresJson) {
 }
 
 template <typename T>
-T ReadUInt(const json& json) {
-  return T(std::stoull(json.get<std::string>()));
+T ReadUInt(const json& obj) {
+  return T(std::stoull(obj.get<std::string>()));
 }
 
 void ReadBytes(const json& byteArrayJson, mcap::ByteArray& output) {

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -340,8 +340,7 @@ TEST_CASE("McapReader::byteRange()", "[reader]") {
     mcap::McapReader reader;
     Buffer buffer;
     writeExampleFile(buffer);
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     auto [startOffset, endOffset] = reader.byteRange(0);
     REQUIRE(startOffset == 25);
@@ -401,8 +400,7 @@ TEST_CASE("McapReader::readMessages()", "[reader]") {
     writer.close();
 
     mcap::McapReader reader;
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     for (const auto& msg : reader.readMessages()) {
       FAIL("Shouldn't have gotten a message: topic " + msg.channel->topic + ", schema " +
@@ -608,8 +606,7 @@ TEST_CASE("LZ4 compression", "[reader][writer]") {
     writer.close();
 
     mcap::McapReader reader;
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     size_t messageCount = 0;
     const auto onProblem = [](const mcap::Status& status) {
@@ -654,8 +651,7 @@ TEST_CASE("zstd compression", "[reader][writer]") {
     writer.close();
 
     mcap::McapReader reader;
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     size_t messageCount = 0;
     const auto onProblem = [](const mcap::Status& status) {
@@ -703,8 +699,7 @@ TEST_CASE("Read Order", "[reader][writer]") {
     writer.close();
 
     mcap::McapReader reader;
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     size_t messageCount = 0;
     const auto onProblem = [](const mcap::Status& status) {
@@ -753,8 +748,7 @@ TEST_CASE("Read Order", "[reader][writer]") {
     writer.close();
 
     mcap::McapReader reader;
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     size_t messageCount = 0;
     const auto onProblem = [](const mcap::Status& status) {
@@ -807,8 +801,7 @@ TEST_CASE("Read Order", "[reader][writer]") {
     writer.close();
 
     mcap::McapReader reader;
-    auto status = reader.open(buffer);
-    requireOk(status);
+    requireOk(reader.open(buffer));
 
     const auto onProblem = [](const mcap::Status& status) {
       FAIL("Status " + std::to_string((int)status.code) + ": " + status.message);


### PR DESCRIPTION
### Changelog
cpp: fixed `-Wshadow` warnings when building with GCC.

### Docs

None

### Description

Fixes #1462 by renaming some variables to avoid shadowing.