### PR TITLE
chore(security): bump protobufjs to 7.5.5 across TypeScript packages

### DIFF
--- a/typescript/examples/bag2mcap/package.json
+++ b/typescript/examples/bag2mcap/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-prettier": "5.0.1",
     "prettier": "3.1.0",
-    "protobufjs": "7.2.5",
+    "protobufjs": "7.5.5",
     "tsx": "4.21.0",
     "typescript": "5.9.3"
   }

--- a/typescript/examples/ulog2mcap/package.json
+++ b/typescript/examples/ulog2mcap/package.json
@@ -31,7 +31,7 @@
     "jest": "30.2.0",
     "long": "5.3.2",
     "prettier": "3.1.0",
-    "protobufjs": "^7.2.5",
+    "protobufjs": "7.5.5",
     "ts-jest": "29.4.6",
     "tsx": "4.21.0",
     "typescript": "5.9.3"

--- a/typescript/examples/validate/package.json
+++ b/typescript/examples/validate/package.json
@@ -39,7 +39,7 @@
     "jest": "29.7.0",
     "lodash-es": "4.17.23",
     "prettier": "3.1.0",
-    "protobufjs": "7.2.5",
+    "protobufjs": "7.5.5",
     "ts-jest": "29.1.1",
     "tsx": "4.21.0",
     "typescript": "5.9.3"

--- a/typescript/support/package.json
+++ b/typescript/support/package.json
@@ -57,7 +57,7 @@
     "@foxglove/wasm-bz2": "^0.3.0",
     "@foxglove/wasm-lz4": "^1.0.2",
     "@foxglove/wasm-zstd": "^1.0.1",
-    "protobufjs": "^7.2.5",
+    "protobufjs": "7.5.5",
     "tslib": "^2.5.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -43,7 +43,7 @@
     "prism-react-renderer": "1.3.5",
     "process": "0.11.10",
     "promise-queue": "2.2.5",
-    "protobufjs": "7.2.5",
+    "protobufjs": "7.5.5",
     "react": "17.0.2",
     "react-async": "10.0.1",
     "react-dom": "17.0.2",


### PR DESCRIPTION
## Summary

Bumps `protobufjs` from `7.2.5` to `7.5.5` across all affected TypeScript packages to address security vulnerabilities in the dependency.

This is meant to fix [this CVE](https://github.com/protobufjs/protobuf.js/security/advisories/GHSA-xq3m-2v4x-88gg
) regarding arbitrary code execution targeting actual protobufjs version used across the repository.

## Security patch

- **typescript/support/package.json** — updated `protobufjs` to `7.5.5` (pinned, was `^7.2.5`)
- **typescript/examples/bag2mcap/package.json** — updated `protobufjs` to `7.5.5`
- **typescript/examples/ulog2mcap/package.json** — updated `protobufjs` to `7.5.5` (pinned, was `^7.2.5`)
- **typescript/examples/validate/package.json** — updated `protobufjs` to `7.5.5`
- **website/package.json** — updated `protobufjs` to `7.5.5`

All version specifiers are pinned to the exact version `7.5.5` for consistency.