### PR TITLE
NPM package publishing via Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
     permissions:
       # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
       id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -248,32 +249,24 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
         # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
         run: npm publish typescript/core/package.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - run: yarn workspace @mcap/support pack
       - name: Publish @mcap/support to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/support/v') }}
         # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
         run: npm publish typescript/support/package.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - run: yarn workspace @mcap/nodejs pack
       - name: Publish @mcap/nodejs to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/nodejs/v') }}
         # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
         run: npm publish typescript/nodejs/package.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - run: yarn workspace @mcap/browser pack
       - name: Publish @mcap/browser to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/browser/v') }}
         # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
         run: npm publish typescript/browser/package.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   typescript-examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

Updates NPM publishing to use [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) since [classic tokens](https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/#if-you-use-npm-classic-tokens) are being deprecated.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move TypeScript package publishing to NPM Trusted Publishing via OIDC, adding required permissions and removing classic token usage.
> 
> - **CI workflow (`.github/workflows/ci.yml`)**:
>   - **TypeScript job**:
>     - Add `permissions.contents: read` alongside `id-token: write` for OIDC.
>     - Configure `actions/setup-node` with `registry-url` for NPM.
>     - Remove `NODE_AUTH_TOKEN` env from all `npm publish` steps for `@mcap/{core,support,nodejs,browser}` (Trusted Publishing).
>     - Keep `npm publish ... --provenance --access public` steps gated by tag refs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd1121be0e428ba6aa2818ea0fd811526bd52e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->