### PR TITLE
info: expand frequency estimate to upper and lower bounds

### DIFF
--- a/go/cli/mcap/cmd/info.go
+++ b/go/cli/mcap/cmd/info.go
@@ -250,16 +250,29 @@ func printInfo(w io.Writer, info *mcap.Info) error {
 				maxHz := float64(channelMessageCount) / durationInSeconds
 				minHz := float64(channelMessageCount-1) / durationInSeconds
 				precision := int(max(0, math.Ceil(-math.Log10(maxHz-minHz))))
-				row = append(
-					row,
-					fmt.Sprintf("%*d msgs (%.*f..%.*fHz)",
-						maxCountWidth,
-						channelMessageCount,
-						precision,
-						minHz,
-						precision,
-						maxHz),
-				)
+				// Cap precision at two decimal places.
+				if precision > 2 {
+					row = append(
+						row,
+						fmt.Sprintf("%*d msgs (%.2fHz)",
+							maxCountWidth,
+							channelMessageCount,
+							maxHz,
+						),
+					)
+				} else {
+					row = append(
+						row,
+						fmt.Sprintf("%*d msgs (%.*f..%.*fHz)",
+							maxCountWidth,
+							channelMessageCount,
+							precision,
+							minHz,
+							precision,
+							maxHz,
+						),
+					)
+				}
 			} else {
 				row = append(row, fmt.Sprintf("%*d msgs", maxCountWidth, channelMessageCount))
 			}


### PR DESCRIPTION
### Changelog

#### CLI
- `mcap info` now estimates upper and lower bounds for frequency of channels.
### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Today `mcap info` attempts to estimate message frequency for all channels with more than one message. The estimate is calculated as `f = k/T`, where `f` is the message frequency in Hz, `k` is the number of messages, and `T` is the duration of the MCAP (`statistics.end - statistics.start`).

@joe-saronic in #1504 points out that for periodic MCAP channels with few (~2) messages, this can produce pretty off estimates. This happens because the boundary conditions at the start and end of the MCAP produce significant errors. For example, in a 3-second recording containing a 1hz topic, the frequency may be calculated as:

```
[|   |   |  |] (4 samples in 3s = 1.3hz)
```

```
[ |   |   |  ] (3 samples in 3s = 1hz)
```

In https://github.com/foxglove/mcap/pull/1505 they propose using message indexes to discover the exact first and last timestamps of every channel, calculating each channel's duration `T'`, then using the formula `f = k-1/T'`. This produces the correct estimate every time for periodic topics with no jitter, but there are two downsides:
- It requires reading message indexes to produce `info`. IMO this makes the proposal a non-starter. Some MCAPs aren't written with message indexes, because they take significant space in the file if messages are small and frequent. reading message indexes also requires seeking and reading many times through the file, which can be prohibitive for large files over a network.
- For topics that aren't perfectly periodic, it discards useful information from the start and end of recording about the period when a message wasn't logged. This makes the estimate more sensitive to timing jitter. 

In this PR, `mcap info` produces an upper and lower bound to the frequency estimate. This aids the user by making the uncertainty of the estimate visible, and does not require reading message indexes. 

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

### Before

```
        (0) /diagnostics              7 msgs (7.09 Hz)     : diagnostic_msgs/DiagnosticArray [ros1msg]  
        (1) /image_color/compressed  30 msgs (30.39 Hz)    : sensor_msgs/CompressedImage [ros1msg]      
        (2) /tf                      99 msgs (100.27 Hz)   : tf2_msgs/TFMessage [ros1msg]               
        (3) /radar/points            20 msgs (20.26 Hz)    : sensor_msgs/PointCloud2 [ros1msg]          
        (4) /radar/range             20 msgs (20.26 Hz)    : sensor_msgs/Range [ros1msg]                
        (5) /radar/tracks            20 msgs (20.26 Hz)    : radar_driver/RadarTracks [ros1msg]         
        (6) /velodyne_points         10 msgs (10.13 Hz)    : sensor_msgs/PointCloud2 [ros1msg]    
```
### After
```
        (0) /diagnostics              7 msgs (6..7Hz)      : diagnostic_msgs/DiagnosticArray [ros1msg]  
        (1) /image_color/compressed  30 msgs (29..30Hz)    : sensor_msgs/CompressedImage [ros1msg]      
        (2) /tf                      99 msgs (99..100Hz)   : tf2_msgs/TFMessage [ros1msg]               
        (3) /radar/points            20 msgs (19..20Hz)    : sensor_msgs/PointCloud2 [ros1msg]          
        (4) /radar/range             20 msgs (19..20Hz)    : sensor_msgs/Range [ros1msg]                
        (5) /radar/tracks            20 msgs (19..20Hz)    : radar_driver/RadarTracks [ros1msg]         
        (6) /velodyne_points         10 msgs (9..10Hz)     : sensor_msgs/PointCloud2 [ros1msg] 
```

Fixes: #1504 
<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `mcap info` now displays per-channel message frequency as lower–upper bounds based on duration, with smart precision handling.
> 
> - **CLI (`mcap info`)**:
>   - **Channel frequency estimation**:
>     - Compute min/max Hz bounds from `channelMessageCount` and `durationInSeconds` (`(k-1)/T..k/T`).
>     - Only compute when `channelMessageCount > 1` and `durationInSeconds > 0`.
>     - Output either a range ``(%.*f..%.*fHz)`` or a single value ``(%.2fHz)`` based on required precision (capped at 2 decimals).
>   - Replaces single-frequency display with bounded estimate in `go/cli/mcap/cmd/info.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6b36c81aaf9114a10124e1be79148e90b497e32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->