### PR TITLE
rust: bump to 0.23.4

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.23.3"
+version = "0.23.4"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Bump the Rust version to `0.23.4` in prep for release.