### PR TITLE
rust: use attribute expect

### DIFF
--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -174,7 +174,7 @@ fn parse_vec<T: BinRead<Args<'static> = ()>>() -> BinResult<Vec<T>> {
     Ok(parsed)
 }
 
-#[allow(clippy::ptr_arg)]
+#[expect(clippy::ptr_arg)]
 #[binrw::writer(writer, endian)]
 fn write_vec<T: BinWrite<Args<'static> = ()>>(v: &Vec<T>) -> BinResult<()> {
     use std::io::SeekFrom;


### PR DESCRIPTION
### Changelog
Replace `#[allow(..)]` with `#[expect(..)]`

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

The allow macro doesnt advise when it is no longer needed. The expect macro should always be used instead.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 722e3423af6d5faa4cf18cb93d5ee750182d55c9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->