### PR TITLE
rust: fix typo in doc comment and missing parenthesis in error message

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -92,7 +92,7 @@ pub enum McapError {
     BadMagic,
     #[error("Footer record couldn't be found at the end of the file, before the magic bytes")]
     BadFooter,
-    #[error("Attachment CRC failed (expected {saved:08X}, got {calculated:08X}")]
+    #[error("Attachment CRC failed (expected {saved:08X}, got {calculated:08X})")]
     BadAttachmentCrc { saved: u32, calculated: u32 },
     #[error("Chunk CRC failed (expected {saved:08X}, got {calculated:08X})")]
     BadChunkCrc { saved: u32, calculated: u32 },

--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -2,7 +2,7 @@
 //!
 //! See <https://mcap.dev/spec>
 //!
-//! You probably want to user higher-level interfaces, like
+//! You probably want to use higher-level interfaces, like
 //! [`Message`](crate::Message), [`Channel`](crate::Channel), and [`Schema`](crate::Schema),
 //! read from iterators like [`MessageStream`](crate::MessageStream).
 


### PR DESCRIPTION
## Summary
- **`rust/src/records.rs`**: Fix typo in module doc comment ("user" -> "use")
- **`rust/src/lib.rs`**: Add missing closing parenthesis in `BadAttachmentCrc` error string, matching the format used by `BadChunkCrc` on the next line

## Details

`records.rs` line 5:
```diff
-//! You probably want to user higher-level interfaces, like
+//! You probably want to use higher-level interfaces, like
```

`lib.rs` line 95:
```diff
-#[error("Attachment CRC failed (expected {saved:08X}, got {calculated:08X}")]
+#[error("Attachment CRC failed (expected {saved:08X}, got {calculated:08X})")]
```