### PR TITLE
python: allow topics specified as string

### DIFF
--- a/python/mcap-protobuf-support/mcap_protobuf/decoder.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/decoder.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Optional, Type
 
 from google.protobuf.descriptor_pb2 import FileDescriptorProto, FileDescriptorSet
 from google.protobuf.descriptor_pool import DescriptorPool
-from google.protobuf.message_factory import GetMessageClassesForFiles, GetMessageClass
+from google.protobuf.message_factory import GetMessageClass, GetMessageClassesForFiles
 
 from mcap.decoder import DecoderFactory as McapDecoderFactory
 from mcap.exceptions import McapError

--- a/python/mcap-protobuf-support/mcap_protobuf/reader.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/reader.py
@@ -27,7 +27,7 @@ warnings.warn(__doc__, DeprecationWarning)
 
 def read_protobuf_messages(
     source: Union[str, bytes, PathLike[str], McapReader, IO[bytes]],
-    topics: Optional[Iterable[str]] = None,
+    topics: Union[Iterable[str], str, None] = None,
     start_time: Optional[Union[int, datetime]] = None,
     end_time: Optional[Union[int, datetime]] = None,
     log_time_order: bool = True,

--- a/python/mcap-ros1-support/mcap_ros1/reader.py
+++ b/python/mcap-ros1-support/mcap_ros1/reader.py
@@ -25,7 +25,7 @@ warnings.warn(__doc__, DeprecationWarning)
 
 def read_ros1_messages(
     source: Union[str, bytes, "PathLike[str]", McapReader, IO[bytes]],
-    topics: Optional[Iterable[str]] = None,
+    topics: Union[Iterable[str], str, None] = None,
     start_time: Optional[Union[int, datetime]] = None,
     end_time: Optional[Union[int, datetime]] = None,
     log_time_order: bool = True,

--- a/python/mcap-ros2-support/mcap_ros2/_dynamic.py
+++ b/python/mcap-ros2-support/mcap_ros2/_dynamic.py
@@ -1,8 +1,8 @@
 """ROS2 message definition parsing and message deserialization."""
 
+import array as py_array
 import re
 from io import BytesIO
-import array as py_array
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 

--- a/python/mcap-ros2-support/mcap_ros2/reader.py
+++ b/python/mcap-ros2-support/mcap_ros2/reader.py
@@ -26,7 +26,7 @@ warnings.warn(__doc__, DeprecationWarning)
 
 def read_ros2_messages(
     source: Union[str, bytes, "PathLike[str]", McapReader, IO[bytes]],
-    topics: Optional[Iterable[str]] = None,
+    topics: Union[Iterable[str], str, None] = None,
     start_time: Optional[Union[int, datetime]] = None,
     end_time: Optional[Union[int, datetime]] = None,
     log_time_order: bool = True,

--- a/python/mcap-ros2-support/tests/test_ros2_writer.py
+++ b/python/mcap-ros2-support/tests/test_ros2_writer.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 from array import array
+from io import BytesIO
 
 from mcap_ros2.decoder import DecoderFactory
 from mcap_ros2.writer import Writer as Ros2Writer

--- a/python/mcap/mcap/reader.py
+++ b/python/mcap/mcap/reader.py
@@ -13,6 +13,7 @@ from typing import (
     NamedTuple,
     Optional,
     Tuple,
+    Union,
 )
 
 from ._message_queue import make_message_queue
@@ -127,7 +128,7 @@ class McapReader(ABC):
     @abstractmethod
     def iter_messages(
         self,
-        topics: Optional[Iterable[str]] = None,
+        topics: Union[Iterable[str], str, None] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
         log_time_order: bool = True,
@@ -149,7 +150,7 @@ class McapReader(ABC):
 
     def iter_decoded_messages(
         self,
-        topics: Optional[Iterable[str]] = None,
+        topics: Union[Iterable[str], str, None] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
         log_time_order: bool = True,
@@ -263,7 +264,7 @@ class SeekingReader(McapReader):
 
     def iter_messages(
         self,
-        topics: Optional[Iterable[str]] = None,
+        topics: Union[Iterable[str], str, None] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
         log_time_order: bool = True,
@@ -282,6 +283,8 @@ class SeekingReader(McapReader):
             yielded in descending log time order.
 
         """
+        if isinstance(topics, str):
+            topics = [topics]
         summary = self.get_summary()
         if summary is None or len(summary.chunk_indexes) == 0:
             # No chunk indices available, so there is no index to search for messages.
@@ -467,7 +470,7 @@ class NonSeekingReader(McapReader):
 
     def iter_messages(
         self,
-        topics: Optional[Iterable[str]] = None,
+        topics: Union[Iterable[str], str, None] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
         log_time_order: bool = True,
@@ -489,6 +492,8 @@ class NonSeekingReader(McapReader):
             setting log_time_order to True on a non-seekable stream will cause the entire content
             of the MCAP to be loaded into memory.
         """
+        if isinstance(topics, str):
+            topics = [topics]
         if not log_time_order:
             for t in self._iter_messages_internal(topics, start_time, end_time):
                 yield t

--- a/python/mcap/tests/test_reader.py
+++ b/python/mcap/tests/test_reader.py
@@ -116,6 +116,22 @@ def test_only_diagnostics(reader_cls: AnyReaderSubclass):
         assert count == 1
 
 
+@pytest.mark.parametrize("reader_cls", READER_SUBCLASSES)
+def test_only_diagnostics_str(reader_cls: AnyReaderSubclass):
+    """test that we can filter by topic string with all reader implementations."""
+    with open(DEMO_MCAP, "rb") as f:
+        reader: McapReader = reader_cls(f)
+        count = 0
+        for schema, channel, message in reader.iter_messages(topics="/diagnostics"):
+            assert isinstance(schema, Schema)
+            assert isinstance(channel, Channel)
+            assert channel.topic == "/diagnostics"
+            assert isinstance(message, Message)
+            count += 1
+
+        assert count == 1
+
+
 def write_json_mcap(filepath: Path):
     with open(filepath, "wb") as f:
         writer = Writer(f)


### PR DESCRIPTION
### Changelog
#### Python
- `reader`: the `iter_messages` methods of the MCAP reader (as well as the ros1, ros2 and protobuf readers) now treat a string argument to `topics` as a single topic to filter on, rather than a sequence of single-character topics.
### Docs

Documented in docstrings.
### Description

#1508 points out that if a user mistakenly provides topics as a single string rather than an iterable of those, the topics filter is interpreted as an iterable of single character strings. This is not plausibly the user's intent, so our options here are to a) reject the argument, or b) accept the argument and "do the right thing". This PR opts for b). 
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
Fixes: #1508 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Readers now accept a single string for `topics` and normalize it internally; tests added.
> 
> - **Readers**:
>   - MCAP: `McapReader.iter_messages`/`iter_decoded_messages` accept `topics: Union[Iterable[str], str, None]`; normalize string to list in `SeekingReader` and `NonSeekingReader`.
>   - ROS1/ROS2/Protobuf: `read_ros*_messages` and `read_protobuf_messages` now accept `topics` as string or iterable.
> - **Tests**:
>   - Add `test_only_diagnostics_str` validating string topic filtering for both reader implementations.
> - **Types/Imports**:
>   - Add `Union` import and update type hints in `python/mcap/mcap/reader.py`.
>   - Minor import reorders in `mcap_ros2/_dynamic.py`, `mcap_ros2/tests/test_ros2_writer.py`, and `mcap_protobuf/decoder.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0b5111178457db6f3381897f7221083d94b4b42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->