### PR TITLE
[typescript] `McapReader`: add option to prefetch message indexes in parallel

### DIFF
--- a/typescript/core/src/CachedReadable.test.ts
+++ b/typescript/core/src/CachedReadable.test.ts
@@ -84,6 +84,57 @@ describe("CachedReadable", () => {
     expect(readable.reads).toHaveLength(3);
   });
 
+  it("concurrent reads for the same offset issue only one underlying read", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 1024);
+
+    const [a, b] = await Promise.all([cached.read(0n, 4n), cached.read(0n, 4n)]);
+    expect(Array.from(a)).toEqual([0, 1, 2, 3]);
+    expect(Array.from(b)).toEqual([0, 1, 2, 3]);
+    expect(readable.reads).toHaveLength(1);
+  });
+
+  it("concurrent reads for the same offset do not double-count cache size", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    // Cache fits exactly one 4-byte read.
+    const cached = new CachedReadable(readable, 4);
+
+    await Promise.all([cached.read(0n, 4n), cached.read(0n, 4n)]);
+    expect(readable.reads).toHaveLength(1);
+
+    // Cache should now be exactly full; a different offset should still be readable on-demand.
+    await cached.read(4n, 4n);
+    expect(readable.reads).toHaveLength(2);
+  });
+
+  it("cleans up pending entry on read failure so retries can succeed", async () => {
+    const data = new Uint8Array([0, 1, 2, 3]);
+    let failNext = true;
+    const readable: IReadable & { reads: number } = {
+      reads: 0,
+      size: async () => BigInt(data.byteLength),
+      read: async (offset, size) => {
+        readable.reads++;
+        if (failNext) {
+          failNext = false;
+          throw new Error("transient error");
+        }
+        return new Uint8Array(data.buffer, Number(offset), Number(size));
+      },
+    };
+    const cached = new CachedReadable(readable, 1024);
+
+    await expect(cached.read(0n, 4n)).rejects.toThrow("transient error");
+    expect(readable.reads).toBe(1);
+
+    // After the failure the pending entry is gone; the next read retries the underlying readable.
+    const result = await cached.read(0n, 4n);
+    expect(Array.from(result)).toEqual([0, 1, 2, 3]);
+    expect(readable.reads).toBe(2);
+  });
+
   it("memoizes size()", async () => {
     const readable = makeReadable(new Uint8Array(16));
     let sizeCalls = 0;

--- a/typescript/core/src/CachedReadable.test.ts
+++ b/typescript/core/src/CachedReadable.test.ts
@@ -109,6 +109,27 @@ describe("CachedReadable", () => {
     expect(readable.reads).toHaveLength(2);
   });
 
+  it("re-reading the same offset with a larger size does not block caching other offsets", async () => {
+    const data = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) {
+      data[i] = i;
+    }
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 12);
+
+    await cached.read(0n, 4n);
+    expect(readable.reads).toHaveLength(1);
+
+    await cached.read(0n, 8n);
+    expect(readable.reads).toHaveLength(2);
+
+    await cached.read(4n, 4n);
+    expect(readable.reads).toHaveLength(3);
+
+    await cached.read(4n, 4n);
+    expect(readable.reads).toHaveLength(3);
+  });
+
   it("cleans up pending entry on read failure so retries can succeed", async () => {
     const data = new Uint8Array([0, 1, 2, 3]);
     let failNext = true;

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -8,6 +8,9 @@ import type { IReadable } from "./types.ts";
  * The cache is capped by `maxCacheSizeBytes`; once the cache is full, new reads pass through
  * without being cached. No eviction is performed.
  *
+ * Concurrent reads for the same offset are deduplicated: the second caller joins the first
+ * in-flight read rather than issuing a redundant underlying read.
+ *
  * Note: reads are cached by *exact* offset. A read that partially overlaps a cached range but
  * starts at a different offset will miss.
  */
@@ -23,6 +26,10 @@ export class CachedReadable implements IReadable {
    */
   #cache = new Map<bigint, Uint8Array>();
   /**
+   * In-flight reads keyed by offset so concurrent callers can await the same promise.
+   */
+  #pending = new Map<bigint, Promise<Uint8Array>>();
+  /**
    * The maximum size of the cache in bytes.
    */
   #maxCacheSizeBytes: number;
@@ -34,6 +41,7 @@ export class CachedReadable implements IReadable {
    * The size of the underlying readable.
    */
   #size: bigint | undefined;
+  supportsConcurrentReads = true;
 
   constructor(readable: IReadable, maxCacheSizeBytes: number) {
     this.#readable = readable;
@@ -41,30 +49,44 @@ export class CachedReadable implements IReadable {
   }
 
   async size(): Promise<bigint> {
-    if (this.#size == undefined) {
-      this.#size = await this.#readable.size();
-    }
-    return this.#size;
+    return (this.#size ??= await this.#readable.size());
   }
 
   async read(offset: bigint, size: bigint): Promise<Uint8Array> {
     const requestedSize = Number(size);
+
     const cached = this.#cache.get(offset);
     if (cached != undefined && cached.byteLength >= requestedSize) {
       return cached.byteLength === requestedSize ? cached : cached.subarray(0, requestedSize);
     }
 
-    const data = await this.#readable.read(offset, size);
-
-    // The underlying readable is allowed to reuse its backing buffer across reads, so we must copy
-    // the bytes before storing them in the cache.
-    if (this.#currentCacheSizeBytes + data.byteLength <= this.#maxCacheSizeBytes) {
-      const copy = new Uint8Array(data);
-      this.#cache.set(offset, copy);
-      this.#currentCacheSizeBytes += copy.byteLength;
-      return copy;
+    // Join an in-flight read for this offset if one is already pending.
+    const pending = this.#pending.get(offset);
+    if (pending != undefined) {
+      const data = await pending;
+      if (data.byteLength >= requestedSize) {
+        return data.byteLength === requestedSize ? data : data.subarray(0, requestedSize);
+      }
+      // The pending read was for fewer bytes; fall through to issue a new read.
     }
 
-    return data;
+    const readPromise = (async () => {
+      try {
+        const data = await this.#readable.read(offset, size);
+        // Always copy to produce a stable buffer for concurrent waiters and to prevent
+        // corruption if the underlying readable reuses its backing buffer.
+        const copy = new Uint8Array(data);
+        if (this.#currentCacheSizeBytes + copy.byteLength <= this.#maxCacheSizeBytes) {
+          this.#cache.set(offset, copy);
+          this.#currentCacheSizeBytes += copy.byteLength;
+        }
+        return copy;
+      } finally {
+        this.#pending.delete(offset);
+      }
+    })();
+
+    this.#pending.set(offset, readPromise);
+    return await readPromise;
   }
 }

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -48,6 +48,23 @@ export class CachedReadable implements IReadable {
     this.#maxCacheSizeBytes = maxCacheSizeBytes;
   }
 
+  /**
+   * The maximum number of bytes the cache can hold. New reads beyond this size pass through
+   * without being cached.
+   */
+  get maxCacheSizeBytes(): number {
+    return this.#maxCacheSizeBytes;
+  }
+
+  /**
+   * Returns true if a read at `offset` of `size` bytes can be served from the cache without
+   * issuing an underlying read.
+   */
+  has(offset: bigint, size: bigint): boolean {
+    const cached = this.#cache.get(offset);
+    return cached != undefined && cached.byteLength >= Number(size);
+  }
+
   async size(): Promise<bigint> {
     return (this.#size ??= await this.#readable.size());
   }

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -76,9 +76,12 @@ export class CachedReadable implements IReadable {
         // Always copy to produce a stable buffer for concurrent waiters and to prevent
         // corruption if the underlying readable reuses its backing buffer.
         const copy = new Uint8Array(data);
-        if (this.#currentCacheSizeBytes + copy.byteLength <= this.#maxCacheSizeBytes) {
+        const existing = this.#cache.get(offset);
+        const existingSize = existing?.byteLength ?? 0;
+        const newTotalSize = this.#currentCacheSizeBytes - existingSize + copy.byteLength;
+        if (newTotalSize <= this.#maxCacheSizeBytes) {
           this.#cache.set(offset, copy);
-          this.#currentCacheSizeBytes += copy.byteLength;
+          this.#currentCacheSizeBytes = newTotalSize;
         }
         return copy;
       } finally {

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -1234,7 +1234,7 @@ describe("McapIndexedReader", () => {
     await expect(collect(reader.readMessages())).rejects.toThrow("prefetch read failed");
   });
 
-  it("warns and falls back to caching when prefetchMessageIndexes is set without supportsConcurrentReads", async () => {
+  it("throws when prefetchMessageIndexes is set without supportsConcurrentReads", async () => {
     const channel: TypedMcapRecord = {
       type: "Channel",
       id: 1,
@@ -1271,24 +1271,176 @@ describe("McapIndexedReader", () => {
     builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
     builder.writeMagic();
 
-    const chunkIndex = chunkIndexes[0]!;
-    let messageIndexStart: bigint | undefined;
-    for (const offset of chunkIndex.messageIndexOffsets.values()) {
-      if (messageIndexStart == undefined || offset < messageIndexStart) {
-        messageIndexStart = offset;
-      }
-    }
-    const messageIndexRange = {
-      start: messageIndexStart!,
-      end: messageIndexStart! + chunkIndex.messageIndexLength,
-    };
-    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
-      offset < messageIndexRange.end && offset + size > messageIndexRange.start;
-
-    const reads: { offset: bigint; size: bigint }[] = [];
     const underlyingReadable = makeReadable(builder.buffer);
     // Readable without supportsConcurrentReads.
     const recordingReadable = {
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: underlyingReadable.read.bind(underlyingReadable),
+    };
+
+    await expect(
+      McapIndexedReader.Initialize({
+        readable: recordingReadable,
+        prefetchMessageIndexes: true,
+      }),
+    ).rejects.toThrow(/supportsConcurrentReads/);
+  });
+
+  it("readMessages does not block on prefetch when the requested chunks are already cached", async () => {
+    const channelA: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const channelB: TypedMcapRecord = {
+      type: "Channel",
+      id: 2,
+      schemaId: 0,
+      topic: "b",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (channel: Channel, idx: number): TypedMcapRecords["Message"] => ({
+      type: "Message",
+      channelId: channel.id,
+      sequence: idx,
+      logTime: BigInt(idx),
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+    const messageA = makeMessage(channelA, 5);
+    const messageB = makeMessage(channelB, 100);
+
+    const chunkA = new ChunkBuilder({ useMessageIndex: true });
+    chunkA.addChannel(channelA);
+    chunkA.addMessage(messageA);
+    const chunkB = new ChunkBuilder({ useMessageIndex: true });
+    chunkB.addChannel(channelB);
+    chunkB.addMessage(messageB);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunkA),
+      writeChunkWithMessageIndexes(builder, chunkB),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channelA);
+    builder.writeChannel(channelB);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const chunkBIndex = chunkIndexes[1]!;
+    let chunkBStart: bigint | undefined;
+    for (const offset of chunkBIndex.messageIndexOffsets.values()) {
+      if (chunkBStart == undefined || offset < chunkBStart) {
+        chunkBStart = offset;
+      }
+    }
+    const chunkBEnd = chunkBStart! + chunkBIndex.messageIndexLength;
+
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+
+    const underlyingReadable = makeReadable(builder.buffer);
+    const gatedReadable = {
+      supportsConcurrentReads: true,
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        // Block only chunk B's index prefetch, leaving chunk A free to populate the cache.
+        if (offset < chunkBEnd && offset + size > chunkBStart!) {
+          await gate;
+        }
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const reader = await McapIndexedReader.Initialize({
+      readable: gatedReadable,
+      prefetchMessageIndexes: true,
+    });
+
+    // Yield until chunk A's prefetch has populated the cache.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+
+    // Requesting only chunk A's time range must not block on chunk B's gated prefetch.
+    const messages = await collect(
+      reader.readMessages({ startTime: 0n, endTime: 10n, topics: [channelA.topic] }),
+    );
+    expect(messages).toEqual([messageA]);
+
+    releaseGate();
+  });
+
+  it("respects an explicit messageIndexCacheSizeBytes smaller than the implied prefetch budget", async () => {
+    const channel: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (idx: number): TypedMcapRecords["Message"] => ({
+      type: "Message",
+      channelId: channel.id,
+      sequence: idx,
+      logTime: BigInt(idx),
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+
+    const chunkA = new ChunkBuilder({ useMessageIndex: true });
+    chunkA.addChannel(channel);
+    chunkA.addMessage(makeMessage(1));
+    const chunkB = new ChunkBuilder({ useMessageIndex: true });
+    chunkB.addChannel(channel);
+    chunkB.addMessage(makeMessage(2));
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunkA),
+      writeChunkWithMessageIndexes(builder, chunkB),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channel);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const messageIndexRanges = chunkIndexes.map((chunkIndex) => {
+      let start: bigint | undefined;
+      for (const offset of chunkIndex.messageIndexOffsets.values()) {
+        if (start == undefined || offset < start) {
+          start = offset;
+        }
+      }
+      return { start: start!, end: start! + chunkIndex.messageIndexLength };
+    });
+    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
+      messageIndexRanges.some(({ start, end }) => offset < end && offset + size > start);
+
+    const reads: { offset: bigint; size: bigint }[] = [];
+    const underlyingReadable = makeReadable(builder.buffer);
+    const recordingReadable = {
+      supportsConcurrentReads: true,
       size: underlyingReadable.size.bind(underlyingReadable),
       read: async (offset: bigint, size: bigint) => {
         reads.push({ offset, size });
@@ -1296,28 +1448,16 @@ describe("McapIndexedReader", () => {
       },
     };
 
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(jest.fn());
-    try {
-      const reader = await McapIndexedReader.Initialize({
-        readable: recordingReadable,
-        prefetchMessageIndexes: true,
-      });
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/supportsConcurrentReads/);
+    // Cache budget only fits one chunk's message index. Prefetch should stop before exceeding it.
+    const oneChunkIndexBytes = Number(chunkIndexes[0]!.messageIndexLength);
+    await McapIndexedReader.Initialize({
+      readable: recordingReadable,
+      prefetchMessageIndexes: true,
+      messageIndexCacheSizeBytes: oneChunkIndexBytes,
+    });
 
-      reads.length = 0;
-      const firstPass = await collect(reader.readMessages());
-      expect(firstPass).toEqual([message]);
-      expect(reads.some(overlapsMessageIndex)).toBe(true);
-
-      // The downgrade still enables caching, so a second pass does not re-read the message index.
-      reads.length = 0;
-      const secondPass = await collect(reader.readMessages());
-      expect(secondPass).toEqual([message]);
-      expect(reads.some(overlapsMessageIndex)).toBe(false);
-    } finally {
-      warnSpy.mockRestore();
-    }
+    const indexReadCount = reads.filter(overlapsMessageIndex).length;
+    expect(indexReadCount).toBe(1);
   });
 
   it("after a prefetch failure, readMessages surfaces the error once and then falls back to on-demand loading", async () => {

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -964,6 +964,456 @@ describe("McapIndexedReader", () => {
     expect(reads.some(overlapsMessageIndex)).toBe(false);
   });
 
+  it("prefetchMessageIndexes reads message indexes before readMessages() is called", async () => {
+    const channelA: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const channelB: TypedMcapRecord = {
+      type: "Channel",
+      id: 2,
+      schemaId: 0,
+      topic: "b",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (channel: Channel, idx: number): TypedMcapRecords["Message"] => ({
+      type: "Message",
+      channelId: channel.id,
+      sequence: idx,
+      logTime: BigInt(idx),
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+
+    const messageA1 = makeMessage(channelA, 1);
+    const messageA2 = makeMessage(channelA, 3);
+    const messageB1 = makeMessage(channelB, 2);
+
+    const chunk1 = new ChunkBuilder({ useMessageIndex: true });
+    chunk1.addChannel(channelA);
+    chunk1.addChannel(channelB);
+    chunk1.addMessage(messageA1);
+    chunk1.addMessage(messageB1);
+    chunk1.addMessage(messageA2);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunk1),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channelA);
+    builder.writeChannel(channelB);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const messageIndexRanges = chunkIndexes.map((chunkIndex) => {
+      let start: bigint | undefined;
+      for (const offset of chunkIndex.messageIndexOffsets.values()) {
+        if (start == undefined || offset < start) {
+          start = offset;
+        }
+      }
+      if (start == undefined) {
+        throw new Error("expected chunk to have message index offsets");
+      }
+      return { start, end: start + chunkIndex.messageIndexLength };
+    });
+
+    const reads: { offset: bigint; size: bigint }[] = [];
+    const underlyingReadable = makeReadable(builder.buffer);
+    const recordingReadable = {
+      supportsConcurrentReads: true,
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        reads.push({ offset, size });
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
+      messageIndexRanges.some(({ start, end }) => offset < end && offset + size > start);
+
+    const reader = await McapIndexedReader.Initialize({
+      readable: recordingReadable,
+      prefetchMessageIndexes: true,
+    });
+
+    expect(reads.some(overlapsMessageIndex)).toBe(true);
+
+    const readCountAfterInit = reads.length;
+    const messages = await collect(reader.readMessages({ topics: [channelA.topic] }));
+    expect(messages).toEqual([messageA1, messageA2]);
+    expect(reads.slice(readCountAfterInit).some(overlapsMessageIndex)).toBe(false);
+  });
+
+  it("readMessages waits for in-flight prefetch before reading message indexes", async () => {
+    const channelA: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const channelB: TypedMcapRecord = {
+      type: "Channel",
+      id: 2,
+      schemaId: 0,
+      topic: "b",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (channel: Channel, idx: number): TypedMcapRecords["Message"] => ({
+      type: "Message",
+      channelId: channel.id,
+      sequence: idx,
+      logTime: BigInt(idx),
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+
+    const messageA1 = makeMessage(channelA, 1);
+    const messageA2 = makeMessage(channelA, 3);
+    const messageB1 = makeMessage(channelB, 2);
+
+    const chunk1 = new ChunkBuilder({ useMessageIndex: true });
+    chunk1.addChannel(channelA);
+    chunk1.addChannel(channelB);
+    chunk1.addMessage(messageA1);
+    chunk1.addMessage(messageB1);
+    chunk1.addMessage(messageA2);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunk1),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channelA);
+    builder.writeChannel(channelB);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const messageIndexRanges = chunkIndexes.map((chunkIndex) => {
+      let start: bigint | undefined;
+      for (const offset of chunkIndex.messageIndexOffsets.values()) {
+        if (start == undefined || offset < start) {
+          start = offset;
+        }
+      }
+      if (start == undefined) {
+        throw new Error("expected chunk to have message index offsets");
+      }
+      return { start, end: start + chunkIndex.messageIndexLength };
+    });
+
+    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
+      messageIndexRanges.some(({ start, end }) => offset < end && offset + size > start);
+
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let messageIndexReadCount = 0;
+
+    const underlyingReadable = makeReadable(builder.buffer);
+    const gatedReadable = {
+      supportsConcurrentReads: true,
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        const result = await underlyingReadable.read(offset, size);
+        if (overlapsMessageIndex({ offset, size })) {
+          await gate;
+          messageIndexReadCount++;
+        }
+        return result;
+      },
+    };
+
+    const reader = await McapIndexedReader.Initialize({
+      readable: gatedReadable,
+      prefetchMessageIndexes: true,
+    });
+
+    expect(messageIndexReadCount).toBe(0);
+
+    const iter = reader.readMessages({ topics: [channelA.topic] });
+    const firstPromise = iter.next();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(messageIndexReadCount).toBe(0);
+
+    releaseGate();
+
+    expect(await firstPromise).toEqual({
+      done: false,
+      value: messageA1,
+    });
+    expect(messageIndexReadCount).toBe(1);
+
+    expect(await iter.next()).toEqual({ done: false, value: messageA2 });
+    expect(await iter.next()).toEqual({ done: true, value: undefined });
+  });
+
+  it("surfaces prefetch errors from readMessages", async () => {
+    const channel: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const message: TypedMcapRecords["Message"] = {
+      type: "Message",
+      channelId: channel.id,
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 0n,
+      data: new Uint8Array(),
+    };
+
+    const chunk = new ChunkBuilder({ useMessageIndex: true });
+    chunk.addChannel(channel);
+    chunk.addMessage(message);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndex = writeChunkWithMessageIndexes(builder, chunk);
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+    const summaryStart = BigInt(builder.length);
+    builder.writeChunkIndex(chunkIndex);
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    let messageIndexStart: bigint | undefined;
+    for (const offset of chunkIndex.messageIndexOffsets.values()) {
+      if (messageIndexStart == undefined || offset < messageIndexStart) {
+        messageIndexStart = offset;
+      }
+    }
+    const messageIndexEnd = messageIndexStart! + chunkIndex.messageIndexLength;
+
+    const underlyingReadable = makeReadable(builder.buffer);
+    const failingReadable = {
+      supportsConcurrentReads: true,
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        if (offset < messageIndexEnd && offset + size > messageIndexStart!) {
+          throw new Error("prefetch read failed");
+        }
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const reader = await McapIndexedReader.Initialize({
+      readable: failingReadable,
+      prefetchMessageIndexes: true,
+    });
+
+    await expect(collect(reader.readMessages())).rejects.toThrow("prefetch read failed");
+  });
+
+  it("warns and falls back to caching when prefetchMessageIndexes is set without supportsConcurrentReads", async () => {
+    const channel: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const message: TypedMcapRecords["Message"] = {
+      type: "Message",
+      channelId: channel.id,
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 0n,
+      data: new Uint8Array(),
+    };
+
+    const chunk = new ChunkBuilder({ useMessageIndex: true });
+    chunk.addChannel(channel);
+    chunk.addMessage(message);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunk),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channel);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const chunkIndex = chunkIndexes[0]!;
+    let messageIndexStart: bigint | undefined;
+    for (const offset of chunkIndex.messageIndexOffsets.values()) {
+      if (messageIndexStart == undefined || offset < messageIndexStart) {
+        messageIndexStart = offset;
+      }
+    }
+    const messageIndexRange = {
+      start: messageIndexStart!,
+      end: messageIndexStart! + chunkIndex.messageIndexLength,
+    };
+    const overlapsMessageIndex = ({ offset, size }: { offset: bigint; size: bigint }) =>
+      offset < messageIndexRange.end && offset + size > messageIndexRange.start;
+
+    const reads: { offset: bigint; size: bigint }[] = [];
+    const underlyingReadable = makeReadable(builder.buffer);
+    // Readable without supportsConcurrentReads.
+    const recordingReadable = {
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        reads.push({ offset, size });
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(jest.fn());
+    try {
+      const reader = await McapIndexedReader.Initialize({
+        readable: recordingReadable,
+        prefetchMessageIndexes: true,
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/supportsConcurrentReads/);
+
+      reads.length = 0;
+      const firstPass = await collect(reader.readMessages());
+      expect(firstPass).toEqual([message]);
+      expect(reads.some(overlapsMessageIndex)).toBe(true);
+
+      // The downgrade still enables caching, so a second pass does not re-read the message index.
+      reads.length = 0;
+      const secondPass = await collect(reader.readMessages());
+      expect(secondPass).toEqual([message]);
+      expect(reads.some(overlapsMessageIndex)).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("after a prefetch failure, readMessages surfaces the error once and then falls back to on-demand loading", async () => {
+    const channelA: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const channelB: TypedMcapRecord = {
+      type: "Channel",
+      id: 2,
+      schemaId: 0,
+      topic: "b",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const makeMessage = (channel: Channel, idx: number): TypedMcapRecords["Message"] => ({
+      type: "Message",
+      channelId: channel.id,
+      sequence: idx,
+      logTime: BigInt(idx),
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+    const messageA = makeMessage(channelA, 10);
+    const messageB = makeMessage(channelB, 20);
+
+    const chunkA = new ChunkBuilder({ useMessageIndex: true });
+    chunkA.addChannel(channelA);
+    chunkA.addMessage(messageA);
+    const chunkB = new ChunkBuilder({ useMessageIndex: true });
+    chunkB.addChannel(channelB);
+    chunkB.addMessage(messageB);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunkA),
+      writeChunkWithMessageIndexes(builder, chunkB),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channelA);
+    builder.writeChannel(channelB);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    // Determine the message index range for chunk B so we can selectively fail its prefetch.
+    const chunkBIndex = chunkIndexes[1]!;
+    let chunkBMessageIndexStart: bigint | undefined;
+    for (const offset of chunkBIndex.messageIndexOffsets.values()) {
+      if (chunkBMessageIndexStart == undefined || offset < chunkBMessageIndexStart) {
+        chunkBMessageIndexStart = offset;
+      }
+    }
+    const chunkBMessageIndexEnd = chunkBMessageIndexStart! + chunkBIndex.messageIndexLength;
+
+    let prefetchActive = true;
+    const underlyingReadable = makeReadable(builder.buffer);
+    const failingReadable = {
+      supportsConcurrentReads: true,
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint) => {
+        if (
+          prefetchActive &&
+          offset < chunkBMessageIndexEnd &&
+          offset + size > chunkBMessageIndexStart!
+        ) {
+          throw new Error("chunk B index read failed");
+        }
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const reader = await McapIndexedReader.Initialize({
+      readable: failingReadable,
+      prefetchMessageIndexes: true,
+    });
+
+    await expect(collect(reader.readMessages())).rejects.toThrow("chunk B index read failed");
+
+    // Subsequent calls fall back to on-demand loading. Simulate that the underlying failure was
+    // transient so the on-demand reads can succeed. Chunk A's indexes were already cached during
+    // the successful half of the prefetch and will be served from cache.
+    prefetchActive = false;
+    const messages = await collect(reader.readMessages());
+    expect(messages).toEqual([messageA, messageB]);
+  });
+
   it("re-reads message indexes across readMessages() calls when messageIndexCacheSizeBytes is not set", async () => {
     const channel: TypedMcapRecord = {
       type: "Channel",

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -8,6 +8,9 @@ import { MCAP_MAGIC } from "./constants.ts";
 import { parseMagic, parseRecord } from "./parse.ts";
 import type { DecompressHandlers, IReadable, TypedMcapRecords } from "./types.ts";
 
+const MAX_PREFETCH_CONCURRENCY = 6;
+const MAX_PREFETCH_CACHE_BYTES = 256 * 1024 * 1024; // 256 MB
+
 type McapIndexedReaderArgs = {
   readable: IReadable;
   chunkIndexes: readonly TypedMcapRecords["ChunkIndex"][];
@@ -31,6 +34,12 @@ type McapIndexedReaderArgs = {
    * that later queries against different channels can be served from the cache.
    */
   messageIndexCacheSizeBytes?: number;
+  /**
+   * When true, message indexes are prefetched in parallel (up to `MAX_PREFETCH_CONCURRENCY`
+   * concurrent reads) during reader construction. Requires the readable to support concurrent
+   * reads (see {@link IReadable.supportsConcurrentReads}).
+   */
+  prefetchMessageIndexes?: boolean;
 };
 
 export class McapIndexedReader {
@@ -50,6 +59,8 @@ export class McapIndexedReader {
   #readable: IReadable;
   #messageIndexReadable: IReadable;
   #decompressHandlers?: DecompressHandlers;
+  #messageIndexPrefetchPromise?: Promise<void>;
+  #messageIndexPrefetchError?: Error;
 
   #messageStartTime: bigint | undefined;
   #messageEndTime: bigint | undefined;
@@ -97,6 +108,87 @@ export class McapIndexedReader {
         this.#attachmentEndTime = attachment.logTime;
       }
     }
+
+    if (
+      args.prefetchMessageIndexes === true &&
+      this.#messageIndexReadable instanceof CachedReadable
+    ) {
+      this.#startMessageIndexPrefetch(this.#messageIndexReadable);
+    }
+  }
+
+  /**
+   * Kick off parallel reads (up to `MAX_PREFETCH_CONCURRENCY`) of every chunk's message index
+   * region through the cached readable. Successful reads populate the byte cache so that later
+   * `readMessages()` calls hit cache.
+   *
+   * The first failure is captured on the instance and surfaced once from the next
+   * `readMessages()` call; subsequent calls fall back to on-demand loading via
+   * `ChunkCursor.loadMessageIndexes()`. Chunks that were successfully prefetched before the
+   * failure remain in cache and continue to be served from there.
+   */
+  #startMessageIndexPrefetch(cachedReadable: CachedReadable): void {
+    type Request = { readStart: bigint; readLength: bigint };
+    const indexRequests: Request[] = [];
+    for (const chunk of this.chunkIndexes) {
+      if (chunk.messageIndexLength === 0n) {
+        continue;
+      }
+      let readStart: bigint | undefined;
+      for (const offset of chunk.messageIndexOffsets.values()) {
+        if (readStart == undefined || offset < readStart) {
+          readStart = offset;
+        }
+      }
+      if (readStart == undefined) {
+        continue;
+      }
+      indexRequests.push({ readStart, readLength: chunk.messageIndexLength });
+    }
+
+    if (indexRequests.length === 0) {
+      return;
+    }
+
+    // Shared state between workers. Accessed via closures (`getError`/`setError`) so that
+    // TypeScript does not narrow the value across awaits; each call re-reads the current value.
+    let prefetchError: Error | undefined;
+    const getError = (): Error | undefined => prefetchError;
+    const setError = (err: Error): void => {
+      prefetchError = err;
+    };
+    let nextIndex = 0;
+    const workers = Array.from(
+      { length: Math.min(MAX_PREFETCH_CONCURRENCY, indexRequests.length) },
+      async () => {
+        for (;;) {
+          // Safe: JS is single-threaded; each worker awaits between iterations,
+          // so nextIndex++ never races.
+          if (getError()) {
+            return;
+          }
+          const i = nextIndex++;
+          if (i >= indexRequests.length) {
+            return;
+          }
+          const req = indexRequests[i]!;
+          try {
+            await cachedReadable.read(req.readStart, req.readLength);
+          } catch (err) {
+            // On the first failure, record the error. Other workers observe the error flag on
+            // their next iteration and exit without processing further requests. Successfully
+            // prefetched entries stay in cache and will be used by on-demand loads.
+            if (!getError()) {
+              setError(err as Error);
+            }
+            return;
+          }
+        }
+      },
+    );
+    this.#messageIndexPrefetchPromise = Promise.all(workers).then(() => {
+      this.#messageIndexPrefetchError = getError();
+    });
   }
 
   #errorWithLibrary(message: string): Error {
@@ -107,6 +199,7 @@ export class McapIndexedReader {
     readable,
     decompressHandlers,
     messageIndexCacheSizeBytes,
+    prefetchMessageIndexes,
   }: {
     readable: IReadable;
 
@@ -115,15 +208,22 @@ export class McapIndexedReader {
      * compression will be called to decompress the chunk data.
      */
     decompressHandlers?: DecompressHandlers;
+
     /**
      * Maximum number of bytes of message index data to cache in memory across calls to
      * `readMessages()`. When > 0, message indexes read on demand are cached so subsequent calls do
      * not re-read them from the underlying readable. Defaults to 0 (no caching).
-     *
-     * When caching is enabled, each chunk's full message index region is read on first access so
-     * that later queries against different channels can be served from the cache.
      */
     messageIndexCacheSizeBytes?: number;
+
+    /**
+     * When true, message indexes are prefetched in parallel (up to 6 concurrent reads) during
+     * reader construction. Requires `readable.supportsConcurrentReads === true`; otherwise a
+     * warning is logged and the option is downgraded to on-demand loading with message index
+     * caching. Implies message index caching; the cache is sized to fit all message indexes,
+     * capped at 256 MB.
+     */
+    prefetchMessageIndexes?: boolean;
   }): Promise<McapIndexedReader> {
     const size = await readable.size();
 
@@ -345,6 +445,26 @@ export class McapIndexedReader {
       throw errorWithLibrary(`${indexReader.bytesRemaining()} bytes remaining in index section`);
     }
 
+    let effectiveCacheSizeBytes = messageIndexCacheSizeBytes ?? 0;
+    let effectivePrefetch = false;
+    if (prefetchMessageIndexes === true) {
+      if (readable.supportsConcurrentReads !== true) {
+        console.warn(
+          "McapIndexedReader: prefetchMessageIndexes was requested but the readable does not declare supportsConcurrentReads; falling back to on-demand loading with message index caching.",
+        );
+      } else {
+        effectivePrefetch = true;
+      }
+      let totalMessageIndexBytes = 0;
+      for (const ci of chunkIndexes) {
+        totalMessageIndexBytes += Number(ci.messageIndexLength);
+      }
+      const targetCacheSizeBytes = Math.min(totalMessageIndexBytes, MAX_PREFETCH_CACHE_BYTES);
+      if (effectiveCacheSizeBytes < targetCacheSizeBytes) {
+        effectiveCacheSizeBytes = targetCacheSizeBytes;
+      }
+    }
+
     return new McapIndexedReader({
       readable,
       chunkIndexes,
@@ -359,7 +479,8 @@ export class McapIndexedReader {
       footer,
       dataEndOffset,
       dataSectionCrc,
-      messageIndexCacheSizeBytes,
+      messageIndexCacheSizeBytes: effectiveCacheSizeBytes,
+      prefetchMessageIndexes: effectivePrefetch,
     });
   }
 
@@ -382,6 +503,19 @@ export class McapIndexedReader {
 
     if (startTime == undefined || endTime == undefined) {
       return;
+    }
+
+    // If a prefetch is in flight, wait for it to complete so any captured error can be surfaced
+    // and all successfully prefetched indexes are in the cache before we start reading.
+    if (this.#messageIndexPrefetchPromise) {
+      const promise = this.#messageIndexPrefetchPromise;
+      this.#messageIndexPrefetchPromise = undefined;
+      await promise;
+      const err = this.#messageIndexPrefetchError;
+      this.#messageIndexPrefetchError = undefined;
+      if (err) {
+        throw err;
+      }
     }
 
     let relevantChannels: Set<number> | undefined;

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -38,6 +38,9 @@ type McapIndexedReaderArgs = {
    * When true, message indexes are prefetched in parallel (up to `MAX_PREFETCH_CONCURRENCY`
    * concurrent reads) during reader construction. Requires the readable to support concurrent
    * reads (see {@link IReadable.supportsConcurrentReads}).
+   *
+   * If messageIndexCacheSizeBytes is set, it will set the cache size to that number if it is lower
+   * than the total message index size.
    */
   prefetchMessageIndexes?: boolean;
 };
@@ -456,10 +459,13 @@ export class McapIndexedReader {
       for (const ci of chunkIndexes) {
         totalMessageIndexBytes += Number(ci.messageIndexLength);
       }
-      const targetCacheSizeBytes = Math.min(totalMessageIndexBytes, MAX_PREFETCH_CACHE_BYTES);
-      if (effectiveCacheSizeBytes < targetCacheSizeBytes) {
-        effectiveCacheSizeBytes = targetCacheSizeBytes;
-      }
+      const derivedCacheSizeBytes = Math.min(totalMessageIndexBytes, MAX_PREFETCH_CACHE_BYTES);
+      // When the caller specified an explicit cache size, respect it as an upper bound; otherwise
+      // size the cache to fit all message indexes (capped at MAX_PREFETCH_CACHE_BYTES).
+      effectiveCacheSizeBytes =
+        messageIndexCacheSizeBytes != undefined
+          ? Math.min(messageIndexCacheSizeBytes, derivedCacheSizeBytes)
+          : derivedCacheSizeBytes;
     }
 
     return new McapIndexedReader({

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -121,9 +121,10 @@ export class McapIndexedReader {
   }
 
   /**
-   * Kick off parallel reads (up to `MAX_PREFETCH_CONCURRENCY`) of every chunk's message index
-   * region through the cached readable. Successful reads populate the byte cache so that later
-   * `readMessages()` calls hit cache.
+   * Kick off parallel reads (up to `MAX_PREFETCH_CONCURRENCY`) of message index regions through
+   * the cached readable, in chunk order, stopping once the next chunk's index would exceed the
+   * cache budget. Successful reads populate the byte cache so that later `readMessages()` calls
+   * hit cache.
    *
    * The first failure is captured on the instance and surfaced once from the next
    * `readMessages()` call; subsequent calls fall back to on-demand loading via
@@ -133,6 +134,7 @@ export class McapIndexedReader {
   #startMessageIndexPrefetch(cachedReadable: CachedReadable): void {
     type Request = { readStart: bigint; readLength: bigint };
     const indexRequests: Request[] = [];
+    let cumulativeBytes = 0;
     for (const chunk of this.chunkIndexes) {
       if (chunk.messageIndexLength === 0n) {
         continue;
@@ -145,6 +147,12 @@ export class McapIndexedReader {
       }
       if (readStart == undefined) {
         continue;
+      }
+      // Stop once the next chunk's index would exceed the cache budget; reads beyond the cap
+      // would consume bandwidth without being cached.
+      cumulativeBytes += Number(chunk.messageIndexLength);
+      if (cumulativeBytes > cachedReadable.maxCacheSizeBytes) {
+        break;
       }
       indexRequests.push({ readStart, readLength: chunk.messageIndexLength });
     }
@@ -198,6 +206,27 @@ export class McapIndexedReader {
     return new Error(`${message} [library=${this.header.library}]`);
   }
 
+  /**
+   * Returns true if the message index region for `chunkIndex` is already present in the cached
+   * readable. Uses the same offset/length that {@link ChunkCursor.loadMessageIndexes} would read
+   * (and that {@link #startMessageIndexPrefetch} prefetches).
+   */
+  #isMessageIndexCached(chunkIndex: TypedMcapRecords["ChunkIndex"]): boolean {
+    if (!(this.#messageIndexReadable instanceof CachedReadable)) {
+      return false;
+    }
+    let readStart: bigint | undefined;
+    for (const offset of chunkIndex.messageIndexOffsets.values()) {
+      if (readStart == undefined || offset < readStart) {
+        readStart = offset;
+      }
+    }
+    if (readStart == undefined) {
+      return false;
+    }
+    return this.#messageIndexReadable.has(readStart, chunkIndex.messageIndexLength);
+  }
+
   static async Initialize({
     readable,
     decompressHandlers,
@@ -221,10 +250,11 @@ export class McapIndexedReader {
 
     /**
      * When true, message indexes are prefetched in parallel (up to 6 concurrent reads) during
-     * reader construction. Requires `readable.supportsConcurrentReads === true`; otherwise a
-     * warning is logged and the option is downgraded to on-demand loading with message index
-     * caching. Implies message index caching; the cache is sized to fit all message indexes,
-     * capped at 256 MB.
+     * reader construction. Requires `readable.supportsConcurrentReads === true`; otherwise an
+     * error is thrown. Implies message index caching: when `messageIndexCacheSizeBytes` is not
+     * set, the cache is sized to fit all message indexes, capped at 256 MB. When
+     * `messageIndexCacheSizeBytes` is set, the smaller of the two values is used and prefetch
+     * stops once it would exceed that budget.
      */
     prefetchMessageIndexes?: boolean;
   }): Promise<McapIndexedReader> {
@@ -483,7 +513,7 @@ export class McapIndexedReader {
       dataEndOffset,
       dataSectionCrc,
       messageIndexCacheSizeBytes: effectiveCacheSizeBytes,
-      prefetchMessageIndexes: effectivePrefetch,
+      prefetchMessageIndexes,
     });
   }
 
@@ -506,19 +536,6 @@ export class McapIndexedReader {
 
     if (startTime == undefined || endTime == undefined) {
       return;
-    }
-
-    // If a prefetch is in flight, wait for it to complete so any captured error can be surfaced
-    // and all successfully prefetched indexes are in the cache before we start reading.
-    if (this.#messageIndexPrefetchPromise) {
-      const promise = this.#messageIndexPrefetchPromise;
-      this.#messageIndexPrefetchPromise = undefined;
-      await promise;
-      const err = this.#messageIndexPrefetchError;
-      this.#messageIndexPrefetchError = undefined;
-      if (err) {
-        throw err;
-      }
     }
 
     let relevantChannels: Set<number> | undefined;
@@ -562,6 +579,18 @@ export class McapIndexedReader {
     for (let cursor; (cursor = chunkCursors.peek()); ) {
       if (!cursor.hasMessageIndexes()) {
         // If we encounter a chunk whose message indexes have not been loaded yet, load them and re-organize the heap.
+        // Only block on the prefetch when this chunk's index is not already cached, so callers
+        // requesting time ranges covered by already-cached chunks proceed without waiting.
+        if (this.#messageIndexPrefetchPromise && !this.#isMessageIndexCached(cursor.chunkIndex)) {
+          const promise = this.#messageIndexPrefetchPromise;
+          this.#messageIndexPrefetchPromise = undefined;
+          await promise;
+          const err = this.#messageIndexPrefetchError;
+          this.#messageIndexPrefetchError = undefined;
+          if (err) {
+            throw err;
+          }
+        }
         await cursor.loadMessageIndexes(this.#messageIndexReadable);
         if (cursor.hasMoreMessages()) {
           chunkCursors.replace(cursor);

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -446,14 +446,11 @@ export class McapIndexedReader {
     }
 
     let effectiveCacheSizeBytes = messageIndexCacheSizeBytes ?? 0;
-    let effectivePrefetch = false;
     if (prefetchMessageIndexes === true) {
       if (readable.supportsConcurrentReads !== true) {
-        console.warn(
-          "McapIndexedReader: prefetchMessageIndexes was requested but the readable does not declare supportsConcurrentReads; falling back to on-demand loading with message index caching.",
+        throw errorWithLibrary(
+          "prefetchMessageIndexes requires the readable to declare supportsConcurrentReads",
         );
-      } else {
-        effectivePrefetch = true;
       }
       let totalMessageIndexBytes = 0;
       for (const ci of chunkIndexes) {

--- a/typescript/core/src/types.ts
+++ b/typescript/core/src/types.ts
@@ -139,4 +139,9 @@ export type DecompressHandlers = {
 export interface IReadable {
   size(): Promise<bigint>;
   read(offset: bigint, size: bigint): Promise<Uint8Array>;
+  /**
+   * When true, multiple `read()` calls may be issued concurrently. `IReadable`s that do not
+   * declare this flag should be treated as if `supportsConcurrentReads === false`.
+   */
+  supportsConcurrentReads?: boolean;
 }


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 -[typescript] Add optional `IReadable`field `supportsConcurrentReads` to advertise capability to `McapReader`s
 - [typescript] Add optional `prefetchMessageIndexes` argument to `McapIndexedReader` which will enable caching and prefetch message indexes if the underlying Readable supports concurrent reads. 

### Docs

<!-- Link to a PR or Linear ticket tracking documentation. Write "None" if no documentation changes are needed. -->

None. Documented in JSDoc docs

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

This allows message indexes to be loaded in parallel starting when the Reader is initialized which significantly speeds up message index reading. Currently the concurrency is locked to up to 6 concurrent requests, based around browser HTTP:1 limits. This could be specified in the future, but I didn't want to add more api surface area. 

If prefetch is enabled and no cache size is specified it will automatically size the cache to the size of the message indexes in the mcap, with a safe maximum cache size of 256MB.

If one of the prefetches fails then it will bail on prefetching and return the error in the first `readMessages` call so that the error can be surfaced to the owner of the Reader. Subsequent reads will act normally.

| numReads | latencyMs | noCache (ms) | cached (ms) | prefetch (ms) | cached vs noCache | prefetch vs noCache | prefetch vs cached |
| -------- | --------- | ------------ | ----------- | ------------- | ----------------- | ------------------- | ------------------ |
| 1        | 0         | 429.7        | 455.1       | 438.4         | -5.9%             | -2.0%               | 3.7%               |
| 1        | 10        | 4,825.1      | 4,707.0     | 2,988.0       | 2.4%              | **38.1%**           | **36.5%**          |
| 5        | 0         | 2,325.7      | 2,198.6     | 2,529.8       | 5.5%              | -8.8%               | -15.1%             |
| 5        | 10        | 23,871.2     | 15,359.5    | 13,487.8      | **35.7%**         | **43.5%**           | 12.2%              |


The losses are expected for the no/lowest-latency, single read cases, since this benchmark uses an in memory mcap buffer and the overhead of the requests wins out. Enabling this option is not advised in those cases. This option is meant to be used primarily for remote file data sources which have a latencies of >20ms. In that range the savings are very apparent.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

