### PR TITLE
Disable Claude PR review workflow for fork PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Restrict the `pr-review` workflow to same-repo PRs to prevent unnecessary runs on forks that lack required secrets.

PRs from forks cannot access repository secrets (e.g., `ANTHROPIC_API_KEY`), making the workflow fail or be ineffective when run on them.

---
<p><a href="https://cursor.com/agents/bc-5e834198-e9e6-40db-a149-5203b802f1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e834198-e9e6-40db-a149-5203b802f1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

