### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ This is a library-only monorepo — there are no services to start. Development 
 ### Environment notes
 
 - **PATH**: The update script ensures `$HOME/.local/bin` (for `uv`) and `$HOME/go/bin` (for `golangci-lint`) are on PATH via `~/.bashrc`. Ensure these are on PATH if running commands in a non-login shell.
-- **Rust toolchain**: The update script runs `rustup update stable && rustup default stable` to ensure the latest stable Rust is installed. The VM's pre-installed rustc 1.83 is too old for some transitive dependencies (e.g., `time` crate requires `edition2024` support).
+- **Rust toolchain**: The update script runs `rustup update stable && rustup default stable` to ensure the latest stable Rust is installed. The pre-installed rustc 1.83 on the VM is too old for some transitive dependencies (e.g., `time` crate requires `edition2024` support).
 - **Git LFS before Rust tests**: The update script runs `git lfs pull` first. Rust tests under `rust/mcap/tests/data/` depend on LFS-tracked `.mcap` fixtures; without them, tests fail with `InvalidMagic` errors.
 - **Python version**: The `python/pyproject.toml` requires `>=3.10,<3.11`. Python 3.10 is installed from the deadsnakes PPA. Use `uv run --python python3.10` or the venv at `python/.venv` directly.
 - **Prettier/fmt:check**: Running `yarn fmt:check` from the repo root will flag files inside `python/.venv/` because `.prettierignore` doesn't exclude it. This is expected in a dev environment; CI doesn't have the venv present. Lint individual TypeScript workspaces with `yarn workspace <name> lint:ci` instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ This is a library-only monorepo — there are no services to start. Development 
 ### Environment notes
 
 - **PATH**: The update script ensures `$HOME/.local/bin` (for `uv`) and `$HOME/go/bin` (for `golangci-lint`) are on PATH via `~/.bashrc`. Ensure these are on PATH if running commands in a non-login shell.
-- **Rust toolchain**: The default Rust stable toolchain must be current (run `rustup default stable`). The pre-installed rustc 1.83 is too old for some transitive dependencies (e.g., `time` crate requires `edition2024` support). The update script handles this.
+- **Rust toolchain**: The update script runs `rustup update stable && rustup default stable` to ensure the latest stable Rust is installed. The VM's pre-installed rustc 1.83 is too old for some transitive dependencies (e.g., `time` crate requires `edition2024` support).
+- **Git LFS before Rust tests**: The update script runs `git lfs pull` first. Rust tests under `rust/mcap/tests/data/` depend on LFS-tracked `.mcap` fixtures; without them, tests fail with `InvalidMagic` errors.
 - **Python version**: The `python/pyproject.toml` requires `>=3.10,<3.11`. Python 3.10 is installed from the deadsnakes PPA. Use `uv run --python python3.10` or the venv at `python/.venv` directly.
 - **Prettier/fmt:check**: Running `yarn fmt:check` from the repo root will flag files inside `python/.venv/` because `.prettierignore` doesn't exclude it. This is expected in a dev environment; CI doesn't have the venv present. Lint individual TypeScript workspaces with `yarn workspace <name> lint:ci` instead.
 - **Go build**: Run `go build ./...` from within a module directory (e.g., `go/mcap`), not from the `go/` workspace root directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,16 @@ The Rust workspace includes the `mcap` library crate under `rust/mcap` and the `
 | Build  | `swift build`                                                        |
 | Test   | `swift test`                                                         |
 | Lint   | See SwiftLint and SwiftFormat commands in `.github/workflows/ci.yml` |
+
+## Cursor Cloud specific instructions
+
+This is a library-only monorepo — there are no services to start. Development involves building and testing the libraries in each language.
+
+### Environment notes
+
+- **PATH**: The update script ensures `$HOME/.local/bin` (for `uv`) and `$HOME/go/bin` (for `golangci-lint`) are on PATH via `~/.bashrc`. Ensure these are on PATH if running commands in a non-login shell.
+- **Rust toolchain**: The default Rust stable toolchain must be current (run `rustup default stable`). The pre-installed rustc 1.83 is too old for some transitive dependencies (e.g., `time` crate requires `edition2024` support). The update script handles this.
+- **Python version**: The `python/pyproject.toml` requires `>=3.10,<3.11`. Python 3.10 is installed from the deadsnakes PPA. Use `uv run --python python3.10` or the venv at `python/.venv` directly.
+- **Prettier/fmt:check**: Running `yarn fmt:check` from the repo root will flag files inside `python/.venv/` because `.prettierignore` doesn't exclude it. This is expected in a dev environment; CI doesn't have the venv present. Lint individual TypeScript workspaces with `yarn workspace <name> lint:ci` instead.
+- **Go build**: Run `go build ./...` from within a module directory (e.g., `go/mcap`), not from the `go/` workspace root directly.
+- **C++ and Swift**: These require Docker and Swift compiler respectively, which are not installed by default in the Cloud VM. They are optional for most development work.

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -185,6 +185,9 @@ overrides:
       - addopts
       - xfail
       - pyyaml
+      - deadsnakes
+      - pyproject
+      - venv
 
   - filename: "python/**/*.rst"
     words:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting environment setup caveats for cloud agents working on this polyglot library monorepo.

## Changes

- Documents PATH requirements for `uv` and `golangci-lint`
- Notes Rust toolchain version requirement (stable must be current; pre-installed 1.83 is too old)
- Explains Python 3.10 constraint from `python/pyproject.toml`
- Documents the Prettier/`.venv` false positive for `yarn fmt:check`
- Clarifies Go build must be run from within module directories
- Notes C++/Swift are optional (require Docker/Swift compiler not in default Cloud VM)

## Testing

All four primary language toolchains verified:

| Language | Build | Test | Lint |
|----------|-------|------|------|
| TypeScript | `yarn typescript:build` | 86 tests passed | `yarn workspace @mcap/core lint:ci` |
| Python | `uv sync --frozen` | 35 tests passed | `flake8` clean |
| Go | `go build ./...` | all passed | golangci-lint (pre-existing style warnings only) |
| Rust | `cargo build -p mcap --all-features` | 12 tests passed | `cargo clippy` clean |

Demo output showing MCAP write/read roundtrip:
[hello_world_demo.log](https://cursor.com/agents/bc-4571a242-e187-4840-a5a7-656aa0d758de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4571a242-e187-4840-a5a7-656aa0d758de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4571a242-e187-4840-a5a7-656aa0d758de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

