### PR TITLE
[typescript] Add message index caching option

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {

--- a/typescript/core/src/CachedReadable.test.ts
+++ b/typescript/core/src/CachedReadable.test.ts
@@ -1,0 +1,102 @@
+import { CachedReadable } from "./CachedReadable.ts";
+import type { IReadable } from "./types.ts";
+
+/**
+ * Create a readable that simulates buffer reuse, like some IReadable implementations do.
+ * Tracks read calls so tests can verify cache behavior.
+ */
+function makeReadable(data: Uint8Array): IReadable & { reads: { offset: bigint; size: bigint }[] } {
+  const reusableBuffer = new Uint8Array(data.byteLength);
+  const reads: { offset: bigint; size: bigint }[] = [];
+  return {
+    reads,
+    size: async () => BigInt(data.byteLength),
+    read: async (offset, size) => {
+      reads.push({ offset, size });
+      reusableBuffer.set(
+        new Uint8Array(data.buffer, data.byteOffset + Number(offset), Number(size)),
+      );
+      reusableBuffer.fill(0xff, Number(size));
+      return new Uint8Array(reusableBuffer.buffer, 0, Number(size));
+    },
+  };
+}
+
+describe("CachedReadable", () => {
+  it("returns cached bytes without re-reading", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 1024);
+
+    const first = await cached.read(2n, 4n);
+    expect(Array.from(first)).toEqual([2, 3, 4, 5]);
+    expect(readable.reads).toHaveLength(1);
+
+    const second = await cached.read(2n, 4n);
+    expect(Array.from(second)).toEqual([2, 3, 4, 5]);
+    expect(readable.reads).toHaveLength(1);
+  });
+
+  it("copies bytes on cache so underlying buffer reuse does not corrupt cache", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 1024);
+
+    const first = await cached.read(0n, 4n);
+    expect(Array.from(first)).toEqual([0, 1, 2, 3]);
+
+    // A different read would overwrite a reused buffer; make sure the first cached entry
+    // is unaffected.
+    await cached.read(4n, 4n);
+    const firstAgain = await cached.read(0n, 4n);
+    expect(Array.from(firstAgain)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("returns a prefix when cached range is larger than requested", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 1024);
+
+    await cached.read(0n, 8n);
+    expect(readable.reads).toHaveLength(1);
+
+    const prefix = await cached.read(0n, 3n);
+    expect(Array.from(prefix)).toEqual([0, 1, 2]);
+    expect(readable.reads).toHaveLength(1);
+  });
+
+  it("reads through without caching when full", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 4);
+
+    await cached.read(0n, 4n);
+    expect(readable.reads).toHaveLength(1);
+
+    // Second read should not fit; passes through but is not cached.
+    await cached.read(4n, 4n);
+    expect(readable.reads).toHaveLength(2);
+    await cached.read(4n, 4n);
+    expect(readable.reads).toHaveLength(3);
+
+    // The first-cached entry is still available.
+    await cached.read(0n, 4n);
+    expect(readable.reads).toHaveLength(3);
+  });
+
+  it("memoizes size()", async () => {
+    const readable = makeReadable(new Uint8Array(16));
+    let sizeCalls = 0;
+    const wrapped: IReadable = {
+      size: async () => {
+        sizeCalls++;
+        return await readable.size();
+      },
+      read: readable.read.bind(readable),
+    };
+    const cached = new CachedReadable(wrapped, 1024);
+    expect(await cached.size()).toBe(16n);
+    expect(await cached.size()).toBe(16n);
+    expect(sizeCalls).toBe(1);
+  });
+});

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -12,10 +12,27 @@ import type { IReadable } from "./types.ts";
  * starts at a different offset will miss.
  */
 export class CachedReadable implements IReadable {
+  /**
+   * The underlying source of the data to be cached.
+   */
   #readable: IReadable;
+  /**
+   * Cached data. Indexed by offset request and stored as a Uint8Array.
+   * If the requested size is less than the cached data, the cached data is returned as a subarray.
+   * If the requested size is greater than the cached data, the a new request is made to the underlying readable.
+   */
   #cache = new Map<bigint, Uint8Array>();
+  /**
+   * The maximum size of the cache in bytes.
+   */
   #maxCacheSizeBytes: number;
+  /**
+   * The current size of the cache in bytes.
+   */
   #currentCacheSizeBytes = 0;
+  /**
+   * The size of the underlying readable.
+   */
   #size: bigint | undefined;
 
   constructor(readable: IReadable, maxCacheSizeBytes: number) {
@@ -24,7 +41,10 @@ export class CachedReadable implements IReadable {
   }
 
   async size(): Promise<bigint> {
-    return (this.#size ??= await this.#readable.size());
+    if (this.#size == undefined) {
+      this.#size = await this.#readable.size();
+    }
+    return this.#size;
   }
 
   async read(offset: bigint, size: bigint): Promise<Uint8Array> {

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -1,0 +1,50 @@
+import type { IReadable } from "./types.ts";
+
+/**
+ * Wraps an {@link IReadable} and caches the bytes returned from `read()` keyed by offset. Reads at
+ * an offset that was previously cached return a subarray of the cached buffer instead of calling
+ * the underlying readable.
+ *
+ * The cache is capped by `maxCacheSizeBytes`; once the cache is full, new reads pass through
+ * without being cached. No eviction is performed.
+ *
+ * Note: reads are cached by *exact* offset. A read that partially overlaps a cached range but
+ * starts at a different offset will miss.
+ */
+export class CachedReadable implements IReadable {
+  #readable: IReadable;
+  #cache = new Map<bigint, Uint8Array>();
+  #maxCacheSizeBytes: number;
+  #currentCacheSizeBytes = 0;
+  #size: bigint | undefined;
+
+  constructor(readable: IReadable, maxCacheSizeBytes: number) {
+    this.#readable = readable;
+    this.#maxCacheSizeBytes = maxCacheSizeBytes;
+  }
+
+  async size(): Promise<bigint> {
+    return (this.#size ??= await this.#readable.size());
+  }
+
+  async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+    const requestedSize = Number(size);
+    const cached = this.#cache.get(offset);
+    if (cached != undefined && cached.byteLength >= requestedSize) {
+      return cached.byteLength === requestedSize ? cached : cached.subarray(0, requestedSize);
+    }
+
+    const data = await this.#readable.read(offset, size);
+
+    // The underlying readable is allowed to reuse its backing buffer across reads, so we must copy
+    // the bytes before storing them in the cache.
+    if (this.#currentCacheSizeBytes + data.byteLength <= this.#maxCacheSizeBytes) {
+      const copy = new Uint8Array(data);
+      this.#cache.set(offset, copy);
+      this.#currentCacheSizeBytes += copy.byteLength;
+      return copy;
+    }
+
+    return data;
+  }
+}

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -4,20 +4,18 @@ import { sortedIndexBy } from "./sortedIndexBy.ts";
 import { sortedLastIndexBy } from "./sortedLastIndex.ts";
 import type { IReadable, TypedMcapRecords } from "./types.ts";
 
-/**
- * Cache of parsed message index entries for chunks. Keyed by chunk start offset, with an inner
- * map keyed by channel id. Shared across ChunkCursor instances so repeated readMessages() calls
- * can reuse previously fetched message indexes.
- */
-export type MessageIndexCache = Map<bigint, Map<number, [logTime: bigint, offset: bigint][]>>;
-
 type ChunkCursorParams = {
   chunkIndex: TypedMcapRecords["ChunkIndex"];
   relevantChannels: Set<number> | undefined;
   startTime: bigint | undefined;
   endTime: bigint | undefined;
   reverse: boolean;
-  messageIndexCache?: MessageIndexCache;
+  /**
+   * When true, `loadMessageIndexes()` reads the full message index region for the chunk (not just
+   * the portion containing `relevantChannels`). This is useful when the underlying readable caches
+   * reads, since it keeps the read offset/size stable across calls with different topic filters.
+   */
+  readFullMessageIndexRange?: boolean;
 };
 
 /**
@@ -34,7 +32,7 @@ export class ChunkCursor {
   #startTime: bigint | undefined;
   #endTime: bigint | undefined;
   #reverse: boolean;
-  #messageIndexCache?: MessageIndexCache;
+  #readFullMessageIndexRange: boolean;
 
   // List of message offsets (across all channels) sorted by logTime.
   #orderedMessageOffsets?: [logTime: bigint, offset: bigint][];
@@ -47,7 +45,7 @@ export class ChunkCursor {
     this.#startTime = params.startTime;
     this.#endTime = params.endTime;
     this.#reverse = params.reverse;
-    this.#messageIndexCache = params.messageIndexCache;
+    this.#readFullMessageIndexRange = params.readFullMessageIndexRange ?? false;
 
     if (this.chunkIndex.messageIndexLength === 0n) {
       // Chunk has no message indexes.
@@ -121,84 +119,59 @@ export class ChunkCursor {
 
   async loadMessageIndexes(readable: IReadable): Promise<void> {
     const reverse = this.#reverse;
+    let messageIndexStartOffset: bigint | undefined;
+    let relevantMessageIndexStartOffset: bigint | undefined;
+    const readFullRange = this.#readFullMessageIndexRange;
+
+    for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
+      if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {
+        messageIndexStartOffset = offset;
+      }
+      if (readFullRange || !this.#relevantChannels || this.#relevantChannels.has(channelId)) {
+        if (
+          relevantMessageIndexStartOffset == undefined ||
+          offset < relevantMessageIndexStartOffset
+        ) {
+          relevantMessageIndexStartOffset = offset;
+        }
+      }
+    }
+    if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
+      this.#orderedMessageOffsets = [];
+      return;
+    }
+
+    // Future optimization: read only message indexes for given channelIds, not all message indexes for the chunk
+    const messageIndexEndOffset = messageIndexStartOffset + this.chunkIndex.messageIndexLength;
+    const messageIndexes = await readable.read(
+      relevantMessageIndexStartOffset,
+      messageIndexEndOffset - relevantMessageIndexStartOffset,
+    );
+    const messageIndexesView = new DataView(
+      messageIndexes.buffer,
+      messageIndexes.byteOffset,
+      messageIndexes.byteLength,
+    );
+
+    const reader = new Reader(messageIndexesView);
     const arrayOfMessageOffsets: [logTime: bigint, offset: bigint][][] = [];
-
-    const cachedChannelOffsets = this.#messageIndexCache?.get(this.chunkIndex.chunkStartOffset);
-    if (cachedChannelOffsets) {
-      for (const [channelId, offsets] of cachedChannelOffsets) {
-        if (
-          offsets.length === 0 ||
-          (this.#relevantChannels && !this.#relevantChannels.has(channelId))
-        ) {
-          continue;
-        }
-        arrayOfMessageOffsets.push(offsets);
+    let record;
+    while ((record = parseRecord(reader, true))) {
+      if (record.type !== "MessageIndex") {
+        continue;
       }
-    } else {
-      let messageIndexStartOffset: bigint | undefined;
-      let relevantMessageIndexStartOffset: bigint | undefined;
-      // When populating the cache we read the full message index region so all channels are cached.
-      const readFullRange = this.#messageIndexCache != undefined;
-
-      for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
-        if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {
-          messageIndexStartOffset = offset;
-        }
-        if (readFullRange || !this.#relevantChannels || this.#relevantChannels.has(channelId)) {
-          if (
-            relevantMessageIndexStartOffset == undefined ||
-            offset < relevantMessageIndexStartOffset
-          ) {
-            relevantMessageIndexStartOffset = offset;
-          }
-        }
-      }
-      if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
-        this.#orderedMessageOffsets = [];
-        this.#messageIndexCache?.set(this.chunkIndex.chunkStartOffset, new Map());
-        return;
+      if (
+        record.records.length === 0 ||
+        (this.#relevantChannels && !this.#relevantChannels.has(record.channelId))
+      ) {
+        continue;
       }
 
-      // Future optimization: read only message indexes for given channelIds, not all message indexes for the chunk
-      const messageIndexEndOffset = messageIndexStartOffset + this.chunkIndex.messageIndexLength;
-      const messageIndexes = await readable.read(
-        relevantMessageIndexStartOffset,
-        messageIndexEndOffset - relevantMessageIndexStartOffset,
-      );
-      const messageIndexesView = new DataView(
-        messageIndexes.buffer,
-        messageIndexes.byteOffset,
-        messageIndexes.byteLength,
-      );
+      arrayOfMessageOffsets.push(record.records);
+    }
 
-      const reader = new Reader(messageIndexesView);
-      const channelOffsetsToCache = this.#messageIndexCache
-        ? new Map<number, [logTime: bigint, offset: bigint][]>()
-        : undefined;
-      let record;
-      while ((record = parseRecord(reader, true))) {
-        if (record.type !== "MessageIndex") {
-          continue;
-        }
-        channelOffsetsToCache?.set(record.channelId, record.records);
-        if (
-          record.records.length === 0 ||
-          (this.#relevantChannels && !this.#relevantChannels.has(record.channelId))
-        ) {
-          continue;
-        }
-
-        arrayOfMessageOffsets.push(record.records);
-      }
-
-      if (reader.bytesRemaining() !== 0) {
-        throw new Error(`${reader.bytesRemaining()} bytes remaining in message index section`);
-      }
-
-      if (channelOffsetsToCache) {
-        // should exist since `channelOffsetsToCache` is only undefined if `this.#messageIndexCache` is undefined
-        this.#messageIndexCache?.set(this.chunkIndex.chunkStartOffset, channelOffsetsToCache);
-      }
+    if (reader.bytesRemaining() !== 0) {
+      throw new Error(`${reader.bytesRemaining()} bytes remaining in message index section`);
     }
 
     this.#orderedMessageOffsets = arrayOfMessageOffsets

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -196,6 +196,7 @@ export class ChunkCursor {
       }
 
       if (channelOffsetsToCache) {
+        // should exist since `channelOffsetsToCache` is only undefined if `this.#messageIndexCache` is undefined
         this.#messageIndexCache?.set(this.chunkIndex.chunkStartOffset, channelOffsetsToCache);
       }
     }

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -4,12 +4,20 @@ import { sortedIndexBy } from "./sortedIndexBy.ts";
 import { sortedLastIndexBy } from "./sortedLastIndex.ts";
 import type { IReadable, TypedMcapRecords } from "./types.ts";
 
+/**
+ * Cache of parsed message index entries for chunks. Keyed by chunk start offset, with an inner
+ * map keyed by channel id. Shared across ChunkCursor instances so repeated readMessages() calls
+ * can reuse previously fetched message indexes.
+ */
+export type MessageIndexCache = Map<bigint, Map<number, [logTime: bigint, offset: bigint][]>>;
+
 type ChunkCursorParams = {
   chunkIndex: TypedMcapRecords["ChunkIndex"];
   relevantChannels: Set<number> | undefined;
   startTime: bigint | undefined;
   endTime: bigint | undefined;
   reverse: boolean;
+  messageIndexCache?: MessageIndexCache;
 };
 
 /**
@@ -26,6 +34,7 @@ export class ChunkCursor {
   #startTime: bigint | undefined;
   #endTime: bigint | undefined;
   #reverse: boolean;
+  #messageIndexCache?: MessageIndexCache;
 
   // List of message offsets (across all channels) sorted by logTime.
   #orderedMessageOffsets?: [logTime: bigint, offset: bigint][];
@@ -38,6 +47,7 @@ export class ChunkCursor {
     this.#startTime = params.startTime;
     this.#endTime = params.endTime;
     this.#reverse = params.reverse;
+    this.#messageIndexCache = params.messageIndexCache;
 
     if (this.chunkIndex.messageIndexLength === 0n) {
       // Chunk has no message indexes.
@@ -111,58 +121,83 @@ export class ChunkCursor {
 
   async loadMessageIndexes(readable: IReadable): Promise<void> {
     const reverse = this.#reverse;
-    let messageIndexStartOffset: bigint | undefined;
-    let relevantMessageIndexStartOffset: bigint | undefined;
+    const arrayOfMessageOffsets: [logTime: bigint, offset: bigint][][] = [];
 
-    for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
-      if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {
-        messageIndexStartOffset = offset;
-      }
-      if (!this.#relevantChannels || this.#relevantChannels.has(channelId)) {
+    const cachedChannelOffsets = this.#messageIndexCache?.get(this.chunkIndex.chunkStartOffset);
+    if (cachedChannelOffsets) {
+      for (const [channelId, offsets] of cachedChannelOffsets) {
         if (
-          relevantMessageIndexStartOffset == undefined ||
-          offset < relevantMessageIndexStartOffset
+          offsets.length === 0 ||
+          (this.#relevantChannels && !this.#relevantChannels.has(channelId))
         ) {
-          relevantMessageIndexStartOffset = offset;
+          continue;
+        }
+        arrayOfMessageOffsets.push(offsets);
+      }
+    } else {
+      let messageIndexStartOffset: bigint | undefined;
+      let relevantMessageIndexStartOffset: bigint | undefined;
+      // When populating the cache we read the full message index region so all channels are cached.
+      const readFullRange = this.#messageIndexCache != undefined;
+
+      for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
+        if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {
+          messageIndexStartOffset = offset;
+        }
+        if (readFullRange || !this.#relevantChannels || this.#relevantChannels.has(channelId)) {
+          if (
+            relevantMessageIndexStartOffset == undefined ||
+            offset < relevantMessageIndexStartOffset
+          ) {
+            relevantMessageIndexStartOffset = offset;
+          }
         }
       }
-    }
-    if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
-      this.#orderedMessageOffsets = [];
-      return;
-    }
-
-    // Future optimization: read only message indexes for given channelIds, not all message indexes for the chunk
-    const messageIndexEndOffset = messageIndexStartOffset + this.chunkIndex.messageIndexLength;
-    const messageIndexes = await readable.read(
-      relevantMessageIndexStartOffset,
-      messageIndexEndOffset - relevantMessageIndexStartOffset,
-    );
-    const messageIndexesView = new DataView(
-      messageIndexes.buffer,
-      messageIndexes.byteOffset,
-      messageIndexes.byteLength,
-    );
-
-    const reader = new Reader(messageIndexesView);
-    const arrayOfMessageOffsets: [logTime: bigint, offset: bigint][][] = [];
-    let record;
-    while ((record = parseRecord(reader, true))) {
-      if (record.type !== "MessageIndex") {
-        continue;
-      }
-      if (
-        record.records.length === 0 ||
-        (this.#relevantChannels && !this.#relevantChannels.has(record.channelId))
-      ) {
-        continue;
+      if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
+        this.#orderedMessageOffsets = [];
+        this.#messageIndexCache?.set(this.chunkIndex.chunkStartOffset, new Map());
+        return;
       }
 
-      arrayOfMessageOffsets.push(record.records);
-    }
+      // Future optimization: read only message indexes for given channelIds, not all message indexes for the chunk
+      const messageIndexEndOffset = messageIndexStartOffset + this.chunkIndex.messageIndexLength;
+      const messageIndexes = await readable.read(
+        relevantMessageIndexStartOffset,
+        messageIndexEndOffset - relevantMessageIndexStartOffset,
+      );
+      const messageIndexesView = new DataView(
+        messageIndexes.buffer,
+        messageIndexes.byteOffset,
+        messageIndexes.byteLength,
+      );
 
-    if (reader.bytesRemaining() !== 0) {
-      throw new Error(`${reader.bytesRemaining()} bytes remaining in message index section`);
+      const reader = new Reader(messageIndexesView);
+      const channelOffsetsToCache = this.#messageIndexCache
+        ? new Map<number, [logTime: bigint, offset: bigint][]>()
+        : undefined;
+      let record;
+      while ((record = parseRecord(reader, true))) {
+        if (record.type !== "MessageIndex") {
+          continue;
+        }
+        channelOffsetsToCache?.set(record.channelId, record.records);
+        if (
+          record.records.length === 0 ||
+          (this.#relevantChannels && !this.#relevantChannels.has(record.channelId))
+        ) {
+          continue;
+        }
+
+        arrayOfMessageOffsets.push(record.records);
+      }
+
+      if (reader.bytesRemaining() !== 0) {
+        throw new Error(`${reader.bytesRemaining()} bytes remaining in message index section`);
+      }
+
+      if (channelOffsetsToCache) {
+        this.#messageIndexCache?.set(this.chunkIndex.chunkStartOffset, channelOffsetsToCache);
+      }
     }
 
     this.#orderedMessageOffsets = arrayOfMessageOffsets

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -861,7 +861,7 @@ describe("McapIndexedReader", () => {
     }
   });
 
-  it("caches message indexes across readMessages() calls when cacheMessageIndexes is enabled", async () => {
+  it("caches message indexes across readMessages() calls when messageIndexCacheSizeBytes > 0", async () => {
     const channelA: TypedMcapRecord = {
       type: "Channel",
       id: 1,
@@ -944,7 +944,7 @@ describe("McapIndexedReader", () => {
 
     const reader = await McapIndexedReader.Initialize({
       readable: recordingReadable,
-      cacheMessageIndexes: true,
+      messageIndexCacheSizeBytes: 1024 * 1024,
     });
 
     reads.length = 0;
@@ -964,7 +964,7 @@ describe("McapIndexedReader", () => {
     expect(reads.some(overlapsMessageIndex)).toBe(false);
   });
 
-  it("re-reads message indexes across readMessages() calls when cacheMessageIndexes is not enabled", async () => {
+  it("re-reads message indexes across readMessages() calls when messageIndexCacheSizeBytes is not set", async () => {
     const channel: TypedMcapRecord = {
       type: "Channel",
       id: 1,

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -861,6 +861,183 @@ describe("McapIndexedReader", () => {
     }
   });
 
+  it("caches message indexes across readMessages() calls when cacheMessageIndexes is enabled", async () => {
+    const channelA: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const channelB: TypedMcapRecord = {
+      type: "Channel",
+      id: 2,
+      schemaId: 0,
+      topic: "b",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (channel: Channel, idx: number): TypedMcapRecords["Message"] => ({
+      type: "Message",
+      channelId: channel.id,
+      sequence: idx,
+      logTime: BigInt(idx),
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+
+    const messageA1 = makeMessage(channelA, 1);
+    const messageA2 = makeMessage(channelA, 3);
+    const messageB1 = makeMessage(channelB, 2);
+
+    const chunk1 = new ChunkBuilder({ useMessageIndex: true });
+    chunk1.addChannel(channelA);
+    chunk1.addChannel(channelB);
+    chunk1.addMessage(messageA1);
+    chunk1.addMessage(messageB1);
+    chunk1.addMessage(messageA2);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunk1),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channelA);
+    builder.writeChannel(channelB);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    // Compute the [start, end) byte range occupied by the message index section of each chunk.
+    const messageIndexRanges = chunkIndexes.map((chunkIndex) => {
+      let start: bigint | undefined;
+      for (const offset of chunkIndex.messageIndexOffsets.values()) {
+        if (start == undefined || offset < start) {
+          start = offset;
+        }
+      }
+      if (start == undefined) {
+        throw new Error("expected chunk to have message index offsets");
+      }
+      return { start, end: start + chunkIndex.messageIndexLength };
+    });
+
+    const reads: { offset: bigint; size: bigint }[] = [];
+    const underlyingReadable = makeReadable(builder.buffer);
+    const recordingReadable = {
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        reads.push({ offset, size });
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
+      messageIndexRanges.some(({ start, end }) => offset < end && offset + size > start);
+
+    const reader = await McapIndexedReader.Initialize({
+      readable: recordingReadable,
+      cacheMessageIndexes: true,
+    });
+
+    reads.length = 0;
+    const firstPass = await collect(reader.readMessages({ topics: [channelA.topic] }));
+    expect(firstPass).toEqual([messageA1, messageA2]);
+    const firstPassReads = reads.slice();
+    expect(firstPassReads.some(overlapsMessageIndex)).toBe(true);
+
+    reads.length = 0;
+    const secondPass = await collect(reader.readMessages({ topics: [channelA.topic] }));
+    expect(secondPass).toEqual([messageA1, messageA2]);
+    expect(reads.some(overlapsMessageIndex)).toBe(false);
+
+    reads.length = 0;
+    const thirdPass = await collect(reader.readMessages({ topics: [channelB.topic] }));
+    expect(thirdPass).toEqual([messageB1]);
+    expect(reads.some(overlapsMessageIndex)).toBe(false);
+  });
+
+  it("re-reads message indexes across readMessages() calls when cacheMessageIndexes is not enabled", async () => {
+    const channel: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const message: TypedMcapRecords["Message"] = {
+      type: "Message",
+      channelId: channel.id,
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 0n,
+      data: new Uint8Array(),
+    };
+
+    const chunk = new ChunkBuilder({ useMessageIndex: true });
+    chunk.addChannel(channel);
+    chunk.addMessage(message);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunk),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channel);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const chunkIndex = chunkIndexes[0]!;
+    let messageIndexStart: bigint | undefined;
+    for (const offset of chunkIndex.messageIndexOffsets.values()) {
+      if (messageIndexStart == undefined || offset < messageIndexStart) {
+        messageIndexStart = offset;
+      }
+    }
+    const messageIndexRange = {
+      start: messageIndexStart!,
+      end: messageIndexStart! + chunkIndex.messageIndexLength,
+    };
+
+    const reads: { offset: bigint; size: bigint }[] = [];
+    const underlyingReadable = makeReadable(builder.buffer);
+    const recordingReadable = {
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        reads.push({ offset, size });
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
+      offset < messageIndexRange.end && offset + size > messageIndexRange.start;
+
+    const reader = await McapIndexedReader.Initialize({ readable: recordingReadable });
+
+    reads.length = 0;
+    await collect(reader.readMessages());
+    expect(reads.some(overlapsMessageIndex)).toBe(true);
+
+    reads.length = 0;
+    await collect(reader.readMessages());
+    // Without caching, the message index is re-read on every call.
+    expect(reads.some(overlapsMessageIndex)).toBe(true);
+  });
+
   it("reads metadata records", async () => {
     const data = [
       ...MCAP_MAGIC,

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -1,7 +1,8 @@
 import { crc32, crc32Final, crc32Init, crc32Update } from "@foxglove/crc";
 import { Heap } from "heap-js";
 
-import { ChunkCursor, type MessageIndexCache } from "./ChunkCursor.ts";
+import { CachedReadable } from "./CachedReadable.ts";
+import { ChunkCursor } from "./ChunkCursor.ts";
 import Reader from "./Reader.ts";
 import { MCAP_MAGIC } from "./constants.ts";
 import { parseMagic, parseRecord } from "./parse.ts";
@@ -22,13 +23,14 @@ type McapIndexedReaderArgs = {
   dataEndOffset: bigint;
   dataSectionCrc?: number;
   /**
-   * When true, message indexes loaded on demand by `readMessages()` are cached on the reader so
-   * subsequent calls do not need to re-read them from the underlying readable. This trades
-   * memory for reduced I/O — cached indexes are held for the lifetime of the reader. The first
-   * read of each chunk fetches indexes for all channels (not just the queried subset) so that
-   * future queries against different channels also benefit from the cache.
+   * Maximum number of bytes of message index data to cache in memory across calls to
+   * `readMessages()`. When > 0, message indexes read on demand are cached so subsequent calls do
+   * not re-read them from the underlying readable. Defaults to 0 (no caching).
+   *
+   * When caching is enabled, each chunk's full message index region is read on first access so
+   * that later queries against different channels can be served from the cache.
    */
-  cacheMessageIndexes?: boolean;
+  messageIndexCacheSizeBytes?: number;
 };
 
 export class McapIndexedReader {
@@ -46,8 +48,8 @@ export class McapIndexedReader {
   readonly dataSectionCrc?: number;
 
   #readable: IReadable;
+  #messageIndexReadable: IReadable;
   #decompressHandlers?: DecompressHandlers;
-  #messageIndexCache?: MessageIndexCache;
 
   #messageStartTime: bigint | undefined;
   #messageEndTime: bigint | undefined;
@@ -68,9 +70,12 @@ export class McapIndexedReader {
     this.footer = args.footer;
     this.dataEndOffset = args.dataEndOffset;
     this.dataSectionCrc = args.dataSectionCrc;
-    if (args.cacheMessageIndexes === true) {
-      this.#messageIndexCache = new Map();
-    }
+
+    const messageIndexCacheSizeBytes = args.messageIndexCacheSizeBytes ?? 0;
+    this.#messageIndexReadable =
+      messageIndexCacheSizeBytes > 0
+        ? new CachedReadable(this.#readable, messageIndexCacheSizeBytes)
+        : this.#readable;
 
     for (const chunk of args.chunkIndexes) {
       if (this.#messageStartTime == undefined || chunk.messageStartTime < this.#messageStartTime) {
@@ -101,7 +106,7 @@ export class McapIndexedReader {
   static async Initialize({
     readable,
     decompressHandlers,
-    cacheMessageIndexes,
+    messageIndexCacheSizeBytes,
   }: {
     readable: IReadable;
 
@@ -112,10 +117,11 @@ export class McapIndexedReader {
     decompressHandlers?: DecompressHandlers;
 
     /**
-     * When true, message indexes loaded on demand by `readMessages()` are cached on the reader so
-     * subsequent calls do not need to re-read them from the underlying readable.
+     * Maximum number of bytes of message index data to cache in memory across calls to
+     * `readMessages()`. When > 0, message indexes read on demand are cached so subsequent calls do
+     * not re-read them from the underlying readable. Defaults to 0 (no caching).
      */
-    cacheMessageIndexes?: boolean;
+    messageIndexCacheSizeBytes?: number;
   }): Promise<McapIndexedReader> {
     const size = await readable.size();
 
@@ -351,7 +357,7 @@ export class McapIndexedReader {
       footer,
       dataEndOffset,
       dataSectionCrc,
-      cacheMessageIndexes,
+      messageIndexCacheSizeBytes,
     });
   }
 
@@ -389,6 +395,7 @@ export class McapIndexedReader {
     const chunkCursors = new Heap<ChunkCursor>((a, b) => a.compare(b));
     let chunksOrdered = true;
     let prevChunkEndTime: bigint | undefined;
+    const readFullMessageIndexRange = this.#messageIndexReadable !== this.#readable;
     for (const chunkIndex of this.chunkIndexes) {
       if (chunkIndex.messageStartTime <= endTime && chunkIndex.messageEndTime >= startTime) {
         chunkCursors.push(
@@ -398,7 +405,7 @@ export class McapIndexedReader {
             startTime,
             endTime,
             reverse,
-            messageIndexCache: this.#messageIndexCache,
+            readFullMessageIndexRange,
           }),
         );
         if (chunksOrdered && prevChunkEndTime != undefined) {
@@ -416,7 +423,7 @@ export class McapIndexedReader {
     for (let cursor; (cursor = chunkCursors.peek()); ) {
       if (!cursor.hasMessageIndexes()) {
         // If we encounter a chunk whose message indexes have not been loaded yet, load them and re-organize the heap.
-        await cursor.loadMessageIndexes(this.#readable);
+        await cursor.loadMessageIndexes(this.#messageIndexReadable);
         if (cursor.hasMoreMessages()) {
           chunkCursors.replace(cursor);
         } else {

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -21,6 +21,13 @@ type McapIndexedReaderArgs = {
   footer: TypedMcapRecords["Footer"];
   dataEndOffset: bigint;
   dataSectionCrc?: number;
+  /**
+   * When true, message indexes loaded on demand by `readMessages()` are cached on the reader so
+   * subsequent calls do not need to re-read them from the underlying readable. This trades
+   * memory for reduced I/O — cached indexes are held for the lifetime of the reader. The first
+   * read of each chunk fetches indexes for all channels (not just the queried subset) so that
+   * future queries against different channels also benefit from the cache.
+   */
   cacheMessageIndexes?: boolean;
 };
 

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -1,7 +1,7 @@
 import { crc32, crc32Final, crc32Init, crc32Update } from "@foxglove/crc";
 import { Heap } from "heap-js";
 
-import { ChunkCursor } from "./ChunkCursor.ts";
+import { ChunkCursor, type MessageIndexCache } from "./ChunkCursor.ts";
 import Reader from "./Reader.ts";
 import { MCAP_MAGIC } from "./constants.ts";
 import { parseMagic, parseRecord } from "./parse.ts";
@@ -21,6 +21,7 @@ type McapIndexedReaderArgs = {
   footer: TypedMcapRecords["Footer"];
   dataEndOffset: bigint;
   dataSectionCrc?: number;
+  cacheMessageIndexes?: boolean;
 };
 
 export class McapIndexedReader {
@@ -39,6 +40,7 @@ export class McapIndexedReader {
 
   #readable: IReadable;
   #decompressHandlers?: DecompressHandlers;
+  #messageIndexCache?: MessageIndexCache;
 
   #messageStartTime: bigint | undefined;
   #messageEndTime: bigint | undefined;
@@ -59,6 +61,9 @@ export class McapIndexedReader {
     this.footer = args.footer;
     this.dataEndOffset = args.dataEndOffset;
     this.dataSectionCrc = args.dataSectionCrc;
+    if (args.cacheMessageIndexes === true) {
+      this.#messageIndexCache = new Map();
+    }
 
     for (const chunk of args.chunkIndexes) {
       if (this.#messageStartTime == undefined || chunk.messageStartTime < this.#messageStartTime) {
@@ -89,6 +94,7 @@ export class McapIndexedReader {
   static async Initialize({
     readable,
     decompressHandlers,
+    cacheMessageIndexes,
   }: {
     readable: IReadable;
 
@@ -97,6 +103,12 @@ export class McapIndexedReader {
      * compression will be called to decompress the chunk data.
      */
     decompressHandlers?: DecompressHandlers;
+
+    /**
+     * When true, message indexes loaded on demand by `readMessages()` are cached on the reader so
+     * subsequent calls do not need to re-read them from the underlying readable.
+     */
+    cacheMessageIndexes?: boolean;
   }): Promise<McapIndexedReader> {
     const size = await readable.size();
 
@@ -332,6 +344,7 @@ export class McapIndexedReader {
       footer,
       dataEndOffset,
       dataSectionCrc,
+      cacheMessageIndexes,
     });
   }
 
@@ -372,7 +385,14 @@ export class McapIndexedReader {
     for (const chunkIndex of this.chunkIndexes) {
       if (chunkIndex.messageStartTime <= endTime && chunkIndex.messageEndTime >= startTime) {
         chunkCursors.push(
-          new ChunkCursor({ chunkIndex, relevantChannels, startTime, endTime, reverse }),
+          new ChunkCursor({
+            chunkIndex,
+            relevantChannels,
+            startTime,
+            endTime,
+            reverse,
+            messageIndexCache: this.#messageIndexCache,
+          }),
         );
         if (chunksOrdered && prevChunkEndTime != undefined) {
           chunksOrdered = chunkIndex.messageStartTime >= prevChunkEndTime;

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -115,11 +115,13 @@ export class McapIndexedReader {
      * compression will be called to decompress the chunk data.
      */
     decompressHandlers?: DecompressHandlers;
-
     /**
      * Maximum number of bytes of message index data to cache in memory across calls to
      * `readMessages()`. When > 0, message indexes read on demand are cached so subsequent calls do
      * not re-read them from the underlying readable. Defaults to 0 (no caching).
+     *
+     * When caching is enabled, each chunk's full message index region is read on first access so
+     * that later queries against different channels can be served from the cache.
      */
     messageIndexCacheSizeBytes?: number;
   }): Promise<McapIndexedReader> {

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -1,3 +1,4 @@
+export { CachedReadable } from "./CachedReadable.ts";
 export { McapIndexedReader } from "./McapIndexedReader.ts";
 export { default as McapStreamReader } from "./McapStreamReader.ts";
 export { McapWriter } from "./McapWriter.ts";

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -1,4 +1,3 @@
-export { CachedReadable } from "./CachedReadable.ts";
 export { McapIndexedReader } from "./McapIndexedReader.ts";
 export { default as McapStreamReader } from "./McapStreamReader.ts";
 export { McapWriter } from "./McapWriter.ts";


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- [typescript] `McapReader`: specify a cache size that would specifically be used for message indexes. 0 by default

### Docs

<!-- Link to a PR or Linear ticket tracking documentation. Write "None" if no documentation changes are needed. -->
None - documented in JSDoc

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

This change adds the option for the typescript `McapIndexedReader` to cache message indexes so that over subsequent reads there are fewer read calls, resulting in faster subsequent message reads. This is especially effective when there is a latency for each read due to I/O restrictions. However, when reading from an in memory buffer there would be little-to-no gains.

Results from local benchmark (not averaged):
For the biggest case (200k messages × 1024 B @ 5 ms latency):

| Number of full mcap reads | % Faster with caching enabled |
| -------- | --------- |
| 1        | −2.2%     |
| 2        | 23.5%     |
| 3        | 28.1%     |
| 4        | 32.4%     |
| 5        | 33.7%     |


When the file is read once this is the expected worst case for the cache, since the cache is populated but never reused. Even there the extra work of allocating the cache map is negligible.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
ERT-2082

