### PR TITLE
Fix OpenSSL installation in Swift CI

### DIFF
--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: install deps
       shell: bash
-      run: sudo apt-get -y install libcurl4-openssl-dev
+      run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev
 
     - name: install swift
       shell: bash


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
CI is currently failing for [unrelated changes](https://github.com/foxglove/mcap/actions/runs/22599772218/job/65480070993?pr=1531) due to an error installing OpenSSL in the Swift setup action. The error is:
```
> Run sudo apt-get -y install libcurl4-openssl-dev
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  libcurl4-doc libidn-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev
0 upgraded, 1 newly installed, 0 to remove and 25 not upgraded.
Need to get 446 kB of archives.
After this operation, 1960 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
Ign:2 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
Ign:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.6
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/c/curl/libcurl4-openssl-dev_8.5.0-2ubuntu10.6_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
This change adds the necessary `apt-get update`  
