### PR TITLE
feat(cli): add volcengine storage service tos:// support

### DIFF
--- a/go/cli/mcap/go.mod
+++ b/go/cli/mcap/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/foxglove/go-rosbag v0.0.7
 	github.com/foxglove/mcap/go/mcap v1.7.4
-	github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be
+	github.com/foxglove/mcap/go/ros v0.0.0-20251222190015-2625e1e9b1e9
 	github.com/klauspost/compress v1.16.7
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.9.0
+	github.com/volcengine/ve-tos-golang-sdk/v2 v2.8.0
 	google.golang.org/protobuf v1.28.0
 )
 
@@ -70,6 +71,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/oauth2 v0.0.0-20220630143837-2104d58473e0 // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go/cli/mcap/go.sum
+++ b/go/cli/mcap/go.sum
@@ -121,6 +121,7 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -140,8 +141,8 @@ github.com/foxglove/go-rosbag v0.0.7 h1:JS9ZzNWnN+DnQhG73N8mLFWPEAF7mW39oLGCjYYH
 github.com/foxglove/go-rosbag v0.0.7/go.mod h1:Kz3doYZfPO6OIawx4tFm9MU9COkuzcYaI963psJeLrA=
 github.com/foxglove/mcap/go/mcap v1.7.4 h1:uoWXtM/2XyqFQ9yQeoj+HZ/PnhlDIhirRNqBYR4vBuA=
 github.com/foxglove/mcap/go/mcap v1.7.4/go.mod h1:MBbbGkXnTAU3fj5ZEDA/ioXIe7gFk21SxfqKW8bQfsE=
-github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be h1:K7lVNHXix6A9Ysz8StgVHp59B0pBAb1HjxH6GITOJMQ=
-github.com/foxglove/mcap/go/ros v0.0.0-20230114025807-456e6a6ca1be/go.mod h1:unwCv59e2oXGhFfSJ4u/A1prNTULz5ZXrGFQEpfNmb0=
+github.com/foxglove/mcap/go/ros v0.0.0-20251222190015-2625e1e9b1e9 h1:aO+gi+vPuFR+NrnP8zlGdgaqSmVejwppvYKiCrdKx6M=
+github.com/foxglove/mcap/go/ros v0.0.0-20251222190015-2625e1e9b1e9/go.mod h1:ljgo3e4oCykooz/WWh0WgsEr/dDP9WNZpjO21/l/WOw=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
@@ -257,6 +258,7 @@ github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGC
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -303,6 +305,7 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
@@ -317,17 +320,22 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.12.0 h1:CZ7eSOd3kZoaYDLbXnmzgQI5RlciuXBMA+18HwHRfZQ=
 github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiuKtSI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=
 github.com/subosito/gotenv v1.4.0/go.mod h1:mZd6rFysKEcUhUHXJk0C/08wAgyDBFuwEYL7vWWGaGo=
+github.com/volcengine/ve-tos-golang-sdk/v2 v2.8.0 h1:iIMHnJQ/zHbJiNZFZn77HonGo39sLZdJbRM1kKCQd4Y=
+github.com/volcengine/ve-tos-golang-sdk/v2 v2.8.0/go.mod h1:IrjK84IJJTuOZOTMv/P18Ydjy/x+ow7fF7q11jAxXLM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -464,6 +472,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -528,6 +538,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -792,8 +803,9 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.66.6 h1:LATuAqN/shcYAOkv3wl2L4rkaKqkcgTBQjOyYDvcPKI=
 gopkg.in/ini.v1 v1.66.6/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/go/cli/mcap/utils/readers/tos.go
+++ b/go/cli/mcap/utils/readers/tos.go
@@ -175,7 +175,6 @@ func ensureEnvVarFromAliases(target string, aliases []string) error {
 		if value := os.Getenv(alias); value != "" {
 			return os.Setenv(target, value)
 		}
-
 	}
 	return nil
 }

--- a/go/cli/mcap/utils/readers/tos.go
+++ b/go/cli/mcap/utils/readers/tos.go
@@ -1,0 +1,181 @@
+package readers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/volcengine/ve-tos-golang-sdk/v2/tos"
+)
+
+var (
+	tosEndpointEnvVars   = []string{"MCAP_TOS_ENDPOINT", "TOS_ENDPOINT"}
+	tosRegionEnvVars     = []string{"MCAP_TOS_REGION", "TOS_REGION"}
+	tosAccessKeyAliasEnv = []string{"MCAP_TOS_ACCESS_KEY", "TOS_ACCESS_KEY"}
+	tosSecretKeyAliasEnv = []string{"MCAP_TOS_SECRET_KEY", "TOS_SECRET_KEY"}
+)
+
+// Automatically register TOS reader when imported.
+func init() {
+	RegisterReader("tos", newTOSReader)
+}
+
+// Factory for TOS readers (called by registry).
+func newTOSReader(ctx context.Context, bucket, path string) (func() error, io.ReadSeekCloser, error) {
+	endpoint := firstNonEmptyEnv(tosEndpointEnvVars...)
+	region := firstNonEmptyEnv(tosRegionEnvVars...)
+	if endpoint == "" && region == "" {
+		return func() error { return nil }, nil, fmt.Errorf(
+			"TOS endpoint or region must be configured (set MCAP_TOS_ENDPOINT/TOS_ENDPOINT or MCAP_TOS_REGION/TOS_REGION)",
+		)
+	}
+
+	opts := []tos.ClientOption{tos.WithRegion(region)}
+
+	useEnvCreds, err := configureTOSEnvCredentials()
+	if err != nil {
+		return func() error { return nil }, nil, fmt.Errorf("failed to configure TOS credentials: %w", err)
+	}
+
+	if useEnvCreds {
+		opts = append(opts, tos.WithCredentialsProvider(&tos.EnvCredentialsProvider{}))
+	}
+
+	client, err := tos.NewClientV2(endpoint, opts...)
+	if err != nil {
+		return func() error { return nil }, nil, fmt.Errorf("failed to create TOS client: %v", err)
+	}
+	rs, err := NewTOSReadSeekCloser(ctx, client, bucket, path)
+	if err != nil {
+		client.Close()
+		return func() error { return nil }, nil, fmt.Errorf("failed to create TOS reader: %w", err)
+	}
+
+	return func() error {
+		client.Close()
+		return nil
+	}, rs, nil
+}
+
+// TOSReadSeekCloser implements io.ReadSeekCloser for objects on TOS.
+type TOSReadSeekCloser struct {
+	ctx    context.Context
+	client *tos.ClientV2
+	bucket string
+	key    string
+	reader io.ReadCloser
+	size   int64
+	offset int64
+}
+
+// NewTOSReadSeekCloser creates a seekable reader backed by TOS.
+func NewTOSReadSeekCloser(ctx context.Context, client *tos.ClientV2, bucket, key string) (*TOSReadSeekCloser, error) {
+	output, err := client.GetObjectV2(ctx, &tos.GetObjectV2Input{
+		Bucket: bucket,
+		Key:    key,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open TOS object: %w", err)
+	}
+
+	return &TOSReadSeekCloser{
+		ctx:    ctx,
+		client: client,
+		bucket: bucket,
+		key:    key,
+		reader: output.Content,
+		size:   output.ContentLength,
+		offset: 0,
+	}, nil
+}
+
+// Read implements io.Reader.
+func (r *TOSReadSeekCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.offset += int64(n)
+	return n, err
+}
+
+// Seek implements io.Seeker backed by range requests.
+func (r *TOSReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
+	var target int64
+	switch whence {
+	case io.SeekStart:
+		target = offset
+	case io.SeekCurrent:
+		target = r.offset + offset
+	case io.SeekEnd:
+		target = r.size + offset
+	default:
+		return 0, fmt.Errorf("invalid whence: %d", whence)
+	}
+
+	if target < 0 || target > r.size {
+		return 0, fmt.Errorf("seek out of bounds: %d", target)
+	}
+	if target == r.offset {
+		return target, nil
+	}
+	if target == r.size {
+		_ = r.reader.Close()
+		r.reader = io.NopCloser(bytes.NewReader(nil))
+		r.offset = target
+		return target, nil
+	}
+
+	_ = r.reader.Close()
+	input := &tos.GetObjectV2Input{
+		Bucket: r.bucket,
+		Key:    r.key,
+	}
+	if target > 0 {
+		input.RangeStart = target
+		input.RangeEnd = r.size - 1
+	}
+	output, err := r.client.GetObjectV2(r.ctx, input)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reopen TOS object: %w", err)
+	}
+	r.reader = output.Content
+	r.offset = target
+	return target, nil
+}
+
+// Close closes the current reader.
+func (r *TOSReadSeekCloser) Close() error {
+	return r.reader.Close()
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := os.Getenv(key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func configureTOSEnvCredentials() (bool, error) {
+	if err := ensureEnvVarFromAliases("TOS_ACCESS_KEY", tosAccessKeyAliasEnv); err != nil {
+		return false, err
+	}
+	if err := ensureEnvVarFromAliases("TOS_SECRET_KEY", tosSecretKeyAliasEnv); err != nil {
+		return false, err
+	}
+	return os.Getenv("TOS_ACCESS_KEY") != "" && os.Getenv("TOS_SECRET_KEY") != "", nil
+}
+
+func ensureEnvVarFromAliases(target string, aliases []string) error {
+	if os.Getenv(target) != "" {
+		return nil
+	}
+	for _, alias := range aliases {
+		if value := os.Getenv(alias); value != "" {
+			return os.Setenv(target, value)
+		}
+
+	}
+	return nil
+}

--- a/go/cli/mcap/utils/readers/tos.go
+++ b/go/cli/mcap/utils/readers/tos.go
@@ -45,7 +45,7 @@ func newTOSReader(ctx context.Context, bucket, path string) (func() error, io.Re
 
 	client, err := tos.NewClientV2(endpoint, opts...)
 	if err != nil {
-		return func() error { return nil }, nil, fmt.Errorf("failed to create TOS client: %v", err)
+		return func() error { return nil }, nil, fmt.Errorf("failed to create TOS client: %w", err)
 	}
 	rs, err := NewTOSReadSeekCloser(ctx, client, bucket, path)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR introduces support for **ByteDance Volcengine TOS** object storage as a remote backend for the MCAP CLI, specifically enabling `tos://` URI reads.

## Motivation

At ByteDance, we extensively use MCAP files stored on TOS for our robotics and VLA (Vision-Language-Action) models. Currently, our internal workflows and tools often require downloading full MCAP files locally before processing. This approach incurs significant bandwidth costs and latency.

To optimize this and avoid maintaining a hard fork of the CLI, we aim to upstream our internal integration to the community. This allows users to inspect and process MCAP files directly from TOS without intermediate downloading.

## Implementation Details

*   Added a `tos://` scheme handler to the CLI's remote file reader.
*   The implementation limits dependencies and strictly follows the existing patterns established by the **S3** and **GCS** integrations to ensure consistency.

## Future Roadmap

This PR serves as the **initial minimal contribution** to establish the workflow. We have developed several advanced optimizations internally for AI training scenarios, which we plan to contribute in subsequent PRs:

- [ ] **High-Performance Access:** Integration with TOS accelerator (SSD layer) to provide higher IOPS for training clusters.
- [ ] **Smart Caching:** Optimizing range requests to accelerate random reads (critical for AI data shuffling).
- [ ] **Write Support:** Implementing append-only write support for handling file merging directly on object storage.
- [ ] **Network Optimization:** High-speed network access (similar to AWS CRT) .
- [ ] **HDFS Support:** Remote read implementation for HDFS protocols.

## Verification

*   Verified locally by building the CLI and running `mcap info tos://bucket/path/to/file.mcap`.
*   Ensured `go.mod` dependencies are minimal.

First time contributor here, happy to join the community! Looking forward to your review.
