### PR TITLE
rust: remove unused error variants

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -82,8 +82,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum McapError {
-    #[error("tried to write to output while attachment is in progress")]
-    AttachmentInProgress,
     #[error("tried to write bytes to an attachment but no attachment was in progress")]
     AttachmentNotInProgress,
     #[error("tried to write {excess} more bytes to attachment than the requested attachment length {attachment_length}")]
@@ -126,14 +124,10 @@ pub enum McapError {
     UnexpectedEof,
     #[error("Chunk ended in the middle of a record")]
     UnexpectedEoc,
-    #[error("Record with opcode {opcode:02X} has length {len}, need at least {expected} to parse")]
-    RecordTooShort { opcode: u8, len: u64, expected: u64 },
     #[error("Message {0} referenced unknown channel {1}")]
     UnknownChannel(u32, u16),
     #[error("Channel `{0}` referenced unknown schema {1}")]
     UnknownSchema(String, u16),
-    #[error("Found record with opcode {0:02X} in a chunk")]
-    UnexpectedChunkRecord(u8),
     #[error("Unsupported compression format `{0}`")]
     UnsupportedCompression(String),
     #[error("Error during decompression: `{0}`")]

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -407,7 +407,7 @@ pub struct ChunkIndex {
 impl ChunkIndex {
     /// Returns the offset in the file to the start of compressed chunk data.
     /// This can be useful for retrieving just the compressed content of a chunk given its index.
-    /// Returns [`McapError::TooLong`] if the resulting offset would be greater than [`u64::MAX`].
+    /// Returns [`McapError::BadChunkStartOffset`] if the resulting offset would be greater than [`u64::MAX`].
     pub fn compressed_data_offset(&self) -> McapResult<u64> {
         let res = self.chunk_start_offset.checked_add(
             1 // opcode


### PR DESCRIPTION
### Changelog
Removed unused error enum variants and fix docstrings to match new error.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Users with error handling expecting errors that will never occur should have compile time failures letting them know their code is outdated.

Also updated our docs to reflect the errors that actually exists.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

