### PR TITLE
python: accept array-like types for array field serialization

### DIFF
--- a/python/mcap-ros2-support/mcap_ros2/_dynamic.py
+++ b/python/mcap-ros2-support/mcap_ros2/_dynamic.py
@@ -23,6 +23,15 @@ PrimitiveValue = Union[bool, int, float, str]
 DefaultValue = Union[PrimitiveValue, List[PrimitiveValue]]
 
 
+def _is_array_like(obj: Any) -> bool:
+    """Check if obj is array-like (has __len__ and __getitem__) but not str/bytes/dict."""
+    return (
+        hasattr(obj, "__len__")
+        and hasattr(obj, "__getitem__")
+        and not isinstance(obj, (str, bytes, dict))
+    )
+
+
 def _parseWstring(reader: CdrReader) -> str:
     raise NotImplementedError("wstring parsing is not implemented")
 
@@ -368,10 +377,13 @@ def _write_complex_type(
                 if array is None:
                     array = []
                 if not isinstance(array, list):
-                    raise ValueError(
-                        f'Field "{field.name}" is not an array but has array type '
-                        f'"{ftype.type}[]"'
-                    )
+                    if _is_array_like(array):
+                        array = list(array)
+                    else:
+                        raise ValueError(
+                            f'Field "{field.name}" is not an array but has array type '
+                            f'"{ftype.type}[]"'
+                        )
 
                 if ftype.is_fixed_size_array() and ftype.array_size is not None:
                     # Fixed length array, ensure the input array is the correct length
@@ -424,16 +436,15 @@ def _write_complex_type(
                 )
                 if array is None:
                     array = []
-                if (
-                    not isinstance(array, list)
-                    and not isinstance(array, tuple)
-                    and not isinstance(array, bytes)
-                    and not isinstance(array, py_array.array)
-                ):
-                    raise ValueError(
-                        f'Field "{field.name}" is not an array ({type(array)}) but has array type '
-                        f'"{ftype.type}[]"'
-                    )
+                if not isinstance(array, (list, tuple, bytes, py_array.array)):
+                    if _is_array_like(array):
+                        array = list(array)
+                    else:
+                        raise ValueError(
+                            f'Field "{field.name}" is not an array '
+                            f"({type(array)}) but has array type "
+                            f'"{ftype.type}[]"'
+                        )
 
                 # Special handling for bytes
                 if isinstance(array, bytes) or (
@@ -476,11 +487,9 @@ def _write_complex_type(
                         )
 
                     if ftype.is_fixed_size_array() and ftype.array_size is not None:
-                        # Convert tuples to lists
+                        # Convert non-list sequences to lists
                         list_array = (
-                            list(array)
-                            if isinstance(array, (tuple, py_array.array))
-                            else array
+                            list(array) if not isinstance(array, list) else array
                         )
                         # Fixed length array, ensure the input array is the correct length
                         while len(list_array) < ftype.array_size:
@@ -501,9 +510,7 @@ def _write_complex_type(
                         ):
                             array = array[: ftype.array_size]
 
-                        array = (
-                            list(array) if isinstance(array, py_array.array) else array
-                        )
+                        array = list(array) if not isinstance(array, list) else array
                         array = _coerce_values(array, ftype.type, field.default_value)
 
                         # Dynamic length array, write a uint32 prefix

--- a/python/mcap-ros2-support/tests/test_ros2_writer.py
+++ b/python/mcap-ros2-support/tests/test_ros2_writer.py
@@ -1,6 +1,8 @@
 from array import array
+from collections.abc import Sequence
 from io import BytesIO
 
+import pytest
 from mcap_ros2.decoder import DecoderFactory
 from mcap_ros2.writer import Writer as Ros2Writer
 
@@ -155,3 +157,100 @@ def test_write_array_field_named_items():
     output.seek(0)
     for msg in read_ros2_messages(output):
         assert list(msg.decoded_message.items) == [10, 20, 30]
+
+
+class FloatList(Sequence):
+    """A minimal Sequence implementation for testing array-like support."""
+
+    def __init__(self, data):
+        self._data = list(data)
+
+    def __getitem__(self, index):
+        return self._data[index]
+
+    def __len__(self):
+        return len(self._data)
+
+
+def _write_and_read_float64_array(data, msgdef="float64[] data"):
+    output = BytesIO()
+    ros_writer = Ros2Writer(output=output)
+    schema = ros_writer.register_msgdef("test_msgs/Floats", msgdef)
+    ros_writer.write_message(
+        topic="/test",
+        schema=schema,
+        message={"data": data},
+        log_time=0,
+        publish_time=0,
+        sequence=0,
+    )
+    ros_writer.finish()
+    output.seek(0)
+    for msg in read_ros2_messages(output):
+        return msg.decoded_message.data
+
+
+def test_write_float64_array_with_sequence():
+    values = FloatList([1.0, 2.0, 3.0])
+    result = _write_and_read_float64_array(values)
+    assert list(result) == [1.0, 2.0, 3.0]
+
+
+def test_write_float64_array_with_list():
+    result = _write_and_read_float64_array([1.0, 2.0, 3.0])
+    assert list(result) == [1.0, 2.0, 3.0]
+
+
+def test_write_float64_array_with_tuple():
+    result = _write_and_read_float64_array((1.0, 2.0, 3.0))
+    assert list(result) == [1.0, 2.0, 3.0]
+
+
+def test_write_float64_array_sequence_matches_list():
+    list_result = _write_and_read_float64_array([1.0, 2.0, 3.0])
+    seq_result = _write_and_read_float64_array(FloatList([1.0, 2.0, 3.0]))
+    assert list(list_result) == list(seq_result)
+
+
+def test_write_float64_array_rejects_string():
+    with pytest.raises(ValueError, match="is not an array"):
+        _write_and_read_float64_array("not an array")
+
+
+def test_write_float64_array_rejects_int():
+    with pytest.raises(ValueError, match="is not an array"):
+        _write_and_read_float64_array(42)
+
+
+def test_write_float64_array_rejects_dict():
+    with pytest.raises(ValueError, match="is not an array"):
+        _write_and_read_float64_array({"a": 1.0})
+
+
+def test_write_fixed_size_float64_array_with_sequence():
+    values = FloatList([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+    result = _write_and_read_float64_array(values, msgdef="float64[9] data")
+    assert list(result) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+
+def test_write_numpy_float64_array():
+    np = pytest.importorskip("numpy")
+    values = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    result = _write_and_read_float64_array(values)
+    assert list(result) == [1.0, 2.0, 3.0]
+
+
+def test_write_numpy_fixed_size_float64_array():
+    np = pytest.importorskip("numpy")
+    values = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], dtype=np.float64)
+    result = _write_and_read_float64_array(values, msgdef="float64[9] data")
+    assert list(result) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+
+def test_write_numpy_float64_array_matches_list():
+    np = pytest.importorskip("numpy")
+    list_result = _write_and_read_float64_array([1.0, 2.0, 3.0])
+    np_result = _write_and_read_float64_array(
+        np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    )
+    assert list(list_result) == list(np_result)


### PR DESCRIPTION
Fixes #1469

Accepts any object with `__len__` and `__getitem__` (e.g. numpy arrays, custom Sequence subclasses) when serializing array fields, instead of only `list`/`tuple`/`bytes`/`array.array`.

Uses duck-typing as suggested in #1469 -- no numpy runtime dependency added.

### What changed

A small `_is_array_like` helper gates the check. Four locations in `_write_complex_type` updated to try `list(array)` on array-like objects before raising `ValueError`. Existing types (`list`, `tuple`, `bytes`, `array.array`) still hit their fast paths via `isinstance` first.

`str`, `bytes`, and `dict` are explicitly excluded from the duck-type check.

### Tests

- Roundtrip with a custom `Sequence` subclass (dynamic and fixed-size arrays)
- Byte-for-byte parity: custom Sequence output matches list output
- Negative tests: `str`, `int`, `dict` correctly rejected
- numpy roundtrip tests (dynamic and fixed-size `float64[9]`) using `pytest.importorskip`

numpy tests use `importorskip` so they run where numpy is available and skip otherwise. Happy to add numpy to dev deps if you'd prefer them to run in CI.