### PR TITLE
Bump `swiftformat`, `swiftlint` and fix violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,8 +494,8 @@ jobs:
       - uses: ./.github/actions/setup-swift
         with:
           swift-version: "6.1"
-      - run: docker run -t --rm -v $(pwd):/work -w /work ghcr.io/realm/swiftlint:0.58.2
-      - run: docker run -t --rm -v $(pwd):/work ghcr.io/nicklockwood/swiftformat:0.55.5 --lint /work
+      - run: docker run -t --rm -v $(pwd):/work -w /work ghcr.io/realm/swiftlint:0.62.2
+      - run: docker run -t --rm -v $(pwd):/work ghcr.io/nicklockwood/swiftformat:0.58.6 --lint /work
       - run: swift build
       - run: swift test
 

--- a/swift/conformance/ReadConformanceRunner.swift
+++ b/swift/conformance/ReadConformanceRunner.swift
@@ -106,7 +106,7 @@ private func readIndexed(file: FileHandle) throws -> Data {
 struct FileHandleReadable: IRandomAccessReadable {
   let fileHandle: FileHandle
 
-  public func size() -> UInt64 {
+  func size() -> UInt64 {
     if #available(macOS 10.15.4, *) {
       return try! fileHandle.seekToEnd()
     } else {
@@ -114,7 +114,7 @@ struct FileHandleReadable: IRandomAccessReadable {
     }
   }
 
-  public func read(offset: UInt64, length: UInt64) -> Data? {
+  func read(offset: UInt64, length: UInt64) -> Data? {
     do {
       if #available(macOS 10.15.4, *) {
         try fileHandle.seek(toOffset: offset)

--- a/swift/mcap/RecordReader.swift
+++ b/swift/mcap/RecordReader.swift
@@ -26,7 +26,7 @@ class RecordReader {
     offset = 0
   }
 
-  public func readMagic() throws -> Bool {
+  func readMagic() throws -> Bool {
     if offset + 8 < buffer.count {
       let prefix = buffer[offset ..< offset + 8]
       if !mcapMagic.elementsEqual(prefix) {
@@ -38,7 +38,7 @@ class RecordReader {
     return false
   }
 
-  public func nextRecord() throws -> Record? {
+  func nextRecord() throws -> Record? {
     try buffer.withUnsafeBytes { buf in
       while offset + 9 < buf.count {
         let op = buf[offset]


### PR DESCRIPTION
### Changelog
None
### Docs

None
### Description
There's no point declaring a class method `public` if the class itself isn't.

```
~/Code/forks/mcap (main) docker run -t --rm -v $(pwd):/work ghcr.io/nicklockwood/swiftformat:0.58.6 --lint /work
Running SwiftFormat...
(lint mode - no files will be changed.)
Reading config file at /work/.swiftformat
/work/swift/mcap/RecordReader.swift:29:1: error: (redundantPublic) Remove redundant public access control from declarations in internal or private types.
/work/swift/mcap/RecordReader.swift:41:1: error: (redundantPublic) Remove redundant public access control from declarations in internal or private types.
/work/swift/conformance/ReadConformanceRunner.swift:109:1: error: (redundantPublic) Remove redundant public access control from declarations in internal or private types.
/work/swift/conformance/ReadConformanceRunner.swift:117:1: error: (redundantPublic) Remove redundant public access control from declarations in internal or private types.
SwiftFormat completed in 0.62s.
Source input did not pass lint check.
2/15 files require formatting, 39 files skipped.
```
