### PR TITLE
docs: fix broken links and minor typos in guides

### DIFF
--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -33,7 +33,7 @@ Installing via `go install` is not supported. To build from source you must clon
 1. Clone the [mcap repository](https://github.com/foxglove/mcap).
 2. `$ cd go/cli/mcap`
 3. `$ make build`
-4. The binary will be built into the a newly created `bin` folder.
+4. The binary will be built into a newly created `bin` folder.
 
 ## Usage
 

--- a/website/docs/guides/getting-started/flatbuffers.md
+++ b/website/docs/guides/getting-started/flatbuffers.md
@@ -6,7 +6,7 @@ description: Read, write, and visualize MCAP files containing FlatBuffers data.
 
 ## Read and write MCAP
 
-If you're starting from scratch, you can write code that allows **writes your FlatBuffers data to MCAP files** and subsequently **reads your FlatBuffers data from your MCAP files**.
+If you're starting from scratch, you can write code that allows you to **write your FlatBuffers data to MCAP files** and subsequently **read your FlatBuffers data from your MCAP files**.
 
 See also the [official FlatBuffers docs](https://google.github.io/flatbuffers/) to learn more about reading and writing FlatBuffers.
 

--- a/website/docs/guides/getting-started/json.md
+++ b/website/docs/guides/getting-started/json.md
@@ -15,7 +15,7 @@ If you're starting from scratch, you can write code that allows you to **write y
 ### Examples
 
 - [Python](https://github.com/foxglove/mcap/tree/main/python/examples/jsonschema) - [CSV to MCAP converter](https://github.com/foxglove/mcap/blob/main/python/examples/jsonschema/pointcloud_csv_to_mcap.py)
-- [C++](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema) - [reader](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/reader.py), [writer](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/writer.py)
+- [C++](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema) - [reader](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/reader.cpp), [writer](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/writer.cpp)
 
 ## Inspect MCAP
 


### PR DESCRIPTION
## Summary
- **json.md**: C++ example links point to `.py` files instead of `.cpp` (results in 404s)
- **flatbuffers.md**: grammar fix ("allows writes your" -> "allows you to write your")
- **cli.md**: remove extra word ("into the a newly" -> "into a newly")

## Details

`website/docs/guides/getting-started/json.md` line 18:
```diff
-- [reader](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/reader.py), [writer](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/writer.py)
+- [reader](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/reader.cpp), [writer](https://github.com/foxglove/mcap/tree/main/cpp/examples/jsonschema/writer.cpp)
```

`website/docs/guides/getting-started/flatbuffers.md` line 9:
```diff
-you can write code that allows **writes your FlatBuffers data to MCAP files** and subsequently **reads your FlatBuffers data from your MCAP files**.
+you can write code that allows you to **write your FlatBuffers data to MCAP files** and subsequently **read your FlatBuffers data from your MCAP files**.
```

`website/docs/guides/cli.md` line 36:
```diff
-The binary will be built into the a newly created `bin` folder.
+The binary will be built into a newly created `bin` folder.
```