### PR TITLE
docs: fix instructions for core mcap versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are several python packages; updating any follows a similar process.
 
 1. Update the version in the appropriate `__init__.py` file
 2. Tag a release matching `releases/python/PACKAGE/vX.Y.Z`
-    - For example, `releases/python/mcap/v1.2.3`
+   - For example, `releases/python/mcap/v1.2.3`
 
 ### TypeScript
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Updates the README to reflect the proper tag pattern for python packages.

The README currently notes that the core mcap python package should be tagged as `releases/python/vX.Y.Z`. However, CI expects it to be tagged like other python packages, using the format `releases/python/mcap/v1.2.3`. We have been using this tag format for a while now (at least since [1.0.0](https://github.com/foxglove/mcap/releases/tag/releases%2Fpython%2Fmcap%2Fv1.0.0))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release docs to standardize Python package tagging.
> 
> - Python: use `releases/python/PACKAGE/vX.Y.Z` for all packages (e.g., `releases/python/mcap/v1.2.3`)
> - Removes prior special-case instruction for the core `mcap` package (`releases/python/vX.Y.Z`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08aee6f7fd0182bc41d9c6b29e7b83c05747e52e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->