### PR TITLE
Add opt-in path-style S3 addressing via MCAP_S3_FORCE_PATH_STYLE

### DIFF
--- a/go/cli/mcap/utils/readers/s3.go
+++ b/go/cli/mcap/utils/readers/s3.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -15,8 +17,15 @@ func init() {
 	RegisterReader("s3", newS3Reader)
 }
 
+func forcePathStyle() bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv("MCAP_S3_FORCE_PATH_STYLE")))
+	return value == "1" || value == "true" || value == "yes"
+}
+
 // Factory for S3 readers (called by registry).
 func newS3Reader(ctx context.Context, bucket, path string) (func() error, io.ReadSeekCloser, error) {
+	pathStyle := forcePathStyle()
+
 	// Try anonymous first
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithCredentialsProvider(aws.AnonymousCredentials{}),
@@ -25,7 +34,12 @@ func newS3Reader(ctx context.Context, bucket, path string) (func() error, io.Rea
 		return func() error { return nil }, nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
-	client := s3.NewFromConfig(cfg)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if pathStyle {
+			o.UsePathStyle = true
+		}
+	})
+
 	rs, err := NewS3ReadSeekCloser(ctx, client, bucket, path)
 	if err == nil {
 		return rs.Close, rs, nil
@@ -37,7 +51,12 @@ func newS3Reader(ctx context.Context, bucket, path string) (func() error, io.Rea
 		return func() error { return nil }, nil, fmt.Errorf("failed to load authenticated AWS config: %w", err)
 	}
 
-	client = s3.NewFromConfig(cfg)
+	client = s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if pathStyle {
+			o.UsePathStyle = true
+		}
+	})
+
 	rs, err = NewS3ReadSeekCloser(ctx, client, bucket, path)
 	if err != nil {
 		return func() error { return nil }, nil, fmt.Errorf("failed to create S3 reader: %w", err)

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -170,6 +170,23 @@ When reading from S3 you must specify the region of the bucket:
 AWS_REGION=eu-north-1 mcap info s3://my-public-bucket/demo.mcap
 ```
 
+Some S3-compatible storage systems require path-style addressing instead of the default virtual-host style. To enable this behavior, set the following environment variable:
+
+```bash
+MCAP_S3_FORCE_PATH_STYLE=true
+```
+
+Example:
+
+```bash
+MCAP_S3_FORCE_PATH_STYLE=true \
+AWS_REGION=eu-north-1 \
+AWS_ENDPOINT_URL_S3=https://s3.example.com:9000 \
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+mcap info s3://my-bucket/demo.mcap
+```
+
 Remote reads will use the index at the end of the file to minimize latency and data transfer.
 
 ### File Diagnostics


### PR DESCRIPTION
### Changelog
Add optional path-style S3 addressing support via the `MCAP_S3_FORCE_PATH_STYLE` environment variable for S3-compatible storage endpoints.

### Docs
This PR updates the CLI documentation to include the new `MCAP_S3_FORCE_PATH_STYLE` environment variable.

### Description

Some S3-compatible object storage systems (such as MinIO, Ceph, or custom S3 gateways) require **path-style addressing**:

```

https://endpoint/bucket/key

```

instead of the default **virtual-host style**:

```

https://bucket.endpoint/key

```

The MCAP CLI currently constructs its S3 client using:

```go
s3.NewFromConfig(cfg)
```

which causes the AWS SDK for Go v2 to use virtual-host style addressing by default. When used with S3-compatible endpoints that do not support bucket subdomains, this can result in DNS errors such as:

```
lookup <bucket>.<endpoint>: no such host
```

This PR adds an optional environment variable:

```
MCAP_S3_FORCE_PATH_STYLE=true
```

When this variable is set, the S3 client is configured with:

```go
o.UsePathStyle = true
```

This allows the CLI to work with S3-compatible object stores that require path-style addressing, while preserving the current default behavior for AWS S3 users.

The change is intentionally minimal:

* No behavior changes unless the environment variable is set
* No refactoring of existing reader logic
* Applies to both anonymous and authenticated S3 client initialization paths

Documentation has also been updated in `website/docs/guides/cli.md`.

#### Manual testing

Built the CLI locally and verified the behavior against an S3-compatible endpoint.

Without the environment variable, the CLI attempted requests using virtual-host style addressing:

```
https://bucket.endpoint/key
```

With the environment variable enabled:

```
MCAP_S3_FORCE_PATH_STYLE=true
```

the CLI correctly used path-style addressing:

```
https://endpoint/bucket/key
```

and successfully read the remote MCAP file.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

MCAP CLI always used virtual-host style addressing when accessing S3:

```
https://bucket.endpoint/key
```

This caused DNS failures when the endpoint did not support bucket subdomains.

</td><td>

Path-style addressing can be enabled when needed:

```
MCAP_S3_FORCE_PATH_STYLE=true
```

Resulting requests:

```
https://endpoint/bucket/key
```

This allows the CLI to work with S3-compatible object stores that require path-style addressing.

</td></tr></table>