### PR TITLE
rust: fix int underflow when chunk wasn't closed

### DIFF
--- a/rust/tests/data/chunk_not_closed.mcap
+++ b/rust/tests/data/chunk_not_closed.mcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b49182be8db86f194a34617cab44720d50460d9caa7ec54cbcf5c19700b8578
+size 92


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- rust: fix int underflow on chunk with invalid size

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

When a chunk doesn't close correctly (loss of power, crash, etc.) the size that was written will be `u64::MAX`. If you try and read a file like this with the Rust reader it breaks because the size of the chunk is expected to be valid. In debug mode this will panic due to underflow, in release mode this value will wrap and break something else down the track.

This change explicitly uses checked calculations for the chunk size and returns an `UnexpectedEoc` error if any of the calculations overflow.

Fixes #1479.
Fixes FIRE-202.
