### PR TITLE
Move strict-message-order to doctor only

### DIFF
--- a/go/cli/mcap/cmd/doctor.go
+++ b/go/cli/mcap/cmd/doctor.go
@@ -732,7 +732,7 @@ var doctorCommand = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(doctorCommand)
 
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+	doctorCommand.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	doctorCommand.Flags().BoolVarP(&strictMessageOrder, "strict-message-order", "",
 		false, "Require that messages have a monotonic log time")
 }


### PR DESCRIPTION
### Changelog:
- `mcap doctor`: `--verbose` and `--strict-message-order` are now correctly registered as flags for the subcommand rather than global flags.