### PR TITLE
cli: fix support for piping stdin to cat

### DIFF
--- a/go/cli/mcap/cmd/cat.go
+++ b/go/cli/mcap/cmd/cat.go
@@ -169,10 +169,10 @@ func (w *jsonOutputWriter) writeMessage(
 func getReadOpts(useIndex bool) []mcap.ReadOpt {
 	topics := strings.FieldsFunc(catTopics, func(c rune) bool { return c == ',' })
 
-	opts := []mcap.ReadOpt{mcap.WithTopics(topics)}
+	opts := []mcap.ReadOpt{mcap.WithTopics(topics), mcap.UsingIndex(useIndex)}
 
 	if useIndex {
-		opts = append(opts, mcap.UsingIndex(true), mcap.InOrder(mcap.LogTimeOrder))
+		opts = append(opts, mcap.InOrder(mcap.LogTimeOrder))
 	}
 	catStart := catStartNano
 	if catStartSec > 0 {

--- a/go/cli/mcap/cmd/cat_test.go
+++ b/go/cli/mcap/cmd/cat_test.go
@@ -47,6 +47,23 @@ func TestCat(t *testing.T) {
 	}
 }
 
+func TestGetReadOptsUseIndex(t *testing.T) {
+	// getReadOpts(false) must set UseIndex=false to allow non-seekable readers (stdin).
+	opts := mcap.ReadOptions{UseIndex: true} // default
+	for _, opt := range getReadOpts(false) {
+		require.NoError(t, opt(&opts))
+	}
+	assert.False(t, opts.UseIndex)
+
+	// getReadOpts(true) must set UseIndex=true and Order=LogTimeOrder for seekable readers.
+	opts = mcap.ReadOptions{}
+	for _, opt := range getReadOpts(true) {
+		require.NoError(t, opt(&opts))
+	}
+	assert.True(t, opts.UseIndex)
+	assert.Equal(t, mcap.LogTimeOrder, opts.Order)
+}
+
 func BenchmarkCat(b *testing.B) {
 	cases := []struct {
 		assertion  string


### PR DESCRIPTION
The cat command supports accepting input from stdin, which is useful for building shell pipelines out of mcap data streams when combined with the JSON transcoding support:

    cat demo.mcap | mcap cat --json | jq ...

Commit 431d1dce2 caused this behavior to break, because it caused a default of useIndex=true to get inherited in the cat options assessment, when "useIndex=false" was requested (as triggered by the stdin handling). That commit seems to assume that the reader will skip the index by default, which is not true at least today (and presumably not then either).

With this new commit, correct behavior is restored:

    [~] $ cat demo.mcap | mcap cat | head -n 1
    1490149580103843113 /diagnostics [diagnostic_msgs/DiagnosticArray] [42 10 0 0 204 224 209 88 99 250]...

this patch also adds a test that confirms that the intent of the original bad commit is still preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores correct reader options for `cat` when reading from stdin vs files.
> 
> - Updates `getReadOpts` to always include `mcap.UsingIndex(useIndex)` and only append `mcap.InOrder(mcap.LogTimeOrder)` when `useIndex` is true
> - Adds `TestGetReadOptsUseIndex` to verify `UseIndex=false` for non-seekable stdin and `UseIndex=true` with `LogTimeOrder` for seekable readers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d76468d4d0635475f6640ea77b1a1d393b43e1f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->