### PR TITLE
Convert swift tests to use `swift-testing`

### DIFF
--- a/swift/crc-tests/CRCTests.swift
+++ b/swift/crc-tests/CRCTests.swift
@@ -1,16 +1,19 @@
 import CRC
-import XCTest
+import Foundation
+import Testing
 
-final class CRC32Tests: XCTestCase {
-  func testKnownValues() {
-    XCTAssertEqual(CRC32().final, 0)
+struct CRC32Tests {
+  @Test
+  func knownValues() {
+    #expect(CRC32().final == 0)
 
     var crc = CRC32()
     crc.update(Data([1]))
-    XCTAssertEqual(crc.final, 2_768_625_435)
+    #expect(crc.final == 2_768_625_435)
   }
 
-  func testUnaligned() {
+  @Test
+  func unaligned() {
     var crc = CRC32()
 
     for offset in 0 ..< 8 {
@@ -20,13 +23,13 @@ final class CRC32Tests: XCTestCase {
       Data(padding + [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]).withUnsafeBytes { buf in
         crc.update(UnsafeRawBufferPointer(rebasing: buf[offset...]))
       }
-      XCTAssertEqual(crc.final, 1_912_684_917)
+      #expect(crc.final == 1_912_684_917)
 
       crc.reset()
       Data(padding + [1]).withUnsafeBytes { buf in
         crc.update(UnsafeRawBufferPointer(rebasing: buf[offset...]))
       }
-      XCTAssertEqual(crc.final, 2_768_625_435)
+      #expect(crc.final == 2_768_625_435)
     }
   }
 }

--- a/swift/test/MCAPRandomAccessReaderTests.swift
+++ b/swift/test/MCAPRandomAccessReaderTests.swift
@@ -1,7 +1,7 @@
-import XCTest
-
 import CRC
+import Foundation
 import MCAP
+import Testing
 
 extension MCAPRandomAccessReader.MessageIterator {
   func readAll() throws -> [Message] {
@@ -24,8 +24,9 @@ extension Message: @retroactive Equatable {
   }
 }
 
-final class MCAPRandomAccessReaderTests: XCTestCase {
-  func testReadsLogTimeOrder() async throws {
+struct MCAPRandomAccessReaderTests {
+  @Test
+  func readsLogTimeOrder() async throws {
     let buffer = Buffer()
     let writer = MCAPWriter(buffer)
     await writer.start(library: "lib", profile: "prof")
@@ -44,10 +45,11 @@ final class MCAPRandomAccessReaderTests: XCTestCase {
     let iterator = reader.messageIterator()
     let messages = try iterator.readAll()
 
-    XCTAssertEqual(messages, [message1, message2])
+    #expect(messages == [message1, message2])
   }
 
-  func testFiltersTopics() async throws {
+  @Test
+  func filtersTopics() async throws {
     let buffer = Buffer()
     let writer = MCAPWriter(buffer)
     await writer.start(library: "lib", profile: "prof")
@@ -65,12 +67,13 @@ final class MCAPRandomAccessReaderTests: XCTestCase {
 
     let reader = try MCAPRandomAccessReader(buffer)
 
-    XCTAssertEqual(try reader.messageIterator().readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(topics: ["topic1"]).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(topics: ["topic2"]).readAll(), [message2])
+    #expect(try reader.messageIterator().readAll() == [message1, message2])
+    #expect(try reader.messageIterator(topics: ["topic1"]).readAll() == [message1])
+    #expect(try reader.messageIterator(topics: ["topic2"]).readAll() == [message2])
   }
 
-  func testFiltersByTime() async throws {
+  @Test
+  func filtersByTime() async throws {
     let buffer = Buffer()
     let writer = MCAPWriter(buffer)
     await writer.start(library: "lib", profile: "prof")
@@ -88,37 +91,37 @@ final class MCAPRandomAccessReaderTests: XCTestCase {
 
     let reader = try MCAPRandomAccessReader(buffer)
 
-    XCTAssertEqual(try reader.messageIterator().readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 1).readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 2).readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 3).readAll(), [message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 4).readAll(), [message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 5).readAll(), [])
+    #expect(try reader.messageIterator().readAll() == [message1, message2])
+    #expect(try reader.messageIterator(startTime: 1).readAll() == [message1, message2])
+    #expect(try reader.messageIterator(startTime: 2).readAll() == [message1, message2])
+    #expect(try reader.messageIterator(startTime: 3).readAll() == [message2])
+    #expect(try reader.messageIterator(startTime: 4).readAll() == [message2])
+    #expect(try reader.messageIterator(startTime: 5).readAll() == [])
 
-    XCTAssertEqual(try reader.messageIterator(endTime: 1).readAll(), [])
-    XCTAssertEqual(try reader.messageIterator(endTime: 2).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(endTime: 3).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(endTime: 4).readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(endTime: 5).readAll(), [message1, message2])
+    #expect(try reader.messageIterator(endTime: 1).readAll() == [])
+    #expect(try reader.messageIterator(endTime: 2).readAll() == [message1])
+    #expect(try reader.messageIterator(endTime: 3).readAll() == [message1])
+    #expect(try reader.messageIterator(endTime: 4).readAll() == [message1, message2])
+    #expect(try reader.messageIterator(endTime: 5).readAll() == [message1, message2])
 
-    XCTAssertEqual(try reader.messageIterator(startTime: 1, endTime: 1).readAll(), [])
-    XCTAssertEqual(try reader.messageIterator(startTime: 1, endTime: 2).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(startTime: 1, endTime: 3).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(startTime: 1, endTime: 4).readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 1, endTime: 5).readAll(), [message1, message2])
+    #expect(try reader.messageIterator(startTime: 1, endTime: 1).readAll() == [])
+    #expect(try reader.messageIterator(startTime: 1, endTime: 2).readAll() == [message1])
+    #expect(try reader.messageIterator(startTime: 1, endTime: 3).readAll() == [message1])
+    #expect(try reader.messageIterator(startTime: 1, endTime: 4).readAll() == [message1, message2])
+    #expect(try reader.messageIterator(startTime: 1, endTime: 5).readAll() == [message1, message2])
 
-    XCTAssertEqual(try reader.messageIterator(startTime: 2, endTime: 2).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(startTime: 2, endTime: 3).readAll(), [message1])
-    XCTAssertEqual(try reader.messageIterator(startTime: 2, endTime: 4).readAll(), [message1, message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 2, endTime: 5).readAll(), [message1, message2])
+    #expect(try reader.messageIterator(startTime: 2, endTime: 2).readAll() == [message1])
+    #expect(try reader.messageIterator(startTime: 2, endTime: 3).readAll() == [message1])
+    #expect(try reader.messageIterator(startTime: 2, endTime: 4).readAll() == [message1, message2])
+    #expect(try reader.messageIterator(startTime: 2, endTime: 5).readAll() == [message1, message2])
 
-    XCTAssertEqual(try reader.messageIterator(startTime: 3, endTime: 3).readAll(), [])
-    XCTAssertEqual(try reader.messageIterator(startTime: 3, endTime: 4).readAll(), [message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 3, endTime: 5).readAll(), [message2])
+    #expect(try reader.messageIterator(startTime: 3, endTime: 3).readAll() == [])
+    #expect(try reader.messageIterator(startTime: 3, endTime: 4).readAll() == [message2])
+    #expect(try reader.messageIterator(startTime: 3, endTime: 5).readAll() == [message2])
 
-    XCTAssertEqual(try reader.messageIterator(startTime: 4, endTime: 4).readAll(), [message2])
-    XCTAssertEqual(try reader.messageIterator(startTime: 4, endTime: 5).readAll(), [message2])
+    #expect(try reader.messageIterator(startTime: 4, endTime: 4).readAll() == [message2])
+    #expect(try reader.messageIterator(startTime: 4, endTime: 5).readAll() == [message2])
 
-    XCTAssertEqual(try reader.messageIterator(startTime: 5, endTime: 5).readAll(), [])
+    #expect(try reader.messageIterator(startTime: 5, endTime: 5).readAll() == [])
   }
 }

--- a/swift/test/MCAPTests.swift
+++ b/swift/test/MCAPTests.swift
@@ -1,20 +1,22 @@
 // swiftlint:disable force_cast
 
-import XCTest
-
 import CRC
+import Foundation
 import MCAP
+import Testing
 
-final class MCAPTests: XCTestCase {
-  func testEmpty() async throws {
+struct MCAPTests {
+  @Test
+  func empty() async throws {
     let buffer = Buffer()
     let writer = MCAPWriter(buffer)
     await writer.start(library: "", profile: "")
     await writer.end()
-    XCTAssertEqual(buffer.data.count, 286)
+    #expect(buffer.data.count == 286)
   }
 
-  func testValidatesChunkCRC() async throws {
+  @Test
+  func validatesChunkCRC() async throws {
     var buffer = Data()
     buffer.append(mcapMagic)
     Header(profile: "", library: "").serialize(to: &buffer)
@@ -32,10 +34,9 @@ final class MCAPTests: XCTestCase {
     let reader = MCAPStreamedReader()
     reader.append(buffer)
     let header = try reader.nextRecord() as! Header
-    XCTAssertEqual(header.profile, "")
-    XCTAssertEqual(header.library, "")
-    XCTAssertThrowsError(try reader.nextRecord()) {
-      XCTAssertEqual($0 as! MCAPReadError, MCAPReadError.invalidCRC(expected: 12345, actual: 1_438_416_925))
-    }
+    #expect(header.profile == "")
+    #expect(header.library == "")
+    let error = #expect(throws: MCAPReadError.self) { try reader.nextRecord() }
+    #expect(error == MCAPReadError.invalidCRC(expected: 12345, actual: 1_438_416_925))
   }
 }


### PR DESCRIPTION

### Changelog

None

### Docs

None

### Description

`swift-testing` has replaced the `XCTest` framework for the happy-path of swift development. Working with swift code thus becomes more enjoyable (personal preference) if the modern testing framework is used.
Maybe one notable invisible change:

> By default, tests run in parallel with respect to each other.
[source](https://developer.apple.com/documentation/testing/parallelization)

Running `swift test` on both main branch and this commit doesn't make any noticeable difference. The test suite is way to small probably for this to register. (~0.27 seconds for me)

<table><tr><th>Before</th><th>After</th></tr><tr><td>

`time swift test` => 0.27s

</td><td>

`time swift test` => 0.27s 😆 

</td></tr></table>

## After console output
<img width="1582" height="1034" alt="Bildschirmfoto 2025-11-18 um 23 14 10" src="https://github.com/user-attachments/assets/46b212a8-a26d-4b4a-80c8-d0f897c1ebac" />

## Before console output
<img width="1582" height="1034" alt="Bildschirmfoto 2025-11-18 um 23 25 33" src="https://github.com/user-attachments/assets/66aab92f-45e9-4ef7-8537-f9adbf683c26" />



