### PR TITLE
cpp: bump to 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ The version number is set at build time based on the tag.
    - cpp/build.sh
    - cpp/docs/conanfile.py
    - cpp/examples/conanfile.py
+   - cpp/mcap/conanfile.py
    - cpp/mcap/include/mcap/types.hpp (`MCAP_LIBRARY_VERSION`)
-   - cpp/mcap/include/conanfile.py
    - cpp/test/conanfile.py
 2. Tag a release matching the version number `releases/cpp/vX.Y.Z`
 

--- a/cpp/bench/conanfile.py
+++ b/cpp/bench/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapBenchmarksConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "benchmark/1.7.0", "mcap/2.1.2"
+    requires = "benchmark/1.7.0", "mcap/2.1.3"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/build-docs.sh
+++ b/cpp/build-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/2.1.2
+conan editable add ./mcap mcap/2.1.3
 conan install docs --install-folder docs/build/Release \
   -s compiler.cppstd=17 -s build_type=Release --build missing
 

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -4,7 +4,7 @@ set -e
 
 conan config init
 
-conan editable add ./mcap mcap/2.1.2
+conan editable add ./mcap mcap/2.1.3
 conan install test --install-folder test/build/Debug \
   -s compiler.cppstd=17 -s build_type=Debug --build missing
 

--- a/cpp/docs/conanfile.py
+++ b/cpp/docs/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapDocsConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "mcap/2.1.2"
+    requires = "mcap/2.1.3"
 
     def build(self):
         cmake = CMake(self)

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -5,7 +5,7 @@ class McapExamplesConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = [
-        "mcap/2.1.2",
+        "mcap/2.1.3",
         "protobuf/3.21.1",
         "nlohmann_json/3.10.5",
         "catch2/2.13.8",

--- a/cpp/mcap/conanfile.py
+++ b/cpp/mcap/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 class McapConan(ConanFile):
     name = "mcap"
-    version = "2.1.2"
+    version = "2.1.3"
     url = "https://github.com/foxglove/mcap"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -14,7 +14,7 @@
 
 namespace mcap {
 
-#define MCAP_LIBRARY_VERSION "2.1.2"
+#define MCAP_LIBRARY_VERSION "2.1.3"
 
 using SchemaId = uint16_t;
 using ChannelId = uint16_t;

--- a/cpp/test/conanfile.py
+++ b/cpp/test/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class McapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "catch2/2.13.8", "mcap/2.1.2", "nlohmann_json/3.10.5"
+    requires = "catch2/2.13.8", "mcap/2.1.3", "nlohmann_json/3.10.5"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Bump the C++ version to `2.1.3` in preparation for release.