### PR TITLE
Fix misspellings detected by typos-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - run: yarn install --immutable
       - run: echo '::add-matcher::.github/cspell-problem-matcher.json'
       - run: yarn spellcheck --no-progress
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos
+      - run: typos
 
   conformance-lint:
     runs-on: ubuntu-latest

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,19 @@
+[files]
+# Ignore vendored code from other projects
+extend-exclude = [
+  "**/vendor/**",
+  "**/_vendor/**",
+]
+
+[default.extend-words]
+# Intentional variable names and test data
+typ = "typ"
+ser = "ser"
+seeked = "seeked"
+wrold = "wrold"  # Intentional test data in buf_read_write_seeker_test.go
+
+[default.extend-identifiers]
+# Intentional variable names in code
+typ = "typ"
+ser = "ser"
+seeked = "seeked"

--- a/go/cli/mcap/utils/utils.go
+++ b/go/cli/mcap/utils/utils.go
@@ -114,7 +114,7 @@ func DefaultString(strings ...string) string {
 	return ""
 }
 
-// NewProgressBar returns an instance of progressbar.ProgresBar.
+// NewProgressBar returns an instance of progressbar.ProgressBar.
 // `max` is the denominator of the progress.
 func NewProgressBar(max int64) *progressbar.ProgressBar {
 	return progressbar.NewOptions64(

--- a/rust/examples/conformance_writer.rs
+++ b/rust/examples/conformance_writer.rs
@@ -91,13 +91,13 @@ fn write_file(spec: &conformance_writer_spec::WriterSpec) {
                 // write data end
             }
             "Footer" => {
-                let summmary_offet_start = record.get_field_u64("summary_start");
-                let summmary_crc = record.get_field_u32("summary_crc");
-                let summmary_start = record.get_field_u64("summary_start");
+                let summary_offset_start = record.get_field_u64("summary_start");
+                let summary_crc = record.get_field_u32("summary_crc");
+                let summary_start = record.get_field_u64("summary_start");
                 let _footer = mcap::records::Footer {
-                    summary_crc: summmary_crc,
-                    summary_offset_start: summmary_offet_start,
-                    summary_start: summmary_start,
+                    summary_crc,
+                    summary_offset_start,
+                    summary_start,
                 };
                 // write footer
             }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -94,9 +94,9 @@ pub enum McapError {
     BadMagic,
     #[error("Footer record couldn't be found at the end of the file, before the magic bytes")]
     BadFooter,
-    #[error("Attachment CRC failed (expeted {saved:08X}, got {calculated:08X}")]
+    #[error("Attachment CRC failed (expected {saved:08X}, got {calculated:08X}")]
     BadAttachmentCrc { saved: u32, calculated: u32 },
-    #[error("Chunk CRC failed (expected {saved:08X}, got {calculated:08X}")]
+    #[error("Chunk CRC failed (expected {saved:08X}, got {calculated:08X})")]
     BadChunkCrc { saved: u32, calculated: u32 },
     #[error("Data section CRC failed (expected {saved:08X}, got {calculated:08X})")]
     BadDataCrc { saved: u32, calculated: u32 },
@@ -112,9 +112,9 @@ pub enum McapError {
     BadSchemaLength { header: u32, available: u32 },
     #[error("Private records must have an opcode >= 0x80, got {opcode:#04x}")]
     PrivateRecordOpcodeIsReserved { opcode: u8 },
-    #[error("Channel `{0}` has mulitple records that don't match.")]
+    #[error("Channel `{0}` has multiple records that don't match.")]
     ConflictingChannels(String),
-    #[error("Schema `{0}` has mulitple records that don't match.")]
+    #[error("Schema `{0}` has multiple records that don't match.")]
     ConflictingSchemas(String),
     #[error("Record parse failed")]
     Parse(#[from] binrw::Error),

--- a/rust/src/read.rs
+++ b/rust/src/read.rs
@@ -535,7 +535,7 @@ const FOOTER_RECORD_LEN: usize = 1 // opcode
 /// then index into the rest of the file with
 /// [`Summary::stream_chunk`], [`attachment`], [`metadata`], etc.
 pub fn footer(mcap: &[u8]) -> McapResult<records::Footer> {
-    // an MCAP must be at least large enough to accomodate a header magic, a footer record and a
+    // an MCAP must be at least large enough to accommodate a header magic, a footer record and a
     // footer magic.
     if mcap.len() < (MAGIC.len() + FOOTER_RECORD_LEN + MAGIC.len()) {
         return Err(McapError::UnexpectedEof);
@@ -671,7 +671,7 @@ impl Summary {
         Ok(messages)
     }
 
-    /// Read the mesage indexes for the given indexed chunk.
+    /// Read the message indexes for the given indexed chunk.
     ///
     /// Channels and their schemas are pulled from this summary.
     /// The offsets in each [`MessageIndexEntry`](records::MessageIndexEntry)

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -4,7 +4,7 @@
 //!
 //! You probably want to user higher-level interfaces, like
 //! [`Message`](crate::Message), [`Channel`](crate::Channel), and [`Schema`](crate::Schema),
-//! read from iterators like [`MesssageStream`](crate::MessageStream).
+//! read from iterators like [`MessageStream`](crate::MessageStream).
 
 use std::{borrow::Cow, collections::BTreeMap};
 

--- a/rust/src/sans_io/linear_reader.rs
+++ b/rust/src/sans_io/linear_reader.rs
@@ -305,7 +305,7 @@ pub struct LinearReader {
     // The core state of the LinearReader state machine. Describes the part of the MCAP
     // file currently being read.
     currently_reading: CurrentlyReading,
-    // Auxilliary state specific to reading records out of chunks. This is stored outside of
+    // Auxiliary state specific to reading records out of chunks. This is stored outside of
     // CurrentlyReading to avoid needing to clone() it on every iteration.
     chunk_state: Option<ChunkState>,
     // MCAP data loaded from the file
@@ -560,7 +560,7 @@ impl LinearReader {
                 CurrentlyReading::ChunkHeader { len } => {
                     // Load the chunk header from the file. The chunk header is of variable length,
                     // depending on the length of the compression string field, so we load
-                    // enough bytes to read that length, then load more if neccessary.
+                    // enough bytes to read that length, then load more if necessary.
                     const MIN_CHUNK_HEADER_SIZE: usize = 8 + 8 + 8 + 4 + 4 + 8;
                     let min_header_buf = load!(MIN_CHUNK_HEADER_SIZE);
                     let compression_len =
@@ -729,7 +729,7 @@ impl LinearReader {
                 }
                 PaddingAfterChunk => {
                     // discard any padding bytes after the chunk records and validate CRCs if
-                    // neccessary
+                    // necessary
                     let state = self
                         .chunk_state
                         .as_mut()

--- a/rust/tests/handles_time0_messages.rs
+++ b/rust/tests/handles_time0_messages.rs
@@ -27,7 +27,7 @@ fn handles_time0_messages() -> Result<()> {
             log_time: 42,
             publish_time: 42,
         },
-        b"Is it really that time agian?",
+        b"Is it really that time again?",
     )?;
 
     out.finish()?;


### PR DESCRIPTION
### Changelog
Fix mispelling detected by typos-cli, mostly in Rust.

### Docs



### Description

The repository currently uses `cspell` in CI, yet there are still misspellings.
https://github.com/crate-ci/typos is a Rust tool which provides similar functionality, requires minimal configuration, and negligible CI overhead.

Uses https://github.com/taiki-e/install-action to install the pre-built typos-cli binary in CI workflow.
The action maintains its own checksums of the tools so that it fails if the binary has been modified.
c.f. https://github.com/taiki-e/install-action/blob/main/manifests/typos.json

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or -->
Fixes: https://github.com/foxglove/mcap/issues/618


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add typos-cli to CI with configuration and fix assorted misspellings across Rust/Go code, tests, comments, and error messages.
> 
> - **CI**:
>   - Integrate `typos` via `taiki-e/install-action` and run it in `spellcheck` job.
>   - Add `.typos.toml` with excludes and allowed words/identifiers.
> - **Rust**:
>   - Correct typos in error messages and docs (e.g., `BadChunkCrc`, "accommodate", "message indexes", `MessageStream`).
>   - Fix variable names in `examples/conformance_writer.rs` (`summary_*`).
>   - Clean up comments in `sans_io/linear_reader.rs` ("Auxiliary", "necessary").
>   - Update test string in `tests/handles_time0_messages.rs` ("again").
> - **Go**:
>   - Fix comment typo in `go/cli/mcap/utils/utils.go` (`ProgressBar`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85595542be5e19478e1217be2ab6746e32e60680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->