### PR TITLE
cpp: Remove redundant close calls in McapWriter

### DIFF
--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -341,7 +341,6 @@ void McapWriter::open(IWritable& writer, const McapWriterOptions& options) {
 
 Status McapWriter::open(const std::string_view filename, const McapWriterOptions& options) {
   // If the writer was opened, close it first
-  close();
   fileOutput_ = std::make_unique<FileWriter>();
   const auto status = fileOutput_->open(filename);
   if (!status.ok()) {
@@ -354,7 +353,6 @@ Status McapWriter::open(const std::string_view filename, const McapWriterOptions
 
 void McapWriter::open(std::ostream& stream, const McapWriterOptions& options) {
   // If the writer was opened, close it first
-  close();
   streamOutput_ = std::make_unique<StreamWriter>(stream);
   open(*streamOutput_, options);
 }


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Remove redundant close calls in McapWriter

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Each open method in McapWriter calls close, but in fact, the method that is ultimately called is the open method that takes IWritable as a parameter.

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

