### PR TITLE
cpp: BufferWriter: Reserve chunkSize in constructor

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -252,6 +252,8 @@ protected:
  */
 class MCAP_PUBLIC BufferWriter final : public IChunkWriter {
 public:
+  explicit BufferWriter(uint64_t chunkSize = 0);
+
   void handleWrite(const std::byte* data, uint64_t size) override;
   void end() override;
   uint64_t size() const override;

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -111,6 +111,10 @@ void IChunkWriter::clear() {
 
 // BufferWriter //////////////////////////////////////////////////////////////
 
+BufferWriter::BufferWriter(uint64_t chunkSize) {
+  buffer_.reserve(chunkSize);
+}
+
 void BufferWriter::handleWrite(const std::byte* data, uint64_t size) {
   buffer_.insert(buffer_.end(), data, data + size);
 }
@@ -313,7 +317,7 @@ void McapWriter::open(IWritable& writer, const McapWriterOptions& options) {
   switch (compression_) {
     case Compression::None:
     default:
-      uncompressedChunk_ = std::make_unique<BufferWriter>();
+      uncompressedChunk_ = std::make_unique<BufferWriter>(chunkSize_);
       break;
 #ifndef MCAP_COMPRESSION_NO_LZ4
     case Compression::Lz4:


### PR DESCRIPTION
### Changelog

cpp: BufferWriter: Reserve chunkSize in constructor

### Docs

None

### Description

The Buffer Writer at a 10M payload scale benefits the most, achieving a 2.22% reduction in median execution time. This is followed by the File Writer at 10M and 1M payload scales, which show performance gains of 0.88% and 0.73% respectively. Additionally, the Stream Writer at the 10M scale shows a measurable improvement of 0.41%.