### PR TITLE
Fix GCC -Warray-bounds false positive in CRC32 getUint32LE.

### DIFF
--- a/cpp/mcap/include/mcap/crc32.hpp
+++ b/cpp/mcap/include/mcap/crc32.hpp
@@ -72,18 +72,19 @@ static constexpr uint32_t CRC32_INIT = 0xffffffff;
  * presented at: https://github.com/komrad36/CRC#option-9-8-byte-tabular
  */
 inline uint32_t crc32Update(const uint32_t prev, const std::byte* const data, const size_t length) {
-  // Process bytes one by one until we reach the proper alignment.
   uint32_t r = prev;
-  size_t offset = 0;
-  for (; (uintptr_t(data + offset) & alignof(uint32_t)) != 0 && offset < length; offset++) {
-    r = CRC32_TABLE[(r ^ uint8_t(data[offset])) & 0xff] ^ (r >> 8);
-  }
-  if (offset == length) {
+
+  // Handle small inputs byte-by-byte, avoiding the 8-byte bulk loop below.
+  if (length <= 8) {
+    for (size_t i = 0; i < length; i++) {
+      r = CRC32_TABLE[(r ^ uint8_t(data[i])) & 0xff] ^ (r >> 8);
+    }
     return r;
   }
 
   // Process 8 bytes (2 uint32s) at a time.
-  size_t remainingBytes = length - offset;
+  size_t offset = 0;
+  size_t remainingBytes = length;
   for (; remainingBytes >= 8; offset += 8, remainingBytes -= 8) {
     r ^= getUint32LE(data + offset);
     uint32_t r2 = getUint32LE(data + offset + 4);


### PR DESCRIPTION
### Changelog

Fix compilation warning with `-Warray-bounds` on.

### Docs

None.

### Description

Add early return in crc32Update for inputs of 8 bytes or fewer, processing them byte-by-byte. This gives GCC a clear proof that getUint32LE is unreachable for small buffers (e.g. 1-byte OpCode), eliminating the false positive without pragmas or noinline.

Also remove the broken alignment loop that incorrectly masked with alignof(uint32_t) instead of alignof(uint32_t) - 1. The loop had no effect on correctness since getUint32LE uses byte-by-byte reads, not aligned uint32_t loads.

Built and ran the unit tests, ensuring that we no longer get the warning.