### PR TITLE
cli: close chunkDataReader

### DIFF
--- a/go/cli/mcap/cmd/du.go
+++ b/go/cli/mcap/cmd/du.go
@@ -57,6 +57,7 @@ func (instance *usage) processChunk(chunk *mcap.Chunk) error {
 		if err != nil {
 			return fmt.Errorf("could not make zstd decoder: %w", err)
 		}
+		defer chunkDataReader.Close()
 		uncompressedBytes, err = io.ReadAll(chunkDataReader)
 		if err != nil {
 			return fmt.Errorf("could not decompress: %w", err)


### PR DESCRIPTION
### Changelog

Fixes a potential memory leak in `mcap du` by properly closing the zstd decoder.

### Docs

None

### Description

Closes the zstd decoder. https://pkg.go.dev/github.com/klauspost/compress@v1.16.7/zstd#Decoder