### PR TITLE
docs: fix minor issues in C++ protobuf guide

### DIFF
--- a/website/docs/guides/cpp/protobuf.md
+++ b/website/docs/guides/cpp/protobuf.md
@@ -240,7 +240,7 @@ Next, we'll register a channel to write our messages to:
 
 ```cpp
 mcap::Channel path_channel("/planner/path", "protobuf", path_schema.id);
-mcap.addChannel(path_channel);  // Assigned channel id written to path_channel.id
+writer.addChannel(path_channel);  // Assigned channel id written to path_channel.id
 ```
 
 ### Write messages
@@ -249,13 +249,13 @@ We can now finally write messages to the channel using its ID:
 
 ```cpp
 foxglove::PosesInFrame poses_msg;
-// Fill in path_msg.
+// Fill in poses_msg.
 uint64_t timestamp_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count();
-poses_msg.mutable_timestamp()->set_seconds(timestamp_ns / 1'000'000'000ull)
-poses_msg.mutable_timestamp()->set_nanos(timestamp_ns % 1'000'000'000ull)
-poses_msg.set_frame_id("base_link")
+poses_msg.mutable_timestamp()->set_seconds(timestamp_ns / 1'000'000'000ull);
+poses_msg.mutable_timestamp()->set_nanos(timestamp_ns % 1'000'000'000ull);
+poses_msg.set_frame_id("base_link");
 // Example path in a straight line down the X axis
 for (int i = 0; i < 10; ++i) {
   auto pose = poses_msg.add_poses();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pass `McapWriterOptions` into `writer.open(...)` in the C++ protobuf guide
- use a consistent `status` variable in the open-error example
- remove the unused local variable from `fdSet(...)`
- fix the remaining sample typos in the same guide section (`writer.addChannel(...)`, `poses_msg` comment, and missing semicolons)

## Testing
- `corepack enable`
- `yarn install --immutable`
- `yarn workspace website build`
- `yarn workspace website build` (after the follow-up review fixes)

## Notes
- the latest website build completed successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d5e98b3-34de-4890-ad2f-efbb06550085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d5e98b3-34de-4890-ad2f-efbb06550085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

