### PR TITLE
add mguida22 to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,10 +21,10 @@
 
 /go @gasmith @james-rms
 
-/python @gasmith @jtbandes @james-rms
+/python @gasmith @jtbandes @james-rms @mguida22
 
 /rust @gasmith @james-rms @bennetthardwick
 
 /swift @jtbandes
 
-/typescript @jtbandes @achim-k
+/typescript @jtbandes @achim-k @mguida22


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Adds myself to CODEOWNERS for python and typescript to help with reviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds @mguida22 as CODEOWNER for `python/` and `typescript/` paths in `.github/CODEOWNERS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb12a15e21322e2af3731f9a7d9400355408197f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->