### PR TITLE
cli: fix attachment log and creation time CLI args

### DIFF
--- a/go/cli/mcap/cmd/attachment.go
+++ b/go/cli/mcap/cmd/attachment.go
@@ -164,7 +164,7 @@ var addAttachmentCmd = &cobra.Command{
 		}
 		logTime := uint64(time.Now().UTC().UnixNano())
 		if addAttachmentLogTime != "" {
-			date, err := parseDateOrNanos(addAttachmentCreationTime)
+			date, err := parseDateOrNanos(addAttachmentLogTime)
 			if err != nil {
 				die("failed to parse log date: %s", err)
 			}
@@ -203,7 +203,7 @@ func init() {
 		"attachment log time in nanoseconds or RFC3339 format (defaults to current timestamp)",
 	)
 	addAttachmentCmd.PersistentFlags().StringVarP(
-		&addAttachmentLogTime,
+		&addAttachmentCreationTime,
 		"creation-time",
 		"",
 		"",


### PR DESCRIPTION
### Changelog
- Fixed a bug where `mcap add attachment --log-time` would fail with a parse error.
- Fixed a bug where `mcap add attachment --creation-time` would set the wrong creation time.
### Docs

None.

### Description

Fixes two bugs in the parsing logic for `mcap add attachment` creation time and log time.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `mcap add attachment` to parse `--log-time` correctly and bind `--creation-time` to the proper variable.
> 
> - **CLI**
>   - **Add Attachment** (`go/cli/mcap/cmd/attachment.go`):
>     - Parse `--log-time` using `addAttachmentLogTime` (was using creation-time var).
>     - Bind `--creation-time` flag to `addAttachmentCreationTime` (was bound to log-time var).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdf15f7b2d54df83c13316f5196d3c01c0d6cab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->