### PR TITLE
rust: fix clippy warnings blocking CI

### DIFF
--- a/rust/mcap/tests/round_trip.rs
+++ b/rust/mcap/tests/round_trip.rs
@@ -114,7 +114,7 @@ fn demo_round_trip_for_opts(opts: WriteOptions) -> Result<()> {
         }
     }
 
-    for (streamed, seeked) in mcap::MessageStream::new(&ours)?.zip_eq(messages.into_iter()) {
+    for (streamed, seeked) in mcap::MessageStream::new(&ours)?.zip_eq(messages) {
         assert_eq!(streamed?, seeked);
     }
 

--- a/rust/mcap_cli/src/commands/filter.rs
+++ b/rust/mcap_cli/src/commands/filter.rs
@@ -508,11 +508,10 @@ fn filter_linear<W: Write + Seek>(
                     data: Cow::Borrowed(data.as_ref()),
                 })?;
             }
-            mcap::records::Record::Metadata(metadata) => {
-                if opts.include_metadata {
+            mcap::records::Record::Metadata(metadata)
+                if opts.include_metadata => {
                     writer.write_metadata(&metadata)?;
                 }
-            }
             mcap::records::Record::Attachment { header, data, .. } => {
                 if !opts.include_attachments {
                     continue;

--- a/rust/mcap_cli/src/commands/filter.rs
+++ b/rust/mcap_cli/src/commands/filter.rs
@@ -508,10 +508,9 @@ fn filter_linear<W: Write + Seek>(
                     data: Cow::Borrowed(data.as_ref()),
                 })?;
             }
-            mcap::records::Record::Metadata(metadata)
-                if opts.include_metadata => {
-                    writer.write_metadata(&metadata)?;
-                }
+            mcap::records::Record::Metadata(metadata) if opts.include_metadata => {
+                writer.write_metadata(&metadata)?;
+            }
             mcap::records::Record::Attachment { header, data, .. } => {
                 if !opts.include_attachments {
                     continue;


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

New warnings (unneeded `.into_iter()` and match/if cleanup) that were causing CI to fail.