### PR TITLE
rust cli: Bring cat command to parity

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -851,7 +851,6 @@ dependencies = [
  "lz4",
  "mcap",
  "memmap2",
- "prost",
  "prost-reflect",
  "regex",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +851,8 @@ dependencies = [
  "lz4",
  "mcap",
  "memmap2",
+ "prost",
+ "prost-reflect",
  "regex",
  "serde_json",
  "simplelog",
@@ -916,6 +924,15 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -1022,6 +1039,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+dependencies = [
+ "base64",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1136,6 +1198,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -24,3 +24,5 @@ mcap = { path = "../mcap" }
 regex = "1"
 serde_json = "1"
 simplelog = "0.12"
+prost-reflect = { version = "0.16.4", features = ["serde"] }
+prost = "0.14.3"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -25,4 +25,3 @@ regex = "1"
 serde_json = "1"
 simplelog = "0.12"
 prost-reflect = { version = "0.16.4", features = ["serde"] }
-prost = "0.14.3"

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -11,7 +11,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | Command      | Status | Notes                                                                                                                                     |
 | ------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`        | 🟢     |                                                                                                                                           |
-| `cat`        | 🟡     | Local and stdin input are implemented, including `--topics`, time-range filters, and `--json`; remote URI input is not yet supported.      |
+| `cat`        | 🟡     | Local and stdin input are implemented, including `--topics`, time-range filters, and `--json`; remote URI input is not yet supported.     |
 | `compress`   | 🟢     |                                                                                                                                           |
 | `convert`    | 🟡     | ROS1 bag → MCAP conversion is implemented (including `none`/`lz4`/`bz2` bag chunk decompression); ROS2 db3 input is not yet supported.    |
 | `decompress` | 🟢     |                                                                                                                                           |

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -47,6 +47,12 @@ port is still pre-production:
    - Apply the same timestamp input syntax consistently across all commands
      that accept times, including `cat`, `filter`, `add attachment`, and any
      future time-filtered commands.
+2. Topic filter arguments:
+   - Current Go-compatible `cat --topics` accepts one comma-separated string.
+   - Before Rust CLI 1.0, decide whether topic filtering should use the comma
+     list, repeatable flags such as `--topic foo --topic bar`, or support both.
+   - Apply the chosen shape consistently across commands that filter by topic so
+     users do not have to learn separate `cat` and `filter` conventions.
 
 ## Intentional divergences from Go CLI
 

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -11,7 +11,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | Command      | Status | Notes                                                                                                                                     |
 | ------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`        | 🟢     |                                                                                                                                           |
-| `cat`        | 🟡     | Core `cat` output is implemented; Go-parity gaps remain (`--topic`/time-range filters, `--json`, stdin input, remote URI input).          |
+| `cat`        | 🟡     | Local and stdin input are implemented, including `--topics`, time-range filters, and `--json`; remote URI input is not yet supported.      |
 | `compress`   | 🟢     |                                                                                                                                           |
 | `convert`    | 🟡     | ROS1 bag → MCAP conversion is implemented (including `none`/`lz4`/`bz2` bag chunk decompression); ROS2 db3 input is not yet supported.    |
 | `decompress` | 🟢     |                                                                                                                                           |

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -38,11 +38,15 @@ port is still pre-production:
      seconds and `--start-nsecs` / `--end-nsecs` select nanoseconds.
    - This matches MCAP's internal timestamp unit and preserves copy/paste from
      existing `mcap cat` output, but it is surprising for CLI users.
-   - For Rust CLI 1.0, consider making decimal seconds the default human input
-     form, e.g. `--start 1.23456789`, while supporting explicit units such as
-     `--start 1709146829659264519ns` and RFC3339 timestamps.
-   - If this changes, deprecate or remove the split `--*-secs` / `--*-nsecs`
-     flags rather than carrying them as the preferred interface.
+   - For Rust CLI 1.0, remove the split `--*-secs` / `--*-nsecs` variants and
+     standardize all commands on `--start` / `--end` where applicable.
+   - Parse `--start` / `--end` values as RFC3339 timestamps, exact decimal
+     seconds strings (for example `1.23456789`), or explicit unit-suffixed
+     durations/timestamps such as `1.5s`, `250ms`, and
+     `1709146829659264519ns`.
+   - Apply the same timestamp input syntax consistently across all commands
+     that accept times, including `cat`, `filter`, `add attachment`, and any
+     future time-filtered commands.
 
 ## Intentional divergences from Go CLI
 

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -26,6 +26,24 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | `sort`       | 🟢     |                                                                                                                                           |
 | `version`    | 🟢     |                                                                                                                                           |
 
+## Pre-1.0 compatibility cleanup
+
+The Rust CLI is currently prioritizing Go CLI parity. Before declaring a Rust CLI
+1.0, revisit compatibility behaviors that are awkward enough to change while the
+port is still pre-production:
+
+1. Time range arguments:
+   - Current Go-compatible behavior treats bare numeric `--start` / `--end`
+     values as integer nanoseconds, while `--start-secs` / `--end-secs` select
+     seconds and `--start-nsecs` / `--end-nsecs` select nanoseconds.
+   - This matches MCAP's internal timestamp unit and preserves copy/paste from
+     existing `mcap cat` output, but it is surprising for CLI users.
+   - For Rust CLI 1.0, consider making decimal seconds the default human input
+     form, e.g. `--start 1.23456789`, while supporting explicit units such as
+     `--start 1709146829659264519ns` and RFC3339 timestamps.
+   - If this changes, deprecate or remove the split `--*-secs` / `--*-nsecs`
+     flags rather than carrying them as the preferred interface.
+
 ## Intentional divergences from Go CLI
 
 1. `mcap du` attachment accounting:

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -110,10 +110,37 @@ pub struct AddCommand {
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
-#[command(arg_required_else_help = true)]
 pub struct CatCommand {
-    /// One or more local paths to MCAP files
+    /// One or more local paths to MCAP files. If omitted, reads from stdin.
     pub files: Vec<PathBuf>,
+
+    /// Comma-separated list of topics to include
+    #[arg(long = "topics", default_value = "")]
+    pub topics: String,
+
+    /// Include messages at or after this time (seconds)
+    #[arg(
+        long = "start-secs",
+        default_value_t = 0,
+        conflicts_with = "start_nsecs"
+    )]
+    pub start_secs: u64,
+
+    /// Include messages at or after this time (nanoseconds)
+    #[arg(long = "start-nsecs", default_value_t = 0)]
+    pub start_nsecs: u64,
+
+    /// Include messages before this time (seconds)
+    #[arg(long = "end-secs", default_value_t = 0, conflicts_with = "end_nsecs")]
+    pub end_secs: u64,
+
+    /// Include messages before this time (nanoseconds)
+    #[arg(long = "end-nsecs", default_value_t = 0)]
+    pub end_nsecs: u64,
+
+    /// Print messages as JSON. Supported message encodings: ros1, protobuf, and json.
+    #[arg(long = "json", default_value_t = false)]
+    pub json: bool,
 }
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -42,7 +42,7 @@ pub fn run(_ctx: &CommandContext, args: CatCommand) -> Result<()> {
     flush_or_ignore_broken_pipe(&mut writer)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct CatOptions {
     topics: Vec<String>,
     start: u64,
@@ -86,17 +86,6 @@ impl CatOptions {
 
     fn include_time(&self, log_time: u64) -> bool {
         log_time >= self.start && self.end.is_none_or(|end| log_time < end)
-    }
-}
-
-impl Default for CatOptions {
-    fn default() -> Self {
-        Self {
-            topics: Vec::new(),
-            start: 0,
-            end: None,
-            json: false,
-        }
     }
 }
 
@@ -162,16 +151,14 @@ fn cat_indexed(
                     .channels
                     .get(&header.channel_id)
                     .ok_or_else(|| anyhow::anyhow!("unknown channel {}", header.channel_id))?;
-                if write_message(
-                    writer,
+                let message = CatMessage {
                     channel,
-                    header.sequence,
-                    header.log_time,
-                    header.publish_time,
+                    sequence: header.sequence,
+                    log_time: header.log_time,
+                    publish_time: header.publish_time,
                     data,
-                    opts,
-                    json_transcoders,
-                )? {
+                };
+                if write_message(writer, message, opts, json_transcoders)? {
                     return Ok(Some(true));
                 }
             }
@@ -192,54 +179,57 @@ fn cat_linear(
         if !opts.include_time(message.log_time) || !opts.include_topic(&message.channel.topic) {
             continue;
         }
-        if write_message(
-            writer,
-            &message.channel,
-            message.sequence,
-            message.log_time,
-            message.publish_time,
-            message.data.as_ref(),
-            opts,
-            json_transcoders,
-        )? {
+        let message = CatMessage {
+            channel: &message.channel,
+            sequence: message.sequence,
+            log_time: message.log_time,
+            publish_time: message.publish_time,
+            data: message.data.as_ref(),
+        };
+        if write_message(writer, message, opts, json_transcoders)? {
             return Ok(true);
         }
     }
     Ok(false)
 }
 
-fn write_message(
-    writer: &mut impl std::io::Write,
-    channel: &mcap::Channel<'_>,
+struct CatMessage<'a> {
+    channel: &'a mcap::Channel<'a>,
     sequence: u32,
     log_time: u64,
     publish_time: u64,
-    data: &[u8],
+    data: &'a [u8],
+}
+
+fn write_message(
+    writer: &mut impl std::io::Write,
+    message: CatMessage<'_>,
     opts: &CatOptions,
     json_transcoders: &mut JsonTranscoders,
 ) -> Result<bool> {
     if opts.json {
         write_json_message(
             writer,
-            channel,
-            sequence,
-            log_time,
-            publish_time,
-            data,
+            message.channel,
+            message.sequence,
+            message.log_time,
+            message.publish_time,
+            message.data,
             json_transcoders,
         )
     } else {
-        let schema_name = channel
+        let schema_name = message
+            .channel
             .schema
             .as_ref()
             .map(|schema| schema.name.as_str())
             .unwrap_or("no schema");
         write_message_fields(
             writer,
-            log_time,
-            &channel.topic,
+            message.log_time,
+            &message.channel.topic,
             schema_name,
-            data,
+            message.data,
             MESSAGE_PREVIEW_LEN,
         )
     }
@@ -1036,17 +1026,15 @@ mod tests {
             json: true,
             ..CatOptions::default()
         };
-        let broken_pipe = super::write_message(
-            &mut out,
-            &message.channel,
-            message.sequence,
-            message.log_time,
-            message.publish_time,
-            message.data.as_ref(),
-            &opts,
-            &mut transcoders,
-        )
-        .expect("json message should write");
+        let cat_message = super::CatMessage {
+            channel: &message.channel,
+            sequence: message.sequence,
+            log_time: message.log_time,
+            publish_time: message.publish_time,
+            data: message.data.as_ref(),
+        };
+        let broken_pipe = super::write_message(&mut out, cat_message, &opts, &mut transcoders)
+            .expect("json message should write");
         assert!(!broken_pipe);
 
         assert_eq!(

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1,7 +1,10 @@
-use std::io::Write as _;
+use std::borrow::Cow;
+use std::collections::{BTreeSet, HashMap};
+use std::io::{IsTerminal as _, Read as _, Write as _};
 
-use anyhow::Result;
+use anyhow::{bail, Context as _, Result};
 use mcap::sans_io::indexed_reader::ReadOrder;
+use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
 
 use crate::cli::CatCommand;
 use crate::commands::common;
@@ -10,34 +13,107 @@ use crate::context::CommandContext;
 const MESSAGE_PREVIEW_LEN: usize = 10;
 
 pub fn run(_ctx: &CommandContext, args: CatCommand) -> Result<()> {
+    let opts = CatOptions::from_args(&args)?;
     let stdout = std::io::stdout();
     let mut writer = std::io::BufWriter::new(stdout.lock());
 
-    for file in args.files {
-        let mcap = common::map_file(&file)?;
-        if cat_mcap(&mut writer, &mcap)? {
+    if args.files.is_empty() {
+        let stdin = std::io::stdin();
+        if stdin.is_terminal() {
+            bail!("supply a file");
+        }
+        let mut input = Vec::new();
+        stdin
+            .lock()
+            .read_to_end(&mut input)
+            .context("failed to read input from stdin")?;
+        if cat_mcap(&mut writer, &input, &opts)? {
             return Ok(());
+        }
+    } else {
+        for file in args.files {
+            let mcap = common::map_file(&file)?;
+            if cat_mcap(&mut writer, &mcap, &opts)? {
+                return Ok(());
+            }
         }
     }
 
-    if let Err(err) = writer.flush() {
-        if err.kind() == std::io::ErrorKind::BrokenPipe {
-            return Ok(());
-        }
-        return Err(err.into());
-    }
-
-    Ok(())
+    flush_or_ignore_broken_pipe(&mut writer)
 }
 
-fn cat_mcap(writer: &mut impl std::io::Write, mcap: &[u8]) -> Result<bool> {
-    if let Some(broken_pipe) = cat_indexed(writer, mcap)? {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CatOptions {
+    topics: Vec<String>,
+    start: u64,
+    end: Option<u64>,
+    json: bool,
+}
+
+impl CatOptions {
+    fn from_args(args: &CatCommand) -> Result<Self> {
+        let topics = args
+            .topics
+            .split(',')
+            .filter(|topic| !topic.is_empty())
+            .map(str::to_string)
+            .collect();
+        let mut start = args.start_nsecs;
+        if args.start_secs > 0 {
+            start = args
+                .start_secs
+                .checked_mul(1_000_000_000)
+                .context("start seconds timestamp overflows nanoseconds")?;
+        }
+        let mut end = args.end_nsecs;
+        if args.end_secs > 0 {
+            end = args
+                .end_secs
+                .checked_mul(1_000_000_000)
+                .context("end seconds timestamp overflows nanoseconds")?;
+        }
+        Ok(Self {
+            topics,
+            start,
+            end: (end != 0).then_some(end),
+            json: args.json,
+        })
+    }
+
+    fn include_topic(&self, topic: &str) -> bool {
+        self.topics.is_empty() || self.topics.iter().any(|included| included == topic)
+    }
+
+    fn include_time(&self, log_time: u64) -> bool {
+        log_time >= self.start && self.end.is_none_or(|end| log_time < end)
+    }
+}
+
+impl Default for CatOptions {
+    fn default() -> Self {
+        Self {
+            topics: Vec::new(),
+            start: 0,
+            end: None,
+            json: false,
+        }
+    }
+}
+
+fn cat_mcap(writer: &mut impl std::io::Write, mcap: &[u8], opts: &CatOptions) -> Result<bool> {
+    let mut json_transcoders = JsonTranscoders::default();
+    if let Some(broken_pipe) = cat_indexed(writer, mcap, opts, &mut json_transcoders)? {
         return Ok(broken_pipe);
     }
-    cat_linear(writer, mcap)
+    cat_linear(writer, mcap, opts, &mut json_transcoders)
 }
 
-fn cat_indexed(writer: &mut impl std::io::Write, mcap: &[u8]) -> Result<Option<bool>> {
+fn cat_indexed(
+    writer: &mut impl std::io::Write,
+    mcap: &[u8],
+    opts: &CatOptions,
+    json_transcoders: &mut JsonTranscoders,
+) -> Result<Option<bool>> {
     let Some(summary) = mcap::Summary::read(mcap)? else {
         return Ok(None);
     };
@@ -45,10 +121,29 @@ fn cat_indexed(writer: &mut impl std::io::Write, mcap: &[u8]) -> Result<Option<b
         return Ok(None);
     }
 
-    let mut reader = mcap::sans_io::IndexedReader::new_with_options(
-        &summary,
-        mcap::sans_io::IndexedReaderOptions::new().with_order(ReadOrder::LogTime),
-    )?;
+    let included_topics: BTreeSet<String> = summary
+        .channels
+        .values()
+        .filter(|channel| opts.include_topic(&channel.topic))
+        .map(|channel| channel.topic.clone())
+        .collect();
+    if !opts.topics.is_empty() && included_topics.is_empty() {
+        return Ok(Some(false));
+    }
+
+    let mut indexed_opts =
+        mcap::sans_io::IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
+    if opts.start != 0 {
+        indexed_opts = indexed_opts.log_time_on_or_after(opts.start);
+    }
+    if let Some(end) = opts.end {
+        indexed_opts = indexed_opts.log_time_before(end);
+    }
+    if !opts.topics.is_empty() {
+        indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
+    }
+
+    let mut reader = mcap::sans_io::IndexedReader::new_with_options(&summary, indexed_opts)?;
 
     while let Some(event) = reader.next_event() {
         match event? {
@@ -67,18 +162,15 @@ fn cat_indexed(writer: &mut impl std::io::Write, mcap: &[u8]) -> Result<Option<b
                     .channels
                     .get(&header.channel_id)
                     .ok_or_else(|| anyhow::anyhow!("unknown channel {}", header.channel_id))?;
-                let schema_name = channel
-                    .schema
-                    .as_ref()
-                    .map(|schema| schema.name.as_str())
-                    .unwrap_or("no schema");
-                if write_message_fields(
+                if write_message(
                     writer,
+                    channel,
+                    header.sequence,
                     header.log_time,
-                    &channel.topic,
-                    schema_name,
+                    header.publish_time,
                     data,
-                    MESSAGE_PREVIEW_LEN,
+                    opts,
+                    json_transcoders,
                 )? {
                     return Ok(Some(true));
                 }
@@ -89,27 +181,68 @@ fn cat_indexed(writer: &mut impl std::io::Write, mcap: &[u8]) -> Result<Option<b
     Ok(Some(false))
 }
 
-fn cat_linear(writer: &mut impl std::io::Write, mcap: &[u8]) -> Result<bool> {
+fn cat_linear(
+    writer: &mut impl std::io::Write,
+    mcap: &[u8],
+    opts: &CatOptions,
+    json_transcoders: &mut JsonTranscoders,
+) -> Result<bool> {
     for message in mcap::MessageStream::new(mcap)? {
         let message = message?;
-        let schema_name = message
-            .channel
-            .schema
-            .as_ref()
-            .map(|schema| schema.name.as_str())
-            .unwrap_or("no schema");
-        if write_message_fields(
+        if !opts.include_time(message.log_time) || !opts.include_topic(&message.channel.topic) {
+            continue;
+        }
+        if write_message(
             writer,
+            &message.channel,
+            message.sequence,
             message.log_time,
-            &message.channel.topic,
-            schema_name,
+            message.publish_time,
             message.data.as_ref(),
-            MESSAGE_PREVIEW_LEN,
+            opts,
+            json_transcoders,
         )? {
             return Ok(true);
         }
     }
     Ok(false)
+}
+
+fn write_message(
+    writer: &mut impl std::io::Write,
+    channel: &mcap::Channel<'_>,
+    sequence: u32,
+    log_time: u64,
+    publish_time: u64,
+    data: &[u8],
+    opts: &CatOptions,
+    json_transcoders: &mut JsonTranscoders,
+) -> Result<bool> {
+    if opts.json {
+        write_json_message(
+            writer,
+            channel,
+            sequence,
+            log_time,
+            publish_time,
+            data,
+            json_transcoders,
+        )
+    } else {
+        let schema_name = channel
+            .schema
+            .as_ref()
+            .map(|schema| schema.name.as_str())
+            .unwrap_or("no schema");
+        write_message_fields(
+            writer,
+            log_time,
+            &channel.topic,
+            schema_name,
+            data,
+            MESSAGE_PREVIEW_LEN,
+        )
+    }
 }
 
 fn write_message_fields(
@@ -150,6 +283,449 @@ fn write_message_fields(
     Ok(false)
 }
 
+fn write_json_message(
+    writer: &mut impl std::io::Write,
+    channel: &mcap::Channel<'_>,
+    sequence: u32,
+    log_time: u64,
+    publish_time: u64,
+    data: &[u8],
+    json_transcoders: &mut JsonTranscoders,
+) -> Result<bool> {
+    let encoded_data = json_transcoders.encode(channel, data)?;
+    let topic = serde_json::to_string(&channel.topic).context("failed to encode topic")?;
+    if let Err(err) = write!(
+        writer,
+        "{{\"topic\":{topic},\"sequence\":{sequence},\"log_time\":"
+    ) {
+        return maybe_broken_pipe(err);
+    }
+    if let Err(err) = write_decimal_time(writer, log_time) {
+        return maybe_broken_pipe(err);
+    }
+    if let Err(err) = write!(writer, ",\"publish_time\":") {
+        return maybe_broken_pipe(err);
+    }
+    if let Err(err) = write_decimal_time(writer, publish_time) {
+        return maybe_broken_pipe(err);
+    }
+    if let Err(err) = writer.write_all(b",\"data\":") {
+        return maybe_broken_pipe(err);
+    }
+    if let Err(err) = writer.write_all(encoded_data.as_ref()) {
+        return maybe_broken_pipe(err);
+    }
+    if let Err(err) = writer.write_all(b"}\n") {
+        return maybe_broken_pipe(err);
+    }
+    Ok(false)
+}
+
+fn write_decimal_time(writer: &mut impl std::io::Write, time: u64) -> std::io::Result<()> {
+    write!(
+        writer,
+        "{}.{:09}",
+        time / 1_000_000_000,
+        time % 1_000_000_000
+    )
+}
+
+fn maybe_broken_pipe(err: std::io::Error) -> Result<bool> {
+    if err.kind() == std::io::ErrorKind::BrokenPipe {
+        Ok(true)
+    } else {
+        Err(err.into())
+    }
+}
+
+fn flush_or_ignore_broken_pipe(writer: &mut impl std::io::Write) -> Result<()> {
+    if let Err(err) = writer.flush() {
+        if err.kind() == std::io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+        return Err(err.into());
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct JsonTranscoders {
+    protobuf_descriptors: HashMap<u16, MessageDescriptor>,
+    ros1_transcoders: HashMap<u16, Ros1MessageDef>,
+}
+
+impl JsonTranscoders {
+    fn encode<'a>(&mut self, channel: &mcap::Channel<'_>, data: &'a [u8]) -> Result<Cow<'a, [u8]>> {
+        let Some(schema) = channel.schema.as_ref() else {
+            return encode_schemaless_json(&channel.message_encoding, data);
+        };
+        if schema.encoding.is_empty() {
+            return encode_schemaless_json(&channel.message_encoding, data);
+        }
+
+        match schema.encoding.as_str() {
+            "jsonschema" => Ok(Cow::Borrowed(data)),
+            "protobuf" => {
+                let descriptor = match self.protobuf_descriptors.get(&schema.id) {
+                    Some(descriptor) => descriptor.clone(),
+                    None => {
+                        let pool = DescriptorPool::decode(schema.data.as_ref())
+                            .context("failed to build file descriptor set")?;
+                        let descriptor = pool.get_message_by_name(&schema.name).ok_or_else(|| {
+                            anyhow::anyhow!("failed to find descriptor: {}", schema.name)
+                        })?;
+                        self.protobuf_descriptors
+                            .insert(schema.id, descriptor.clone());
+                        descriptor
+                    }
+                };
+                let message = DynamicMessage::decode(descriptor, data)
+                    .context("failed to parse message")?;
+                let json = serde_json::to_vec(&message).context("failed to marshal message")?;
+                Ok(Cow::Owned(json))
+            }
+            "ros1msg" => {
+                let transcoder = match self.ros1_transcoders.get(&schema.id) {
+                    Some(transcoder) => transcoder,
+                    None => {
+                        let transcoder = Ros1MessageDef::parse(&schema.name, schema.data.as_ref())
+                            .with_context(|| {
+                                format!("failed to build transcoder for {}", channel.topic)
+                            })?;
+                        self.ros1_transcoders.insert(schema.id, transcoder);
+                        self.ros1_transcoders
+                            .get(&schema.id)
+                            .expect("transcoder was just inserted")
+                    }
+                };
+                let json = transcoder
+                    .transcode(data)
+                    .with_context(|| format!("failed to transcode {} record on {}", schema.name, channel.topic))?;
+                Ok(Cow::Owned(json))
+            }
+            encoding => bail!(
+                "JSON output only supported for ros1msg, protobuf, and jsonschema schemas. Found: {encoding}"
+            ),
+        }
+    }
+}
+
+fn encode_schemaless_json<'a>(message_encoding: &str, data: &'a [u8]) -> Result<Cow<'a, [u8]>> {
+    match message_encoding {
+        "json" => Ok(Cow::Borrowed(data)),
+        encoding => bail!(
+            "for schema-less channels, JSON output is only supported with 'json' message encoding. found: {encoding}"
+        ),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Ros1MessageDef {
+    root_type: String,
+    definitions: HashMap<String, Ros1Definition>,
+}
+
+#[derive(Debug, Clone)]
+struct Ros1Definition {
+    package: String,
+    fields: Vec<Ros1Field>,
+}
+
+#[derive(Debug, Clone)]
+struct Ros1Field {
+    field_type: Ros1FieldType,
+    name: String,
+}
+
+#[derive(Debug, Clone)]
+struct Ros1FieldType {
+    base: String,
+    array: Option<Option<usize>>,
+}
+
+impl Ros1MessageDef {
+    fn parse(root_type: &str, data: &[u8]) -> Result<Self> {
+        let schema = std::str::from_utf8(data).context("schema data is not utf8")?;
+        let mut definitions = HashMap::<String, Ros1Definition>::new();
+        let mut current_type = root_type.to_string();
+        definitions.insert(current_type.clone(), Ros1Definition::new(&current_type));
+
+        for line in schema.lines() {
+            let line = line.trim();
+            if line.starts_with("MSG:") {
+                current_type =
+                    normalize_ros1_type(line.trim_start_matches("MSG:").trim(), root_type);
+                definitions
+                    .entry(current_type.clone())
+                    .or_insert_with(|| Ros1Definition::new(&current_type));
+                continue;
+            }
+            if line.starts_with('=') {
+                continue;
+            }
+            let Some(field) = parse_ros1_field(line) else {
+                continue;
+            };
+            definitions
+                .entry(current_type.clone())
+                .or_insert_with(|| Ros1Definition::new(&current_type))
+                .fields
+                .push(field);
+        }
+
+        Ok(Self {
+            root_type: root_type.to_string(),
+            definitions,
+        })
+    }
+
+    fn transcode(&self, data: &[u8]) -> Result<Vec<u8>> {
+        let mut cursor = 0usize;
+        let mut out = Vec::new();
+        self.write_message(&mut out, &self.root_type, data, &mut cursor)?;
+        if cursor > data.len() {
+            bail!("ROS1 decoder read past end of message");
+        }
+        Ok(out)
+    }
+
+    fn write_message(
+        &self,
+        out: &mut Vec<u8>,
+        type_name: &str,
+        data: &[u8],
+        cursor: &mut usize,
+    ) -> Result<()> {
+        let definition = self
+            .definitions
+            .get(type_name)
+            .ok_or_else(|| anyhow::anyhow!("unknown ROS1 message type {type_name}"))?;
+        out.push(b'{');
+        for (index, field) in definition.fields.iter().enumerate() {
+            if index > 0 {
+                out.push(b',');
+            }
+            serde_json::to_writer(&mut *out, &field.name)?;
+            out.push(b':');
+            self.write_value(out, &definition.package, &field.field_type, data, cursor)?;
+        }
+        out.push(b'}');
+        Ok(())
+    }
+
+    fn write_value(
+        &self,
+        out: &mut Vec<u8>,
+        package: &str,
+        field_type: &Ros1FieldType,
+        data: &[u8],
+        cursor: &mut usize,
+    ) -> Result<()> {
+        if let Some(array_len) = field_type.array {
+            let len = match array_len {
+                Some(len) => len,
+                None => read_u32(data, cursor)? as usize,
+            };
+            out.push(b'[');
+            for index in 0..len {
+                if index > 0 {
+                    out.push(b',');
+                }
+                self.write_single_value(out, package, &field_type.base, data, cursor)?;
+            }
+            out.push(b']');
+            return Ok(());
+        }
+
+        self.write_single_value(out, package, &field_type.base, data, cursor)
+    }
+
+    fn write_single_value(
+        &self,
+        out: &mut Vec<u8>,
+        package: &str,
+        base_type: &str,
+        data: &[u8],
+        cursor: &mut usize,
+    ) -> Result<()> {
+        match base_type {
+            "bool" => out.extend_from_slice(if read_u8(data, cursor)? == 0 {
+                b"false"
+            } else {
+                b"true"
+            }),
+            "int8" | "byte" => write!(out, "{}", read_i8(data, cursor)?)?,
+            "uint8" | "char" => write!(out, "{}", read_u8(data, cursor)?)?,
+            "int16" => write!(out, "{}", read_i16(data, cursor)?)?,
+            "uint16" => write!(out, "{}", read_u16(data, cursor)?)?,
+            "int32" => write!(out, "{}", read_i32(data, cursor)?)?,
+            "uint32" => write!(out, "{}", read_u32(data, cursor)?)?,
+            "int64" => write!(out, "{}", read_i64(data, cursor)?)?,
+            "uint64" => write!(out, "{}", read_u64(data, cursor)?)?,
+            "float32" => serde_json::to_writer(&mut *out, &read_f32(data, cursor)?)?,
+            "float64" => serde_json::to_writer(&mut *out, &read_f64(data, cursor)?)?,
+            "string" => {
+                let len = read_u32(data, cursor)? as usize;
+                let bytes = read_exact(data, cursor, len)?;
+                let value = String::from_utf8_lossy(bytes);
+                serde_json::to_writer(&mut *out, value.as_ref())?;
+            }
+            "time" => {
+                let sec = read_u32(data, cursor)? as u64;
+                let nsec = read_u32(data, cursor)? as u64;
+                write!(out, "{sec}.{nsec:09}")?;
+            }
+            "duration" => {
+                let sec = read_i32(data, cursor)?;
+                let nsec = read_i32(data, cursor)?;
+                if sec < 0 || nsec < 0 {
+                    write!(
+                        out,
+                        "-{}.{:09}",
+                        sec.saturating_abs(),
+                        nsec.saturating_abs()
+                    )?;
+                } else {
+                    write!(out, "{sec}.{nsec:09}")?;
+                }
+            }
+            nested_type => {
+                let resolved = resolve_ros1_type(package, nested_type);
+                self.write_message(out, &resolved, data, cursor)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Ros1Definition {
+    fn new(type_name: &str) -> Self {
+        let package = type_name
+            .split_once('/')
+            .map(|(package, _)| package.to_string())
+            .unwrap_or_default();
+        Self {
+            package,
+            fields: Vec::new(),
+        }
+    }
+}
+
+fn normalize_ros1_type(type_name: &str, root_type: &str) -> String {
+    if type_name.contains('/') {
+        type_name.to_string()
+    } else {
+        resolve_ros1_type(
+            root_type
+                .split_once('/')
+                .map(|(package, _)| package)
+                .unwrap_or(""),
+            type_name,
+        )
+    }
+}
+
+fn resolve_ros1_type(package: &str, type_name: &str) -> String {
+    if type_name.contains('/') {
+        type_name.to_string()
+    } else if type_name == "Header" {
+        "std_msgs/Header".to_string()
+    } else {
+        format!("{package}/{type_name}")
+    }
+}
+
+fn parse_ros1_field(line: &str) -> Option<Ros1Field> {
+    let line = line
+        .split_once('#')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(line)
+        .trim();
+    if line.is_empty() || line.contains('=') {
+        return None;
+    }
+    let mut parts = line.split_whitespace();
+    let type_token = parts.next()?;
+    let name = parts.next()?.to_string();
+    Some(Ros1Field {
+        field_type: parse_ros1_field_type(type_token),
+        name,
+    })
+}
+
+fn parse_ros1_field_type(type_token: &str) -> Ros1FieldType {
+    let type_token = type_token
+        .split_once("<=")
+        .map(|(base, _)| base)
+        .unwrap_or(type_token);
+    if let Some(array_start) = type_token.find('[') {
+        let base = type_token[..array_start].to_string();
+        let array_suffix = &type_token[array_start + 1..type_token.len().saturating_sub(1)];
+        let array = if array_suffix.is_empty() {
+            Some(None)
+        } else {
+            Some(array_suffix.parse::<usize>().ok())
+        };
+        Ros1FieldType { base, array }
+    } else {
+        Ros1FieldType {
+            base: type_token.to_string(),
+            array: None,
+        }
+    }
+}
+
+fn read_exact<'a>(data: &'a [u8], cursor: &mut usize, len: usize) -> Result<&'a [u8]> {
+    let end = cursor
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("ROS1 cursor overflow"))?;
+    let slice = data
+        .get(*cursor..end)
+        .ok_or_else(|| anyhow::anyhow!("ROS1 message ended unexpectedly"))?;
+    *cursor = end;
+    Ok(slice)
+}
+
+fn read_u8(data: &[u8], cursor: &mut usize) -> Result<u8> {
+    Ok(read_exact(data, cursor, 1)?[0])
+}
+
+fn read_i8(data: &[u8], cursor: &mut usize) -> Result<i8> {
+    Ok(read_u8(data, cursor)? as i8)
+}
+
+fn read_u16(data: &[u8], cursor: &mut usize) -> Result<u16> {
+    Ok(u16::from_le_bytes(read_exact(data, cursor, 2)?.try_into()?))
+}
+
+fn read_i16(data: &[u8], cursor: &mut usize) -> Result<i16> {
+    Ok(i16::from_le_bytes(read_exact(data, cursor, 2)?.try_into()?))
+}
+
+fn read_u32(data: &[u8], cursor: &mut usize) -> Result<u32> {
+    Ok(u32::from_le_bytes(read_exact(data, cursor, 4)?.try_into()?))
+}
+
+fn read_i32(data: &[u8], cursor: &mut usize) -> Result<i32> {
+    Ok(i32::from_le_bytes(read_exact(data, cursor, 4)?.try_into()?))
+}
+
+fn read_u64(data: &[u8], cursor: &mut usize) -> Result<u64> {
+    Ok(u64::from_le_bytes(read_exact(data, cursor, 8)?.try_into()?))
+}
+
+fn read_i64(data: &[u8], cursor: &mut usize) -> Result<i64> {
+    Ok(i64::from_le_bytes(read_exact(data, cursor, 8)?.try_into()?))
+}
+
+fn read_f32(data: &[u8], cursor: &mut usize) -> Result<f32> {
+    Ok(f32::from_le_bytes(read_exact(data, cursor, 4)?.try_into()?))
+}
+
+fn read_f64(data: &[u8], cursor: &mut usize) -> Result<f64> {
+    Ok(f64::from_le_bytes(read_exact(data, cursor, 8)?.try_into()?))
+}
+
 fn write_payload_preview(
     writer: &mut impl std::io::Write,
     data: &[u8],
@@ -180,7 +756,7 @@ fn write_payload_preview(
 mod tests {
     use std::{borrow::Cow, collections::BTreeMap, io::Cursor, sync::Arc};
 
-    use super::{cat_mcap, write_payload_preview};
+    use super::{cat_mcap, write_payload_preview, CatOptions, JsonTranscoders, Ros1MessageDef};
 
     fn sample_message(schema_name: Option<&str>, data: Vec<u8>) -> mcap::Message<'static> {
         let schema = schema_name.map(|name| {
@@ -328,6 +904,44 @@ mod tests {
         cursor.into_inner()
     }
 
+    fn build_multi_topic_mcap() -> Vec<u8> {
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .chunk_size(Some(1024))
+                .create(&mut cursor)
+                .expect("writer");
+            let schema_id = writer
+                .add_schema("Example", "jsonschema", br#"{"type":"object"}"#)
+                .expect("schema");
+            let camera_id = writer
+                .add_channel(schema_id, "/camera", "json", &BTreeMap::new())
+                .expect("camera channel");
+            let radar_id = writer
+                .add_channel(schema_id, "/radar", "json", &BTreeMap::new())
+                .expect("radar channel");
+            for (sequence, channel_id, log_time, data) in [
+                (1, camera_id, 10, br#"{"camera":1}"#.as_slice()),
+                (2, radar_id, 20, br#"{"radar":1}"#.as_slice()),
+                (3, camera_id, 30, br#"{"camera":2}"#.as_slice()),
+            ] {
+                writer
+                    .write_to_known_channel(
+                        &mcap::records::MessageHeader {
+                            channel_id,
+                            sequence,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        data,
+                    )
+                    .expect("write message");
+            }
+            writer.finish().expect("finish");
+        }
+        cursor.into_inner()
+    }
+
     #[test]
     fn payload_preview_includes_full_message_when_short() {
         assert_eq!(payload_preview_string(&[1, 2, 3], 10), "[1 2 3]");
@@ -364,7 +978,8 @@ mod tests {
     fn cat_prefers_log_time_order_when_index_available() {
         let mcap = build_out_of_order_chunked_mcap();
         let mut out = Vec::new();
-        let broken_pipe = cat_mcap(&mut out, &mcap).expect("cat should succeed");
+        let broken_pipe =
+            cat_mcap(&mut out, &mcap, &CatOptions::default()).expect("cat should succeed");
         assert!(!broken_pipe);
 
         let output = String::from_utf8(out).expect("valid utf8 output");
@@ -379,7 +994,8 @@ mod tests {
     fn cat_falls_back_to_linear_order_without_index() {
         let mcap = build_out_of_order_linear_mcap_without_summary();
         let mut out = Vec::new();
-        let broken_pipe = cat_mcap(&mut out, &mcap).expect("cat should succeed");
+        let broken_pipe =
+            cat_mcap(&mut out, &mcap, &CatOptions::default()).expect("cat should succeed");
         assert!(!broken_pipe);
 
         let output = String::from_utf8(out).expect("valid utf8 output");
@@ -387,6 +1003,83 @@ mod tests {
         assert_eq!(
             lines,
             vec!["30 /demo [Example] [1]", "10 /demo [Example] [2]"]
+        );
+    }
+
+    #[test]
+    fn cat_applies_topic_and_time_filters() {
+        let mcap = build_multi_topic_mcap();
+        let opts = CatOptions {
+            topics: vec!["/camera".to_string()],
+            start: 20,
+            end: None,
+            json: false,
+        };
+        let mut out = Vec::new();
+        let broken_pipe = cat_mcap(&mut out, &mcap, &opts).expect("cat should succeed");
+        assert!(!broken_pipe);
+
+        let output = String::from_utf8(out).expect("valid utf8 output");
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(
+            lines,
+            vec![r#"30 /camera [Example] [123 34 99 97 109 101 114 97 34 58]..."#]
+        );
+    }
+
+    #[test]
+    fn cat_json_wraps_jsonschema_messages() {
+        let message = sample_message(Some("Example"), br#"{"value":1}"#.to_vec());
+        let mut out = Vec::new();
+        let mut transcoders = JsonTranscoders::default();
+        let opts = CatOptions {
+            json: true,
+            ..CatOptions::default()
+        };
+        let broken_pipe = super::write_message(
+            &mut out,
+            &message.channel,
+            message.sequence,
+            message.log_time,
+            message.publish_time,
+            message.data.as_ref(),
+            &opts,
+            &mut transcoders,
+        )
+        .expect("json message should write");
+        assert!(!broken_pipe);
+
+        assert_eq!(
+            String::from_utf8(out).expect("valid utf8 output"),
+            r#"{"topic":"/demo","sequence":1,"log_time":0.000000042,"publish_time":0.000000043,"data":{"value":1}}"#
+                .to_string()
+                + "\n"
+        );
+    }
+
+    #[test]
+    fn ros1_transcoder_handles_nested_messages_and_arrays() {
+        let schema = b"Header header\nint32[] values\nstring label\n================================================================================\nMSG: std_msgs/Header\nuint32 seq\ntime stamp\nstring frame_id\n";
+        let transcoder =
+            Ros1MessageDef::parse("demo/Example", schema).expect("schema should parse");
+        let mut data = Vec::new();
+        data.extend_from_slice(&7u32.to_le_bytes());
+        data.extend_from_slice(&1u32.to_le_bytes());
+        data.extend_from_slice(&2u32.to_le_bytes());
+        data.extend_from_slice(&3u32.to_le_bytes());
+        data.extend_from_slice(b"map");
+        data.extend_from_slice(&2u32.to_le_bytes());
+        data.extend_from_slice(&10i32.to_le_bytes());
+        data.extend_from_slice(&20i32.to_le_bytes());
+        data.extend_from_slice(&5u32.to_le_bytes());
+        data.extend_from_slice(b"hello");
+
+        let json = transcoder
+            .transcode(&data)
+            .expect("message should transcode");
+        assert_eq!(
+            String::from_utf8(json).expect("valid utf8"),
+            r#"{"header":{"seq":7,"stamp":1.000000002,"frame_id":"map"},"values":[10,20],"label":"hello"}"#
         );
     }
 }

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -554,9 +554,6 @@ impl Ros1MessageDef {
         let mut cursor = 0usize;
         let mut out = Vec::new();
         self.write_message(&mut out, &self.root_type, data, &mut cursor)?;
-        if cursor > data.len() {
-            bail!("ROS1 decoder read past end of message");
-        }
         Ok(out)
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -633,8 +633,8 @@ impl Ros1MessageDef {
             "uint32" => write!(out, "{}", read_u32(data, cursor)?)?,
             "int64" => write!(out, "{}", read_i64(data, cursor)?)?,
             "uint64" => write!(out, "{}", read_u64(data, cursor)?)?,
-            "float32" => serde_json::to_writer(&mut *out, &read_f32(data, cursor)?)?,
-            "float64" => serde_json::to_writer(&mut *out, &read_f64(data, cursor)?)?,
+            "float32" => write_ros1_float(out, read_f32(data, cursor)? as f64)?,
+            "float64" => write_ros1_float(out, read_f64(data, cursor)?)?,
             "string" => {
                 let len = read_u32(data, cursor)? as usize;
                 let bytes = read_exact(data, cursor, len)?;
@@ -716,21 +716,16 @@ fn parse_ros1_field(line: &str) -> Option<Ros1Field> {
 }
 
 fn parse_ros1_field_type(type_token: &str) -> Ros1FieldType {
-    let type_token = type_token
-        .split_once("<=")
-        .map(|(base, _)| base)
-        .unwrap_or(type_token);
     if let Some(array_start) = type_token.find('[') {
-        let Some(array_suffix) =
-            type_token.get(array_start + 1..type_token.len().saturating_sub(1))
+        let base = strip_bound(&type_token[..array_start]).to_string();
+        let Some(array_end) = type_token[array_start + 1..]
+            .find(']')
+            .map(|relative| array_start + 1 + relative)
         else {
-            return Ros1FieldType {
-                base: type_token.to_string(),
-                array: None,
-            };
+            return Ros1FieldType { base, array: None };
         };
-        let base = type_token[..array_start].to_string();
-        let array = if array_suffix.is_empty() {
+        let array_suffix = &type_token[array_start + 1..array_end];
+        let array = if array_suffix.is_empty() || array_suffix.starts_with("<=") {
             Some(None)
         } else {
             Some(array_suffix.parse::<usize>().ok())
@@ -738,9 +733,30 @@ fn parse_ros1_field_type(type_token: &str) -> Ros1FieldType {
         Ros1FieldType { base, array }
     } else {
         Ros1FieldType {
-            base: type_token.to_string(),
+            base: strip_bound(type_token).to_string(),
             array: None,
         }
+    }
+}
+
+fn strip_bound(type_token: &str) -> &str {
+    type_token
+        .split_once("<=")
+        .map(|(base, _)| base)
+        .unwrap_or(type_token)
+}
+
+fn write_ros1_float(writer: &mut impl std::io::Write, value: f64) -> std::io::Result<()> {
+    if value.is_nan() {
+        writer.write_all(br#""NaN""#)
+    } else if value == f64::INFINITY {
+        writer.write_all(br#""Infinity""#)
+    } else if value == f64::NEG_INFINITY {
+        writer.write_all(br#""-Infinity""#)
+    } else {
+        serde_json::to_writer(writer, &value)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(())
     }
 }
 
@@ -842,7 +858,7 @@ mod tests {
     use std::{borrow::Cow, collections::BTreeMap, io::Cursor, sync::Arc};
 
     use super::{
-        cat_mcap, cat_streaming, parse_ros1_field_type, write_payload_preview,
+        cat_mcap, cat_streaming, parse_ros1_field_type, write_payload_preview, write_ros1_float,
         write_signed_decimal_time, CatOptions, JsonTranscoders, Ros1MessageDef,
     };
 
@@ -1237,7 +1253,39 @@ mod tests {
     #[test]
     fn malformed_ros1_array_type_does_not_panic() {
         let field_type = parse_ros1_field_type("int32[");
-        assert_eq!(field_type.base, "int32[");
+        assert_eq!(field_type.base, "int32");
         assert!(field_type.array.is_none());
+    }
+
+    #[test]
+    fn bounded_ros1_array_type_is_variable_length_array() {
+        let field_type = parse_ros1_field_type("int32[<=10]");
+        assert_eq!(field_type.base, "int32");
+        assert_eq!(field_type.array, Some(None));
+    }
+
+    #[test]
+    fn bounded_ros1_scalar_type_strips_bound() {
+        let field_type = parse_ros1_field_type("string<=10");
+        assert_eq!(field_type.base, "string");
+        assert!(field_type.array.is_none());
+    }
+
+    #[test]
+    fn ros1_float_special_values_match_protojson_strings() {
+        let mut out = Vec::new();
+        write_ros1_float(&mut out, f64::NAN).expect("nan should write");
+        assert_eq!(String::from_utf8(out).expect("valid utf8"), r#""NaN""#);
+
+        let mut out = Vec::new();
+        write_ros1_float(&mut out, f64::INFINITY).expect("infinity should write");
+        assert_eq!(String::from_utf8(out).expect("valid utf8"), r#""Infinity""#);
+
+        let mut out = Vec::new();
+        write_ros1_float(&mut out, f64::NEG_INFINITY).expect("negative infinity should write");
+        assert_eq!(
+            String::from_utf8(out).expect("valid utf8"),
+            r#""-Infinity""#
+        );
     }
 }

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -194,9 +194,7 @@ fn cat_streaming(
     mut source: impl std::io::Read,
     opts: &CatOptions,
 ) -> Result<bool> {
-    let mut reader = mcap::sans_io::LinearReader::new_with_options(
-        mcap::sans_io::LinearReaderOptions::default().with_validate_chunk_crcs(true),
-    );
+    let mut reader = mcap::sans_io::LinearReader::new();
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap};
-use std::io::{IsTerminal as _, Read as _, Write as _};
+use std::io::{self, IsTerminal as _, Write as _};
+use std::sync::Arc;
 
 use anyhow::{bail, Context as _, Result};
 use mcap::sans_io::indexed_reader::ReadOrder;
@@ -22,12 +23,7 @@ pub fn run(_ctx: &CommandContext, args: CatCommand) -> Result<()> {
         if stdin.is_terminal() {
             bail!("supply a file");
         }
-        let mut input = Vec::new();
-        stdin
-            .lock()
-            .read_to_end(&mut input)
-            .context("failed to read input from stdin")?;
-        if cat_mcap(&mut writer, &input, &opts)? {
+        if cat_streaming(&mut writer, stdin.lock(), &opts)? {
             return Ok(());
         }
     } else {
@@ -193,17 +189,144 @@ fn cat_linear(
     Ok(false)
 }
 
-struct CatMessage<'a> {
-    channel: &'a mcap::Channel<'a>,
+fn cat_streaming(
+    writer: &mut impl std::io::Write,
+    mut source: impl std::io::Read,
+    opts: &CatOptions,
+) -> Result<bool> {
+    let mut reader = mcap::sans_io::LinearReader::new_with_options(
+        mcap::sans_io::LinearReaderOptions::default().with_validate_chunk_crcs(true),
+    );
+    let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
+    let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
+    let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
+    let mut json_transcoders = JsonTranscoders::default();
+
+    while let Some(event) = reader.next_event() {
+        match event? {
+            mcap::sans_io::LinearReadEvent::ReadRequest(need) => {
+                let read = source
+                    .read(reader.insert(need))
+                    .context("failed to read input from stdin")?;
+                reader.notify_read(read);
+            }
+            mcap::sans_io::LinearReadEvent::Record { data, opcode } => {
+                let record = mcap::parse_record(opcode, data)?;
+                if handle_linear_record(
+                    writer,
+                    record,
+                    opts,
+                    &mut schemas,
+                    &mut channel_defs,
+                    &mut channels,
+                    &mut json_transcoders,
+                )? {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn handle_linear_record(
+    writer: &mut impl std::io::Write,
+    record: mcap::records::Record<'_>,
+    opts: &CatOptions,
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
+    channels: &mut HashMap<u16, Arc<mcap::Channel<'static>>>,
+    json_transcoders: &mut JsonTranscoders,
+) -> Result<bool> {
+    match record {
+        mcap::records::Record::Schema { header, data } => {
+            let schema = Arc::new(mcap::Schema {
+                id: header.id,
+                name: header.name,
+                encoding: header.encoding,
+                data: Cow::Owned(data.into_owned()),
+            });
+            schemas.insert(schema.id, schema);
+        }
+        mcap::records::Record::Channel(channel) => {
+            if channel.schema_id == 0 || schemas.contains_key(&channel.schema_id) {
+                let resolved = build_channel(&channel, schemas)?;
+                channels.insert(channel.id, resolved);
+            }
+            channel_defs.insert(channel.id, channel);
+        }
+        mcap::records::Record::Message { header, data } => {
+            if !opts.include_time(header.log_time) {
+                return Ok(false);
+            }
+
+            let channel = if let Some(channel) = channels.get(&header.channel_id) {
+                channel.clone()
+            } else {
+                let Some(channel_def) = channel_defs.get(&header.channel_id) else {
+                    bail!("message references unknown channel {}", header.channel_id);
+                };
+                let resolved = build_channel(channel_def, schemas)?;
+                channels.insert(header.channel_id, resolved.clone());
+                resolved
+            };
+
+            if !opts.include_topic(&channel.topic) {
+                return Ok(false);
+            }
+
+            let message = CatMessage {
+                channel: &channel,
+                sequence: header.sequence,
+                log_time: header.log_time,
+                publish_time: header.publish_time,
+                data: data.as_ref(),
+            };
+            return write_message(writer, message, opts, json_transcoders);
+        }
+        _ => {}
+    }
+
+    Ok(false)
+}
+
+fn build_channel(
+    channel: &mcap::records::Channel,
+    schemas: &HashMap<u16, Arc<mcap::Schema<'static>>>,
+) -> Result<Arc<mcap::Channel<'static>>> {
+    let schema = if channel.schema_id == 0 {
+        None
+    } else {
+        Some(schemas.get(&channel.schema_id).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "encountered channel with topic {} with unknown schema ID {}",
+                channel.topic,
+                channel.schema_id
+            )
+        })?)
+    };
+
+    Ok(Arc::new(mcap::Channel {
+        id: channel.id,
+        topic: channel.topic.clone(),
+        schema,
+        message_encoding: channel.message_encoding.clone(),
+        metadata: channel.metadata.clone(),
+    }))
+}
+
+struct CatMessage<'a, 'schema, 'data> {
+    channel: &'a mcap::Channel<'schema>,
     sequence: u32,
     log_time: u64,
     publish_time: u64,
-    data: &'a [u8],
+    data: &'data [u8],
 }
 
 fn write_message(
     writer: &mut impl std::io::Write,
-    message: CatMessage<'_>,
+    message: CatMessage<'_, '_, '_>,
     opts: &CatOptions,
     json_transcoders: &mut JsonTranscoders,
 ) -> Result<bool> {
@@ -243,34 +366,13 @@ fn write_message_fields(
     data: &[u8],
     max_preview_bytes: usize,
 ) -> Result<bool> {
-    if let Err(err) = common::write_raw_time(writer, log_time) {
-        if err.kind() == std::io::ErrorKind::BrokenPipe {
-            return Ok(true);
-        }
-        return Err(err.into());
-    }
-    if let Err(err) = write!(writer, " {} [{}] ", topic, schema_name) {
-        if err.kind() == std::io::ErrorKind::BrokenPipe {
-            return Ok(true);
-        }
-        return Err(err.into());
-    }
-
-    if let Err(err) = write_payload_preview(writer, data, max_preview_bytes) {
-        if err.kind() == std::io::ErrorKind::BrokenPipe {
-            return Ok(true);
-        }
-        return Err(err.into());
-    }
-
-    if let Err(err) = writeln!(writer) {
-        if err.kind() == std::io::ErrorKind::BrokenPipe {
-            return Ok(true);
-        }
-        return Err(err.into());
-    }
-
-    Ok(false)
+    let result: io::Result<()> = (|| {
+        common::write_raw_time(writer, log_time)?;
+        write!(writer, " {} [{}] ", topic, schema_name)?;
+        write_payload_preview(writer, data, max_preview_bytes)?;
+        writeln!(writer)
+    })();
+    io_result_to_broken_pipe(result)
 }
 
 fn write_json_message(
@@ -283,54 +385,35 @@ fn write_json_message(
     json_transcoders: &mut JsonTranscoders,
 ) -> Result<bool> {
     let encoded_data = json_transcoders.encode(channel, data)?;
+    // Unlike the Go CLI's current manual string concatenation, escaping here keeps
+    // JSON valid for topics containing quotes or backslashes.
     let topic = serde_json::to_string(&channel.topic).context("failed to encode topic")?;
-    if let Err(err) = write!(
-        writer,
-        "{{\"topic\":{topic},\"sequence\":{sequence},\"log_time\":"
-    ) {
-        return maybe_broken_pipe(err);
-    }
-    if let Err(err) = write_decimal_time(writer, log_time) {
-        return maybe_broken_pipe(err);
-    }
-    if let Err(err) = write!(writer, ",\"publish_time\":") {
-        return maybe_broken_pipe(err);
-    }
-    if let Err(err) = write_decimal_time(writer, publish_time) {
-        return maybe_broken_pipe(err);
-    }
-    if let Err(err) = writer.write_all(b",\"data\":") {
-        return maybe_broken_pipe(err);
-    }
-    if let Err(err) = writer.write_all(encoded_data.as_ref()) {
-        return maybe_broken_pipe(err);
-    }
-    if let Err(err) = writer.write_all(b"}\n") {
-        return maybe_broken_pipe(err);
-    }
-    Ok(false)
+    let result: io::Result<()> = (|| {
+        write!(
+            writer,
+            "{{\"topic\":{topic},\"sequence\":{sequence},\"log_time\":"
+        )?;
+        writer.write_all(common::decimal_time(log_time).as_bytes())?;
+        write!(writer, ",\"publish_time\":")?;
+        writer.write_all(common::decimal_time(publish_time).as_bytes())?;
+        writer.write_all(b",\"data\":")?;
+        writer.write_all(encoded_data.as_ref())?;
+        writer.write_all(b"}\n")
+    })();
+    io_result_to_broken_pipe(result)
 }
 
-fn write_decimal_time(writer: &mut impl std::io::Write, time: u64) -> std::io::Result<()> {
-    write!(
-        writer,
-        "{}.{:09}",
-        time / 1_000_000_000,
-        time % 1_000_000_000
-    )
-}
-
-fn maybe_broken_pipe(err: std::io::Error) -> Result<bool> {
-    if err.kind() == std::io::ErrorKind::BrokenPipe {
-        Ok(true)
-    } else {
-        Err(err.into())
+fn io_result_to_broken_pipe(result: io::Result<()>) -> Result<bool> {
+    match result {
+        Ok(()) => Ok(false),
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(true),
+        Err(err) => Err(err.into()),
     }
 }
 
 fn flush_or_ignore_broken_pipe(writer: &mut impl std::io::Write) -> Result<()> {
     if let Err(err) = writer.flush() {
-        if err.kind() == std::io::ErrorKind::BrokenPipe {
+        if err.kind() == io::ErrorKind::BrokenPipe {
             return Ok(());
         }
         return Err(err.into());
@@ -568,16 +651,7 @@ impl Ros1MessageDef {
             "duration" => {
                 let sec = read_i32(data, cursor)?;
                 let nsec = read_i32(data, cursor)?;
-                if sec < 0 || nsec < 0 {
-                    write!(
-                        out,
-                        "-{}.{:09}",
-                        sec.saturating_abs(),
-                        nsec.saturating_abs()
-                    )?;
-                } else {
-                    write!(out, "{sec}.{nsec:09}")?;
-                }
+                write_signed_decimal_time(out, sec, nsec)?;
             }
             nested_type => {
                 let resolved = resolve_ros1_type(package, nested_type);
@@ -649,8 +723,15 @@ fn parse_ros1_field_type(type_token: &str) -> Ros1FieldType {
         .map(|(base, _)| base)
         .unwrap_or(type_token);
     if let Some(array_start) = type_token.find('[') {
+        let Some(array_suffix) =
+            type_token.get(array_start + 1..type_token.len().saturating_sub(1))
+        else {
+            return Ros1FieldType {
+                base: type_token.to_string(),
+                array: None,
+            };
+        };
         let base = type_token[..array_start].to_string();
-        let array_suffix = &type_token[array_start + 1..type_token.len().saturating_sub(1)];
         let array = if array_suffix.is_empty() {
             Some(None)
         } else {
@@ -663,6 +744,22 @@ fn parse_ros1_field_type(type_token: &str) -> Ros1FieldType {
             array: None,
         }
     }
+}
+
+fn write_signed_decimal_time(
+    writer: &mut impl std::io::Write,
+    seconds: i32,
+    nanos: i32,
+) -> std::io::Result<()> {
+    let total_nanos = seconds as i128 * 1_000_000_000i128 + nanos as i128;
+    let sign = if total_nanos < 0 { "-" } else { "" };
+    let abs = total_nanos.abs();
+    write!(
+        writer,
+        "{sign}{}.{:09}",
+        abs / 1_000_000_000,
+        abs % 1_000_000_000
+    )
 }
 
 fn read_exact<'a>(data: &'a [u8], cursor: &mut usize, len: usize) -> Result<&'a [u8]> {
@@ -746,7 +843,10 @@ fn write_payload_preview(
 mod tests {
     use std::{borrow::Cow, collections::BTreeMap, io::Cursor, sync::Arc};
 
-    use super::{cat_mcap, write_payload_preview, CatOptions, JsonTranscoders, Ros1MessageDef};
+    use super::{
+        cat_mcap, cat_streaming, parse_ros1_field_type, write_payload_preview,
+        write_signed_decimal_time, CatOptions, JsonTranscoders, Ros1MessageDef,
+    };
 
     fn sample_message(schema_name: Option<&str>, data: Vec<u8>) -> mcap::Message<'static> {
         let schema = schema_name.map(|name| {
@@ -1018,6 +1118,26 @@ mod tests {
     }
 
     #[test]
+    fn cat_streaming_reads_without_buffering_full_input() {
+        let mcap = build_multi_topic_mcap();
+        let opts = CatOptions {
+            topics: vec!["/radar".to_string()],
+            ..CatOptions::default()
+        };
+        let mut out = Vec::new();
+        let broken_pipe = cat_streaming(&mut out, Cursor::new(mcap), &opts)
+            .expect("streaming cat should succeed");
+        assert!(!broken_pipe);
+
+        let output = String::from_utf8(out).expect("valid utf8 output");
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(
+            lines,
+            vec![r#"20 /radar [Example] [123 34 114 97 100 97 114 34 58 49]..."#]
+        );
+    }
+
+    #[test]
     fn cat_json_wraps_jsonschema_messages() {
         let message = sample_message(Some("Example"), br#"{"value":1}"#.to_vec());
         let mut out = Vec::new();
@@ -1046,6 +1166,40 @@ mod tests {
     }
 
     #[test]
+    fn protobuf_json_uses_lower_camel_case_and_omits_zero_values() {
+        let descriptor = vec![
+            10, 122, 10, 12, 115, 97, 109, 112, 108, 101, 46, 112, 114, 111, 116, 111, 18, 4, 116,
+            101, 115, 116, 34, 92, 10, 6, 83, 97, 109, 112, 108, 101, 18, 29, 10, 10, 115, 110, 97,
+            107, 101, 95, 99, 97, 115, 101, 24, 1, 32, 1, 40, 9, 82, 9, 115, 110, 97, 107, 101, 67,
+            97, 115, 101, 18, 29, 10, 10, 122, 101, 114, 111, 95, 118, 97, 108, 117, 101, 24, 2,
+            32, 1, 40, 13, 82, 9, 122, 101, 114, 111, 86, 97, 108, 117, 101, 18, 20, 10, 5, 99,
+            111, 117, 110, 116, 24, 3, 32, 1, 40, 13, 82, 5, 99, 111, 117, 110, 116, 98, 6, 112,
+            114, 111, 116, 111, 51,
+        ];
+        let schema = Arc::new(mcap::Schema {
+            id: 1,
+            name: "test.Sample".to_string(),
+            encoding: "protobuf".to_string(),
+            data: Cow::Owned(descriptor),
+        });
+        let channel = Arc::new(mcap::Channel {
+            id: 1,
+            topic: "proto".to_string(),
+            schema: Some(schema),
+            message_encoding: "protobuf".to_string(),
+            metadata: BTreeMap::new(),
+        });
+        let mut transcoders = JsonTranscoders::default();
+        let encoded = transcoders
+            .encode(&channel, &[10, 5, b'h', b'e', b'l', b'l', b'o', 24, 7])
+            .expect("protobuf should encode");
+        assert_eq!(
+            String::from_utf8(encoded.into_owned()).expect("valid utf8"),
+            r#"{"snakeCase":"hello","count":7}"#
+        );
+    }
+
+    #[test]
     fn ros1_transcoder_handles_nested_messages_and_arrays() {
         let schema = b"Header header\nint32[] values\nstring label\n================================================================================\nMSG: std_msgs/Header\nuint32 seq\ntime stamp\nstring frame_id\n";
         let transcoder =
@@ -1069,5 +1223,23 @@ mod tests {
             String::from_utf8(json).expect("valid utf8"),
             r#"{"header":{"seq":7,"stamp":1.000000002,"frame_id":"map"},"values":[10,20],"label":"hello"}"#
         );
+    }
+
+    #[test]
+    fn ros1_duration_formats_signed_total_nanoseconds() {
+        let mut out = Vec::new();
+        write_signed_decimal_time(&mut out, 5, -100).expect("duration should format");
+        assert_eq!(String::from_utf8(out).expect("valid utf8"), "4.999999900");
+
+        let mut out = Vec::new();
+        write_signed_decimal_time(&mut out, -5, 100).expect("duration should format");
+        assert_eq!(String::from_utf8(out).expect("valid utf8"), "-4.999999900");
+    }
+
+    #[test]
+    fn malformed_ros1_array_type_does_not_panic() {
+        let field_type = parse_ros1_field_type("int32[");
+        assert_eq!(field_type.base, "int32[");
+        assert!(field_type.array.is_none());
     }
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -72,13 +72,60 @@ mod tests {
             args.command,
             Command::Cat(CatCommand {
                 files: vec!["a.mcap".into(), "b.mcap".into()],
+                topics: String::new(),
+                start_secs: 0,
+                start_nsecs: 0,
+                end_secs: 0,
+                end_nsecs: 0,
+                json: false,
             })
         );
     }
 
     #[test]
-    fn cat_requires_at_least_one_file() {
-        Args::try_parse_from(["mcap", "cat"]).expect_err("cat requires at least one file");
+    fn parses_cat_without_files_for_stdin() {
+        let args = Args::try_parse_from(["mcap", "cat"]).expect("cat should parse");
+        assert_eq!(
+            args.command,
+            Command::Cat(CatCommand {
+                files: Vec::new(),
+                topics: String::new(),
+                start_secs: 0,
+                start_nsecs: 0,
+                end_secs: 0,
+                end_nsecs: 0,
+                json: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_cat_subcommand_with_flags() {
+        let args = Args::try_parse_from([
+            "mcap",
+            "cat",
+            "demo.mcap",
+            "--topics",
+            "/tf,/odom",
+            "--start-secs",
+            "10",
+            "--end-nsecs",
+            "20000000000",
+            "--json",
+        ])
+        .expect("cat should parse");
+        assert_eq!(
+            args.command,
+            Command::Cat(CatCommand {
+                files: vec!["demo.mcap".into()],
+                topics: "/tf,/odom".to_string(),
+                start_secs: 10,
+                start_nsecs: 0,
+                end_secs: 0,
+                end_nsecs: 20_000_000_000,
+                json: true,
+            })
+        );
     }
 
     #[test]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -129,6 +129,33 @@ mod tests {
     }
 
     #[test]
+    fn cat_rejects_conflicting_time_units() {
+        let parse_err = Args::try_parse_from([
+            "mcap",
+            "cat",
+            "demo.mcap",
+            "--start-secs",
+            "1",
+            "--start-nsecs",
+            "1",
+        ])
+        .expect_err("start seconds and nanoseconds should conflict");
+        assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        let parse_err = Args::try_parse_from([
+            "mcap",
+            "cat",
+            "demo.mcap",
+            "--end-secs",
+            "1",
+            "--end-nsecs",
+            "1",
+        ])
+        .expect_err("end seconds and nanoseconds should conflict");
+        assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
     fn requires_subcommand() {
         let parse_err = Args::try_parse_from(["mcap"]).expect_err("subcommand is required");
         assert_eq!(

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -11,6 +11,11 @@ const TEN_MESSAGES = "{dataDir}/TenMessages/TenMessages-ch-chx-mx-pad-rch-rsh-st
 const ONE_ATTACHMENT = "{dataDir}/OneAttachment/OneAttachment-ax-st-sum.mcap";
 const ONE_METADATA = "{dataDir}/OneMetadata/OneMetadata-mdx-st-sum.mcap";
 
+/* cspell:disable */
+const PROTOBUF_JSON_MCAP_BASE64 =
+  "iU1DQVAwDQoBCAAAAAAAAAAAAAAAAAAAAAOdAAAAAAAAAAEACwAAAHRlc3QuU2FtcGxlCAAAAHByb3RvYnVmfAAAAAp6CgxzYW1wbGUucHJvdG8SBHRlc3QiXAoGU2FtcGxlEh0KCnNuYWtlX2Nhc2UYASABKAlSCXNuYWtlQ2FzZRIdCgp6ZXJvX3ZhbHVlGAIgASgNUgl6ZXJvVmFsdWUSFAoFY291bnQYAyABKA1SBWNvdW50YgZwcm90bzMEHQAAAAAAAAABAAEABQAAAHByb3RvCAAAAHByb3RvYnVmAAAAAAUfAAAAAAAAAAEAAQAAAAIAAAAAAAAAAQAAAAAAAAAKBWhlbGxvGAcPBAAAAAAAAAAAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACJTUNBUDANCg==";
+/* cspell:enable */
+
 const HELP_PATHS = [
   ["add"],
   ["add", "attachment"],
@@ -165,6 +170,25 @@ export const cases: CliTestCase[] = [
       exitCode: "same",
       stdout: { kind: "text" },
       stderr: { kind: "ignore" },
+    },
+  },
+  {
+    id: "cat-json-protobuf-stdin",
+    description:
+      "Cat --json protobuf output matches Go field casing and zero-value omission for stdin input.",
+    tags: ["cat", "json", "protobuf", "stdin"],
+    setup: [
+      {
+        type: "writeBase64",
+        to: "{caseWorkDir}/protobuf.mcap",
+        contents: PROTOBUF_JSON_MCAP_BASE64,
+      },
+    ],
+    invocation: { args: ["cat", "--json"], stdin: { path: "{caseWorkDir}/protobuf.mcap" } },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "json" },
+      stderr: { kind: "text" },
     },
   },
   {

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -112,7 +112,7 @@ export const cases: CliTestCase[] = [
     },
   },
   {
-    id: "cat-topic-filter-excludes-nonmatching-topic",
+    id: "cat-topic-filter-excludes-missing-topic",
     description: "Cat topic filtering emits no messages when no requested topic matches.",
     tags: ["cat", "stdout", "topics"],
     invocation: { args: ["cat", ONE_MESSAGE, "--topics", "missing"] },

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -11,6 +11,13 @@ const TEN_MESSAGES = "{dataDir}/TenMessages/TenMessages-ch-chx-mx-pad-rch-rsh-st
 const ONE_ATTACHMENT = "{dataDir}/OneAttachment/OneAttachment-ax-st-sum.mcap";
 const ONE_METADATA = "{dataDir}/OneMetadata/OneMetadata-mdx-st-sum.mcap";
 
+// Single-message protobuf MCAP fixture for `test.Sample`:
+// message Sample {
+//   string snake_case = 1;
+//   uint32 zero_value = 2;
+//   uint32 count = 3;
+// }
+// Payload sets snake_case="hello", zero_value=0, count=7.
 /* cspell:disable */
 const PROTOBUF_JSON_MCAP_BASE64 =
   "iU1DQVAwDQoBCAAAAAAAAAAAAAAAAAAAAAOdAAAAAAAAAAEACwAAAHRlc3QuU2FtcGxlCAAAAHByb3RvYnVmfAAAAAp6CgxzYW1wbGUucHJvdG8SBHRlc3QiXAoGU2FtcGxlEh0KCnNuYWtlX2Nhc2UYASABKAlSCXNuYWtlQ2FzZRIdCgp6ZXJvX3ZhbHVlGAIgASgNUgl6ZXJvVmFsdWUSFAoFY291bnQYAyABKA1SBWNvdW50YgZwcm90bzMEHQAAAAAAAAABAAEABQAAAHByb3RvCAAAAHByb3RvYnVmAAAAAAUfAAAAAAAAAAEAAQAAAAIAAAAAAAAAAQAAAAAAAAAKBWhlbGxvGAcPBAAAAAAAAAAAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACJTUNBUDANCg==";

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -157,7 +157,8 @@ export const cases: CliTestCase[] = [
   },
   {
     id: "cat-json-unsupported-schema-errors",
-    description: "Cat --json accepts the flag and errors consistently for unsupported schema encodings.",
+    description:
+      "Cat --json accepts the flag and errors consistently for unsupported schema encodings.",
     tags: ["cat", "json"],
     invocation: { args: ["cat", ONE_MESSAGE, "--json"] },
     comparison: {

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -101,6 +101,72 @@ export const cases: CliTestCase[] = [
     },
   },
   {
+    id: "cat-topic-filter-includes-matching-topic",
+    description: "Cat topic filtering includes messages on requested topics.",
+    tags: ["cat", "stdout", "topics"],
+    invocation: { args: ["cat", ONE_MESSAGE, "--topics", "example"] },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "bytes" },
+      stderr: { kind: "text" },
+    },
+  },
+  {
+    id: "cat-topic-filter-excludes-nonmatching-topic",
+    description: "Cat topic filtering emits no messages when no requested topic matches.",
+    tags: ["cat", "stdout", "topics"],
+    invocation: { args: ["cat", ONE_MESSAGE, "--topics", "missing"] },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text" },
+    },
+  },
+  {
+    id: "cat-time-filter-includes-range",
+    description: "Cat time filtering includes messages in the requested nanosecond range.",
+    tags: ["cat", "stdout", "time"],
+    invocation: { args: ["cat", ONE_MESSAGE, "--start-nsecs", "2", "--end-nsecs", "3"] },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "bytes" },
+      stderr: { kind: "text" },
+    },
+  },
+  {
+    id: "cat-time-filter-excludes-out-of-range",
+    description: "Cat time filtering emits no messages outside the requested range.",
+    tags: ["cat", "stdout", "time"],
+    invocation: { args: ["cat", ONE_MESSAGE, "--start-nsecs", "3"] },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text" },
+    },
+  },
+  {
+    id: "cat-stdin-one-message",
+    description: "Cat reads stdin when no file argument is supplied.",
+    tags: ["cat", "stdout", "stdin"],
+    invocation: { args: ["cat"], stdin: { path: ONE_MESSAGE } },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "bytes" },
+      stderr: { kind: "text" },
+    },
+  },
+  {
+    id: "cat-json-unsupported-schema-errors",
+    description: "Cat --json accepts the flag and errors consistently for unsupported schema encodings.",
+    tags: ["cat", "json"],
+    invocation: { args: ["cat", ONE_MESSAGE, "--json"] },
+    comparison: {
+      exitCode: "same",
+      stdout: { kind: "text" },
+      stderr: { kind: "ignore" },
+    },
+  },
+  {
     id: "info-one-message",
     description: "Info output reports the same stable summary fields for a representative MCAP.",
     tags: ["info", "stdout"],
@@ -434,66 +500,6 @@ export const cases: CliTestCase[] = [
       rustBehavior: {
         exitCode: "nonzero",
         stderr: { kind: "contains", value: "unrecognized" },
-      },
-    },
-  },
-  {
-    id: "known-difference-cat-json-flag",
-    description: "Go CLI parses cat --json; Rust CLI does not yet.",
-    tags: ["known-difference", "cat"],
-    invocation: { args: ["cat", ONE_MESSAGE, "--json"] },
-    knownDifference: {
-      id: "cat-json-flag",
-      summary: "Go cat accepts --json while Rust cat currently rejects it.",
-      reason: "The Rust cat command implementation is still partial.",
-      desiredBehavior: "Rust cat should support Go-compatible JSON output before v1.0.",
-      goBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "JSON output only supported" },
-      },
-      rustBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "unexpected argument" },
-      },
-    },
-  },
-  {
-    id: "known-difference-cat-topics-flag",
-    description: "Go CLI supports topic filtering in cat; Rust CLI does not yet.",
-    tags: ["known-difference", "cat"],
-    invocation: { args: ["cat", ONE_MESSAGE, "--topics", "example"] },
-    knownDifference: {
-      id: "cat-topics-flag",
-      summary: "Go cat supports --topics but Rust cat currently rejects it.",
-      reason: "The Rust cat command implementation is still partial.",
-      desiredBehavior: "Rust cat should support Go-compatible topic filtering before v1.0.",
-      goBehavior: {
-        exitCode: 0,
-        stdout: { kind: "contains", value: "example" },
-      },
-      rustBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "unexpected argument" },
-      },
-    },
-  },
-  {
-    id: "known-difference-cat-stdin",
-    description: "Go CLI reads cat input from stdin; Rust CLI currently requires file arguments.",
-    tags: ["known-difference", "cat", "stdin"],
-    invocation: { args: ["cat"], stdin: { path: ONE_MESSAGE } },
-    knownDifference: {
-      id: "cat-stdin",
-      summary: "Go cat reads stdin when no file is supplied but Rust cat requires file arguments.",
-      reason: "The Rust cat command implementation is still partial.",
-      desiredBehavior: "Rust cat should support stdin input before v1.0.",
-      goBehavior: {
-        exitCode: 0,
-        stdout: { kind: "contains", value: "example" },
-      },
-      rustBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "Usage:" },
       },
     },
   },

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -204,6 +204,50 @@ export const cases: CliTestCase[] = [
     },
   },
   {
+    id: "cat-json-ros1msg-stdin",
+    description:
+      "Cat --json emits ROS1 messages as NDJSON with Go-compatible nested message, special float, duration, and array output.",
+    tags: ["cat", "json", "ros1msg", "stdin"],
+    setup: [
+      {
+        type: "writeRos1JsonMcap",
+        to: "{caseWorkDir}/ros1.mcap",
+        messages: [
+          {
+            sequence: 1,
+            logTime: 2,
+            publishTime: 1,
+            headerSeq: 7,
+            stampSec: 1,
+            stampNsec: 2,
+            frameId: "map",
+            durationSec: 4,
+            durationNsec: 5,
+            values: [10, 20],
+          },
+          {
+            sequence: 2,
+            logTime: 3,
+            publishTime: 2,
+            headerSeq: 8,
+            stampSec: 2,
+            stampNsec: 3,
+            frameId: "odom",
+            durationSec: 5,
+            durationNsec: 6,
+            values: [30],
+          },
+        ],
+      },
+    ],
+    invocation: { args: ["cat", "--json"], stdin: { path: "{caseWorkDir}/ros1.mcap" } },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "ndjson" },
+      stderr: { kind: "text" },
+    },
+  },
+  {
     id: "info-one-message",
     description: "Info output reports the same stable summary fields for a representative MCAP.",
     tags: ["info", "stdout"],

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -1,4 +1,4 @@
-/* cspell:words pprof */
+/* cspell:words ndjson pprof */
 
 import type { CliTestCase } from "./types.ts";
 
@@ -10,18 +10,6 @@ const ONE_SCHEMALESS =
 const TEN_MESSAGES = "{dataDir}/TenMessages/TenMessages-ch-chx-mx-pad-rch-rsh-st-sum.mcap";
 const ONE_ATTACHMENT = "{dataDir}/OneAttachment/OneAttachment-ax-st-sum.mcap";
 const ONE_METADATA = "{dataDir}/OneMetadata/OneMetadata-mdx-st-sum.mcap";
-
-// Single-message protobuf MCAP fixture for `test.Sample`:
-// message Sample {
-//   string snake_case = 1;
-//   uint32 zero_value = 2;
-//   uint32 count = 3;
-// }
-// Payload sets snake_case="hello", zero_value=0, count=7.
-/* cspell:disable */
-const PROTOBUF_JSON_MCAP_BASE64 =
-  "iU1DQVAwDQoBCAAAAAAAAAAAAAAAAAAAAAOdAAAAAAAAAAEACwAAAHRlc3QuU2FtcGxlCAAAAHByb3RvYnVmfAAAAAp6CgxzYW1wbGUucHJvdG8SBHRlc3QiXAoGU2FtcGxlEh0KCnNuYWtlX2Nhc2UYASABKAlSCXNuYWtlQ2FzZRIdCgp6ZXJvX3ZhbHVlGAIgASgNUgl6ZXJvVmFsdWUSFAoFY291bnQYAyABKA1SBWNvdW50YgZwcm90bzMEHQAAAAAAAAABAAEABQAAAHByb3RvCAAAAHByb3RvYnVmAAAAAAUfAAAAAAAAAAEAAQAAAAIAAAAAAAAAAQAAAAAAAAAKBWhlbGxvGAcPBAAAAAAAAAAAAAAAAhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACJTUNBUDANCg==";
-/* cspell:enable */
 
 const HELP_PATHS = [
   ["add"],
@@ -182,19 +170,36 @@ export const cases: CliTestCase[] = [
   {
     id: "cat-json-protobuf-stdin",
     description:
-      "Cat --json protobuf output matches Go field casing and zero-value omission for stdin input.",
+      "Cat --json emits protobuf messages as NDJSON with Go-compatible field casing and zero-value omission.",
     tags: ["cat", "json", "protobuf", "stdin"],
     setup: [
       {
-        type: "writeBase64",
+        type: "writeProtobufJsonMcap",
         to: "{caseWorkDir}/protobuf.mcap",
-        contents: PROTOBUF_JSON_MCAP_BASE64,
+        messages: [
+          {
+            sequence: 1,
+            logTime: 2,
+            publishTime: 1,
+            snakeCase: "hello",
+            zeroValue: 0,
+            count: 7,
+          },
+          {
+            sequence: 2,
+            logTime: 3,
+            publishTime: 2,
+            snakeCase: "world",
+            zeroValue: 0,
+            count: 8,
+          },
+        ],
       },
     ],
     invocation: { args: ["cat", "--json"], stdin: { path: "{caseWorkDir}/protobuf.mcap" } },
     comparison: {
       exitCode: 0,
-      stdout: { kind: "json" },
+      stdout: { kind: "ndjson" },
       stderr: { kind: "text" },
     },
   },

--- a/tests/cli-conformance/src/comparators.ts
+++ b/tests/cli-conformance/src/comparators.ts
@@ -1,3 +1,5 @@
+/* cspell:words ndjson */
+
 import * as Diff from "diff";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -171,6 +173,16 @@ async function compareBuffers(
       }
       return expectedJson === actualJson ? [] : [formatPatch(label, expectedJson, actualJson)];
     }
+    case "ndjson": {
+      const expectedJson = parseCanonicalNdjson("go", bufferToUtf8(expected));
+      const actualJson = parseCanonicalNdjson("rust", bufferToUtf8(actual));
+      if (typeof expectedJson !== "string" || typeof actualJson !== "string") {
+        return [expectedJson, actualJson]
+          .filter((result): result is { error: string } => typeof result !== "string")
+          .map((result) => `${label} ${result.error}`);
+      }
+      return expectedJson === actualJson ? [] : [formatPatch(label, expectedJson, actualJson)];
+    }
     case "table": {
       const expectedTable = normalizeTable(bufferToUtf8(expected));
       const actualTable = normalizeTable(bufferToUtf8(actual));
@@ -282,6 +294,29 @@ function parseCanonicalJson(
       }`,
     };
   }
+}
+
+function parseCanonicalNdjson(
+  implementation: "go" | "rust",
+  text: string,
+): string | { error: string } {
+  const lines = text
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const parsedLines = [];
+  for (const [index, line] of lines.entries()) {
+    try {
+      parsedLines.push(JSON.parse(line));
+    } catch (error) {
+      return {
+        error: `${implementation} NDJSON parse failed on line ${index + 1}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+  }
+  return stableStringify(parsedLines);
 }
 
 function normalizeInfo(text: string): string {

--- a/tests/cli-conformance/src/fixtures.ts
+++ b/tests/cli-conformance/src/fixtures.ts
@@ -44,6 +44,12 @@ export async function applyFixtureActions(
         await fs.writeFile(to, Buffer.from(action.bytes));
         break;
       }
+      case "writeBase64": {
+        const to = resolvePlaceholders(action.to, context);
+        await fs.mkdir(path.dirname(to), { recursive: true });
+        await fs.writeFile(to, Buffer.from(action.contents, "base64"));
+        break;
+      }
       case "mkdir": {
         await fs.mkdir(resolvePlaceholders(action.path, context), { recursive: true });
         break;

--- a/tests/cli-conformance/src/fixtures.ts
+++ b/tests/cli-conformance/src/fixtures.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { makeProtobufJsonMcap } from "./protobufJsonFixture.ts";
 import type { FixtureAction, PathContext } from "./types.ts";
 
 const PLACEHOLDER_PATTERN = /\{(repoRoot|dataDir|workDir|caseWorkDir)\}/g;
@@ -44,10 +45,10 @@ export async function applyFixtureActions(
         await fs.writeFile(to, Buffer.from(action.bytes));
         break;
       }
-      case "writeBase64": {
+      case "writeProtobufJsonMcap": {
         const to = resolvePlaceholders(action.to, context);
         await fs.mkdir(path.dirname(to), { recursive: true });
-        await fs.writeFile(to, Buffer.from(action.contents, "base64"));
+        await fs.writeFile(to, makeProtobufJsonMcap(action));
         break;
       }
       case "mkdir": {

--- a/tests/cli-conformance/src/fixtures.ts
+++ b/tests/cli-conformance/src/fixtures.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { makeProtobufJsonMcap } from "./protobufJsonFixture.ts";
+import { makeRos1JsonMcap } from "./ros1JsonFixture.ts";
 import type { FixtureAction, PathContext } from "./types.ts";
 
 const PLACEHOLDER_PATTERN = /\{(repoRoot|dataDir|workDir|caseWorkDir)\}/g;
@@ -49,6 +50,12 @@ export async function applyFixtureActions(
         const to = resolvePlaceholders(action.to, context);
         await fs.mkdir(path.dirname(to), { recursive: true });
         await fs.writeFile(to, makeProtobufJsonMcap(action));
+        break;
+      }
+      case "writeRos1JsonMcap": {
+        const to = resolvePlaceholders(action.to, context);
+        await fs.mkdir(path.dirname(to), { recursive: true });
+        await fs.writeFile(to, makeRos1JsonMcap(action));
         break;
       }
       case "mkdir": {

--- a/tests/cli-conformance/src/mcapFixtureHelpers.ts
+++ b/tests/cli-conformance/src/mcapFixtureHelpers.ts
@@ -1,0 +1,51 @@
+export const MCAP_MAGIC = Buffer.from([0x89, 0x4d, 0x43, 0x41, 0x50, 0x30, 0x0d, 0x0a]);
+
+export function record(opcode: number, body: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([opcode]), uint64(body.length), body]);
+}
+
+export function mcapString(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([uint32(bytes.length), bytes]);
+}
+
+export function prefixedBytes(value: Buffer): Buffer {
+  return Buffer.concat([uint32(value.length), value]);
+}
+
+export function uint16(value: number): Buffer {
+  const out = Buffer.alloc(2);
+  out.writeUInt16LE(value);
+  return out;
+}
+
+export function uint32(value: number): Buffer {
+  const out = Buffer.alloc(4);
+  out.writeUInt32LE(value);
+  return out;
+}
+
+export function int32(value: number): Buffer {
+  const out = Buffer.alloc(4);
+  out.writeInt32LE(value);
+  return out;
+}
+
+export function float32(value: number): Buffer {
+  const out = Buffer.alloc(4);
+  out.writeFloatLE(value);
+  return out;
+}
+
+export function uint64(value: bigint | number): Buffer {
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new Error(`uint64 number value must be a safe integer: ${value.toString()}`);
+  }
+  const integer = typeof value === "bigint" ? value : BigInt(value);
+  if (integer < 0n) {
+    throw new Error(`uint64 value must be non-negative: ${value.toString()}`);
+  }
+  const out = Buffer.alloc(8);
+  out.writeBigUInt64LE(integer);
+  return out;
+}

--- a/tests/cli-conformance/src/protobufJsonFixture.ts
+++ b/tests/cli-conformance/src/protobufJsonFixture.ts
@@ -1,0 +1,154 @@
+/* cspell:words varint */
+
+const MCAP_MAGIC = Buffer.from([0x89, 0x4d, 0x43, 0x41, 0x50, 0x30, 0x0d, 0x0a]);
+
+type ProtobufJsonMessage = {
+  sequence: number;
+  logTime: number;
+  publishTime: number;
+  snakeCase: string;
+  zeroValue?: number;
+  count: number;
+};
+
+export type ProtobufJsonFixtureOptions = {
+  messages: ProtobufJsonMessage[];
+};
+
+export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffer {
+  const descriptor = sampleDescriptorSet();
+  const records = [
+    record(0x01, Buffer.concat([mcapString(""), mcapString("")])),
+    record(
+      0x03,
+      Buffer.concat([
+        uint16(1),
+        mcapString("test.Sample"),
+        mcapString("protobuf"),
+        prefixedBytes(descriptor),
+      ]),
+    ),
+    record(
+      0x04,
+      Buffer.concat([uint16(1), uint16(1), mcapString("proto"), mcapString("protobuf"), uint32(0)]),
+    ),
+    ...options.messages.map((message) =>
+      record(
+        0x05,
+        Buffer.concat([
+          uint16(1),
+          uint32(message.sequence),
+          uint64(message.logTime),
+          uint64(message.publishTime),
+          sampleMessage(message),
+        ]),
+      ),
+    ),
+    record(0x0f, uint32(0)),
+    record(0x02, Buffer.concat([uint64(0), uint64(0), uint32(0)])),
+  ];
+  return Buffer.concat([MCAP_MAGIC, ...records, MCAP_MAGIC]);
+}
+
+function sampleDescriptorSet(): Buffer {
+  // FileDescriptorSet for:
+  //
+  // syntax = "proto3";
+  // package test;
+  // message Sample {
+  //   string snake_case = 1;
+  //   uint32 zero_value = 2;
+  //   uint32 count = 3;
+  // }
+  const sampleMessageDescriptor = Buffer.concat([
+    protoString(1, "Sample"),
+    protoField(2, fieldDescriptor("snake_case", 1, 9, "snakeCase")),
+    protoField(2, fieldDescriptor("zero_value", 2, 13, "zeroValue")),
+    protoField(2, fieldDescriptor("count", 3, 13, "count")),
+  ]);
+  const fileDescriptor = Buffer.concat([
+    protoString(1, "sample.proto"),
+    protoString(2, "test"),
+    protoField(4, sampleMessageDescriptor),
+    protoString(12, "proto3"),
+  ]);
+  return protoField(1, fileDescriptor);
+}
+
+function fieldDescriptor(
+  name: string,
+  fieldNumber: number,
+  type: number,
+  jsonName: string,
+): Buffer {
+  return Buffer.concat([
+    protoString(1, name),
+    protoUint64(3, fieldNumber),
+    protoUint64(4, 1), // LABEL_OPTIONAL
+    protoUint64(5, type),
+    protoString(10, jsonName),
+  ]);
+}
+
+function sampleMessage(message: ProtobufJsonMessage): Buffer {
+  const fields = [protoString(1, message.snakeCase)];
+  if (message.zeroValue != undefined) {
+    fields.push(protoUint64(2, message.zeroValue));
+  }
+  fields.push(protoUint64(3, message.count));
+  return Buffer.concat(fields);
+}
+
+function record(opcode: number, body: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([opcode]), uint64(body.length), body]);
+}
+
+function mcapString(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([uint32(bytes.length), bytes]);
+}
+
+function prefixedBytes(value: Buffer): Buffer {
+  return Buffer.concat([uint32(value.length), value]);
+}
+
+function protoField(fieldNumber: number, value: Buffer): Buffer {
+  return Buffer.concat([varint((fieldNumber << 3) | 2), varint(value.length), value]);
+}
+
+function protoString(fieldNumber: number, value: string): Buffer {
+  return protoField(fieldNumber, Buffer.from(value, "utf8"));
+}
+
+function protoUint64(fieldNumber: number, value: number): Buffer {
+  return Buffer.concat([varint((fieldNumber << 3) | 0), varint(value)]);
+}
+
+function varint(value: number): Buffer {
+  const bytes: number[] = [];
+  let remaining = value;
+  while (remaining >= 0x80) {
+    bytes.push((remaining & 0x7f) | 0x80);
+    remaining = Math.floor(remaining / 0x80);
+  }
+  bytes.push(remaining);
+  return Buffer.from(bytes);
+}
+
+function uint16(value: number): Buffer {
+  const out = Buffer.alloc(2);
+  out.writeUInt16LE(value);
+  return out;
+}
+
+function uint32(value: number): Buffer {
+  const out = Buffer.alloc(4);
+  out.writeUInt32LE(value);
+  return out;
+}
+
+function uint64(value: number): Buffer {
+  const out = Buffer.alloc(8);
+  out.writeBigUInt64LE(BigInt(value));
+  return out;
+}

--- a/tests/cli-conformance/src/protobufJsonFixture.ts
+++ b/tests/cli-conformance/src/protobufJsonFixture.ts
@@ -1,6 +1,14 @@
 /* cspell:words varint */
 
-const MCAP_MAGIC = Buffer.from([0x89, 0x4d, 0x43, 0x41, 0x50, 0x30, 0x0d, 0x0a]);
+import {
+  MCAP_MAGIC,
+  mcapString,
+  prefixedBytes,
+  record,
+  uint16,
+  uint32,
+  uint64,
+} from "./mcapFixtureHelpers.ts";
 
 type ProtobufJsonMessage = {
   sequence: number;
@@ -99,19 +107,6 @@ function sampleMessage(message: ProtobufJsonMessage): Buffer {
   return Buffer.concat(fields);
 }
 
-function record(opcode: number, body: Buffer): Buffer {
-  return Buffer.concat([Buffer.from([opcode]), uint64(body.length), body]);
-}
-
-function mcapString(value: string): Buffer {
-  const bytes = Buffer.from(value, "utf8");
-  return Buffer.concat([uint32(bytes.length), bytes]);
-}
-
-function prefixedBytes(value: Buffer): Buffer {
-  return Buffer.concat([uint32(value.length), value]);
-}
-
 function protoField(fieldNumber: number, value: Buffer): Buffer {
   return Buffer.concat([varint((fieldNumber << 3) | 2), varint(value.length), value]);
 }
@@ -133,29 +128,4 @@ function varint(value: number): Buffer {
   }
   bytes.push(remaining);
   return Buffer.from(bytes);
-}
-
-function uint16(value: number): Buffer {
-  const out = Buffer.alloc(2);
-  out.writeUInt16LE(value);
-  return out;
-}
-
-function uint32(value: number): Buffer {
-  const out = Buffer.alloc(4);
-  out.writeUInt32LE(value);
-  return out;
-}
-
-function uint64(value: bigint | number): Buffer {
-  if (typeof value === "number" && !Number.isSafeInteger(value)) {
-    throw new Error(`uint64 number value must be a safe integer: ${value.toString()}`);
-  }
-  const integer = typeof value === "bigint" ? value : BigInt(value);
-  if (integer < 0n) {
-    throw new Error(`uint64 value must be non-negative: ${value.toString()}`);
-  }
-  const out = Buffer.alloc(8);
-  out.writeBigUInt64LE(integer);
-  return out;
 }

--- a/tests/cli-conformance/src/protobufJsonFixture.ts
+++ b/tests/cli-conformance/src/protobufJsonFixture.ts
@@ -4,8 +4,8 @@ const MCAP_MAGIC = Buffer.from([0x89, 0x4d, 0x43, 0x41, 0x50, 0x30, 0x0d, 0x0a])
 
 type ProtobufJsonMessage = {
   sequence: number;
-  logTime: number;
-  publishTime: number;
+  logTime: bigint | number;
+  publishTime: bigint | number;
   snakeCase: string;
   zeroValue?: number;
   count: number;
@@ -147,8 +147,15 @@ function uint32(value: number): Buffer {
   return out;
 }
 
-function uint64(value: number): Buffer {
+function uint64(value: bigint | number): Buffer {
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new Error(`uint64 number value must be a safe integer: ${value.toString()}`);
+  }
+  const integer = typeof value === "bigint" ? value : BigInt(value);
+  if (integer < 0n) {
+    throw new Error(`uint64 value must be non-negative: ${value.toString()}`);
+  }
   const out = Buffer.alloc(8);
-  out.writeBigUInt64LE(BigInt(value));
+  out.writeBigUInt64LE(integer);
   return out;
 }

--- a/tests/cli-conformance/src/ros1JsonFixture.ts
+++ b/tests/cli-conformance/src/ros1JsonFixture.ts
@@ -1,0 +1,101 @@
+import {
+  float32,
+  int32,
+  MCAP_MAGIC,
+  mcapString,
+  prefixedBytes,
+  record,
+  uint16,
+  uint32,
+  uint64,
+} from "./mcapFixtureHelpers.ts";
+
+type Ros1JsonMessage = {
+  sequence: number;
+  logTime: bigint | number;
+  publishTime: bigint | number;
+  headerSeq: number;
+  stampSec: number;
+  stampNsec: number;
+  frameId: string;
+  durationSec: number;
+  durationNsec: number;
+  values: number[];
+};
+
+export type Ros1JsonFixtureOptions = {
+  messages: Ros1JsonMessage[];
+};
+
+export function makeRos1JsonMcap(options: Ros1JsonFixtureOptions): Buffer {
+  const schema = Buffer.from(
+    [
+      "Header header",
+      "float32 nan_value",
+      "float32 pos_inf",
+      "float32 neg_inf",
+      "duration offset",
+      "int32[] values",
+      "================================================================================",
+      "MSG: std_msgs/Header",
+      "uint32 seq",
+      "time stamp",
+      "string frame_id",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const records = [
+    record(0x01, Buffer.concat([mcapString(""), mcapString("")])),
+    record(
+      0x03,
+      Buffer.concat([
+        uint16(1),
+        mcapString("demo/JsonEdgeCases"),
+        mcapString("ros1msg"),
+        prefixedBytes(schema),
+      ]),
+    ),
+    record(
+      0x04,
+      Buffer.concat([uint16(1), uint16(1), mcapString("ros1"), mcapString("ros1"), uint32(0)]),
+    ),
+    ...options.messages.map((message) =>
+      record(
+        0x05,
+        Buffer.concat([
+          uint16(1),
+          uint32(message.sequence),
+          uint64(message.logTime),
+          uint64(message.publishTime),
+          ros1Message(message),
+        ]),
+      ),
+    ),
+    record(0x0f, uint32(0)),
+    record(0x02, Buffer.concat([uint64(0), uint64(0), uint32(0)])),
+  ];
+  return Buffer.concat([MCAP_MAGIC, ...records, MCAP_MAGIC]);
+}
+
+function ros1Message(message: Ros1JsonMessage): Buffer {
+  return Buffer.concat([
+    uint32(message.headerSeq),
+    uint32(message.stampSec),
+    uint32(message.stampNsec),
+    ros1String(message.frameId),
+    float32(Number.NaN),
+    float32(Number.POSITIVE_INFINITY),
+    float32(Number.NEGATIVE_INFINITY),
+    int32(message.durationSec),
+    int32(message.durationNsec),
+    uint32(message.values.length),
+    ...message.values.map((value) => int32(value)),
+  ]);
+}
+
+function ros1String(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([uint32(bytes.length), bytes]);
+}

--- a/tests/cli-conformance/src/types.ts
+++ b/tests/cli-conformance/src/types.ts
@@ -30,8 +30,8 @@ export type FixtureAction =
       to: string;
       messages: Array<{
         sequence: number;
-        logTime: number;
-        publishTime: number;
+        logTime: bigint | number;
+        publishTime: bigint | number;
         snakeCase: string;
         zeroValue?: number;
         count: number;

--- a/tests/cli-conformance/src/types.ts
+++ b/tests/cli-conformance/src/types.ts
@@ -38,6 +38,22 @@ export type FixtureAction =
       }>;
     }
   | {
+      type: "writeRos1JsonMcap";
+      to: string;
+      messages: Array<{
+        sequence: number;
+        logTime: bigint | number;
+        publishTime: bigint | number;
+        headerSeq: number;
+        stampSec: number;
+        stampNsec: number;
+        frameId: string;
+        durationSec: number;
+        durationNsec: number;
+        values: number[];
+      }>;
+    }
+  | {
       type: "mkdir";
       path: string;
     };

--- a/tests/cli-conformance/src/types.ts
+++ b/tests/cli-conformance/src/types.ts
@@ -24,6 +24,11 @@ export type FixtureAction =
       bytes: number[];
     }
   | {
+      type: "writeBase64";
+      to: string;
+      contents: string;
+    }
+  | {
       type: "mkdir";
       path: string;
     };

--- a/tests/cli-conformance/src/types.ts
+++ b/tests/cli-conformance/src/types.ts
@@ -1,3 +1,5 @@
+/* cspell:words ndjson */
+
 export type CliImplementation = "go" | "rust";
 
 export type PathContext = {
@@ -24,9 +26,16 @@ export type FixtureAction =
       bytes: number[];
     }
   | {
-      type: "writeBase64";
+      type: "writeProtobufJsonMcap";
       to: string;
-      contents: string;
+      messages: Array<{
+        sequence: number;
+        logTime: number;
+        publishTime: number;
+        snakeCase: string;
+        zeroValue?: number;
+        count: number;
+      }>;
     }
   | {
       type: "mkdir";
@@ -79,6 +88,10 @@ export type JsonComparatorSpec = {
   kind: "json";
 };
 
+export type NdjsonComparatorSpec = {
+  kind: "ndjson";
+};
+
 export type TableComparatorSpec = {
   kind: "table";
 };
@@ -113,6 +126,7 @@ export type McapComparatorSpec = {
 export type ComparatorSpec =
   | TextComparatorSpec
   | JsonComparatorSpec
+  | NdjsonComparatorSpec
   | TableComparatorSpec
   | CommandListComparatorSpec
   | InfoComparatorSpec


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

None

### Docs

None

### Description

Adds the remaining local-file `mcap cat` parity behaviors to the Rust CLI, except remote S3/GCS input.

The command now accepts Go-compatible `--topics`, `--start-secs`, `--start-nsecs`, `--end-secs`, `--end-nsecs`, and `--json` flags, reads from stdin when no file is provided, and applies the same indexed-vs-linear read strategy as before.

JSON output supports raw JSON/jsonschema payloads, dynamic protobuf decoding via descriptor sets, and ROS1 message-definition transcoding for embedded `ros1msg` schemas. CLI conformance cases were promoted from known differences to parity cases for the newly supported `cat` behaviors, including generated multi-message protobuf and ROS1 NDJSON stdin cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d129ac17-8c71-4a83-b46c-672199375bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d129ac17-8c71-4a83-b46c-672199375bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

