### PR TITLE
rust cli: Implement merge command

### DIFF
--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -602,6 +602,10 @@ impl<W: Write + Seek> Writer<W> {
     /// duplicate content. This is useful when preserving distinct channel IDs from an input file
     /// is required, even if multiple channels share identical topic/schema/encoding/metadata.
     ///
+    /// Adding an explicit ID does not advance the internal allocator used by
+    /// [`Self::add_channel`]. Automatically allocated IDs continue to use the first available
+    /// channel ID.
+    ///
     /// If a channel with the same ID is already known:
     /// - returns `Ok(id)` if its content matches
     /// - returns [`McapError::ConflictingChannels`] if its content differs
@@ -635,14 +639,6 @@ impl<W: Write + Seek> Writer<W> {
             return Ok(id);
         }
 
-        // Compute next channel ID before mutating internal maps so there is no
-        // early-return error path that leaves partially-updated state.
-        let next_channel_id = if id >= self.next_channel_id {
-            id.saturating_add(1)
-        } else {
-            self.next_channel_id
-        };
-
         self.write_channel(records::Channel {
             id,
             schema_id,
@@ -659,7 +655,6 @@ impl<W: Write + Seek> Writer<W> {
                 .expect("neither content nor new ID should be present in canonical_channels");
             self.all_channel_ids.insert(id, id);
         }
-        self.next_channel_id = next_channel_id;
 
         Ok(id)
     }
@@ -2224,6 +2219,122 @@ mod tests {
             .add_channel_with_id(7, schema_id, "/other", "json", &BTreeMap::new())
             .expect_err("conflicting channel id should fail");
         assert_matches!(err, McapError::ConflictingChannels(_));
+    }
+
+    #[test]
+    fn add_channel_with_id_is_idempotent_for_same_id_and_content() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        let first = writer
+            .add_channel_with_id(7, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to add channel");
+        let second = writer
+            .add_channel_with_id(7, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to re-add identical channel");
+        assert_eq!(first, second);
+
+        writer.finish().expect("failed to finish");
+        let mcap = writer.into_inner().into_inner();
+        let summary = crate::Summary::read(&mcap)
+            .expect("failed to read summary")
+            .expect("summary should be present");
+        assert_eq!(summary.channels.len(), 1);
+    }
+
+    #[test]
+    fn add_channel_with_id_does_not_advance_allocator() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        let explicit_id = writer
+            .add_channel_with_id(9000, schema_id, "/explicit", "json", &BTreeMap::new())
+            .expect("failed to add explicit channel");
+        assert_eq!(explicit_id, 9000);
+
+        let first_auto = writer
+            .add_channel(schema_id, "/auto1", "json", &BTreeMap::new())
+            .expect("failed to add first automatic channel");
+        let second_auto = writer
+            .add_channel(schema_id, "/auto2", "json", &BTreeMap::new())
+            .expect("failed to add second automatic channel");
+
+        assert_eq!(first_auto, 1);
+        assert_eq!(second_auto, 2);
+    }
+
+    #[test]
+    fn add_channel_with_id_max_keeps_allocator_progress() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        writer
+            .add_channel_with_id(u16::MAX, schema_id, "/max", "json", &BTreeMap::new())
+            .expect("failed to add max-id channel");
+        let auto_id = writer
+            .add_channel(schema_id, "/auto", "json", &BTreeMap::new())
+            .expect("failed to add automatic channel after max-id channel");
+        assert_eq!(auto_id, 1);
+    }
+
+    #[test]
+    fn add_channel_with_id_is_idempotent_for_matching_existing_id() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        let first = writer
+            .add_channel_with_id(7, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to add channel");
+        let second = writer
+            .add_channel_with_id(7, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("re-adding same id/content should be ok");
+
+        assert_eq!(first, 7);
+        assert_eq!(second, 7);
+
+        writer.finish().expect("failed to finish");
+        let mcap = writer.into_inner().into_inner();
+        let summary = crate::Summary::read(&mcap)
+            .expect("failed to read summary")
+            .expect("summary should be present");
+        assert_eq!(summary.channels.len(), 1);
+    }
+
+    #[test]
+    fn add_channel_with_id_keeps_auto_allocator_at_lowest_free_id() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        writer
+            .add_channel_with_id(9000, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to add explicit channel");
+        let auto_id = writer
+            .add_channel(schema_id, "/auto", "json", &BTreeMap::new())
+            .expect("failed to add auto channel");
+        assert_eq!(auto_id, 1);
+
+        writer
+            .add_channel_with_id(u16::MAX, schema_id, "/max", "json", &BTreeMap::new())
+            .expect("failed to add explicit max id");
+        let next_auto_id = writer
+            .add_channel(schema_id, "/next-auto", "json", &BTreeMap::new())
+            .expect("failed to add next auto channel");
+        assert_eq!(next_auto_id, 2);
     }
 
     #[test]

--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -635,21 +635,13 @@ impl<W: Write + Seek> Writer<W> {
             return Ok(id);
         }
 
-        if let Some(canonical_id) = self.canonical_channels.get_by_left(&content).copied() {
-            self.all_channel_ids.insert(id, canonical_id);
+        // Compute next channel ID before mutating internal maps so there is no
+        // early-return error path that leaves partially-updated state.
+        let next_channel_id = if id >= self.next_channel_id {
+            id.saturating_add(1)
         } else {
-            self.canonical_channels
-                .insert_no_overwrite(content.into_owned(), id)
-                .expect("neither content nor new ID should be present in canonical_channels");
-            self.all_channel_ids.insert(id, id);
-        }
-
-        if id >= self.next_channel_id {
-            if id == u16::MAX {
-                return Err(McapError::TooManyChannels);
-            }
-            self.next_channel_id = id + 1;
-        }
+            self.next_channel_id
+        };
 
         self.write_channel(records::Channel {
             id,
@@ -658,6 +650,16 @@ impl<W: Write + Seek> Writer<W> {
             message_encoding: message_encoding.into(),
             metadata: metadata.clone(),
         })?;
+
+        if let Some(canonical_id) = self.canonical_channels.get_by_left(&content).copied() {
+            self.all_channel_ids.insert(id, canonical_id);
+        } else {
+            self.canonical_channels
+                .insert_no_overwrite(content.into_owned(), id)
+                .expect("neither content nor new ID should be present in canonical_channels");
+            self.all_channel_ids.insert(id, id);
+        }
+        self.next_channel_id = next_channel_id;
 
         Ok(id)
     }

--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -596,6 +596,72 @@ impl<W: Write + Seek> Writer<W> {
         Ok(id)
     }
 
+    /// Adds a channel with an explicit ID.
+    ///
+    /// Unlike [`Self::add_channel`], this method does not coalesce away channel records with
+    /// duplicate content. This is useful when preserving distinct channel IDs from an input file
+    /// is required, even if multiple channels share identical topic/schema/encoding/metadata.
+    ///
+    /// If a channel with the same ID is already known:
+    /// - returns `Ok(id)` if its content matches
+    /// - returns [`McapError::ConflictingChannels`] if its content differs
+    pub fn add_channel_with_id(
+        &mut self,
+        id: u16,
+        schema_id: u16,
+        topic: &str,
+        message_encoding: &str,
+        metadata: &BTreeMap<String, String>,
+    ) -> McapResult<u16> {
+        if schema_id != 0 && !self.all_schema_ids.contains_key(&schema_id) {
+            return Err(McapError::UnknownSchema(topic.into(), schema_id));
+        }
+
+        let content = ChannelContent {
+            topic: Cow::Borrowed(topic),
+            schema_id,
+            message_encoding: Cow::Borrowed(message_encoding),
+            metadata: Cow::Borrowed(metadata),
+        };
+
+        if let Some(existing_canonical_id) = self.all_channel_ids.get(&id).copied() {
+            let Some(current_canonical_id) = self.canonical_channels.get_by_left(&content).copied()
+            else {
+                return Err(McapError::ConflictingChannels(topic.into()));
+            };
+            if existing_canonical_id != current_canonical_id {
+                return Err(McapError::ConflictingChannels(topic.into()));
+            }
+            return Ok(id);
+        }
+
+        if let Some(canonical_id) = self.canonical_channels.get_by_left(&content).copied() {
+            self.all_channel_ids.insert(id, canonical_id);
+        } else {
+            self.canonical_channels
+                .insert_no_overwrite(content.into_owned(), id)
+                .expect("neither content nor new ID should be present in canonical_channels");
+            self.all_channel_ids.insert(id, id);
+        }
+
+        if id >= self.next_channel_id {
+            if id == u16::MAX {
+                return Err(McapError::TooManyChannels);
+            }
+            self.next_channel_id = id + 1;
+        }
+
+        self.write_channel(records::Channel {
+            id,
+            schema_id,
+            topic: topic.into(),
+            message_encoding: message_encoding.into(),
+            metadata: metadata.clone(),
+        })?;
+
+        Ok(id)
+    }
+
     /// Write a channel record into the MCAP.
     fn write_channel(&mut self, channel: records::Channel) -> McapResult<()> {
         let record = Record::Channel(channel);
@@ -2090,6 +2156,72 @@ mod tests {
             .expect("summary should be present");
         assert_eq!(summary.channels.len(), 2);
         assert_eq!(summary.schemas.len(), 2);
+    }
+
+    #[test]
+    fn add_channel_with_id_preserves_duplicate_content_channels() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        let channel_one = writer
+            .add_channel_with_id(schema_id, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to add channel one");
+        let channel_two = writer
+            .add_channel_with_id(schema_id + 1, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to add channel two");
+
+        assert_ne!(channel_one, channel_two);
+
+        writer
+            .write_to_known_channel(
+                &MessageHeader {
+                    channel_id: channel_one,
+                    sequence: 0,
+                    log_time: 1,
+                    publish_time: 1,
+                },
+                &[1],
+            )
+            .expect("failed to write first message");
+        writer
+            .write_to_known_channel(
+                &MessageHeader {
+                    channel_id: channel_two,
+                    sequence: 0,
+                    log_time: 2,
+                    publish_time: 2,
+                },
+                &[2],
+            )
+            .expect("failed to write second message");
+
+        writer.finish().expect("failed to finish");
+        let mcap = writer.into_inner().into_inner();
+        let summary = crate::Summary::read(&mcap)
+            .expect("failed to read summary")
+            .expect("summary should be present");
+        assert_eq!(summary.channels.len(), 2);
+    }
+
+    #[test]
+    fn add_channel_with_id_rejects_conflicting_existing_id() {
+        let file = std::io::Cursor::new(Vec::new());
+        let mut writer = Writer::new(file).expect("failed to construct writer");
+        let schema_id = writer
+            .add_schema("schema", "jsonschema", br#"{}"#)
+            .expect("failed to add schema");
+
+        writer
+            .add_channel_with_id(7, schema_id, "/topic", "json", &BTreeMap::new())
+            .expect("failed to add channel");
+
+        let err = writer
+            .add_channel_with_id(7, schema_id, "/other", "json", &BTreeMap::new())
+            .expect_err("conflicting channel id should fail");
+        assert_matches!(err, McapError::ConflictingChannels(_));
     }
 
     #[test]

--- a/rust/mcap_cli/README.md
+++ b/rust/mcap_cli/README.md
@@ -21,7 +21,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | `get`        | 🟢     |                                                                                                                                        |
 | `info`       | 🟢     |                                                                                                                                        |
 | `list`       | 🟢     |                                                                                                                                        |
-| `merge`      | 🔴     |                                                                                                                                        |
+| `merge`      | 🟢     |                                                                                                                                        |
 | `recover`    | 🔴     |                                                                                                                                        |
 | `sort`       | 🔴     |                                                                                                                                        |
 | `version`    | 🟢     |                                                                                                                                        |

--- a/rust/mcap_cli/README.md
+++ b/rust/mcap_cli/README.md
@@ -21,7 +21,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | `get`        | 🟢     |                                                                                                                                           |
 | `info`       | 🟢     |                                                                                                                                           |
 | `list`       | 🟢     |                                                                                                                                           |
-| `merge`      | 🟢     | Channel coalescing may produce non-monotonic or colliding message sequence values within a coalesced output channel (same as Go CLI).     |
+| `merge`      | 🟢     |                                                                                                                                           |
 | `recover`    | 🟡     | Best-effort recovery is implemented for messages, attachments, and metadata; Go-parity gaps remain around raw chunk passthrough behavior. |
 | `sort`       | 🟢     |                                                                                                                                           |
 | `version`    | 🟢     |                                                                                                                                           |

--- a/rust/mcap_cli/README.md
+++ b/rust/mcap_cli/README.md
@@ -21,7 +21,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | `get`        | 🟢     |                                                                                                                                           |
 | `info`       | 🟢     |                                                                                                                                           |
 | `list`       | 🟢     |                                                                                                                                           |
-| `merge`      | 🟢     | Channel coalescing may produce non-monotonic or colliding message sequence values within a coalesced output channel (same as Go CLI).   |
+| `merge`      | 🟢     | Channel coalescing may produce non-monotonic or colliding message sequence values within a coalesced output channel (same as Go CLI).     |
 | `recover`    | 🟡     | Best-effort recovery is implemented for messages, attachments, and metadata; Go-parity gaps remain around raw chunk passthrough behavior. |
 | `sort`       | 🟢     |                                                                                                                                           |
 | `version`    | 🟢     |                                                                                                                                           |

--- a/rust/mcap_cli/README.md
+++ b/rust/mcap_cli/README.md
@@ -21,7 +21,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | `get`        | 🟢     |                                                                                                                                           |
 | `info`       | 🟢     |                                                                                                                                           |
 | `list`       | 🟢     |                                                                                                                                           |
-| `merge`      | 🟢     |                                                                                                                                           |
+| `merge`      | 🟢     | Channel coalescing may produce non-monotonic or colliding message sequence values within a coalesced output channel (same as Go CLI).   |
 | `recover`    | 🟡     | Best-effort recovery is implemented for messages, attachments, and metadata; Go-parity gaps remain around raw chunk passthrough behavior. |
 | `sort`       | 🟢     |                                                                                                                                           |
 | `version`    | 🟢     |                                                                                                                                           |

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -231,11 +231,25 @@ pub struct ConvertCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub chunked: bool,
 }
 
@@ -272,18 +286,35 @@ pub struct MergeCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub chunked: bool,
 
     /// Allow duplicate-named metadata records in output
     #[arg(long, default_value_t = false)]
     pub allow_duplicate_metadata: bool,
 
-    /// Channel coalescing behavior
+    /// Channel coalescing behavior:
+    /// - auto: coalesce channels with matching topic, schema, and metadata
+    /// - force: same as auto but ignores metadata
+    /// - none: do not coalesce channels
     #[arg(long, value_enum, default_value = "auto")]
     pub coalesce_channels: CoalesceChannels,
 }

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -231,25 +231,11 @@ pub struct ConvertCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(
-        long,
-        action = ArgAction::Set,
-        num_args = 0..=1,
-        require_equals = true,
-        default_missing_value = "true",
-        default_value_t = true
-    )]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(
-        long,
-        action = ArgAction::Set,
-        num_args = 0..=1,
-        require_equals = true,
-        default_missing_value = "true",
-        default_value_t = true
-    )]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub chunked: bool,
 }
 

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -231,11 +231,23 @@ pub struct ConvertCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub chunked: bool,
 }
 
@@ -280,7 +292,6 @@ pub struct MergeCommand {
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
-        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -294,7 +305,6 @@ pub struct MergeCommand {
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
-        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -305,7 +315,8 @@ pub struct MergeCommand {
     pub allow_duplicate_metadata: bool,
 
     /// Channel coalescing behavior:
-    /// - auto: coalesce channels with matching topic, schema, and metadata
+    /// - auto: coalesce channels with matching topic, schema, encoding, and
+    ///   metadata
     /// - force: same as auto but ignores metadata
     /// - none: do not coalesce channels
     #[arg(long, value_enum, default_value = "auto")]
@@ -428,11 +439,23 @@ pub struct SortCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub chunked: bool,
 }
 

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -271,6 +271,7 @@ pub enum CoalesceChannels {
 #[command(arg_required_else_help = true)]
 pub struct MergeCommand {
     /// One or more local paths to MCAP files
+    #[arg(required = true)]
     pub files: Vec<PathBuf>,
 
     /// Output file path. If omitted, writes to stdout.

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -57,7 +57,7 @@ pub enum Command {
     /// List records of an MCAP file
     List(ListCommand),
     /// Merge a selection of MCAP files by record timestamp
-    Merge,
+    Merge(MergeCommand),
     /// Recover data from a potentially corrupt MCAP file
     Recover,
     /// Read an MCAP file and write messages sorted by log time
@@ -237,6 +237,55 @@ pub struct ConvertCommand {
     /// Enable chunked output MCAP writing
     #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub chunked: bool,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeCompression {
+    Zstd,
+    Lz4,
+    None,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoalesceChannels {
+    Auto,
+    Force,
+    None,
+}
+
+#[derive(clap::Args, Debug, PartialEq, Eq)]
+#[command(arg_required_else_help = true)]
+pub struct MergeCommand {
+    /// One or more local paths to MCAP files
+    pub files: Vec<PathBuf>,
+
+    /// Output file path. If omitted, writes to stdout.
+    #[arg(short = 'o', long = "output-file")]
+    pub output_file: Option<PathBuf>,
+
+    /// Chunk compression algorithm for output MCAP
+    #[arg(long, value_enum, default_value = "zstd")]
+    pub compression: MergeCompression,
+
+    /// Target uncompressed chunk size in bytes
+    #[arg(long, default_value_t = 8 * 1024 * 1024)]
+    pub chunk_size: u64,
+
+    /// Include chunk CRC checksums in output MCAP
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    pub include_crc: bool,
+
+    /// Enable chunked output MCAP writing
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    pub chunked: bool,
+
+    /// Allow duplicate-named metadata records in output
+    #[arg(long, default_value_t = false)]
+    pub allow_duplicate_metadata: bool,
+
+    /// Channel coalescing behavior
+    #[arg(long, value_enum, default_value = "auto")]
+    pub coalesce_channels: CoalesceChannels,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -231,23 +231,11 @@ pub struct ConvertCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(
-        long,
-        action = ArgAction::Set,
-        num_args = 0..=1,
-        default_missing_value = "true",
-        default_value_t = true
-    )]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(
-        long,
-        action = ArgAction::Set,
-        num_args = 0..=1,
-        default_missing_value = "true",
-        default_value_t = true
-    )]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub chunked: bool,
 }
 
@@ -286,12 +274,16 @@ pub struct MergeCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Explicit values use the `--include-crc=<true|false>` form so this
-    /// optional bool never consumes the first positional input file.
+    /// Supports bare `--include-crc` (true) and explicit values via
+    /// `--include-crc=<true|false>`.
+    ///
+    /// Requiring `=` for explicit values avoids an optional bool from consuming
+    /// the first positional input file.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -299,12 +291,16 @@ pub struct MergeCommand {
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Explicit values use the `--chunked=<true|false>` form so this optional
-    /// bool never consumes the first positional input file.
+    /// Supports bare `--chunked` (true) and explicit values via
+    /// `--chunked=<true|false>`.
+    ///
+    /// Requiring `=` for explicit values avoids an optional bool from consuming
+    /// the first positional input file.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -439,23 +435,11 @@ pub struct SortCommand {
     pub chunk_size: u64,
 
     /// Include chunk CRC checksums in output MCAP
-    #[arg(
-        long,
-        action = ArgAction::Set,
-        num_args = 0..=1,
-        default_missing_value = "true",
-        default_value_t = true
-    )]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing
-    #[arg(
-        long,
-        action = ArgAction::Set,
-        num_args = 0..=1,
-        default_missing_value = "true",
-        default_value_t = true
-    )]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub chunked: bool,
 }
 

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -272,7 +272,10 @@ pub struct MergeCommand {
     #[arg(long, default_value_t = 8 * 1024 * 1024)]
     pub chunk_size: u64,
 
-    /// Include chunk CRC checksums in output MCAP
+    /// Include chunk CRC checksums in output MCAP.
+    ///
+    /// Explicit values use the `--include-crc=<true|false>` form so this
+    /// optional bool never consumes the first positional input file.
     #[arg(
         long,
         action = ArgAction::Set,
@@ -283,7 +286,10 @@ pub struct MergeCommand {
     )]
     pub include_crc: bool,
 
-    /// Enable chunked output MCAP writing
+    /// Enable chunked output MCAP writing.
+    ///
+    /// Explicit values use the `--chunked=<true|false>` form so this optional
+    /// bool never consumes the first positional input file.
     #[arg(
         long,
         action = ArgAction::Set,

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -244,7 +244,7 @@ pub struct VersionCommand {
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConvertCompression {
+pub enum CompressionFormat {
     Zstd,
     Lz4,
     None,
@@ -260,7 +260,7 @@ pub struct ConvertCommand {
 
     /// Chunk compression algorithm for output MCAP
     #[arg(long, value_enum, default_value = "zstd")]
-    pub compression: ConvertCompression,
+    pub compression: CompressionFormat,
 
     /// Target uncompressed chunk size in bytes
     #[arg(long, default_value_t = 8 * 1024 * 1024)]
@@ -313,7 +313,7 @@ pub struct MergeCommand {
 
     /// Chunk compression algorithm for output MCAP
     #[arg(long, value_enum, default_value = "zstd")]
-    pub compression: ConvertCompression,
+    pub compression: CompressionFormat,
 
     /// Target uncompressed chunk size in bytes
     #[arg(long, default_value_t = 8 * 1024 * 1024)]
@@ -345,7 +345,9 @@ pub struct MergeCommand {
     )]
     pub chunked: bool,
 
-    /// Allow duplicate-named metadata records in output
+    /// Allow duplicate-named metadata records in output.
+    ///
+    /// Identical metadata records are still deduplicated by content.
     #[arg(long, default_value_t = false)]
     pub allow_duplicate_metadata: bool,
 
@@ -354,6 +356,10 @@ pub struct MergeCommand {
     ///   metadata
     /// - force: same as auto but ignores metadata
     /// - none: do not coalesce channels
+    ///
+    /// Note: coalescing channels may produce non-monotonic or colliding
+    /// sequence values within a coalesced output channel (matches Go CLI
+    /// behavior).
     #[arg(long, value_enum, default_value = "auto")]
     pub coalesce_channels: CoalesceChannels,
 }
@@ -491,7 +497,7 @@ pub struct SortCommand {
 
     /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
     #[arg(long, value_enum, default_value = "zstd")]
-    pub compression: ConvertCompression,
+    pub compression: CompressionFormat,
 
     /// Target uncompressed chunk size in bytes
     #[arg(long, default_value_t = 4 * 1024 * 1024)]

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -268,12 +268,12 @@ pub struct ConvertCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Accepts `--include-crc`, `--include-crc=false`, and
-    /// `--include-crc false` to match Go CLI ergonomics.
+    /// Accepts bare `--include-crc` and explicit `--include-crc=<bool>`.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -281,12 +281,12 @@ pub struct ConvertCommand {
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Accepts `--chunked`, `--chunked=false`, and `--chunked false` to
-    /// match Go CLI ergonomics.
+    /// Accepts bare `--chunked` and explicit `--chunked=<bool>`.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -328,12 +328,12 @@ pub struct MergeCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Accepts `--include-crc`, `--include-crc=false`, and
-    /// `--include-crc false` to match Go CLI ergonomics.
+    /// Accepts bare `--include-crc` and explicit `--include-crc=<bool>`.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -341,12 +341,12 @@ pub struct MergeCommand {
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Accepts `--chunked`, `--chunked=false`, and `--chunked false` to match
-    /// Go CLI ergonomics.
+    /// Accepts bare `--chunked` and explicit `--chunked=<bool>`.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -506,12 +506,12 @@ pub struct SortCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Accepts `--include-crc`, `--include-crc=false`, and
-    /// `--include-crc false` to match Go CLI ergonomics.
+    /// Accepts bare `--include-crc` and explicit `--include-crc=<bool>`.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -519,12 +519,12 @@ pub struct SortCommand {
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Accepts `--chunked`, `--chunked=false`, and `--chunked false` to match
-    /// Go CLI ergonomics.
+    /// Accepts bare `--chunked` and explicit `--chunked=<bool>`.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
+        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -268,16 +268,28 @@ pub struct ConvertCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Uses existing convert command parsing semantics to remain compatible
-    /// with scripts that pass values as `--include-crc false`.
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    /// Accepts `--include-crc`, `--include-crc=false`, and
+    /// `--include-crc false` to match Go CLI ergonomics.
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Uses existing convert command parsing semantics to remain compatible
-    /// with scripts that pass values as `--chunked false`.
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    /// Accepts `--chunked`, `--chunked=false`, and `--chunked false` to
+    /// match Go CLI ergonomics.
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub chunked: bool,
 }
 
@@ -316,16 +328,12 @@ pub struct MergeCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Supports bare `--include-crc` (true) and explicit values via
-    /// `--include-crc=<true|false>`.
-    ///
-    /// Requiring `=` for explicit values avoids an optional bool from consuming
-    /// the first positional input file.
+    /// Accepts `--include-crc`, `--include-crc=false`, and
+    /// `--include-crc false` to match Go CLI ergonomics.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
-        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -333,16 +341,12 @@ pub struct MergeCommand {
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Supports bare `--chunked` (true) and explicit values via
-    /// `--chunked=<true|false>`.
-    ///
-    /// Requiring `=` for explicit values avoids an optional bool from consuming
-    /// the first positional input file.
+    /// Accepts `--chunked`, `--chunked=false`, and `--chunked false` to match
+    /// Go CLI ergonomics.
     #[arg(
         long,
         action = ArgAction::Set,
         num_args = 0..=1,
-        require_equals = true,
         default_missing_value = "true",
         default_value_t = true
     )]
@@ -502,16 +506,28 @@ pub struct SortCommand {
 
     /// Include chunk CRC checksums in output MCAP.
     ///
-    /// Uses existing sort command parsing semantics to remain compatible with
-    /// scripts that pass values as `--include-crc false`.
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    /// Accepts `--include-crc`, `--include-crc=false`, and
+    /// `--include-crc false` to match Go CLI ergonomics.
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub include_crc: bool,
 
     /// Enable chunked output MCAP writing.
     ///
-    /// Uses existing sort command parsing semantics to remain compatible with
-    /// scripts that pass values as `--chunked false`.
-    #[arg(long, action = ArgAction::Set, default_value_t = true)]
+    /// Accepts `--chunked`, `--chunked=false`, and `--chunked false` to match
+    /// Go CLI ergonomics.
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true
+    )]
     pub chunked: bool,
 }
 

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -294,13 +294,6 @@ pub struct ConvertCommand {
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MergeCompression {
-    Zstd,
-    Lz4,
-    None,
-}
-
-#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoalesceChannels {
     Auto,
     Force,
@@ -320,7 +313,7 @@ pub struct MergeCommand {
 
     /// Chunk compression algorithm for output MCAP
     #[arg(long, value_enum, default_value = "zstd")]
-    pub compression: MergeCompression,
+    pub compression: ConvertCompression,
 
     /// Target uncompressed chunk size in bytes
     #[arg(long, default_value_t = 8 * 1024 * 1024)]

--- a/rust/mcap_cli/src/cli.rs
+++ b/rust/mcap_cli/src/cli.rs
@@ -266,11 +266,17 @@ pub struct ConvertCommand {
     #[arg(long, default_value_t = 8 * 1024 * 1024)]
     pub chunk_size: u64,
 
-    /// Include chunk CRC checksums in output MCAP
+    /// Include chunk CRC checksums in output MCAP.
+    ///
+    /// Uses existing convert command parsing semantics to remain compatible
+    /// with scripts that pass values as `--include-crc false`.
     #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub include_crc: bool,
 
-    /// Enable chunked output MCAP writing
+    /// Enable chunked output MCAP writing.
+    ///
+    /// Uses existing convert command parsing semantics to remain compatible
+    /// with scripts that pass values as `--chunked false`.
     #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub chunked: bool,
 }
@@ -494,11 +500,17 @@ pub struct SortCommand {
     #[arg(long, default_value_t = 4 * 1024 * 1024)]
     pub chunk_size: u64,
 
-    /// Include chunk CRC checksums in output MCAP
+    /// Include chunk CRC checksums in output MCAP.
+    ///
+    /// Uses existing sort command parsing semantics to remain compatible with
+    /// scripts that pass values as `--include-crc false`.
     #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub include_crc: bool,
 
-    /// Enable chunked output MCAP writing
+    /// Enable chunked output MCAP writing.
+    ///
+    /// Uses existing sort command parsing semantics to remain compatible with
+    /// scripts that pass values as `--chunked false`.
     #[arg(long, action = ArgAction::Set, default_value_t = true)]
     pub chunked: bool,
 }

--- a/rust/mcap_cli/src/commands.rs
+++ b/rust/mcap_cli/src/commands.rs
@@ -59,7 +59,7 @@ pub fn dispatch(ctx: &CommandContext, command: Command) -> Result<()> {
         Command::Doctor(args) => doctor::run(ctx, args),
         Command::Du(args) => du::run(ctx, args),
         Command::Filter(args) => filter::run(ctx, args),
-        Command::Merge => merge::run(ctx),
+        Command::Merge(args) => merge::run(ctx, args),
         Command::Recover => recover::run(ctx),
         Command::Sort => sort::run(ctx),
     }

--- a/rust/mcap_cli/src/commands.rs
+++ b/rust/mcap_cli/src/commands.rs
@@ -27,10 +27,6 @@ use anyhow::Result;
 use crate::cli::{AddSubcommand, Command, GetSubcommand, ListSubcommand};
 use crate::context::CommandContext;
 
-pub fn not_implemented(command_name: &str) -> anyhow::Error {
-    anyhow::anyhow!("'{command_name}' is not implemented yet")
-}
-
 pub fn dispatch(ctx: &CommandContext, command: Command) -> Result<()> {
     match command {
         Command::Info(args) => info::run(ctx, args),

--- a/rust/mcap_cli/src/commands.rs
+++ b/rust/mcap_cli/src/commands.rs
@@ -256,7 +256,7 @@ mod tests {
                 file: PathBuf::from("does-not-exist.mcap"),
                 output_file: PathBuf::from("sorted.mcap"),
                 chunk_size: 4 * 1024 * 1024,
-                compression: crate::cli::ConvertCompression::Zstd,
+                compression: crate::cli::CompressionFormat::Zstd,
                 include_crc: true,
                 chunked: true,
             }),

--- a/rust/mcap_cli/src/commands/convert.rs
+++ b/rust/mcap_cli/src/commands/convert.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use mcap::{Compression, WriteOptions};
 
-use crate::cli::{ConvertCommand, ConvertCompression};
+use crate::cli::{CompressionFormat, ConvertCommand};
 use crate::context::CommandContext;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,15 +44,15 @@ fn validate_input(file_type: InputFileType, input: &mut File) -> Result<()> {
 }
 
 fn build_write_options(
-    compression: ConvertCompression,
+    compression: CompressionFormat,
     chunk_size: u64,
     include_crc: bool,
     chunked: bool,
 ) -> WriteOptions {
     let compression = match compression {
-        ConvertCompression::Zstd => Some(Compression::Zstd),
-        ConvertCompression::Lz4 => Some(Compression::Lz4),
-        ConvertCompression::None => None,
+        CompressionFormat::Zstd => Some(Compression::Zstd),
+        CompressionFormat::Lz4 => Some(Compression::Lz4),
+        CompressionFormat::None => None,
     };
 
     WriteOptions::new()
@@ -90,11 +90,11 @@ mod tests {
     use std::path::Path;
 
     use super::{build_write_options, detect_file_type, InputFileType};
-    use crate::cli::ConvertCompression;
+    use crate::cli::CompressionFormat;
 
     fn build_sample_mcap(include_crc: bool) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
-        let opts = build_write_options(ConvertCompression::None, 1024, include_crc, true);
+        let opts = build_write_options(CompressionFormat::None, 1024, include_crc, true);
         {
             let mut writer = opts.create(&mut output).expect("writer");
             let schema_id = writer

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -1,8 +1,980 @@
-use anyhow::Result;
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
+use std::io::{IsTerminal as _, Seek, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
 
-use crate::commands::not_implemented;
+use anyhow::{bail, Context, Result};
+use mcap::records::{MessageHeader, Record};
+
+use crate::cli::{CoalesceChannels, MergeCommand, MergeCompression};
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext) -> Result<()> {
-    Err(not_implemented("merge"))
+const PLEASE_REDIRECT: &str =
+    "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
+
+#[derive(Debug, Clone)]
+struct MergeOptions {
+    files: Vec<PathBuf>,
+    output_file: Option<PathBuf>,
+    compression: Option<mcap::Compression>,
+    chunk_size: u64,
+    include_crc: bool,
+    chunked: bool,
+    allow_duplicate_metadata: bool,
+    coalesce_channels: CoalesceChannels,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SchemaKey {
+    name: String,
+    encoding: String,
+    data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ChannelKey {
+    schema_id: u16,
+    topic: String,
+    message_encoding: String,
+    metadata: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct MetadataKey {
+    name: String,
+    entries: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+struct InputRef<'a> {
+    name: &'a str,
+    data: &'a [u8],
+}
+
+#[derive(Debug, Clone)]
+struct PendingMessage {
+    input_idx: usize,
+    input_channel_id: u16,
+    sequence: u32,
+    log_time: u64,
+    publish_time: u64,
+    data: Vec<u8>,
+}
+
+impl PartialEq for PendingMessage {
+    fn eq(&self, other: &Self) -> bool {
+        self.log_time == other.log_time
+            && self.input_idx == other.input_idx
+            && self.input_channel_id == other.input_channel_id
+    }
+}
+
+impl Eq for PendingMessage {}
+
+impl PartialOrd for PendingMessage {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PendingMessage {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .log_time
+            .cmp(&self.log_time)
+            .then_with(|| other.input_idx.cmp(&self.input_idx))
+            .then_with(|| other.input_channel_id.cmp(&self.input_channel_id))
+    }
+}
+
+#[derive(Default)]
+struct MetadataState {
+    seen_metadata: HashSet<MetadataKey>,
+    metadata_by_name: HashMap<String, MetadataKey>,
+}
+
+#[derive(Default)]
+struct IdMaps {
+    schema_ids: HashMap<(usize, u16), u16>,
+    schema_ids_by_content: HashMap<SchemaKey, u16>,
+    channel_ids: HashMap<(usize, u16), u16>,
+    channel_ids_by_content: HashMap<ChannelKey, u16>,
+    next_output_channel_id: u16,
+}
+
+pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
+    let opts = build_merge_options(args);
+
+    let mut mapped_inputs = Vec::with_capacity(opts.files.len());
+    let mut input_names = Vec::with_capacity(opts.files.len());
+    for path in &opts.files {
+        let mapped = crate::commands::common::map_file(path)?;
+        mapped_inputs.push(mapped);
+        input_names.push(path.display().to_string());
+    }
+
+    let input_refs: Vec<InputRef<'_>> = mapped_inputs
+        .iter()
+        .zip(input_names.iter())
+        .map(|(mapped, name)| InputRef {
+            name: name.as_str(),
+            data: mapped.as_ref(),
+        })
+        .collect();
+
+    if let Some(output_path) = &opts.output_file {
+        let output = std::fs::File::create(output_path)
+            .with_context(|| format!("failed to open '{}' for writing", output_path.display()))?;
+        merge_inputs(&input_refs, output, &opts, false)
+    } else {
+        if std::io::stdout().is_terminal() {
+            bail!("{PLEASE_REDIRECT}");
+        }
+        let stdout = std::io::stdout();
+        let output = mcap::write::NoSeek::new(stdout.lock());
+        merge_inputs(&input_refs, output, &opts, true)
+    }
+}
+
+fn build_merge_options(args: MergeCommand) -> MergeOptions {
+    let compression = match args.compression {
+        MergeCompression::Zstd => Some(mcap::Compression::Zstd),
+        MergeCompression::Lz4 => Some(mcap::Compression::Lz4),
+        MergeCompression::None => None,
+    };
+
+    MergeOptions {
+        files: args.files,
+        output_file: args.output_file,
+        compression,
+        chunk_size: args.chunk_size,
+        include_crc: args.include_crc,
+        chunked: args.chunked,
+        allow_duplicate_metadata: args.allow_duplicate_metadata,
+        coalesce_channels: args.coalesce_channels,
+    }
+}
+
+fn merge_inputs<W: Write + Seek>(
+    inputs: &[InputRef<'_>],
+    sink: W,
+    opts: &MergeOptions,
+    disable_seeking: bool,
+) -> Result<()> {
+    let profiles = inputs
+        .iter()
+        .map(read_profile)
+        .collect::<Result<Vec<_>>>()?;
+    let output_profile = output_profile(&profiles);
+
+    let mut write_options = mcap::WriteOptions::new()
+        .profile(output_profile)
+        .use_chunks(opts.chunked)
+        .chunk_size(Some(opts.chunk_size))
+        .compression(opts.compression)
+        .calculate_chunk_crcs(opts.include_crc)
+        .calculate_data_section_crc(opts.include_crc)
+        .calculate_summary_section_crc(opts.include_crc)
+        .calculate_attachment_crcs(opts.include_crc)
+        .disable_seeking(disable_seeking);
+
+    // Keep writer's default library field.
+    if !opts.chunked {
+        write_options = write_options.emit_message_indexes(false);
+    }
+
+    let mut writer = write_options
+        .create(sink)
+        .context("failed to create mcap writer")?;
+
+    let summaries = inputs
+        .iter()
+        .map(|input| {
+            mcap::Summary::read(input.data)
+                .with_context(|| format!("failed to read summary from '{}'", input.name))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut metadata_state = MetadataState::default();
+    for (idx, input) in inputs.iter().enumerate() {
+        let metadata = collect_metadata_records(input, summaries[idx].as_ref())?;
+        for metadata_record in metadata {
+            write_merged_metadata(
+                &mut writer,
+                &mut metadata_state,
+                metadata_record,
+                opts.allow_duplicate_metadata,
+            )?;
+        }
+    }
+
+    merge_messages(inputs, &mut writer, opts.coalesce_channels)?;
+
+    for (idx, input) in inputs.iter().enumerate() {
+        let attachments = collect_attachments(input, summaries[idx].as_ref())?;
+        for attachment in attachments {
+            writer.attach(&attachment)?;
+        }
+    }
+
+    writer.finish().context("failed to finish mcap writer")?;
+    Ok(())
+}
+
+fn read_profile(input: &InputRef<'_>) -> Result<String> {
+    let mut reader = mcap::read::LinearReader::new(input.data)
+        .with_context(|| format!("failed to read '{}'", input.name))?;
+    match reader.next() {
+        Some(Ok(Record::Header(header))) => Ok(header.profile),
+        Some(Ok(_)) | None => Ok(String::new()),
+        Some(Err(err)) => Err(anyhow::Error::from(err))
+            .with_context(|| format!("failed to read header from '{}'", input.name)),
+    }
+}
+
+fn output_profile(profiles: &[String]) -> String {
+    let Some(first) = profiles.first() else {
+        return String::new();
+    };
+    if profiles.iter().all(|profile| profile == first) {
+        first.clone()
+    } else {
+        String::new()
+    }
+}
+
+fn collect_metadata_records(
+    input: &InputRef<'_>,
+    summary: Option<&mcap::Summary>,
+) -> Result<Vec<mcap::records::Metadata>> {
+    if let Some(summary) = summary {
+        let metadata_count = summary
+            .stats
+            .as_ref()
+            .map(|stats| stats.metadata_count)
+            .unwrap_or(0);
+        if metadata_count == summary.metadata_indexes.len() as u32 {
+            let mut indexes = summary.metadata_indexes.clone();
+            indexes.sort_by_key(|index| index.offset);
+            return indexes
+                .into_iter()
+                .map(|index| {
+                    mcap::read::metadata(input.data, &index).with_context(|| {
+                        format!(
+                            "failed to read metadata '{}' at offset {} from '{}'",
+                            index.name, index.offset, input.name
+                        )
+                    })
+                })
+                .collect();
+        }
+    }
+
+    let mut metadata = Vec::new();
+    for record in mcap::read::LinearReader::new(input.data)
+        .with_context(|| format!("failed to read '{}'", input.name))?
+    {
+        if let Record::Metadata(record) =
+            record.with_context(|| format!("failed to parse '{}'", input.name))?
+        {
+            metadata.push(record);
+        }
+    }
+    Ok(metadata)
+}
+
+fn write_merged_metadata<W: Write + Seek>(
+    writer: &mut mcap::Writer<W>,
+    state: &mut MetadataState,
+    metadata_record: mcap::records::Metadata,
+    allow_duplicate_metadata: bool,
+) -> Result<()> {
+    let key = metadata_key(&metadata_record);
+    if let Some(existing) = state.metadata_by_name.get(&metadata_record.name) {
+        if existing != &key && !allow_duplicate_metadata {
+            bail!(
+                "metadata name '{}' was previously encountered. Supply --allow-duplicate-metadata to override.",
+                metadata_record.name
+            );
+        }
+    }
+
+    if state.seen_metadata.insert(key.clone()) {
+        writer.write_metadata(&metadata_record)?;
+    }
+    state
+        .metadata_by_name
+        .entry(metadata_record.name.clone())
+        .or_insert(key);
+    Ok(())
+}
+
+fn metadata_key(metadata_record: &mcap::records::Metadata) -> MetadataKey {
+    MetadataKey {
+        name: metadata_record.name.clone(),
+        entries: metadata_record
+            .metadata
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    }
+}
+
+fn collect_attachments(
+    input: &InputRef<'_>,
+    summary: Option<&mcap::Summary>,
+) -> Result<Vec<mcap::Attachment<'static>>> {
+    if let Some(summary) = summary {
+        let attachment_count = summary
+            .stats
+            .as_ref()
+            .map(|stats| stats.attachment_count)
+            .unwrap_or(0);
+        if attachment_count == summary.attachment_indexes.len() as u32 {
+            let mut indexes = summary.attachment_indexes.clone();
+            indexes.sort_by_key(|index| index.offset);
+            return indexes
+                .into_iter()
+                .map(|index| {
+                    mcap::read::attachment(input.data, &index)
+                        .map(owned_attachment)
+                        .with_context(|| {
+                            format!(
+                                "failed to read attachment '{}' at offset {} from '{}'",
+                                index.name, index.offset, input.name
+                            )
+                        })
+                })
+                .collect();
+        }
+    }
+
+    let mut attachments = Vec::new();
+    for record in mcap::read::LinearReader::new(input.data)
+        .with_context(|| format!("failed to read '{}'", input.name))?
+    {
+        if let Record::Attachment { header, data, .. } =
+            record.with_context(|| format!("failed to parse '{}'", input.name))?
+        {
+            attachments.push(mcap::Attachment {
+                log_time: header.log_time,
+                create_time: header.create_time,
+                name: header.name,
+                media_type: header.media_type,
+                data: std::borrow::Cow::Owned(data.into_owned()),
+            });
+        }
+    }
+
+    Ok(attachments)
+}
+
+fn owned_attachment(input: mcap::Attachment<'_>) -> mcap::Attachment<'static> {
+    mcap::Attachment {
+        log_time: input.log_time,
+        create_time: input.create_time,
+        name: input.name,
+        media_type: input.media_type,
+        data: std::borrow::Cow::Owned(input.data.into_owned()),
+    }
+}
+
+fn merge_messages<W: Write + Seek>(
+    inputs: &[InputRef<'_>],
+    writer: &mut mcap::Writer<W>,
+    coalesce_channels: CoalesceChannels,
+) -> Result<()> {
+    let mut streams = inputs
+        .iter()
+        .map(|input| {
+            mcap::read::RawMessageStream::new(input.data)
+                .with_context(|| format!("failed to stream messages from '{}'", input.name))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut id_maps = IdMaps {
+        next_output_channel_id: 1,
+        ..IdMaps::default()
+    };
+
+    let mut heap = BinaryHeap::<PendingMessage>::new();
+    for (input_idx, stream) in streams.iter_mut().enumerate() {
+        if let Some(message) = next_message(stream).with_context(|| {
+            format!(
+                "failed reading initial message from '{}'",
+                inputs[input_idx].name
+            )
+        })? {
+            heap.push(PendingMessage {
+                input_idx,
+                input_channel_id: message.header.channel_id,
+                sequence: message.header.sequence,
+                log_time: message.header.log_time,
+                publish_time: message.header.publish_time,
+                data: message.data.into_owned(),
+            });
+        }
+    }
+
+    while let Some(message) = heap.pop() {
+        let output_channel_id = ensure_output_channel_id(
+            &mut id_maps,
+            writer,
+            &streams[message.input_idx],
+            message.input_idx,
+            message.input_channel_id,
+            coalesce_channels,
+        )?;
+
+        writer.write_to_known_channel(
+            &MessageHeader {
+                channel_id: output_channel_id,
+                sequence: message.sequence,
+                log_time: message.log_time,
+                publish_time: message.publish_time,
+            },
+            &message.data,
+        )?;
+
+        if let Some(next_message) =
+            next_message(&mut streams[message.input_idx]).with_context(|| {
+                format!(
+                    "failed reading next message from '{}'",
+                    inputs[message.input_idx].name
+                )
+            })?
+        {
+            heap.push(PendingMessage {
+                input_idx: message.input_idx,
+                input_channel_id: next_message.header.channel_id,
+                sequence: next_message.header.sequence,
+                log_time: next_message.header.log_time,
+                publish_time: next_message.header.publish_time,
+                data: next_message.data.into_owned(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn next_message(
+    stream: &mut mcap::read::RawMessageStream<'_>,
+) -> Result<Option<mcap::read::RawMessage<'static>>> {
+    match stream.next() {
+        Some(Ok(message)) => Ok(Some(mcap::read::RawMessage {
+            header: message.header,
+            data: std::borrow::Cow::Owned(message.data.into_owned()),
+        })),
+        Some(Err(err)) => Err(err.into()),
+        None => Ok(None),
+    }
+}
+
+fn ensure_output_channel_id<W: Write + Seek>(
+    id_maps: &mut IdMaps,
+    writer: &mut mcap::Writer<W>,
+    stream: &mcap::read::RawMessageStream<'_>,
+    input_idx: usize,
+    input_channel_id: u16,
+    coalesce_channels: CoalesceChannels,
+) -> Result<u16> {
+    if let Some(output_channel_id) = id_maps.channel_ids.get(&(input_idx, input_channel_id)) {
+        return Ok(*output_channel_id);
+    }
+
+    let channel = stream.get_channel(input_channel_id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "encountered message referencing unknown channel {} in input {}",
+            input_channel_id,
+            input_idx
+        )
+    })?;
+
+    let output_schema_id = if let Some(schema) = channel.schema.as_ref() {
+        ensure_output_schema_id(id_maps, writer, input_idx, schema)?
+    } else {
+        0
+    };
+
+    if coalesce_channels != CoalesceChannels::None {
+        let channel_key = make_channel_key(
+            output_schema_id,
+            &channel.topic,
+            &channel.message_encoding,
+            &channel.metadata,
+            coalesce_channels,
+        );
+        if let Some(output_channel_id) = id_maps.channel_ids_by_content.get(&channel_key).copied() {
+            id_maps
+                .channel_ids
+                .insert((input_idx, input_channel_id), output_channel_id);
+            return Ok(output_channel_id);
+        }
+
+        let output_channel_id = reserve_next_channel_id(id_maps)?;
+        writer.add_channel_with_id(
+            output_channel_id,
+            output_schema_id,
+            &channel.topic,
+            &channel.message_encoding,
+            &channel.metadata,
+        )?;
+        id_maps
+            .channel_ids
+            .insert((input_idx, input_channel_id), output_channel_id);
+        id_maps
+            .channel_ids_by_content
+            .insert(channel_key, output_channel_id);
+        return Ok(output_channel_id);
+    }
+
+    let output_channel_id = reserve_next_channel_id(id_maps)?;
+    writer.add_channel_with_id(
+        output_channel_id,
+        output_schema_id,
+        &channel.topic,
+        &channel.message_encoding,
+        &channel.metadata,
+    )?;
+    id_maps
+        .channel_ids
+        .insert((input_idx, input_channel_id), output_channel_id);
+    Ok(output_channel_id)
+}
+
+fn ensure_output_schema_id<W: Write + Seek>(
+    id_maps: &mut IdMaps,
+    writer: &mut mcap::Writer<W>,
+    input_idx: usize,
+    schema: &Arc<mcap::Schema<'_>>,
+) -> Result<u16> {
+    if let Some(output_schema_id) = id_maps.schema_ids.get(&(input_idx, schema.id)) {
+        return Ok(*output_schema_id);
+    }
+
+    let key = SchemaKey {
+        name: schema.name.clone(),
+        encoding: schema.encoding.clone(),
+        data: schema.data.clone().into_owned(),
+    };
+
+    let output_schema_id = if let Some(existing_schema_id) = id_maps.schema_ids_by_content.get(&key)
+    {
+        *existing_schema_id
+    } else {
+        let id = writer.add_schema(&schema.name, &schema.encoding, schema.data.as_ref())?;
+        id_maps.schema_ids_by_content.insert(key, id);
+        id
+    };
+
+    id_maps
+        .schema_ids
+        .insert((input_idx, schema.id), output_schema_id);
+    Ok(output_schema_id)
+}
+
+fn reserve_next_channel_id(id_maps: &mut IdMaps) -> Result<u16> {
+    if id_maps.next_output_channel_id == 0 {
+        bail!("cannot merge more than 65535 channels");
+    }
+    let id = id_maps.next_output_channel_id;
+    id_maps.next_output_channel_id = id_maps.next_output_channel_id.wrapping_add(1);
+    Ok(id)
+}
+
+fn make_channel_key(
+    schema_id: u16,
+    topic: &str,
+    message_encoding: &str,
+    metadata: &BTreeMap<String, String>,
+    coalesce_channels: CoalesceChannels,
+) -> ChannelKey {
+    let metadata_entries = if coalesce_channels == CoalesceChannels::Force {
+        Vec::new()
+    } else {
+        metadata
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect()
+    };
+
+    ChannelKey {
+        schema_id,
+        topic: topic.to_string(),
+        message_encoding: message_encoding.to_string(),
+        metadata: metadata_entries,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct TestMessage {
+        channel_id: u16,
+        topic: String,
+        metadata: BTreeMap<String, String>,
+        log_time: u64,
+        payload: Vec<u8>,
+    }
+
+    fn build_mcap(
+        profile: &str,
+        messages: &[TestMessage],
+        metadata_records: &[mcap::records::Metadata],
+        attachments: &[mcap::Attachment<'_>],
+        emit_attachment_indexes: bool,
+        emit_metadata_indexes: bool,
+    ) -> Vec<u8> {
+        let mut output = Cursor::new(Vec::<u8>::new());
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .profile(profile)
+                .emit_attachment_indexes(emit_attachment_indexes)
+                .emit_metadata_indexes(emit_metadata_indexes)
+                .create(&mut output)
+                .expect("writer");
+
+            let mut channels = BTreeMap::<u16, std::sync::Arc<mcap::Channel<'static>>>::new();
+            let schema = std::sync::Arc::new(mcap::Schema {
+                id: 1,
+                name: "example".to_string(),
+                encoding: "jsonschema".to_string(),
+                data: std::borrow::Cow::Borrowed(br#"{"type":"object"}"#),
+            });
+
+            for message in messages {
+                let channel = channels
+                    .entry(message.channel_id)
+                    .or_insert_with(|| {
+                        std::sync::Arc::new(mcap::Channel {
+                            id: message.channel_id,
+                            topic: message.topic.clone(),
+                            schema: Some(schema.clone()),
+                            message_encoding: "json".to_string(),
+                            metadata: message.metadata.clone(),
+                        })
+                    })
+                    .clone();
+                writer
+                    .write(&mcap::Message {
+                        channel,
+                        sequence: message.log_time as u32,
+                        log_time: message.log_time,
+                        publish_time: message.log_time,
+                        data: std::borrow::Cow::Borrowed(message.payload.as_slice()),
+                    })
+                    .expect("write message");
+            }
+
+            for metadata in metadata_records {
+                writer.write_metadata(metadata).expect("write metadata");
+            }
+            for attachment in attachments {
+                writer.attach(attachment).expect("write attachment");
+            }
+
+            writer.finish().expect("finish");
+        }
+        output.into_inner()
+    }
+
+    fn merge_bytes(
+        inputs: &[(&str, &[u8])],
+        coalesce_channels: CoalesceChannels,
+        allow_duplicate_metadata: bool,
+    ) -> Result<Vec<u8>> {
+        let options = MergeOptions {
+            files: Vec::new(),
+            output_file: None,
+            compression: None,
+            chunk_size: 1024,
+            include_crc: true,
+            chunked: true,
+            allow_duplicate_metadata,
+            coalesce_channels,
+        };
+        let input_refs = inputs
+            .iter()
+            .map(|(name, data)| InputRef { name, data: *data })
+            .collect::<Vec<_>>();
+
+        let mut output = Cursor::new(Vec::<u8>::new());
+        merge_inputs(&input_refs, &mut output, &options, false)?;
+        Ok(output.into_inner())
+    }
+
+    #[test]
+    fn build_merge_options_maps_cli_fields() {
+        let options = build_merge_options(MergeCommand {
+            files: vec!["a.mcap".into(), "b.mcap".into()],
+            output_file: Some("out.mcap".into()),
+            compression: MergeCompression::Lz4,
+            chunk_size: 4096,
+            include_crc: false,
+            chunked: false,
+            allow_duplicate_metadata: true,
+            coalesce_channels: CoalesceChannels::Force,
+        });
+
+        assert_eq!(
+            options.files,
+            vec![PathBuf::from("a.mcap"), PathBuf::from("b.mcap")]
+        );
+        assert_eq!(options.output_file, Some(PathBuf::from("out.mcap")));
+        assert!(matches!(options.compression, Some(mcap::Compression::Lz4)));
+        assert_eq!(options.chunk_size, 4096);
+        assert!(!options.include_crc);
+        assert!(!options.chunked);
+        assert!(options.allow_duplicate_metadata);
+        assert_eq!(options.coalesce_channels, CoalesceChannels::Force);
+    }
+
+    #[test]
+    fn merge_orders_messages_by_log_time_then_input_index() {
+        let left = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/left".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 10,
+                payload: vec![1],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+        let right = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/right".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 10,
+                payload: vec![2],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("left", left.as_slice()), ("right", right.as_slice())],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect("merge");
+        let mut topics = Vec::<String>::new();
+        for message in mcap::MessageStream::new(&merged).expect("stream") {
+            let message = message.expect("message");
+            topics.push(message.channel.topic.clone());
+        }
+        assert_eq!(topics, vec!["/left".to_string(), "/right".to_string()]);
+    }
+
+    #[test]
+    fn merge_sets_empty_profile_when_inputs_disagree() {
+        let a = build_mcap("a", &[], &[], &[], true, true);
+        let b = build_mcap("b", &[], &[], &[], true, true);
+
+        let merged = merge_bytes(
+            &[("a", a.as_slice()), ("b", b.as_slice())],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect("merge");
+
+        let header = match mcap::read::LinearReader::new(&merged)
+            .expect("reader")
+            .next()
+            .expect("header")
+            .expect("record")
+        {
+            Record::Header(header) => header,
+            _ => panic!("expected header"),
+        };
+        assert!(header.profile.is_empty());
+    }
+
+    #[test]
+    fn merge_rejects_duplicate_metadata_name_by_default() {
+        let first = build_mcap(
+            "p",
+            &[],
+            &[mcap::records::Metadata {
+                name: "robot".to_string(),
+                metadata: BTreeMap::from([(String::from("a"), String::from("1"))]),
+            }],
+            &[],
+            true,
+            true,
+        );
+        let second = build_mcap(
+            "p",
+            &[],
+            &[mcap::records::Metadata {
+                name: "robot".to_string(),
+                metadata: BTreeMap::from([(String::from("a"), String::from("2"))]),
+            }],
+            &[],
+            true,
+            true,
+        );
+
+        let err = merge_bytes(
+            &[("a", first.as_slice()), ("b", second.as_slice())],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect_err("merge should fail");
+        assert!(err
+            .to_string()
+            .contains("metadata name 'robot' was previously encountered"));
+    }
+
+    #[test]
+    fn merge_force_coalesces_channels_ignoring_metadata() {
+        let left = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: BTreeMap::from([(String::from("host"), String::from("left"))]),
+                log_time: 0,
+                payload: vec![1],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+        let right = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: BTreeMap::from([(String::from("host"), String::from("right"))]),
+                log_time: 1,
+                payload: vec![2],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("left", left.as_slice()), ("right", right.as_slice())],
+            CoalesceChannels::Force,
+            false,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.channels.len(), 1);
+    }
+
+    #[test]
+    fn merge_none_does_not_coalesce_channels() {
+        let left = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 0,
+                payload: vec![1],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+        let right = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 1,
+                payload: vec![2],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("left", left.as_slice()), ("right", right.as_slice())],
+            CoalesceChannels::None,
+            false,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.channels.len(), 2);
+    }
+
+    #[test]
+    fn merge_copies_attachments_with_and_without_indexes() {
+        let indexed = build_mcap(
+            "profile",
+            &[],
+            &[],
+            &[mcap::Attachment {
+                log_time: 1,
+                create_time: 1,
+                name: "indexed.bin".to_string(),
+                media_type: "application/octet-stream".to_string(),
+                data: std::borrow::Cow::Borrowed(&[1, 2, 3]),
+            }],
+            true,
+            true,
+        );
+
+        let unindexed = build_mcap(
+            "profile",
+            &[],
+            &[],
+            &[mcap::Attachment {
+                log_time: 2,
+                create_time: 2,
+                name: "unindexed.bin".to_string(),
+                media_type: "application/octet-stream".to_string(),
+                data: std::borrow::Cow::Borrowed(&[4, 5, 6]),
+            }],
+            false,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[
+                ("indexed", indexed.as_slice()),
+                ("unindexed", unindexed.as_slice()),
+            ],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.stats.as_ref().expect("stats").attachment_count, 2);
+        assert_eq!(summary.attachment_indexes.len(), 2);
+    }
 }

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -91,7 +91,7 @@ impl Ord for PendingMessage {
 #[derive(Default)]
 struct MetadataState {
     seen_metadata: HashSet<MetadataKey>,
-    metadata_by_name: HashMap<String, MetadataKey>,
+    metadata_names: HashSet<String>,
 }
 
 #[derive(Default)]
@@ -290,23 +290,18 @@ fn write_merged_metadata<W: Write + Seek>(
     metadata_record: mcap::records::Metadata,
     allow_duplicate_metadata: bool,
 ) -> Result<()> {
-    let key = metadata_key(&metadata_record);
-    if let Some(existing) = state.metadata_by_name.get(&metadata_record.name) {
-        if existing != &key && !allow_duplicate_metadata {
-            bail!(
-                "metadata name '{}' was previously encountered. Supply --allow-duplicate-metadata to override.",
-                metadata_record.name
-            );
-        }
+    if state.metadata_names.contains(&metadata_record.name) && !allow_duplicate_metadata {
+        bail!(
+            "metadata name '{}' was previously encountered. Supply --allow-duplicate-metadata to override.",
+            metadata_record.name
+        );
     }
 
+    let key = metadata_key(&metadata_record);
     if state.seen_metadata.insert(key.clone()) {
         writer.write_metadata(&metadata_record)?;
     }
-    state
-        .metadata_by_name
-        .entry(metadata_record.name.clone())
-        .or_insert(key);
+    state.metadata_names.insert(metadata_record.name.clone());
     Ok(())
 }
 

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -881,6 +881,50 @@ mod tests {
     }
 
     #[test]
+    fn merge_auto_keeps_channels_distinct_when_metadata_differs() {
+        let left = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: BTreeMap::from([(String::from("host"), String::from("left"))]),
+                log_time: 0,
+                payload: vec![1],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+        let right = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: BTreeMap::from([(String::from("host"), String::from("right"))]),
+                log_time: 1,
+                payload: vec![2],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("left", left.as_slice()), ("right", right.as_slice())],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.channels.len(), 2);
+    }
+
+    #[test]
     fn merge_none_does_not_coalesce_channels() {
         let left = build_mcap(
             "profile",

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -702,7 +702,7 @@ mod tests {
         };
         let input_refs = inputs
             .iter()
-            .map(|(name, data)| InputRef { name, data: *data })
+            .map(|(name, data)| InputRef { name, data })
             .collect::<Vec<_>>();
 
         let mut output = Cursor::new(Vec::<u8>::new());

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use mcap::records::{MessageHeader, Record};
 
-use crate::cli::{CoalesceChannels, MergeCommand, MergeCompression};
+use crate::cli::{CoalesceChannels, ConvertCompression, MergeCommand};
 use crate::context::CommandContext;
 
 #[derive(Debug, Clone)]
@@ -146,9 +146,9 @@ pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
 
 fn build_merge_options(args: MergeCommand) -> MergeOptions {
     let compression = match args.compression {
-        MergeCompression::Zstd => Some(mcap::Compression::Zstd),
-        MergeCompression::Lz4 => Some(mcap::Compression::Lz4),
-        MergeCompression::None => None,
+        ConvertCompression::Zstd => Some(mcap::Compression::Zstd),
+        ConvertCompression::Lz4 => Some(mcap::Compression::Lz4),
+        ConvertCompression::None => None,
     };
 
     MergeOptions {
@@ -278,27 +278,25 @@ fn collect_attachments(
     summary: Option<&mcap::Summary>,
 ) -> Result<Vec<mcap::Attachment<'static>>> {
     if let Some(summary) = summary {
-        let attachment_count = summary
-            .stats
-            .as_ref()
-            .map(|stats| stats.attachment_count)
-            .unwrap_or(0);
-        if attachment_count == summary.attachment_indexes.len() as u32 {
-            let mut indexes = summary.attachment_indexes.clone();
-            indexes.sort_by_key(|index| index.offset);
-            return indexes
-                .into_iter()
-                .map(|index| {
-                    mcap::read::attachment(input.data, &index)
-                        .map(owned_attachment)
-                        .with_context(|| {
-                            format!(
-                                "failed to read attachment '{}' at offset {} from '{}'",
-                                index.name, index.offset, input.name
-                            )
-                        })
-                })
-                .collect();
+        let attachment_count = summary.stats.as_ref().map(|stats| stats.attachment_count);
+        if let Some(attachment_count) = attachment_count {
+            if attachment_count == summary.attachment_indexes.len() as u32 {
+                let mut indexes = summary.attachment_indexes.clone();
+                indexes.sort_by_key(|index| index.offset);
+                return indexes
+                    .into_iter()
+                    .map(|index| {
+                        mcap::read::attachment(input.data, &index)
+                            .map(owned_attachment)
+                            .with_context(|| {
+                                format!(
+                                    "failed to read attachment '{}' at offset {} from '{}'",
+                                    index.name, index.offset, input.name
+                                )
+                            })
+                    })
+                    .collect();
+            }
         }
     }
 
@@ -676,12 +674,33 @@ mod tests {
         emit_attachment_indexes: bool,
         emit_metadata_indexes: bool,
     ) -> Vec<u8> {
+        build_mcap_with_options(
+            profile,
+            messages,
+            metadata_records,
+            attachments,
+            emit_attachment_indexes,
+            emit_metadata_indexes,
+            true,
+        )
+    }
+
+    fn build_mcap_with_options(
+        profile: &str,
+        messages: &[TestMessage],
+        metadata_records: &[mcap::records::Metadata],
+        attachments: &[mcap::Attachment<'_>],
+        emit_attachment_indexes: bool,
+        emit_metadata_indexes: bool,
+        emit_statistics: bool,
+    ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::<u8>::new());
         {
             let mut writer = mcap::WriteOptions::new()
                 .profile(profile)
                 .emit_attachment_indexes(emit_attachment_indexes)
                 .emit_metadata_indexes(emit_metadata_indexes)
+                .emit_statistics(emit_statistics)
                 .create(&mut output)
                 .expect("writer");
 
@@ -759,7 +778,7 @@ mod tests {
         let options = build_merge_options(MergeCommand {
             files: vec!["a.mcap".into(), "b.mcap".into()],
             output_file: Some("out.mcap".into()),
-            compression: MergeCompression::Lz4,
+            compression: ConvertCompression::Lz4,
             chunk_size: 4096,
             include_crc: false,
             chunked: false,
@@ -1104,5 +1123,37 @@ mod tests {
             .expect("present");
         assert_eq!(summary.stats.as_ref().expect("stats").attachment_count, 2);
         assert_eq!(summary.attachment_indexes.len(), 2);
+    }
+
+    #[test]
+    fn merge_copies_attachments_without_statistics_record() {
+        let no_stats = build_mcap_with_options(
+            "profile",
+            &[],
+            &[],
+            &[mcap::Attachment {
+                log_time: 3,
+                create_time: 3,
+                name: "nostats.bin".to_string(),
+                media_type: "application/octet-stream".to_string(),
+                data: std::borrow::Cow::Borrowed(&[7, 8, 9]),
+            }],
+            true,
+            true,
+            false,
+        );
+
+        let merged = merge_bytes(
+            &[("no-stats", no_stats.as_slice())],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.stats.as_ref().expect("stats").attachment_count, 1);
+        assert_eq!(summary.attachment_indexes.len(), 1);
     }
 }

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -209,10 +209,7 @@ fn merge_inputs<W: Write + Seek>(
     )?;
 
     for (idx, input) in inputs.iter().enumerate() {
-        let attachments = collect_attachments(input, summaries[idx].as_ref())?;
-        for attachment in attachments {
-            writer.attach(&attachment)?;
-        }
+        write_attachments(&mut writer, input, summaries[idx].as_ref())?;
     }
 
     writer.finish().context("failed to finish mcap writer")?;
@@ -273,61 +270,54 @@ fn metadata_key(metadata_record: &mcap::records::Metadata) -> MetadataKey {
     }
 }
 
-fn collect_attachments(
+fn write_attachments<W: Write + Seek>(
+    writer: &mut mcap::Writer<W>,
     input: &InputRef<'_>,
     summary: Option<&mcap::Summary>,
-) -> Result<Vec<mcap::Attachment<'static>>> {
+) -> Result<()> {
     if let Some(summary) = summary {
         let attachment_count = summary.stats.as_ref().map(|stats| stats.attachment_count);
         if let Some(attachment_count) = attachment_count {
             if attachment_count == summary.attachment_indexes.len() as u32 {
                 let mut indexes = summary.attachment_indexes.clone();
                 indexes.sort_by_key(|index| index.offset);
-                return indexes
-                    .into_iter()
-                    .map(|index| {
-                        mcap::read::attachment(input.data, &index)
-                            .map(owned_attachment)
-                            .with_context(|| {
-                                format!(
-                                    "failed to read attachment '{}' at offset {} from '{}'",
-                                    index.name, index.offset, input.name
-                                )
-                            })
-                    })
-                    .collect();
+                for index in indexes {
+                    let attachment =
+                        mcap::read::attachment(input.data, &index).with_context(|| {
+                            format!(
+                                "failed to read attachment '{}' at offset {} from '{}'",
+                                index.name, index.offset, input.name
+                            )
+                        })?;
+                    writer.attach(&attachment).with_context(|| {
+                        format!(
+                            "failed to write attachment '{}' from '{}'",
+                            index.name, input.name
+                        )
+                    })?;
+                }
+                return Ok(());
             }
         }
     }
 
-    let mut attachments = Vec::new();
     for record in mcap::read::LinearReader::new(input.data)
         .with_context(|| format!("failed to read '{}'", input.name))?
     {
         if let Record::Attachment { header, data, .. } =
             record.with_context(|| format!("failed to parse '{}'", input.name))?
         {
-            attachments.push(mcap::Attachment {
+            writer.attach(&mcap::Attachment {
                 log_time: header.log_time,
                 create_time: header.create_time,
                 name: header.name,
                 media_type: header.media_type,
-                data: std::borrow::Cow::Owned(data.into_owned()),
-            });
+                data: std::borrow::Cow::Borrowed(data.as_ref()),
+            })?;
         }
     }
 
-    Ok(attachments)
-}
-
-fn owned_attachment(input: mcap::Attachment<'_>) -> mcap::Attachment<'static> {
-    mcap::Attachment {
-        log_time: input.log_time,
-        create_time: input.create_time,
-        name: input.name,
-        media_type: input.media_type,
-        data: std::borrow::Cow::Owned(input.data.into_owned()),
-    }
+    Ok(())
 }
 
 impl<'a> InputMessageReader<'a> {

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -10,9 +10,6 @@ use mcap::records::{MessageHeader, Record};
 use crate::cli::{CoalesceChannels, MergeCommand, MergeCompression};
 use crate::context::CommandContext;
 
-const PLEASE_REDIRECT: &str =
-    "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
-
 #[derive(Debug, Clone)]
 struct MergeOptions {
     files: Vec<PathBuf>,
@@ -38,12 +35,6 @@ struct ChannelKey {
     topic: String,
     message_encoding: String,
     metadata: Vec<(String, String)>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct MetadataKey {
-    name: String,
-    entries: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -90,7 +81,6 @@ impl Ord for PendingMessage {
 
 #[derive(Default)]
 struct MetadataState {
-    seen_metadata: HashSet<MetadataKey>,
     metadata_names: HashSet<String>,
 }
 
@@ -129,7 +119,7 @@ pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
         merge_inputs(&input_refs, output, &opts, false)
     } else {
         if std::io::stdout().is_terminal() {
-            bail!("{PLEASE_REDIRECT}");
+            bail!("{}", crate::commands::common::PLEASE_REDIRECT);
         }
         let stdout = std::io::stdout();
         let output = mcap::write::NoSeek::new(stdout.lock());
@@ -179,7 +169,6 @@ fn merge_inputs<W: Write + Seek>(
         .calculate_attachment_crcs(opts.include_crc)
         .disable_seeking(disable_seeking);
 
-    // Keep writer's default library field.
     if !opts.chunked {
         write_options = write_options.emit_message_indexes(false);
     }
@@ -190,11 +179,10 @@ fn merge_inputs<W: Write + Seek>(
 
     let summaries = inputs
         .iter()
-        .map(|input| {
-            mcap::Summary::read(input.data)
-                .with_context(|| format!("failed to read summary from '{}'", input.name))
-        })
-        .collect::<Result<Vec<_>>>()?;
+        // Match Go CLI behavior by treating summary lookup as best effort and
+        // falling back to linear scans when summary parsing fails.
+        .map(|input| mcap::Summary::read(input.data).unwrap_or_default())
+        .collect::<Vec<_>>();
 
     let mut metadata_state = MetadataState::default();
     for (idx, input) in inputs.iter().enumerate() {
@@ -297,23 +285,9 @@ fn write_merged_metadata<W: Write + Seek>(
         );
     }
 
-    let key = metadata_key(&metadata_record);
-    if state.seen_metadata.insert(key.clone()) {
-        writer.write_metadata(&metadata_record)?;
-    }
+    writer.write_metadata(&metadata_record)?;
     state.metadata_names.insert(metadata_record.name.clone());
     Ok(())
-}
-
-fn metadata_key(metadata_record: &mcap::records::Metadata) -> MetadataKey {
-    MetadataKey {
-        name: metadata_record.name.clone(),
-        entries: metadata_record
-            .metadata
-            .iter()
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect(),
-    }
 }
 
 fn collect_attachments(
@@ -834,6 +808,45 @@ mod tests {
         assert!(err
             .to_string()
             .contains("metadata name 'robot' was previously encountered"));
+    }
+
+    #[test]
+    fn merge_allow_duplicate_metadata_writes_identical_records() {
+        let first = build_mcap(
+            "p",
+            &[],
+            &[mcap::records::Metadata {
+                name: "robot".to_string(),
+                metadata: BTreeMap::from([(String::from("a"), String::from("1"))]),
+            }],
+            &[],
+            true,
+            true,
+        );
+        let second = build_mcap(
+            "p",
+            &[],
+            &[mcap::records::Metadata {
+                name: "robot".to_string(),
+                metadata: BTreeMap::from([(String::from("a"), String::from("1"))]),
+            }],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("a", first.as_slice()), ("b", second.as_slice())],
+            CoalesceChannels::Auto,
+            true,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.stats.as_ref().expect("stats").metadata_count, 2);
+        assert_eq!(summary.metadata_indexes.len(), 2);
     }
 
     #[test]

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use mcap::records::{MessageHeader, Record};
 
-use crate::cli::{CoalesceChannels, ConvertCompression, MergeCommand};
+use crate::cli::{CoalesceChannels, CompressionFormat, MergeCommand};
 use crate::context::CommandContext;
 
 #[derive(Debug, Clone)]
@@ -146,9 +146,9 @@ pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
 
 fn build_merge_options(args: MergeCommand) -> MergeOptions {
     let compression = match args.compression {
-        ConvertCompression::Zstd => Some(mcap::Compression::Zstd),
-        ConvertCompression::Lz4 => Some(mcap::Compression::Lz4),
-        ConvertCompression::None => None,
+        CompressionFormat::Zstd => Some(mcap::Compression::Zstd),
+        CompressionFormat::Lz4 => Some(mcap::Compression::Lz4),
+        CompressionFormat::None => None,
     };
 
     MergeOptions {
@@ -778,7 +778,7 @@ mod tests {
         let options = build_merge_options(MergeCommand {
             files: vec!["a.mcap".into(), "b.mcap".into()],
             output_file: Some("out.mcap".into()),
-            compression: ConvertCompression::Lz4,
+            compression: CompressionFormat::Lz4,
             chunk_size: 4096,
             include_crc: false,
             chunked: false,
@@ -803,13 +803,22 @@ mod tests {
     fn merge_orders_messages_by_log_time_then_input_index() {
         let left = build_mcap(
             "profile",
-            &[TestMessage {
-                channel_id: 1,
-                topic: "/left".to_string(),
-                metadata: BTreeMap::new(),
-                log_time: 10,
-                payload: vec![1],
-            }],
+            &[
+                TestMessage {
+                    channel_id: 1,
+                    topic: "/left".to_string(),
+                    metadata: BTreeMap::new(),
+                    log_time: 5,
+                    payload: vec![1],
+                },
+                TestMessage {
+                    channel_id: 1,
+                    topic: "/left".to_string(),
+                    metadata: BTreeMap::new(),
+                    log_time: 10,
+                    payload: vec![3],
+                },
+            ],
             &[],
             &[],
             true,
@@ -817,13 +826,22 @@ mod tests {
         );
         let right = build_mcap(
             "profile",
-            &[TestMessage {
-                channel_id: 1,
-                topic: "/right".to_string(),
-                metadata: BTreeMap::new(),
-                log_time: 10,
-                payload: vec![2],
-            }],
+            &[
+                TestMessage {
+                    channel_id: 1,
+                    topic: "/right".to_string(),
+                    metadata: BTreeMap::new(),
+                    log_time: 3,
+                    payload: vec![2],
+                },
+                TestMessage {
+                    channel_id: 1,
+                    topic: "/right".to_string(),
+                    metadata: BTreeMap::new(),
+                    log_time: 10,
+                    payload: vec![4],
+                },
+            ],
             &[],
             &[],
             true,
@@ -836,12 +854,25 @@ mod tests {
             false,
         )
         .expect("merge");
-        let mut topics = Vec::<String>::new();
+        let mut ordered_messages = Vec::<(u64, String, Vec<u8>)>::new();
         for message in mcap::MessageStream::new(&merged).expect("stream") {
             let message = message.expect("message");
-            topics.push(message.channel.topic.clone());
+            ordered_messages.push((
+                message.log_time,
+                message.channel.topic.clone(),
+                message.data.to_vec(),
+            ));
         }
-        assert_eq!(topics, vec!["/left".to_string(), "/right".to_string()]);
+        assert_eq!(
+            ordered_messages,
+            vec![
+                (3, "/right".to_string(), vec![2]),
+                (5, "/left".to_string(), vec![1]),
+                // Tie at log_time=10 resolves by input index: left before right.
+                (10, "/left".to_string(), vec![3]),
+                (10, "/right".to_string(), vec![4]),
+            ]
+        );
     }
 
     #[test]
@@ -1030,6 +1061,51 @@ mod tests {
             .expect("summary")
             .expect("present");
         assert_eq!(summary.channels.len(), 2);
+    }
+
+    #[test]
+    fn merge_auto_coalesces_channels_when_metadata_matches() {
+        let metadata = BTreeMap::from([(String::from("host"), String::from("same"))]);
+        let left = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata: metadata.clone(),
+                log_time: 0,
+                payload: vec![1],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+        let right = build_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/topic".to_string(),
+                metadata,
+                log_time: 1,
+                payload: vec![2],
+            }],
+            &[],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("left", left.as_slice()), ("right", right.as_slice())],
+            CoalesceChannels::Auto,
+            false,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.channels.len(), 1);
     }
 
     #[test]

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -976,6 +976,45 @@ mod tests {
     }
 
     #[test]
+    fn merge_allow_duplicate_metadata_keeps_same_name_with_different_content() {
+        let first = build_mcap(
+            "p",
+            &[],
+            &[mcap::records::Metadata {
+                name: "robot".to_string(),
+                metadata: BTreeMap::from([(String::from("a"), String::from("1"))]),
+            }],
+            &[],
+            true,
+            true,
+        );
+        let second = build_mcap(
+            "p",
+            &[],
+            &[mcap::records::Metadata {
+                name: "robot".to_string(),
+                metadata: BTreeMap::from([(String::from("a"), String::from("2"))]),
+            }],
+            &[],
+            true,
+            true,
+        );
+
+        let merged = merge_bytes(
+            &[("a", first.as_slice()), ("b", second.as_slice())],
+            CoalesceChannels::Auto,
+            true,
+        )
+        .expect("merge");
+
+        let summary = mcap::Summary::read(&merged)
+            .expect("summary")
+            .expect("present");
+        assert_eq!(summary.stats.as_ref().expect("stats").metadata_count, 2);
+        assert_eq!(summary.metadata_indexes.len(), 2);
+    }
+
+    #[test]
     fn merge_force_coalesces_channels_ignoring_metadata() {
         let left = build_mcap(
             "profile",

--- a/rust/mcap_cli/src/commands/merge.rs
+++ b/rust/mcap_cli/src/commands/merge.rs
@@ -37,16 +37,32 @@ struct ChannelKey {
     metadata: Vec<(String, String)>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct MetadataKey {
+    name: String,
+    entries: Vec<(String, String)>,
+}
+
 #[derive(Debug, Clone)]
 struct InputRef<'a> {
     name: &'a str,
     data: &'a [u8],
 }
 
+struct InputMessageReader<'a> {
+    name: &'a str,
+    records: mcap::read::ChunkFlattener<'a>,
+    schemas: HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channels: HashMap<u16, Arc<mcap::Channel<'static>>>,
+}
+
+type InputMessage = (Arc<mcap::Channel<'static>>, MessageHeader, Vec<u8>);
+
 #[derive(Debug, Clone)]
 struct PendingMessage {
     input_idx: usize,
     input_channel_id: u16,
+    channel: Arc<mcap::Channel<'static>>,
     sequence: u32,
     log_time: u64,
     publish_time: u64,
@@ -81,6 +97,7 @@ impl Ord for PendingMessage {
 
 #[derive(Default)]
 struct MetadataState {
+    seen_metadata: HashSet<MetadataKey>,
     metadata_names: HashSet<String>,
 }
 
@@ -184,20 +201,12 @@ fn merge_inputs<W: Write + Seek>(
         .map(|input| mcap::Summary::read(input.data).unwrap_or_default())
         .collect::<Vec<_>>();
 
-    let mut metadata_state = MetadataState::default();
-    for (idx, input) in inputs.iter().enumerate() {
-        let metadata = collect_metadata_records(input, summaries[idx].as_ref())?;
-        for metadata_record in metadata {
-            write_merged_metadata(
-                &mut writer,
-                &mut metadata_state,
-                metadata_record,
-                opts.allow_duplicate_metadata,
-            )?;
-        }
-    }
-
-    merge_messages(inputs, &mut writer, opts.coalesce_channels)?;
+    merge_messages(
+        inputs,
+        &mut writer,
+        opts.coalesce_channels,
+        opts.allow_duplicate_metadata,
+    )?;
 
     for (idx, input) in inputs.iter().enumerate() {
         let attachments = collect_attachments(input, summaries[idx].as_ref())?;
@@ -232,46 +241,6 @@ fn output_profile(profiles: &[String]) -> String {
     }
 }
 
-fn collect_metadata_records(
-    input: &InputRef<'_>,
-    summary: Option<&mcap::Summary>,
-) -> Result<Vec<mcap::records::Metadata>> {
-    if let Some(summary) = summary {
-        let metadata_count = summary
-            .stats
-            .as_ref()
-            .map(|stats| stats.metadata_count)
-            .unwrap_or(0);
-        if metadata_count == summary.metadata_indexes.len() as u32 {
-            let mut indexes = summary.metadata_indexes.clone();
-            indexes.sort_by_key(|index| index.offset);
-            return indexes
-                .into_iter()
-                .map(|index| {
-                    mcap::read::metadata(input.data, &index).with_context(|| {
-                        format!(
-                            "failed to read metadata '{}' at offset {} from '{}'",
-                            index.name, index.offset, input.name
-                        )
-                    })
-                })
-                .collect();
-        }
-    }
-
-    let mut metadata = Vec::new();
-    for record in mcap::read::LinearReader::new(input.data)
-        .with_context(|| format!("failed to read '{}'", input.name))?
-    {
-        if let Record::Metadata(record) =
-            record.with_context(|| format!("failed to parse '{}'", input.name))?
-        {
-            metadata.push(record);
-        }
-    }
-    Ok(metadata)
-}
-
 fn write_merged_metadata<W: Write + Seek>(
     writer: &mut mcap::Writer<W>,
     state: &mut MetadataState,
@@ -285,9 +254,23 @@ fn write_merged_metadata<W: Write + Seek>(
         );
     }
 
-    writer.write_metadata(&metadata_record)?;
-    state.metadata_names.insert(metadata_record.name.clone());
+    let key = metadata_key(&metadata_record);
+    if state.seen_metadata.insert(key) {
+        writer.write_metadata(&metadata_record)?;
+        state.metadata_names.insert(metadata_record.name.clone());
+    }
     Ok(())
+}
+
+fn metadata_key(metadata_record: &mcap::records::Metadata) -> MetadataKey {
+    MetadataKey {
+        name: metadata_record.name.clone(),
+        entries: metadata_record
+            .metadata
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    }
 }
 
 fn collect_attachments(
@@ -349,27 +332,134 @@ fn owned_attachment(input: mcap::Attachment<'_>) -> mcap::Attachment<'static> {
     }
 }
 
+impl<'a> InputMessageReader<'a> {
+    fn new(input: &InputRef<'a>) -> Result<Self> {
+        Ok(Self {
+            name: input.name,
+            records: mcap::read::ChunkFlattener::new(input.data)
+                .with_context(|| format!("failed to stream records from '{}'", input.name))?,
+            schemas: HashMap::new(),
+            channels: HashMap::new(),
+        })
+    }
+}
+
+fn next_message_from_input<W: Write + Seek>(
+    input: &mut InputMessageReader<'_>,
+    writer: &mut mcap::Writer<W>,
+    metadata_state: &mut MetadataState,
+    allow_duplicate_metadata: bool,
+) -> Result<Option<InputMessage>> {
+    for record in input.records.by_ref() {
+        let record = record.with_context(|| format!("failed to parse '{}'", input.name))?;
+        match record {
+            Record::Schema { header, data } => {
+                let schema = Arc::new(mcap::Schema {
+                    id: header.id,
+                    name: header.name.clone(),
+                    encoding: header.encoding.clone(),
+                    data: std::borrow::Cow::Owned(data.into_owned()),
+                });
+                if let Some(existing) = input.schemas.get(&header.id) {
+                    if existing.name != schema.name
+                        || existing.encoding != schema.encoding
+                        || existing.data.as_ref() != schema.data.as_ref()
+                    {
+                        return Err(mcap::McapError::ConflictingSchemas(header.name).into());
+                    }
+                } else {
+                    input.schemas.insert(header.id, schema);
+                }
+            }
+            Record::Channel(channel) => {
+                let schema = if channel.schema_id == 0 {
+                    None
+                } else {
+                    Some(
+                        input
+                            .schemas
+                            .get(&channel.schema_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "encountered channel '{}' with unknown schema {} in '{}'",
+                                    channel.topic,
+                                    channel.schema_id,
+                                    input.name
+                                )
+                            })?,
+                    )
+                };
+                let parsed_channel = Arc::new(mcap::Channel {
+                    id: channel.id,
+                    topic: channel.topic.clone(),
+                    schema: schema.clone(),
+                    message_encoding: channel.message_encoding.clone(),
+                    metadata: channel.metadata.clone(),
+                });
+
+                if let Some(existing) = input.channels.get(&channel.id) {
+                    if existing.topic != parsed_channel.topic
+                        || existing.schema.as_ref().map(|schema| schema.id)
+                            != parsed_channel.schema.as_ref().map(|schema| schema.id)
+                        || existing.message_encoding != parsed_channel.message_encoding
+                        || existing.metadata != parsed_channel.metadata
+                    {
+                        return Err(mcap::McapError::ConflictingChannels(channel.topic).into());
+                    }
+                } else {
+                    input.channels.insert(channel.id, parsed_channel);
+                }
+            }
+            Record::Metadata(metadata) => {
+                write_merged_metadata(writer, metadata_state, metadata, allow_duplicate_metadata)?;
+            }
+            Record::Message { header, data } => {
+                let channel = input
+                    .channels
+                    .get(&header.channel_id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "encountered message referencing unknown channel {} in '{}'",
+                            header.channel_id,
+                            input.name
+                        )
+                    })?;
+                return Ok(Some((channel, header, data.into_owned())));
+            }
+            _ => {}
+        }
+    }
+    Ok(None)
+}
+
 fn merge_messages<W: Write + Seek>(
     inputs: &[InputRef<'_>],
     writer: &mut mcap::Writer<W>,
     coalesce_channels: CoalesceChannels,
+    allow_duplicate_metadata: bool,
 ) -> Result<()> {
     let mut streams = inputs
         .iter()
-        .map(|input| {
-            mcap::read::RawMessageStream::new(input.data)
-                .with_context(|| format!("failed to stream messages from '{}'", input.name))
-        })
+        .map(InputMessageReader::new)
         .collect::<Result<Vec<_>>>()?;
 
     let mut id_maps = IdMaps {
         next_output_channel_id: 1,
         ..IdMaps::default()
     };
+    let mut metadata_state = MetadataState::default();
 
     let mut heap = BinaryHeap::<PendingMessage>::new();
     for (input_idx, stream) in streams.iter_mut().enumerate() {
-        if let Some(message) = next_message(stream).with_context(|| {
+        if let Some((channel, header, data)) = next_message_from_input(
+            stream,
+            writer,
+            &mut metadata_state,
+            allow_duplicate_metadata,
+        )
+        .with_context(|| {
             format!(
                 "failed reading initial message from '{}'",
                 inputs[input_idx].name
@@ -377,11 +467,12 @@ fn merge_messages<W: Write + Seek>(
         })? {
             heap.push(PendingMessage {
                 input_idx,
-                input_channel_id: message.header.channel_id,
-                sequence: message.header.sequence,
-                log_time: message.header.log_time,
-                publish_time: message.header.publish_time,
-                data: message.data.into_owned(),
+                input_channel_id: header.channel_id,
+                channel,
+                sequence: header.sequence,
+                log_time: header.log_time,
+                publish_time: header.publish_time,
+                data,
             });
         }
     }
@@ -390,9 +481,9 @@ fn merge_messages<W: Write + Seek>(
         let output_channel_id = ensure_output_channel_id(
             &mut id_maps,
             writer,
-            &streams[message.input_idx],
             message.input_idx,
             message.input_channel_id,
+            &message.channel,
             coalesce_channels,
         )?;
 
@@ -406,21 +497,26 @@ fn merge_messages<W: Write + Seek>(
             &message.data,
         )?;
 
-        if let Some(next_message) =
-            next_message(&mut streams[message.input_idx]).with_context(|| {
-                format!(
-                    "failed reading next message from '{}'",
-                    inputs[message.input_idx].name
-                )
-            })?
-        {
+        if let Some((channel, header, data)) = next_message_from_input(
+            &mut streams[message.input_idx],
+            writer,
+            &mut metadata_state,
+            allow_duplicate_metadata,
+        )
+        .with_context(|| {
+            format!(
+                "failed reading next message from '{}'",
+                inputs[message.input_idx].name
+            )
+        })? {
             heap.push(PendingMessage {
                 input_idx: message.input_idx,
-                input_channel_id: next_message.header.channel_id,
-                sequence: next_message.header.sequence,
-                log_time: next_message.header.log_time,
-                publish_time: next_message.header.publish_time,
-                data: next_message.data.into_owned(),
+                input_channel_id: header.channel_id,
+                channel,
+                sequence: header.sequence,
+                log_time: header.log_time,
+                publish_time: header.publish_time,
+                data,
             });
         }
     }
@@ -428,38 +524,17 @@ fn merge_messages<W: Write + Seek>(
     Ok(())
 }
 
-fn next_message(
-    stream: &mut mcap::read::RawMessageStream<'_>,
-) -> Result<Option<mcap::read::RawMessage<'static>>> {
-    match stream.next() {
-        Some(Ok(message)) => Ok(Some(mcap::read::RawMessage {
-            header: message.header,
-            data: std::borrow::Cow::Owned(message.data.into_owned()),
-        })),
-        Some(Err(err)) => Err(err.into()),
-        None => Ok(None),
-    }
-}
-
 fn ensure_output_channel_id<W: Write + Seek>(
     id_maps: &mut IdMaps,
     writer: &mut mcap::Writer<W>,
-    stream: &mcap::read::RawMessageStream<'_>,
     input_idx: usize,
     input_channel_id: u16,
+    channel: &Arc<mcap::Channel<'_>>,
     coalesce_channels: CoalesceChannels,
 ) -> Result<u16> {
     if let Some(output_channel_id) = id_maps.channel_ids.get(&(input_idx, input_channel_id)) {
         return Ok(*output_channel_id);
     }
-
-    let channel = stream.get_channel(input_channel_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "encountered message referencing unknown channel {} in input {}",
-            input_channel_id,
-            input_idx
-        )
-    })?;
 
     let output_schema_id = if let Some(schema) = channel.schema.as_ref() {
         ensure_output_schema_id(id_maps, writer, input_idx, schema)?
@@ -805,13 +880,14 @@ mod tests {
             false,
         )
         .expect_err("merge should fail");
-        assert!(err
-            .to_string()
-            .contains("metadata name 'robot' was previously encountered"));
+        assert!(
+            format!("{err:#}").contains("metadata name 'robot' was previously encountered"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]
-    fn merge_allow_duplicate_metadata_writes_identical_records() {
+    fn merge_allow_duplicate_metadata_deduplicates_identical_records() {
         let first = build_mcap(
             "p",
             &[],
@@ -845,8 +921,8 @@ mod tests {
         let summary = mcap::Summary::read(&merged)
             .expect("summary")
             .expect("present");
-        assert_eq!(summary.stats.as_ref().expect("stats").metadata_count, 2);
-        assert_eq!(summary.metadata_indexes.len(), 2);
+        assert_eq!(summary.stats.as_ref().expect("stats").metadata_count, 1);
+        assert_eq!(summary.metadata_indexes.len(), 1);
     }
 
     #[test]

--- a/rust/mcap_cli/src/commands/sort.rs
+++ b/rust/mcap_cli/src/commands/sort.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 
-use crate::cli::{ConvertCompression, SortCommand};
+use crate::cli::{CompressionFormat, SortCommand};
 use crate::commands::common;
 use crate::context::CommandContext;
 
@@ -53,11 +53,11 @@ fn build_sort_options(args: &SortCommand) -> SortOptions {
     }
 }
 
-fn convert_compression(value: ConvertCompression) -> Option<mcap::Compression> {
+fn convert_compression(value: CompressionFormat) -> Option<mcap::Compression> {
     match value {
-        ConvertCompression::Zstd => Some(mcap::Compression::Zstd),
-        ConvertCompression::Lz4 => Some(mcap::Compression::Lz4),
-        ConvertCompression::None => None,
+        CompressionFormat::Zstd => Some(mcap::Compression::Zstd),
+        CompressionFormat::Lz4 => Some(mcap::Compression::Lz4),
+        CompressionFormat::None => None,
     }
 }
 
@@ -237,7 +237,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{sort_to_writer, validate_sort_input, SortOptions};
-    use crate::cli::ConvertCompression;
+    use crate::cli::CompressionFormat;
     use crate::cli::SortCommand;
     use crate::context::CommandContext;
 
@@ -422,7 +422,7 @@ mod tests {
             SortCommand {
                 file: input_path.clone(),
                 output_file: output_path.clone(),
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 4 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -452,7 +452,7 @@ mod tests {
             SortCommand {
                 file: file_path.clone(),
                 output_file: file_path.clone(),
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 4 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -488,13 +488,13 @@ mod tests {
 
     #[test]
     fn convert_compression_maps_variants() {
-        assert!(super::convert_compression(ConvertCompression::None).is_none());
+        assert!(super::convert_compression(CompressionFormat::None).is_none());
         assert!(matches!(
-            super::convert_compression(ConvertCompression::Lz4),
+            super::convert_compression(CompressionFormat::Lz4),
             Some(mcap::Compression::Lz4)
         ));
         assert!(matches!(
-            super::convert_compression(ConvertCompression::Zstd),
+            super::convert_compression(CompressionFormat::Zstd),
             Some(mcap::Compression::Zstd)
         ));
     }

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -460,6 +460,32 @@ mod tests {
     }
 
     #[test]
+    fn parses_merge_bool_flags_without_explicit_values() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "merge",
+            "a.mcap",
+            "b.mcap",
+            "--include-crc",
+            "--chunked",
+        ])
+        .expect("merge bool flags should parse without explicit values");
+        assert_eq!(
+            args.command,
+            Command::Merge(MergeCommand {
+                files: vec!["a.mcap".into(), "b.mcap".into()],
+                output_file: None,
+                compression: MergeCompression::Zstd,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: true,
+                chunked: true,
+                allow_duplicate_metadata: false,
+                coalesce_channels: CoalesceChannels::Auto,
+            })
+        );
+    }
+
+    #[test]
     fn merge_requires_at_least_one_file() {
         Args::try_parse_from(["mcap", "merge"]).expect_err("merge requires at least one file");
     }

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -36,10 +36,11 @@ mod tests {
 
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
-        Command, ConvertCommand, ConvertCompression, DoctorCommand, DuCommand, FilterCommand,
-        GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand,
-        ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
-        ListMetadataCommand, ListSchemasCommand, ListSubcommand, VersionCommand,
+        CoalesceChannels, Command, ConvertCommand, ConvertCompression, DoctorCommand, DuCommand,
+        FilterCommand, GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand,
+        InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
+        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, MergeCompression,
+        VersionCommand,
     };
 
     #[test]
@@ -402,5 +403,64 @@ mod tests {
                 chunk_size: 2048,
             })
         );
+    }
+
+    #[test]
+    fn parses_merge_with_defaults() {
+        let args = Args::try_parse_from(["mcap", "merge", "a.mcap", "b.mcap"])
+            .expect("merge should parse");
+        assert_eq!(
+            args.command,
+            Command::Merge(MergeCommand {
+                files: vec!["a.mcap".into(), "b.mcap".into()],
+                output_file: None,
+                compression: MergeCompression::Zstd,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: true,
+                chunked: true,
+                allow_duplicate_metadata: false,
+                coalesce_channels: CoalesceChannels::Auto,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_merge_with_all_flags() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "merge",
+            "a.mcap",
+            "b.mcap",
+            "-o",
+            "out.mcap",
+            "--compression",
+            "none",
+            "--chunk-size",
+            "2048",
+            "--include-crc=false",
+            "--chunked=false",
+            "--allow-duplicate-metadata",
+            "--coalesce-channels",
+            "force",
+        ])
+        .expect("merge with flags should parse");
+        assert_eq!(
+            args.command,
+            Command::Merge(MergeCommand {
+                files: vec!["a.mcap".into(), "b.mcap".into()],
+                output_file: Some("out.mcap".into()),
+                compression: MergeCompression::None,
+                chunk_size: 2048,
+                include_crc: false,
+                chunked: false,
+                allow_duplicate_metadata: true,
+                coalesce_channels: CoalesceChannels::Force,
+            })
+        );
+    }
+
+    #[test]
+    fn merge_requires_at_least_one_file() {
+        Args::try_parse_from(["mcap", "merge"]).expect_err("merge requires at least one file");
     }
 }

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -544,7 +544,6 @@ mod tests {
 
     #[test]
     fn sort_requires_output_file() {
-        Args::try_parse_from(["mcap", "sort", "in.mcap"])
-            .expect_err("sort requires --output-file");
+        Args::try_parse_from(["mcap", "sort", "in.mcap"]).expect_err("sort requires --output-file");
     }
 }

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -489,4 +489,10 @@ mod tests {
     fn merge_requires_at_least_one_file() {
         Args::try_parse_from(["mcap", "merge"]).expect_err("merge requires at least one file");
     }
+
+    #[test]
+    fn merge_requires_file_even_when_flags_are_present() {
+        Args::try_parse_from(["mcap", "merge", "--compression", "zstd"])
+            .expect_err("merge should require at least one file");
+    }
 }

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -359,8 +359,8 @@ mod tests {
     }
 
     #[test]
-    fn parses_convert_bool_flags_with_space_separated_values() {
-        let args = Args::try_parse_from([
+    fn convert_rejects_space_separated_bool_values() {
+        Args::try_parse_from([
             "mcap",
             "convert",
             "input.bag",
@@ -370,18 +370,7 @@ mod tests {
             "--chunked",
             "false",
         ])
-        .expect("convert bool flags should parse with space-separated values");
-        assert_eq!(
-            args.command,
-            Command::Convert(ConvertCommand {
-                input: "input.bag".into(),
-                output: "output.mcap".into(),
-                compression: ConvertCompression::Zstd,
-                chunk_size: 8 * 1024 * 1024,
-                include_crc: false,
-                chunked: false,
-            })
-        );
+        .expect_err("convert bool flags should require --flag=<value> when explicit");
     }
 
     #[test]
@@ -650,8 +639,8 @@ mod tests {
     }
 
     #[test]
-    fn parses_sort_bool_flags_with_space_separated_values() {
-        let args = Args::try_parse_from([
+    fn sort_rejects_space_separated_bool_values() {
+        Args::try_parse_from([
             "mcap",
             "sort",
             "in.mcap",
@@ -662,18 +651,7 @@ mod tests {
             "--chunked",
             "false",
         ])
-        .expect("sort bool flags should parse with space-separated values");
-        assert_eq!(
-            args.command,
-            Command::Sort(SortCommand {
-                file: "in.mcap".into(),
-                output_file: "out.mcap".into(),
-                chunk_size: 4 * 1024 * 1024,
-                compression: ConvertCompression::Zstd,
-                include_crc: false,
-                chunked: false,
-            })
-        );
+        .expect_err("sort bool flags should require --flag=<value> when explicit");
     }
 
     #[test]
@@ -757,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_merge_bool_flags_with_space_separated_values() {
+    fn merge_treats_space_separated_bool_values_as_positional_files() {
         let args = Args::try_parse_from([
             "mcap",
             "merge",
@@ -768,16 +746,21 @@ mod tests {
             "--chunked",
             "false",
         ])
-        .expect("merge bool flags should parse with space-separated values");
+        .expect("merge should parse and treat trailing bool-like tokens as files");
         assert_eq!(
             args.command,
             Command::Merge(MergeCommand {
-                files: vec!["a.mcap".into(), "b.mcap".into()],
+                files: vec![
+                    "a.mcap".into(),
+                    "b.mcap".into(),
+                    "false".into(),
+                    "false".into()
+                ],
                 output_file: None,
                 compression: MergeCompression::Zstd,
                 chunk_size: 8 * 1024 * 1024,
-                include_crc: false,
-                chunked: false,
+                include_crc: true,
+                chunked: true,
                 allow_duplicate_metadata: false,
                 coalesce_channels: CoalesceChannels::Auto,
             })

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -40,8 +40,8 @@ mod tests {
         DecompressCommand, DoctorCommand, DuCommand, FilterCommand, GetAttachmentCommand,
         GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand, ListAttachmentsCommand,
         ListChannelsCommand, ListChunksCommand, ListCommand, ListMetadataCommand,
-        ListSchemasCommand, ListSubcommand, MergeCommand, MergeCompression, RecoverCommand,
-        SortCommand, VersionCommand,
+        ListSchemasCommand, ListSubcommand, MergeCommand, RecoverCommand, SortCommand,
+        VersionCommand,
     };
 
     #[test]
@@ -663,7 +663,7 @@ mod tests {
             Command::Merge(MergeCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
                 output_file: None,
-                compression: MergeCompression::Zstd,
+                compression: ConvertCompression::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -698,7 +698,7 @@ mod tests {
             Command::Merge(MergeCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
                 output_file: Some("out.mcap".into()),
-                compression: MergeCompression::None,
+                compression: ConvertCompression::None,
                 chunk_size: 2048,
                 include_crc: false,
                 chunked: false,
@@ -724,7 +724,7 @@ mod tests {
             Command::Merge(MergeCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
                 output_file: None,
-                compression: MergeCompression::Zstd,
+                compression: ConvertCompression::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -757,7 +757,7 @@ mod tests {
                     "false".into()
                 ],
                 output_file: None,
-                compression: MergeCompression::Zstd,
+                compression: ConvertCompression::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -36,7 +36,7 @@ mod tests {
 
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
-        CoalesceChannels, Command, CompressCommand, ConvertCommand, ConvertCompression,
+        CoalesceChannels, Command, CompressCommand, CompressionFormat, ConvertCommand,
         DecompressCommand, DoctorCommand, DuCommand, FilterCommand, GetAttachmentCommand,
         GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand, ListAttachmentsCommand,
         ListChannelsCommand, ListChunksCommand, ListCommand, ListMetadataCommand,
@@ -298,7 +298,7 @@ mod tests {
             Command::Convert(ConvertCommand {
                 input: "input.bag".into(),
                 output: "output.mcap".into(),
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -326,7 +326,7 @@ mod tests {
             Command::Convert(ConvertCommand {
                 input: "input.bag".into(),
                 output: "output.mcap".into(),
-                compression: ConvertCompression::None,
+                compression: CompressionFormat::None,
                 chunk_size: 1024,
                 include_crc: false,
                 chunked: false,
@@ -350,7 +350,7 @@ mod tests {
             Command::Convert(ConvertCommand {
                 input: "input.bag".into(),
                 output: "output.mcap".into(),
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -550,7 +550,7 @@ mod tests {
                 file: "in.mcap".into(),
                 output_file: "out.mcap".into(),
                 chunk_size: 4 * 1024 * 1024,
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 include_crc: true,
                 chunked: true,
             })
@@ -606,7 +606,7 @@ mod tests {
                 file: "in.mcap".into(),
                 output_file: "out.mcap".into(),
                 chunk_size: 1024,
-                compression: ConvertCompression::None,
+                compression: CompressionFormat::None,
                 include_crc: false,
                 chunked: false,
             })
@@ -631,7 +631,7 @@ mod tests {
                 file: "in.mcap".into(),
                 output_file: "out.mcap".into(),
                 chunk_size: 4 * 1024 * 1024,
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 include_crc: true,
                 chunked: true,
             })
@@ -663,7 +663,7 @@ mod tests {
             Command::Merge(MergeCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
                 output_file: None,
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -698,7 +698,7 @@ mod tests {
             Command::Merge(MergeCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
                 output_file: Some("out.mcap".into()),
-                compression: ConvertCompression::None,
+                compression: CompressionFormat::None,
                 chunk_size: 2048,
                 include_crc: false,
                 chunked: false,
@@ -724,7 +724,7 @@ mod tests {
             Command::Merge(MergeCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
                 output_file: None,
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
@@ -757,7 +757,7 @@ mod tests {
                     "false".into()
                 ],
                 output_file: None,
-                compression: ConvertCompression::Zstd,
+                compression: CompressionFormat::Zstd,
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,

--- a/rust/mcap_cli/src/main.rs
+++ b/rust/mcap_cli/src/main.rs
@@ -335,6 +335,56 @@ mod tests {
     }
 
     #[test]
+    fn parses_convert_bool_flags_without_explicit_values() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "convert",
+            "input.bag",
+            "output.mcap",
+            "--include-crc",
+            "--chunked",
+        ])
+        .expect("convert bool flags should parse without explicit values");
+        assert_eq!(
+            args.command,
+            Command::Convert(ConvertCommand {
+                input: "input.bag".into(),
+                output: "output.mcap".into(),
+                compression: ConvertCompression::Zstd,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: true,
+                chunked: true,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_convert_bool_flags_with_space_separated_values() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "convert",
+            "input.bag",
+            "output.mcap",
+            "--include-crc",
+            "false",
+            "--chunked",
+            "false",
+        ])
+        .expect("convert bool flags should parse with space-separated values");
+        assert_eq!(
+            args.command,
+            Command::Convert(ConvertCommand {
+                input: "input.bag".into(),
+                output: "output.mcap".into(),
+                compression: ConvertCompression::Zstd,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: false,
+                chunked: false,
+            })
+        );
+    }
+
+    #[test]
     fn parses_doctor_subcommand() {
         let args =
             Args::try_parse_from(["mcap", "doctor", "demo.mcap"]).expect("doctor should parse");
@@ -575,6 +625,58 @@ mod tests {
     }
 
     #[test]
+    fn parses_sort_bool_flags_without_explicit_values() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "sort",
+            "in.mcap",
+            "-o",
+            "out.mcap",
+            "--include-crc",
+            "--chunked",
+        ])
+        .expect("sort bool flags should parse without explicit values");
+        assert_eq!(
+            args.command,
+            Command::Sort(SortCommand {
+                file: "in.mcap".into(),
+                output_file: "out.mcap".into(),
+                chunk_size: 4 * 1024 * 1024,
+                compression: ConvertCompression::Zstd,
+                include_crc: true,
+                chunked: true,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_sort_bool_flags_with_space_separated_values() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "sort",
+            "in.mcap",
+            "-o",
+            "out.mcap",
+            "--include-crc",
+            "false",
+            "--chunked",
+            "false",
+        ])
+        .expect("sort bool flags should parse with space-separated values");
+        assert_eq!(
+            args.command,
+            Command::Sort(SortCommand {
+                file: "in.mcap".into(),
+                output_file: "out.mcap".into(),
+                chunk_size: 4 * 1024 * 1024,
+                compression: ConvertCompression::Zstd,
+                include_crc: false,
+                chunked: false,
+            })
+        );
+    }
+
+    #[test]
     fn parses_merge_with_defaults() {
         let args = Args::try_parse_from(["mcap", "merge", "a.mcap", "b.mcap"])
             .expect("merge should parse");
@@ -648,6 +750,34 @@ mod tests {
                 chunk_size: 8 * 1024 * 1024,
                 include_crc: true,
                 chunked: true,
+                allow_duplicate_metadata: false,
+                coalesce_channels: CoalesceChannels::Auto,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_merge_bool_flags_with_space_separated_values() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "merge",
+            "a.mcap",
+            "b.mcap",
+            "--include-crc",
+            "false",
+            "--chunked",
+            "false",
+        ])
+        .expect("merge bool flags should parse with space-separated values");
+        assert_eq!(
+            args.command,
+            Command::Merge(MergeCommand {
+                files: vec!["a.mcap".into(), "b.mcap".into()],
+                output_file: None,
+                compression: MergeCompression::Zstd,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: false,
+                chunked: false,
                 allow_duplicate_metadata: false,
                 coalesce_channels: CoalesceChannels::Auto,
             })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `mcap merge` in the Rust CLI with support for:
  - positional input files
  - `-o/--output-file`
  - `--compression`, `--chunk-size`, `--include-crc`, `--chunked`
  - `--allow-duplicate-metadata`
  - `--coalesce-channels` (`auto`, `force`, `none`)
- merge message streams in deterministic order by `(log_time, input index, input channel id)`
- merge metadata and attachments from all inputs with Go-parity behavior:
  - summary lookup is best-effort; corrupt/missing summaries fall back to linear scans
  - metadata are emitted while iterating each input stream (instead of a pre-pass bulk write)
  - with `--allow-duplicate-metadata`, identical metadata records are deduplicated by content
  - attachment indexed fast-path is used only when Statistics are present and counts match indexes; otherwise linear-scan fallback is used
- wire merge command parsing + dispatch and add parser/behavior tests
- mark Rust CLI `merge` command as implemented in README

## CLI option follow-ups
- unified compression enum usage by reusing `CompressionFormat` for merge/convert/sort
- standardized bool-flag parsing across merge/convert/sort:
  - bare flag sets true (e.g. `--include-crc`)
  - explicit value uses equals syntax (e.g. `--include-crc=false`)

This avoids optional-bool value parsing from consuming positional filenames in variadic `merge` input lists.

## Testing
- `cd rust && cargo fmt --all -- --check`
- `cd rust && cargo clippy --locked -p mcap_cli --all-targets -- --no-deps -D warnings`
- `cd rust && cargo test --locked -p mcap_cli merge`
- `cd rust && cargo test --locked -p mcap_cli parses_`
- `cd rust && cargo test --locked -p mcap_cli convert_rejects_space_separated_bool_values`
- `cd rust && cargo test --locked -p mcap_cli sort_rejects_space_separated_bool_values`

## Changelog
- **Rust CLI:** implemented `mcap merge` with deterministic multi-input merge behavior, channel coalescing modes, Go-parity metadata/attachment handling, and consistent bool-flag parsing across merge/convert/sort.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d41ec211-bce5-4a0e-915b-3b1676dcf7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d41ec211-bce5-4a0e-915b-3b1676dcf7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

