### PR TITLE
Add a parallel (multithreaded) MCAP reader to the C++ library

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -51,6 +51,9 @@ test: dev-image
 test-host:
 	./test/build/Debug/bin/unit-tests
 	./test/build/Debug/bin/unit-tests-nocompress
+	./test/build/Debug/bin/unit-tests-noparallel
+	./test/build/Debug/bin/parallel-reader-test
+	./test/build/Debug/bin/parallel-reader-test-nocompress
 
 .PHONY: hdoc-build
 hdoc-build:

--- a/cpp/mcap/include/mcap/byte_semaphore.hpp
+++ b/cpp/mcap/include/mcap/byte_semaphore.hpp
@@ -1,0 +1,109 @@
+#pragma once
+//
+// byte_semaphore.hpp
+//
+// A counting semaphore measured in BYTES, used to cap the total resident
+// (decompressed) memory of the parallel reader. A worker acquires
+// `chunk.uncompressedSize` credits before decompressing a chunk and releases
+// them once the chunk is fully drained and unpinned. The total outstanding
+// credits can never exceed the configured capacity, EXCEPT for the deliberate
+// oversized-chunk case described below.
+//
+// The cap is SOFT. There are two ways to take credits:
+//
+//   * acquire()      - blocking; respects the cap. Used for SPECULATIVE look-ahead
+//                      chunks. This is the back-pressure path: when the consumer is
+//                      slow or memory is full, prefetch workers park here.
+//   * forceAcquire() - non-blocking; ALWAYS succeeds, even if it drives the pool
+//                      over capacity (the counter goes negative). Used for chunks
+//                      the merge MUST decompress to emit the next in-order message,
+//                      where blocking would deadlock. Exceeding the cap to avoid the
+//                      lock is the intended behavior.
+//
+// The overshoot is bounded: the set of chunks force-acquired at once is the
+// temporal overlap depth at the current emit frontier, and it self-corrects,
+// because while available_ is negative every blocking acquire() parks, so no new
+// speculative memory is taken until releases bring the pool back above water.
+//
+// Oversized chunk: a single chunk may exceed the entire budget (chunkSize is a
+// soft ceiling; an oversized message produces an oversized chunk). A blocking
+// acquire() for such a chunk is admitted once ALL other credits are free, after
+// which the counter goes negative and other acquirers park until it is released.
+//
+// C++17 only (no std::counting_semaphore).
+//
+#include <algorithm>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+namespace mcap::internal {
+
+class ByteSemaphore {
+public:
+  explicit ByteSemaphore(uint64_t capacityBytes)
+      : capacity_(capacityBytes)
+      , available_(int64_t(capacityBytes)) {}
+
+  // Blocks until `n` credits can be granted. If `n > capacity`, blocks until the
+  // semaphore is fully replenished (available_ == capacity_), then grants it,
+  // driving available_ negative so all other acquirers wait.
+  void acquire(uint64_t n) {
+    std::unique_lock<std::mutex> lk(m_);
+    const int64_t need = int64_t(n);
+    const int64_t threshold = std::min<int64_t>(need, int64_t(capacity_));
+    cv_.wait(lk, [&] {
+      return available_ >= threshold;
+    });
+    available_ -= need;
+  }
+
+  // Non-blocking variant. Returns false if the request cannot be granted right
+  // now (including an oversized request when the pool is not fully free).
+  bool tryAcquire(uint64_t n) {
+    std::lock_guard<std::mutex> lk(m_);
+    const int64_t need = int64_t(n);
+    const int64_t threshold = std::min<int64_t>(need, int64_t(capacity_));
+    if (available_ < threshold) {
+      return false;
+    }
+    available_ -= need;
+    return true;
+  }
+
+  void release(uint64_t n) {
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      available_ += int64_t(n);
+    }
+    cv_.notify_all();
+  }
+
+  // Unconditionally grant `n` credits without waiting, even if this drives the
+  // pool over capacity (available_ negative). For chunks the merge MUST have to
+  // make forward progress; exceeding the cap here is deliberate and preferable
+  // to deadlocking. No notify: we only took credits, we did not return any.
+  void forceAcquire(uint64_t n) {
+    std::lock_guard<std::mutex> lk(m_);
+    available_ -= int64_t(n);
+  }
+
+  uint64_t capacity() const {
+    return capacity_;
+  }
+
+  // Test/diagnostic only: current granted (outstanding) bytes. May briefly
+  // exceed capacity when an oversized chunk is resident.
+  int64_t outstanding() const {
+    std::lock_guard<std::mutex> lk(m_);
+    return int64_t(capacity_) - available_;
+  }
+
+private:
+  const uint64_t capacity_;
+  int64_t available_;  // signed: goes negative while an oversized chunk is held
+  mutable std::mutex m_;
+  std::condition_variable cv_;
+};
+
+}  // namespace mcap::internal

--- a/cpp/mcap/include/mcap/mcap.hpp
+++ b/cpp/mcap/include/mcap/mcap.hpp
@@ -1,4 +1,18 @@
 #pragma once
 
 #include "reader.hpp"
+
+#ifndef MCAP_NO_PARALLEL
+// Parallel (multithreaded) reader. Purely additive: provides the standalone
+// mcap::ParallelReader (and MmapReader) without modifying McapReader. The only
+// touch to an existing type is IReadable::supportsConcurrentRead() in reader.hpp.
+// Define MCAP_NO_PARALLEL to omit it entirely (e.g. for platforms that can't link
+// a threading library).
+#  include "byte_semaphore.hpp"
+#  include "mmap_reader.hpp"
+#  include "parallel_budget.hpp"
+#  include "parallel_reader.hpp"
+#  include "thread_pool.hpp"
+#endif
+
 #include "writer.hpp"

--- a/cpp/mcap/include/mcap/mmap_reader.hpp
+++ b/cpp/mcap/include/mcap/mmap_reader.hpp
@@ -1,0 +1,169 @@
+#pragma once
+//
+// mmap_reader.hpp
+//
+// An IReadable backed by a read-only memory mapping. read() returns a pointer
+// directly into the mapping and never mutates shared state, so it is safe to
+// call concurrently from many threads -- which is exactly what the parallel
+// reader's decompression workers require. Pointers stay valid for the lifetime
+// of the MmapReader (a stronger guarantee than the IReadable contract demands).
+//
+// POSIX (mmap) and Windows (CreateFileMapping/MapViewOfFile) implementations
+// behind one interface.
+//
+#include "reader.hpp"  // IReadable, Status, StatusCode (included by mcap.hpp before us)
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#if defined(_WIN32)
+// cspell:ignore NOMINMAX
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef NOMINMAX
+#    define NOMINMAX  // keep windows.h from defining min()/max() macros
+#  endif
+#  include <windows.h>
+#else
+#  include <sys/mman.h>
+#  include <sys/stat.h>
+
+#  include <fcntl.h>
+#  include <unistd.h>
+#endif
+
+namespace mcap {
+
+class MmapReader final : public IReadable {
+public:
+  MmapReader() = default;
+  ~MmapReader() override {
+    close();
+  }
+
+  MmapReader(const MmapReader&) = delete;
+  MmapReader& operator=(const MmapReader&) = delete;
+
+  // The mapping is immutable after open(), so read() is safe from many threads.
+  bool supportsConcurrentRead() const override {
+    return true;
+  }
+
+#if defined(_WIN32)
+  Status open(std::string_view path) {
+    close();
+    const std::string p(path);
+    fileHandle_ = ::CreateFileA(p.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                                FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (fileHandle_ == INVALID_HANDLE_VALUE) {
+      return Status{StatusCode::OpenFailed, "could not open " + p};
+    }
+    LARGE_INTEGER fileSize{};
+    if (!::GetFileSizeEx(fileHandle_, &fileSize)) {
+      close();
+      return Status{StatusCode::OpenFailed, "GetFileSizeEx failed for " + p};
+    }
+    size_ = uint64_t(fileSize.QuadPart);
+    if (size_ == 0) {
+      close();
+      return Status{StatusCode::FileTooSmall, "empty file " + p};
+    }
+    mapHandle_ = ::CreateFileMappingA(fileHandle_, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    if (mapHandle_ == nullptr) {
+      close();
+      return Status{StatusCode::OpenFailed, "CreateFileMapping failed for " + p};
+    }
+    void* view = ::MapViewOfFile(mapHandle_, FILE_MAP_READ, 0, 0, 0);
+    if (view == nullptr) {
+      close();
+      return Status{StatusCode::OpenFailed, "MapViewOfFile failed for " + p};
+    }
+    base_ = static_cast<const std::byte*>(view);
+    return StatusCode::Success;
+  }
+
+  void close() {
+    if (base_ != nullptr) {
+      ::UnmapViewOfFile(static_cast<const void*>(base_));
+      base_ = nullptr;
+    }
+    if (mapHandle_ != nullptr) {
+      ::CloseHandle(mapHandle_);
+      mapHandle_ = nullptr;
+    }
+    if (fileHandle_ != INVALID_HANDLE_VALUE) {
+      ::CloseHandle(fileHandle_);
+      fileHandle_ = INVALID_HANDLE_VALUE;
+    }
+    size_ = 0;
+  }
+#else
+  Status open(std::string_view path) {
+    close();
+    const std::string p(path);
+    fd_ = ::open(p.c_str(), O_RDONLY);
+    if (fd_ < 0) {
+      return Status{StatusCode::OpenFailed, "could not open " + p};
+    }
+    struct stat st {};
+    if (::fstat(fd_, &st) != 0) {
+      close();
+      return Status{StatusCode::OpenFailed, "fstat failed for " + p};
+    }
+    size_ = uint64_t(st.st_size);
+    if (size_ == 0) {
+      close();
+      return Status{StatusCode::FileTooSmall, "empty file " + p};
+    }
+    void* m = ::mmap(nullptr, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
+    if (m == MAP_FAILED) {
+      close();
+      return Status{StatusCode::OpenFailed, "mmap failed for " + p};
+    }
+    base_ = static_cast<const std::byte*>(m);
+    // Forward sequential scans benefit from readahead.
+    ::madvise(const_cast<void*>(static_cast<const void*>(base_)), size_, MADV_WILLNEED);
+    return StatusCode::Success;
+  }
+
+  void close() {
+    if (base_ != nullptr) {
+      ::munmap(const_cast<void*>(static_cast<const void*>(base_)), size_);
+      base_ = nullptr;
+    }
+    if (fd_ >= 0) {
+      ::close(fd_);
+      fd_ = -1;
+    }
+    size_ = 0;
+  }
+#endif
+
+  uint64_t size() const override {
+    return size_;
+  }
+
+  // Thread-safe for concurrent calls: no shared mutable state.
+  uint64_t read(std::byte** output, uint64_t offset, uint64_t size) override {
+    if (base_ == nullptr || offset >= size_) {
+      return 0;
+    }
+    const uint64_t available = size_ - offset;
+    *output = const_cast<std::byte*>(base_ + offset);
+    return std::min(size, available);
+  }
+
+private:
+  const std::byte* base_ = nullptr;
+  uint64_t size_ = 0;
+#if defined(_WIN32)
+  void* fileHandle_ = INVALID_HANDLE_VALUE;  // HANDLE
+  void* mapHandle_ = nullptr;                // HANDLE
+#else
+  int fd_ = -1;
+#endif
+};
+
+}  // namespace mcap

--- a/cpp/mcap/include/mcap/parallel_budget.hpp
+++ b/cpp/mcap/include/mcap/parallel_budget.hpp
@@ -1,0 +1,202 @@
+#pragma once
+//
+// parallel_budget.hpp
+//
+// Implements the memory cap for the parallel reader. Two parts:
+//
+//   1. computeResidencyProfile(): a sweep-line over the chunk index that, BEFORE
+//      reading any message, computes the worst-case resident-memory floor for
+//      time-ordered reads. For log-time order a chunk is resident for its entire
+//      [messageStartTime, messageEndTime] span, so the binding constraint is the
+//      maximum byte-sum of chunk intervals overlapping any instant ("stabbing
+//      depth in bytes"). This is the number the cap must respect.
+//
+//   2. resolveBudget(): given a user cap and a read order, decides the effective
+//      byte budget for the ByteSemaphore. For LOG-TIME order the effective budget
+//      can never drop below the floor without deadlocking the k-way merge (a
+//      required chunk that does not fit the budget can't be decompressed). The resolver
+//      enforces that, per the chosen policy.
+//
+// Topic filtering is honored: only chunks containing a selected channel count,
+// since unselected chunks are never decompressed. A chunk contributes its FULL
+// uncompressedSize when counted (the whole chunk must be decompressed to read
+// any selected message inside it).
+//
+// C++17. Header-only; no implementation macro required (pure inline helpers over
+// the public ChunkIndex type).
+//
+#include <mcap/types.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace mcap {
+
+// Worst-case residency characteristics derived from the chunk index.
+struct ResidencyProfile {
+  size_t consideredChunks = 0;     // chunks containing a selected channel
+  uint64_t maxDepthChunks = 0;     // max overlapping chunk intervals at any instant
+  uint64_t maxDepthBytes = 0;      // max sum of uncompressedSize overlapping any instant
+  uint64_t uMaxBytes = 0;          // largest single chunk's uncompressedSize
+  uint64_t totalUncompressed = 0;  // sum over considered chunks (fully-buffered upper bound)
+};
+
+namespace internal {
+
+// A chunk counts if no filter is given, or it carries at least one selected channel.
+inline bool chunkSelected(const ChunkIndex& c,
+                          const std::unordered_set<ChannelId>& selectedChannels) {
+  if (selectedChannels.empty()) {
+    return true;
+  }
+  for (const auto& [channelId, _offset] : c.messageIndexOffsets) {
+    if (selectedChannels.count(channelId) != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace internal
+
+inline ResidencyProfile computeResidencyProfile(
+  const std::vector<ChunkIndex>& chunkIndexes,
+  const std::unordered_set<ChannelId>& selectedChannels = {}) {
+  ResidencyProfile p;
+
+  // Sweep-line events. A chunk is live over the CLOSED interval
+  // [messageStartTime, messageEndTime]; we expire it at messageEndTime + 1 so
+  // that two chunks touching at a shared boundary are treated as overlapping
+  // (conservative: never under-counts, so the cap never deadlocks). At equal
+  // timestamps, expiries (-) are processed before starts (+).
+  struct Event {
+    Timestamp t;
+    int order;  // 0 = expire (-), 1 = start (+)
+    int64_t dChunks;
+    int64_t dBytes;
+  };
+  std::vector<Event> events;
+  events.reserve(chunkIndexes.size() * 2);
+
+  for (const auto& c : chunkIndexes) {
+    if (!internal::chunkSelected(c, selectedChannels)) {
+      continue;
+    }
+    p.consideredChunks++;
+    p.totalUncompressed += c.uncompressedSize;
+    p.uMaxBytes = std::max(p.uMaxBytes, c.uncompressedSize);
+    const Timestamp start = c.messageStartTime;
+    const Timestamp expire = (c.messageEndTime == MaxTime) ? MaxTime : (c.messageEndTime + 1);
+    events.push_back({start, 1, +1, int64_t(c.uncompressedSize)});
+    events.push_back({expire, 0, -1, -int64_t(c.uncompressedSize)});
+  }
+
+  std::sort(events.begin(), events.end(), [](const Event& a, const Event& b) {
+    if (a.t != b.t) return a.t < b.t;
+    return a.order < b.order;  // expiries before starts at the same instant
+  });
+
+  int64_t curChunks = 0, curBytes = 0;
+  for (const auto& e : events) {
+    curChunks += e.dChunks;
+    curBytes += e.dBytes;
+    p.maxDepthChunks = std::max<uint64_t>(p.maxDepthChunks, uint64_t(curChunks));
+    p.maxDepthBytes = std::max<uint64_t>(p.maxDepthBytes, uint64_t(curBytes));
+  }
+  return p;
+}
+
+// Policy for what to do when the user's cap is below the order's intrinsic floor.
+enum class MemoryCapPolicy {
+  Adapt,                 // raise the effective budget up to the floor (never deadlocks;
+                         // may exceed the user cap — flagged in BudgetDecision)
+  Strict,                // do not exceed the user cap; report infeasible (caller decides)
+  EvictAndReDecompress,  // honor a sub-floor cap by evicting + re-decompressing chunks
+                         // (bounded redundant CPU; never below one chunk)
+  FallBackToSerial,      // if the cap is below the floor, signal the caller to read serially
+};
+
+struct BudgetDecision {
+  uint64_t effectiveBudgetBytes = 0;      // pass this to ByteSemaphore
+  uint64_t floorBytes = 0;                // minimum to progress without eviction, this order
+  bool feasibleWithoutEviction = true;    // false only under Strict when cap < floor
+  bool exceedsUserCap = false;            // true under Adapt when raised above the cap
+  bool requiresEviction = false;          // true under EvictAndReDecompress when cap < floor
+  bool fallBackToSerial = false;          // true under FallBackToSerial when cap < floor
+  double estReDecompressionFactor = 1.0;  // >1 when eviction is in play (rough)
+  std::string note;
+};
+
+// order: only the log-time orders carry the overlap floor; file order needs just
+// one resident chunk (its largest). userCapBytes == 0 means "no user cap".
+// desiredLookaheadBytes is extra budget above the floor for prefetch (clamped by cap).
+inline BudgetDecision resolveBudget(const ResidencyProfile& profile,
+                                    ReadMessageOptions::ReadOrder order, uint64_t userCapBytes,
+                                    MemoryCapPolicy policy = MemoryCapPolicy::Adapt,
+                                    uint64_t desiredLookaheadBytes = 0) {
+  const bool timeOrdered = (order == ReadMessageOptions::ReadOrder::LogTimeOrder ||
+                            order == ReadMessageOptions::ReadOrder::ReverseLogTimeOrder);
+
+  // File order: one chunk drained at a time -> floor is the largest single chunk.
+  // Log/Reverse order: floor is the stabbing depth in bytes (which is always >=
+  // the largest single chunk, since that chunk alone occupies its own instant).
+  const uint64_t oneChunk = std::max<uint64_t>(profile.uMaxBytes, 1);
+  const uint64_t floor = timeOrdered ? std::max(profile.maxDepthBytes, oneChunk) : oneChunk;
+
+  BudgetDecision d;
+  d.floorBytes = floor;
+
+  const uint64_t unlimited = (userCapBytes == 0);
+
+  if (unlimited) {
+    d.effectiveBudgetBytes = floor + desiredLookaheadBytes;
+    return d;
+  }
+
+  if (userCapBytes >= floor) {
+    // Cap is feasible; use it for look-ahead up to floor + desired prefetch.
+    d.effectiveBudgetBytes = std::max(floor, std::min(userCapBytes, floor + desiredLookaheadBytes));
+    return d;
+  }
+
+  // userCapBytes < floor: the interesting case.
+  switch (policy) {
+    case MemoryCapPolicy::Adapt:
+      d.effectiveBudgetBytes = floor;
+      d.exceedsUserCap = true;
+      d.note =
+        "user cap (" + std::to_string(userCapBytes) + " B) is below the " +
+        (timeOrdered ? std::string("log-time overlap floor") : std::string("largest-chunk floor")) +
+        " (" + std::to_string(floor) + " B); raised to the floor to avoid deadlock";
+      return d;
+
+    case MemoryCapPolicy::Strict:
+      d.effectiveBudgetBytes = userCapBytes;
+      d.feasibleWithoutEviction = false;
+      d.note = "user cap is below the floor (" + std::to_string(floor) +
+               " B); not feasible without eviction in this order";
+      return d;
+
+    case MemoryCapPolicy::EvictAndReDecompress:
+      // Must still hold at least one (largest) chunk, or even a single chunk can't fit.
+      d.effectiveBudgetBytes = std::max(userCapBytes, oneChunk);
+      d.requiresEviction = (d.effectiveBudgetBytes < floor);
+      d.estReDecompressionFactor =
+        d.requiresEviction ? double(floor) / double(d.effectiveBudgetBytes) : 1.0;
+      d.note = "honoring sub-floor cap via eviction; expect ~" +
+               std::to_string(d.estReDecompressionFactor) + "x redundant decompression";
+      return d;
+
+    case MemoryCapPolicy::FallBackToSerial:
+      d.fallBackToSerial = true;
+      d.effectiveBudgetBytes = oneChunk;
+      d.note = "user cap below floor; falling back to the serial reader";
+      return d;
+  }
+  return d;  // unreachable
+}
+
+}  // namespace mcap

--- a/cpp/mcap/include/mcap/parallel_reader.hpp
+++ b/cpp/mcap/include/mcap/parallel_reader.hpp
@@ -1,0 +1,801 @@
+#pragma once
+//
+// parallel_reader.hpp
+//
+// Parallel, memory-capped MCAP message reader for TIMESTAMP order (log-time,
+// forward and reverse). Decompresses chunks on a thread pool ahead of the merge
+// frontier, then emits messages in exactly the same order as the serial
+// IndexedMessageReader (verified against it by the parity tests).
+//
+// Design (see the design doc for the full rationale):
+//   * Up front: filter chunks to overlapping + topic-selected, sort by start time
+//     (forward) / end time (reverse); compute the residency profile and resolve a
+//     byte budget for the ByteSemaphore.
+//   * The CONSUMER thread owns budget decisions (so force-vs-block is race-free):
+//       - REQUIRED chunks (start <= current frontier) -> forceAcquire (may exceed
+//         the cap; never blocks; this is what guarantees progress / no deadlock).
+//       - PREFETCH chunks (further ahead) -> tryAcquire (respects the cap; if the
+//         budget is full we simply don't prefetch yet -> back-pressure).
+//   * Workers only decompress: read compressed bytes from a concurrent
+//     IReadable (MmapReader), DecompressAll into an owned buffer, parse the
+//     trailing MessageIndex records into a sorted, filtered entry list, fulfill a
+//     promise. Budget is released when the ReadyChunk is destroyed (drained +
+//     unpinned).
+//   * A k-way merge over per-chunk cursors emits the global (timestamp,
+//     RecordOffset) order, reusing mcap::RecordOffset's operators so tie-breaks
+//     match the serial reader exactly.
+//
+// Header-only inline for now; in the fork, split into .hpp/.inl behind
+// MCAP_IMPLEMENTATION like the rest of the library.
+//
+#include "byte_semaphore.hpp"
+#include "mmap_reader.hpp"  // MmapReader, for ParallelReader::open(path)
+#include "parallel_budget.hpp"
+#include "reader.hpp"  // McapReader, IReadable, RecordReader, etc. (included by mcap.hpp before us)
+#include "thread_pool.hpp"
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <future>
+#include <memory>
+#include <new>
+#include <optional>
+#include <queue>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+#  include <zstd.h>
+#endif
+
+namespace mcap {
+
+struct ParallelReadOptions {
+  ReadMessageOptions read;        // startTime/endTime/topicFilter/readOrder
+  unsigned threadCount = 0;       // 0 -> hardware_concurrency()
+  uint64_t maxBytesInFlight = 0;  // soft cap; 0 -> floor + lookahead (unbounded-ish)
+  uint64_t lookaheadBytes = 0;    // prefetch headroom above the floor; 0 -> auto
+  MemoryCapPolicy capPolicy =
+    MemoryCapPolicy::Adapt;  // default: exceed the cap rather than deadlock
+  // Reject a chunk whose declared uncompressed size exceeds this (corruption /
+  // decompression-bomb guard). 0 disables the check. Default 2 GiB: no legitimate
+  // MCAP chunk approaches this.
+  uint64_t maxChunkUncompressedSize = 2ull << 30;
+};
+
+namespace internal {
+
+// Allocator that DEFAULT-initializes elements (no value-init), so resize() on a
+// byte buffer does NOT zero-fill memory we're about to overwrite with
+// decompressed bytes. (std::vector<std::byte>::resize would memset to 0 first.)
+template <class T>
+struct NoInitAllocator {
+  using value_type = T;
+  NoInitAllocator() noexcept = default;
+  template <class U>
+  NoInitAllocator(const NoInitAllocator<U>&) noexcept {}
+  template <class U>
+  struct rebind {
+    using other = NoInitAllocator<U>;
+  };
+  T* allocate(std::size_t n) {
+    return static_cast<T*>(::operator new(n * sizeof(T)));
+  }
+  void deallocate(T* p, std::size_t) noexcept {
+    ::operator delete(p);
+  }
+  template <class U, class... Args>
+  void construct(U* p, Args&&... args) {
+    ::new (static_cast<void*>(p)) U(std::forward<Args>(args)...);
+  }
+  template <class U>
+  void construct(U* p) noexcept {
+    ::new (static_cast<void*>(p)) U;  // default-init: leaves std::byte uninitialized
+  }
+};
+template <class A, class B>
+bool operator==(const NoInitAllocator<A>&, const NoInitAllocator<B>&) noexcept {
+  return true;
+}
+template <class A, class B>
+bool operator!=(const NoInitAllocator<A>&, const NoInitAllocator<B>&) noexcept {
+  return false;
+}
+
+// Decompressed-chunk buffer: same layout as ByteArray, but resize() leaves new
+// bytes uninitialized (the decompressor overwrites every byte immediately).
+using RawByteArray = std::vector<std::byte, NoInitAllocator<std::byte>>;
+
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+// One reusable ZSTD_DCtx per worker thread, avoiding a context allocate/free for
+// every chunk (the one-shot ZSTD_decompress creates and destroys one each call).
+// Thread-local because a DCtx is stateful and not safe to share concurrently.
+inline ZSTD_DCtx* threadLocalZstdDCtx() {
+  struct Holder {
+    ZSTD_DCtx* ctx = ZSTD_createDCtx();
+    ~Holder() {
+      if (ctx) ZSTD_freeDCtx(ctx);
+    }
+  };
+  thread_local Holder holder;
+  return holder.ctx;
+}
+#endif
+
+// Diagnostic counters for the parallel engine. Shared (shared_ptr) between the
+// view and every ReadyChunk so decompressed-byte accounting can be decremented
+// from ~ReadyChunk -- the point where that memory is actually freed.
+struct ParallelStats {
+  std::atomic<uint64_t> chunksDecompressed{0};    // decompress jobs that produced bytes
+  std::atomic<uint64_t> chunksScheduled{0};       // schedule attempts that ran a job
+  std::atomic<uint64_t> chunksForced{0};          // scheduled via forceAcquire (required path)
+  std::atomic<int64_t> liveDecompressedBytes{0};  // currently-resident decompressed bytes
+  std::atomic<int64_t> peakDecompressedBytes{0};  // high-water mark of the above
+
+  void addLive(uint64_t n) {
+    const int64_t now = liveDecompressedBytes.fetch_add(int64_t(n)) + int64_t(n);
+    int64_t prev = peakDecompressedBytes.load(std::memory_order_relaxed);
+    while (now > prev && !peakDecompressedBytes.compare_exchange_weak(prev, now)) {
+    }
+  }
+  void subLive(uint64_t n) {
+    liveDecompressedBytes.fetch_sub(int64_t(n));
+  }
+};
+
+// A decompressed chunk plus its filtered, sorted message entries. Releases its
+// budget credits back to the semaphore on destruction (RAII), which is how
+// "drained + unpinned" frees memory and relieves back-pressure.
+struct PMsgEntry {
+  Timestamp timestamp;
+  ByteOffset offset;       // offset of the Message record within the decompressed chunk
+  ByteOffset chunkOffset;  // chunk start offset in the file (for RecordOffset tie-break)
+};
+
+struct ReadyChunk {
+  RawByteArray bytes;              // decompressed payload (uninitialized resize)
+  std::vector<PMsgEntry> entries;  // in emit order (sorted by the active comparator)
+  Status status;
+  std::shared_ptr<ByteSemaphore> sem;    // shared so the semaphore outlives every chunk
+  std::shared_ptr<ParallelStats> stats;  // shared diagnostic accounting
+  uint64_t budgetHeld = 0;
+  uint64_t liveBytesAccounted = 0;  // decompressed bytes counted into stats->live
+  ~ReadyChunk() {
+    if (stats && liveBytesAccounted != 0) {
+      stats->subLive(liveBytesAccounted);
+    }
+    if (sem && budgetHeld != 0) {
+      sem->release(budgetHeld);
+    }
+  }
+};
+using ReadyChunkPtr = std::shared_ptr<ReadyChunk>;
+
+struct ChunkPlan {
+  Timestamp startTime = 0;
+  Timestamp endTime = 0;
+  ByteOffset chunkStartOffset = 0;
+  ByteOffset messageIndexEndOffset = 0;
+  uint64_t uncompressedSize = 0;
+};
+
+// Canonical emit order: true if message A should be emitted before B, comparing by
+// timestamp and then RecordOffset (tie-break), flipped for reverse. This is the
+// SINGLE source of truth for ordering in the parallel reader -- used by both the
+// per-chunk entry sort (entryLess) and the k-way merge heap (makeHeapComparator),
+// so the two can never disagree. The RecordOffset tie-break itself is shared with
+// the serial reader via RecordOffset's comparison operators.
+inline bool messageOrderLess(Timestamp tsA, RecordOffset roA, Timestamp tsB, RecordOffset roB,
+                             bool reverse) {
+  if (tsA != tsB) {
+    return reverse ? (tsA > tsB) : (tsA < tsB);
+  }
+  return reverse ? (roA > roB) : (roA < roB);
+}
+
+inline bool entryLess(const PMsgEntry& a, const PMsgEntry& b, bool reverse) {
+  return messageOrderLess(a.timestamp, RecordOffset{a.offset, a.chunkOffset}, b.timestamp,
+                          RecordOffset{b.offset, b.chunkOffset}, reverse);
+}
+
+}  // namespace internal
+
+class ParallelMessageView {
+public:
+  ParallelMessageView(McapReader& reader, IReadable* source, const ParallelReadOptions& opts,
+                      const ProblemCallback& onProblem)
+      : reader_(reader)
+      , source_(source)
+      , opts_(opts)
+      , onProblem_(onProblem)
+      , reverse_(opts.read.readOrder == ReadMessageOptions::ReadOrder::ReverseLogTimeOrder)
+      , heap_(makeHeapComparator()) {
+    init();
+  }
+
+  ~ParallelMessageView() {
+    cancelled_.store(true);  // make queued workers bail instead of decompressing
+    if (pool_) pool_->shutdown();
+  }
+
+  ParallelMessageView(const ParallelMessageView&) = delete;
+  ParallelMessageView& operator=(const ParallelMessageView&) = delete;
+
+  Status status() const {
+    return status_;
+  }
+
+  // Diagnostic counters (chunk counts, peak resident decompressed bytes).
+  const internal::ParallelStats& stats() const {
+    return *stats_;
+  }
+
+  // ---- iterator ---------------------------------------------------------
+  struct Iterator {
+    using iterator_category = std::input_iterator_tag;
+    using value_type = MessageView;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const MessageView*;
+    using reference = const MessageView&;
+
+    Iterator() = default;
+    explicit Iterator(ParallelMessageView& v)
+        : view_(&v) {
+      ++(*this);  // prime first message
+    }
+
+    reference operator*() const {
+      return *view_->curView_;
+    }
+    pointer operator->() const {
+      return &*view_->curView_;
+    }
+
+    Iterator& operator++() {
+      if (view_ && !view_->produceNext()) {
+        view_ = nullptr;  // exhausted -> equals end()
+      }
+      return *this;
+    }
+    void operator++(int) {
+      ++(*this);
+    }
+
+    friend bool operator==(const Iterator& a, const Iterator& b) {
+      return a.view_ == b.view_;
+    }
+    friend bool operator!=(const Iterator& a, const Iterator& b) {
+      return !(a == b);
+    }
+
+  private:
+    ParallelMessageView* view_ = nullptr;
+  };
+
+  Iterator begin() {
+    if (!status_.ok()) return end();
+    return Iterator{*this};
+  }
+  Iterator end() {
+    return Iterator{};
+  }
+
+private:
+  // ---- a live cursor over one ready chunk -------------------------------
+  struct Cursor {
+    internal::ReadyChunkPtr chunk;
+    size_t idx = 0;
+    bool live() const {
+      return chunk && idx < chunk->entries.size();
+    }
+    const internal::PMsgEntry& head() const {
+      return chunk->entries[idx];
+    }
+  };
+
+  struct HeapItem {
+    Timestamp timestamp;
+    RecordOffset ro;
+    size_t cursorId;
+  };
+
+  std::function<bool(const HeapItem&, const HeapItem&)> makeHeapComparator() {
+    const bool reverse = reverse_;
+    // priority_queue is a max-heap: "true means a is LOWER priority than b", i.e. a
+    // emits AFTER b, i.e. b emits before a. Reuse the one ordering definition.
+    return [reverse](const HeapItem& a, const HeapItem& b) {
+      return internal::messageOrderLess(b.timestamp, b.ro, a.timestamp, a.ro, reverse);
+    };
+  }
+
+  void init() {
+    // The engine reads the same source from many worker threads at once, so it
+    // only works on a source whose read() has no shared mutable cursor/buffer.
+    if (source_ == nullptr || !source_->supportsConcurrentRead()) {
+      status_ = Status{StatusCode::InvalidMessageReadOptions,
+                       "parallel reading requires a source that supports concurrent reads "
+                       "(open the ParallelReader on a file path or an MmapReader)"};
+      onProblem_(status_);
+      return;
+    }
+    // Ensure the summary (chunk index, channels, schemas) is available.
+    if (reader_.chunkIndexes().empty()) {
+      status_ = reader_.readSummary(ReadSummaryMethod::AllowFallbackScan);
+      if (!status_.ok()) {
+        onProblem_(status_);
+        return;
+      }
+    }
+    const auto& chunkIndexes = reader_.chunkIndexes();
+    if (chunkIndexes.empty() ||
+        std::all_of(chunkIndexes.begin(), chunkIndexes.end(), [](const ChunkIndex& ci) {
+          return ci.messageIndexLength == 0;
+        })) {
+      status_ = Status{StatusCode::NoMessageIndexesAvailable,
+                       "cannot read in time order without message indexes"};
+      onProblem_(status_);
+      return;
+    }
+
+    // Selected channels (topic filter).
+    for (const auto& [channelId, channel] : reader_.channels()) {
+      if (!opts_.read.topicFilter || opts_.read.topicFilter(channel->topic)) {
+        selectedChannels_.insert(channelId);
+      }
+    }
+
+    // Build the plan list: chunks overlapping the time range that carry a
+    // selected channel, sorted by start time (forward) / end time (reverse).
+    for (const auto& ci : chunkIndexes) {
+      if (ci.messageStartTime >= opts_.read.endTime) continue;
+      if (ci.messageEndTime < opts_.read.startTime) continue;
+      bool hasSelected = false;
+      for (const auto& [channelId, _off] : ci.messageIndexOffsets) {
+        if (selectedChannels_.count(channelId) != 0) {
+          hasSelected = true;
+          break;
+        }
+      }
+      if (!hasSelected) continue;
+      if (opts_.maxChunkUncompressedSize != 0 &&
+          ci.uncompressedSize > opts_.maxChunkUncompressedSize) {
+        status_ = Status{StatusCode::DecompressionSizeMismatch,
+                         "chunk uncompressedSize (" + std::to_string(ci.uncompressedSize) +
+                           " B) exceeds maxChunkUncompressedSize; possible corruption"};
+        onProblem_(status_);
+        return;
+      }
+      internal::ChunkPlan plan;
+      plan.startTime = ci.messageStartTime;
+      plan.endTime = ci.messageEndTime;
+      plan.chunkStartOffset = ci.chunkStartOffset;
+      plan.messageIndexEndOffset = ci.chunkStartOffset + ci.chunkLength + ci.messageIndexLength;
+      plan.uncompressedSize = ci.uncompressedSize;
+      plans_.push_back(plan);
+    }
+    std::sort(plans_.begin(), plans_.end(),
+              [this](const internal::ChunkPlan& a, const internal::ChunkPlan& b) {
+                return reverse_ ? (a.endTime > b.endTime) : (a.startTime < b.startTime);
+              });
+
+    scheduled_.assign(plans_.size(), false);
+    futures_.resize(plans_.size());
+
+    // Memory cap: profile the (filtered) chunk set and resolve a byte budget.
+    const auto profile = computeResidencyProfile(chunkIndexes, selectedChannels_);
+    uint64_t lookahead = opts_.lookaheadBytes;
+    if (lookahead == 0) {
+      const unsigned t =
+        opts_.threadCount ? opts_.threadCount : std::thread::hardware_concurrency();
+      lookahead = uint64_t(std::max(1u, t)) * (profile.uMaxBytes ? profile.uMaxBytes : 1);
+    }
+    budget_ = resolveBudget(profile, opts_.read.readOrder, opts_.maxBytesInFlight, opts_.capPolicy,
+                            lookahead);
+    if (budget_.fallBackToSerial || !budget_.feasibleWithoutEviction) {
+      // Caller asked for a regime this engine won't honor silently. Surface it;
+      // the caller can fall back to McapReader::readMessages.
+      status_ = Status{StatusCode::InvalidMessageReadOptions, budget_.note};
+      onProblem_(status_);
+      return;
+    }
+    sem_ = std::make_shared<internal::ByteSemaphore>(
+      std::max<uint64_t>(budget_.effectiveBudgetBytes, 1));
+    pool_ = std::make_unique<internal::ThreadPool>(opts_.threadCount);
+  }
+
+  // Decompress + parse one chunk on a worker. `budgetHeld` was already acquired
+  // by the consumer (force or try), so workers never touch the semaphore.
+  void runChunkJob(size_t planIdx, uint64_t budgetHeld,
+                   std::shared_ptr<std::promise<internal::ReadyChunkPtr>> prom) {
+    auto rc = std::make_shared<internal::ReadyChunk>();
+    rc->sem = sem_;  // shared ownership: semaphore outlives this chunk
+    rc->stats = stats_;
+    rc->budgetHeld = budgetHeld;
+
+    // Fast-bail for queued jobs once the view is being torn down, so early exit
+    // (e.g. interactive scrubbing) doesn't wait for the whole prefetch window.
+    if (cancelled_.load(std::memory_order_relaxed)) {
+      rc->status = Status{StatusCode::ReadFailed, "cancelled"};
+      prom->set_value(std::move(rc));
+      return;
+    }
+
+    // Any throw in decompression/parsing/allocation is converted to a Status; the
+    // promise is ALWAYS fulfilled so the consumer can never hang on get().
+    try {
+      const auto& plan = plans_[planIdx];
+      RecordReader rr(*source_, plan.chunkStartOffset, plan.messageIndexEndOffset);
+      bool gotChunk = false;
+      for (auto rec = rr.next(); rec.has_value(); rec = rr.next()) {
+        if (!rr.status().ok()) {
+          rc->status = rr.status();
+          break;
+        }
+        if (rec->opcode == OpCode::Chunk) {
+          Chunk chunk;
+          rc->status = McapReader::ParseChunk(*rec, &chunk);
+          if (!rc->status.ok()) break;
+          rc->status = decompressInto(chunk, rc->bytes);
+          if (!rc->status.ok()) break;
+          gotChunk = true;
+        } else if (rec->opcode == OpCode::MessageIndex) {
+          MessageIndex mi;
+          rc->status = McapReader::ParseMessageIndex(*rec, &mi);
+          if (!rc->status.ok()) break;
+          if (selectedChannels_.count(mi.channelId) == 0) continue;
+          for (const auto& [ts, off] : mi.records) {
+            if (ts >= opts_.read.startTime && ts < opts_.read.endTime) {
+              rc->entries.push_back({ts, off, plan.chunkStartOffset});
+            }
+          }
+        }
+      }
+      if (rc->status.ok() && !gotChunk) {
+        rc->status = Status{StatusCode::InvalidChunkOffset, "no chunk record at planned offset"};
+      }
+      if (rc->status.ok()) {
+        std::sort(rc->entries.begin(), rc->entries.end(),
+                  [this](const internal::PMsgEntry& a, const internal::PMsgEntry& b) {
+                    return internal::entryLess(a, b, reverse_);
+                  });
+        // Account the decompressed payload as resident until ~ReadyChunk frees it.
+        rc->liveBytesAccounted = rc->bytes.size();
+        stats_->addLive(rc->liveBytesAccounted);
+        stats_->chunksDecompressed.fetch_add(1, std::memory_order_relaxed);
+      }
+    } catch (const std::exception& e) {
+      rc->bytes.clear();
+      rc->entries.clear();
+      rc->status = Status{StatusCode::DecompressionFailed,
+                          std::string("exception decompressing chunk: ") + e.what()};
+    } catch (...) {
+      rc->bytes.clear();
+      rc->entries.clear();
+      rc->status = Status{StatusCode::DecompressionFailed, "unknown exception decompressing chunk"};
+    }
+    prom->set_value(std::move(rc));
+  }
+
+  Status decompressInto(const Chunk& chunk, internal::RawByteArray& out) {
+    const auto comp = McapReader::ParseCompression(chunk.compression);
+    if (!comp.has_value()) {
+      return Status{StatusCode::UnrecognizedCompression, "unrecognized: " + chunk.compression};
+    }
+    if (*comp == Compression::None) {
+      out.assign(chunk.records, chunk.records + chunk.uncompressedSize);
+      return StatusCode::Success;
+    }
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+    if (*comp == Compression::Zstd) {
+      // Reuse a per-thread DCtx and decompress into an uninitialized buffer (the
+      // resize below does not zero-fill, since zstd overwrites every byte).
+      out.resize(chunk.uncompressedSize);
+      ZSTD_DCtx* decompressCtx = internal::threadLocalZstdDCtx();
+      if (decompressCtx == nullptr) {
+        out.clear();
+        return Status{StatusCode::DecompressionFailed, "ZSTD_createDCtx failed"};
+      }
+      const size_t n = ZSTD_decompressDCtx(decompressCtx, out.data(), out.size(), chunk.records,
+                                           chunk.compressedSize);
+      if (ZSTD_isError(n)) {
+        out.clear();
+        return Status{StatusCode::DecompressionFailed,
+                      std::string("zstd decompression failed: ") + ZSTD_getErrorName(n)};
+      }
+      if (n != chunk.uncompressedSize) {
+        out.clear();
+        return Status{StatusCode::DecompressionSizeMismatch,
+                      "zstd: decompressed size does not match declared uncompressedSize"};
+      }
+      return StatusCode::Success;
+    }
+#endif
+#ifndef MCAP_COMPRESSION_NO_LZ4
+    if (*comp == Compression::Lz4) {
+      // LZ4Reader writes into a std::vector<std::byte>; decompress into a temp and
+      // copy across. LZ4 is not the optimized path here (correctness over speed).
+      ByteArray tmp;
+      LZ4Reader lz4;  // per-job instance: LZ4Reader is not thread-safe to share
+      const Status s =
+        lz4.decompressAll(chunk.records, chunk.compressedSize, chunk.uncompressedSize, &tmp);
+      if (!s.ok()) return s;
+      out.assign(tmp.begin(), tmp.end());
+      return StatusCode::Success;
+    }
+#endif
+    return Status{StatusCode::UnsupportedCompression, "unsupported: " + chunk.compression};
+  }
+
+  // Schedule chunk `planIdx` for decompression if not already scheduled.
+  // `force` -> forceAcquire (required chunk, may exceed cap). Otherwise tryAcquire
+  // (prefetch) and return false if the budget is full.
+  bool scheduleChunk(size_t planIdx, bool force) {
+    if (scheduled_[planIdx]) return true;
+    const uint64_t need = plans_[planIdx].uncompressedSize;
+    if (force) {
+      sem_->forceAcquire(need);
+    } else if (!sem_->tryAcquire(need)) {
+      return false;  // budget full -> back-pressure, try again later
+    }
+    auto prom = std::make_shared<std::promise<internal::ReadyChunkPtr>>();
+    futures_[planIdx] = prom->get_future();
+    scheduled_[planIdx] = true;
+    stats_->chunksScheduled.fetch_add(1, std::memory_order_relaxed);
+    if (force) stats_->chunksForced.fetch_add(1, std::memory_order_relaxed);
+    pool_->submit([this, planIdx, need, prom] {
+      runChunkJob(planIdx, need, prom);
+    });
+    return true;
+  }
+
+  // Opportunistically prefetch chunks ahead of the cursor frontier, within budget.
+  // Resumes from a monotonic cursor so it never re-walks the already-scheduled
+  // prefix: the old version restarted at nextPlanToCursor_ on every message,
+  // re-scanning the whole ~budget-wide scheduled window (O(window) per message),
+  // which profiling showed was the dominant consumer-thread cost.
+  void prefetch() {
+    while (nextPlanToPrefetch_ < plans_.size()) {
+      if (scheduled_[nextPlanToPrefetch_]) {
+        ++nextPlanToPrefetch_;  // already scheduled (here or force-scheduled); skip for good
+        continue;
+      }
+      if (!scheduleChunk(nextPlanToPrefetch_, /*force=*/false)) {
+        break;  // budget full -> retry this same index next time
+      }
+      ++nextPlanToPrefetch_;
+    }
+  }
+
+  void addCursor(size_t planIdx) {
+    // Block until this (already-scheduled) chunk is decompressed.
+    internal::ReadyChunkPtr rc = futures_[planIdx].get();
+    if (!rc->status.ok()) {
+      status_ = rc->status;
+      onProblem_(status_);
+      return;
+    }
+    cursors_.push_back(Cursor{rc, 0});
+    const size_t cursorId = cursors_.size() - 1;
+    if (cursors_[cursorId].live()) {
+      const auto& e = cursors_[cursorId].head();
+      heap_.push(HeapItem{e.timestamp, RecordOffset{e.offset, e.chunkOffset}, cursorId});
+    }
+  }
+
+  // Produce the next message in order. Returns false when exhausted.
+  bool produceNext() {
+    if (!status_.ok()) return false;
+    curView_.reset();
+
+    for (;;) {
+      prefetch();
+
+      // Admission: ensure every chunk that could contain a message at or before
+      // (forward) / at or after (reverse) the current heap frontier has a cursor.
+      // Required chunks are force-scheduled so they never block on the budget.
+      while (nextPlanToCursor_ < plans_.size()) {
+        const auto& plan = plans_[nextPlanToCursor_];
+        bool required;
+        if (heap_.empty()) {
+          required = true;  // need at least the next chunk to know the frontier
+        } else {
+          const Timestamp frontier = heap_.top().timestamp;
+          required = reverse_ ? (plan.endTime >= frontier) : (plan.startTime <= frontier);
+        }
+        if (!required) break;
+        scheduleChunk(nextPlanToCursor_, /*force=*/true);
+        addCursor(nextPlanToCursor_);
+        if (!status_.ok()) return false;
+        nextPlanToCursor_++;
+      }
+
+      if (heap_.empty()) {
+        pinned_.reset();  // exhausted: drop the last pinned chunk so budget/memory return to 0
+        return false;     // nothing left
+      }
+
+      const HeapItem top = heap_.top();
+      heap_.pop();
+      Cursor& cur = cursors_[top.cursorId];
+      const internal::PMsgEntry entry = cur.head();
+
+      // Pin the backing chunk for the message we're about to emit so its bytes
+      // (curMessage_.data points into them) stay valid until we advance to a
+      // DIFFERENT chunk. Re-pinning only on a chunk change avoids an atomic
+      // shared_ptr inc/dec for every message within a chunk -- profiling showed
+      // that per-message refcount churn was a leading consumer-side cost. Dropping
+      // the cursor's own reference when it drains (below) stays safe: pinned_ holds
+      // this chunk until the next chunk's first message rotates it out.
+      if (pinned_.get() != cur.chunk.get()) {
+        pinned_ = cur.chunk;
+      }
+
+      // Read the message out of the decompressed chunk (zero-copy into rc->bytes).
+      BufferReader br;
+      br.reset(cur.chunk->bytes.data(), cur.chunk->bytes.size(), cur.chunk->bytes.size());
+      RecordReader rr(br, entry.offset, cur.chunk->bytes.size());
+      auto rec = rr.next();
+      if (!rr.status().ok() || !rec.has_value() || rec->opcode != OpCode::Message) {
+        status_ = Status{StatusCode::InvalidRecord, "expected a message record in chunk"};
+        onProblem_(status_);
+        return false;
+      }
+      status_ = McapReader::ParseMessage(*rec, &curMessage_);
+      if (!status_.ok()) {
+        onProblem_(status_);
+        return false;
+      }
+
+      // Advance the cursor; re-push its next head if any. When a cursor is
+      // exhausted, release the chunk it held: pinned_ still owns the chunk backing
+      // the message we're emitting, so dropping cursors_'s reference here makes the
+      // ReadyChunk destruct once pinned_ rotates on the next ++ -- which returns
+      // its bytes to the ByteSemaphore so prefetch can keep filling the window.
+      // Without this, cursors_ retains every chunk for the whole iteration: the
+      // budget is never reclaimed, prefetch dies, and resident memory grows to the
+      // entire uncompressed dataset.
+      cur.idx++;
+      if (cur.live()) {
+        const auto& e = cur.head();
+        heap_.push(HeapItem{e.timestamp, RecordOffset{e.offset, e.chunkOffset}, top.cursorId});
+      } else {
+        cur.chunk.reset();
+      }
+
+      // Resolve channel/schema.
+      auto channel = reader_.channel(curMessage_.channelId);
+      if (!channel) {
+        onProblem_(Status{StatusCode::InvalidChannelId, "message references missing channel"});
+        continue;  // skip, keep going
+      }
+      SchemaPtr schema;
+      if (channel->schemaId != 0) {
+        schema = reader_.schema(channel->schemaId);
+      }
+      curView_.emplace(curMessage_, channel, schema, RecordOffset{entry.offset, entry.chunkOffset});
+      return true;
+    }
+  }
+
+  // ---- state ------------------------------------------------------------
+  McapReader& reader_;
+  IReadable* source_ = nullptr;
+  ParallelReadOptions opts_;
+  ProblemCallback onProblem_;
+  bool reverse_ = false;
+
+  std::unordered_set<ChannelId> selectedChannels_;
+  std::vector<internal::ChunkPlan> plans_;
+  std::vector<bool> scheduled_;
+  std::vector<std::future<internal::ReadyChunkPtr>> futures_;
+  size_t nextPlanToCursor_ = 0;
+  size_t nextPlanToPrefetch_ = 0;  // monotonic prefetch cursor (never re-scans scheduled prefix)
+
+  std::shared_ptr<internal::ByteSemaphore> sem_;
+  std::unique_ptr<internal::ThreadPool> pool_;
+  std::shared_ptr<internal::ParallelStats> stats_ = std::make_shared<internal::ParallelStats>();
+  BudgetDecision budget_;
+
+  std::vector<Cursor> cursors_;
+  std::priority_queue<HeapItem, std::vector<HeapItem>,
+                      std::function<bool(const HeapItem&, const HeapItem&)>>
+    heap_;
+
+  Message curMessage_;
+  std::optional<MessageView> curView_;
+  internal::ReadyChunkPtr pinned_;  // keeps curMessage_.data alive until next ++
+  std::atomic<bool> cancelled_{false};
+  Status status_;
+};
+
+// A self-contained multithreaded MCAP reader. It COMPOSES a McapReader (used via
+// its public API for the summary, channels, schemas, and chunk index) and OWNS the
+// concurrent-safe source it reads from. All parallel-specific surface lives here;
+// the core McapReader / reader.hpp are untouched apart from the general-purpose
+// IReadable::supportsConcurrentRead() capability bit.
+//
+//   ParallelReader pr;
+//   if (!pr.open("file.mcap").ok()) { ... }
+//   ParallelReadOptions opts; opts.read.readOrder = ReadOrder::LogTimeOrder;
+//   for (const auto& mv : pr.readMessages(onProblem, opts)) { decode(mv); }
+//
+class ParallelReader {
+public:
+  ParallelReader() = default;
+  ~ParallelReader() = default;
+  ParallelReader(const ParallelReader&) = delete;
+  ParallelReader& operator=(const ParallelReader&) = delete;
+
+  // Open a file via an internally-owned, read-only memory mapping (concurrent-safe)
+  // and parse its summary. This is the common entry point.
+  Status open(std::string_view path) {
+    close();
+    auto src = std::make_unique<MmapReader>();
+    Status status = src->open(path);
+    if (!status.ok()) {
+      return status;
+    }
+    status = reader_.open(*src);
+    if (!status.ok()) {
+      return status;
+    }
+    ownedSource_ = std::move(src);
+    source_ = ownedSource_.get();
+    return reader_.readSummary(ReadSummaryMethod::AllowFallbackScan);
+  }
+
+  // Open against a caller-provided source. It MUST support concurrent reads
+  // (source.supportsConcurrentRead() == true), e.g. an MmapReader or an in-memory
+  // BufferReader; otherwise readMessages() reports an error and yields nothing.
+  // The caller retains ownership of `concurrentSource` (it must outlive this).
+  Status open(IReadable& concurrentSource) {
+    close();
+    const Status status = reader_.open(concurrentSource);
+    if (!status.ok()) {
+      return status;
+    }
+    source_ = &concurrentSource;
+    return reader_.readSummary(ReadSummaryMethod::AllowFallbackScan);
+  }
+
+  void close() {
+    reader_.close();
+    ownedSource_.reset();
+    source_ = nullptr;
+  }
+
+  // Iterate messages in the requested order, decompressing chunks on a thread pool
+  // ahead of the merge frontier. Output matches the serial reader exactly. If the
+  // reader is not open on a concurrent-safe source, the view yields nothing and
+  // reports an error via `onProblem`.
+  ParallelMessageView readMessages(const ProblemCallback& onProblem,
+                                   const ParallelReadOptions& options) {
+    return ParallelMessageView(reader_, source_, options, onProblem);
+  }
+
+  // Access to the composed reader's parsed summary data (valid after open()).
+  McapReader& reader() {
+    return reader_;
+  }
+  const std::optional<Statistics>& statistics() const {
+    return reader_.statistics();
+  }
+  std::unordered_map<ChannelId, ChannelPtr> channels() const {
+    return reader_.channels();
+  }
+  std::unordered_map<SchemaId, SchemaPtr> schemas() const {
+    return reader_.schemas();
+  }
+  const std::vector<ChunkIndex>& chunkIndexes() const {
+    return reader_.chunkIndexes();
+  }
+
+private:
+  McapReader reader_;
+  std::unique_ptr<IReadable> ownedSource_;  // owns an MmapReader when open(path) is used
+  IReadable* source_ = nullptr;             // the concurrent source reader_ reads from
+};
+
+}  // namespace mcap

--- a/cpp/mcap/include/mcap/reader.hpp
+++ b/cpp/mcap/include/mcap/reader.hpp
@@ -66,6 +66,18 @@ struct MCAP_PUBLIC IReadable {
    *   method should return 0.
    */
   virtual uint64_t read(std::byte** output, uint64_t offset, uint64_t size) = 0;
+
+  /**
+   * @brief Returns true if read() is safe to call concurrently from multiple
+   * threads (i.e. it has no shared mutable cursor/buffer). The default is false,
+   * which is correct for any source returning a pointer into one shared buffer
+   * (FileReader, FileStreamReader). Sources backed by an immutable mapping
+   * (MmapReader) or an immutable buffer override this to return true. The
+   * parallel reader requires a source for which this is true.
+   */
+  virtual bool supportsConcurrentRead() const {
+    return false;
+  }
 };
 
 /**

--- a/cpp/mcap/include/mcap/thread_pool.hpp
+++ b/cpp/mcap/include/mcap/thread_pool.hpp
@@ -1,0 +1,89 @@
+#pragma once
+//
+// thread_pool.hpp
+//
+// Minimal FIFO thread pool (C++17, no external deps). Workers pull jobs in
+// submission order. Used by the parallel reader to decompress chunks. The pool
+// joins all workers on destruction.
+//
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace mcap::internal {
+
+class ThreadPool {
+public:
+  explicit ThreadPool(unsigned n) {
+    if (n == 0) {
+      n = std::thread::hardware_concurrency();
+      if (n == 0) n = 4;
+    }
+    workers_.reserve(n);
+    for (unsigned i = 0; i < n; i++) {
+      workers_.emplace_back([this] {
+        run();
+      });
+    }
+  }
+
+  ~ThreadPool() {
+    shutdown();
+  }
+
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
+
+  void submit(std::function<void()> job) {
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      jobs_.push(std::move(job));
+    }
+    cv_.notify_one();
+  }
+
+  void shutdown() {
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      if (stopping_) return;
+      stopping_ = true;
+    }
+    cv_.notify_all();
+    for (auto& t : workers_) {
+      if (t.joinable()) t.join();
+    }
+    workers_.clear();
+  }
+
+  unsigned size() const {
+    return unsigned(workers_.size());
+  }
+
+private:
+  void run() {
+    for (;;) {
+      std::function<void()> job;
+      {
+        std::unique_lock<std::mutex> lk(m_);
+        cv_.wait(lk, [this] {
+          return stopping_ || !jobs_.empty();
+        });
+        if (stopping_ && jobs_.empty()) return;
+        job = std::move(jobs_.front());
+        jobs_.pop();
+      }
+      job();
+    }
+  }
+
+  std::vector<std::thread> workers_;
+  std::queue<std::function<void()>> jobs_;
+  std::mutex m_;
+  std::condition_variable cv_;
+  bool stopping_ = false;
+};
+
+}  // namespace mcap::internal

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -16,6 +16,9 @@ endif()
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+# The parallel reader uses a thread pool.
+find_package(Threads REQUIRED)
+
 add_executable(streamed-reader-conformance streamed_reader_conformance.cpp)
 target_link_libraries(streamed-reader-conformance ${CONAN_LIBS})
 
@@ -31,3 +34,15 @@ target_link_libraries(unit-tests ${CONAN_LIBS})
 add_executable(unit-tests-nocompress unit_tests.cpp)
 target_link_libraries(unit-tests-nocompress ${CONAN_LIBS})
 target_compile_definitions(unit-tests-nocompress PRIVATE MCAP_COMPRESSION_NO_LZ4 MCAP_COMPRESSION_NO_ZSTD)
+
+# Proves the serial API still builds with the parallel reader compiled out.
+add_executable(unit-tests-noparallel unit_tests.cpp)
+target_link_libraries(unit-tests-noparallel ${CONAN_LIBS})
+target_compile_definitions(unit-tests-noparallel PRIVATE MCAP_NO_PARALLEL)
+
+add_executable(parallel-reader-test parallel_reader_test.cpp)
+target_link_libraries(parallel-reader-test ${CONAN_LIBS} Threads::Threads)
+
+add_executable(parallel-reader-test-nocompress parallel_reader_test.cpp)
+target_link_libraries(parallel-reader-test-nocompress ${CONAN_LIBS} Threads::Threads)
+target_compile_definitions(parallel-reader-test-nocompress PRIVATE MCAP_COMPRESSION_NO_LZ4 MCAP_COMPRESSION_NO_ZSTD)

--- a/cpp/test/parallel_reader_test.cpp
+++ b/cpp/test/parallel_reader_test.cpp
@@ -1,0 +1,448 @@
+#define MCAP_IMPLEMENTATION
+#include <mcap/mcap.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+using namespace mcap;
+using Order = ReadMessageOptions::ReadOrder;
+
+namespace {
+
+// ---- synthetic file generation ------------------------------------------------
+
+struct Spec {
+  std::string name;
+  Compression compression;
+  uint64_t chunkSize;
+  int channels;
+  uint32_t perChannel;
+  size_t payload;
+  bool overlap;      // interleave channels so chunk time-ranges overlap
+  bool tie = false;  // all channels share identical timestamps (RecordOffset tie-break)
+};
+
+std::string writeFile(const std::filesystem::path& dir, const Spec& s) {
+  const auto path = (dir / (s.name + ".mcap")).string();
+  McapWriterOptions o{"parallel-test"};
+  o.compression = s.compression;
+  o.chunkSize = s.chunkSize;
+  o.forceCompression = (s.compression != Compression::None);
+  McapWriter w;
+  REQUIRE(w.open(path, o).ok());
+  Schema sc{"m", "raw", std::string_view{"x"}};
+  w.addSchema(sc);
+  std::vector<Channel> ch;
+  for (int c = 0; c < s.channels; c++) {
+    Channel k{"/t" + std::to_string(c), "raw", sc.id};
+    w.addChannel(k);
+    ch.push_back(k);
+  }
+  std::vector<std::byte> payload(s.payload);
+  auto one = [&](int c, uint32_t seq) {
+    const Timestamp t = s.tie
+                          ? Timestamp(uint64_t(seq) * 1000)
+                          : Timestamp((uint64_t(seq) * uint64_t(s.channels) + uint64_t(c)) * 1000);
+    std::memcpy(payload.data(), &t, sizeof(t));  // identity-encode for divergence diagnostics
+    Message m;
+    m.channelId = ch[size_t(c)].id;
+    m.sequence = seq;
+    m.logTime = t;
+    m.publishTime = t;
+    m.dataSize = payload.size();
+    m.data = payload.data();
+    REQUIRE(w.write(m).ok());
+  };
+  if (s.overlap) {
+    for (int c = 0; c < s.channels; c++)
+      for (uint32_t seq = 0; seq < s.perChannel; seq++) one(c, seq);
+  } else {
+    for (uint32_t seq = 0; seq < s.perChannel; seq++)
+      for (int c = 0; c < s.channels; c++) one(c, seq);
+  }
+  w.close();
+  return path;
+}
+
+// Portable unique temp directory (avoids POSIX getpid(), which is undeclared on MSVC).
+std::filesystem::path uniqueTempDir(const std::string& tag) {
+  static std::atomic<uint64_t> counter{0};
+  std::random_device rd;
+  const uint64_t unique = (uint64_t(rd()) << 32) ^ uint64_t(rd()) ^ (counter.fetch_add(1) << 1);
+  auto dir = std::filesystem::temp_directory_path() / (tag + std::to_string(unique));
+  std::filesystem::create_directories(dir);
+  return dir;
+}
+
+// ---- canonical message + comparison -------------------------------------------
+
+struct Canonical {
+  Timestamp logTime;
+  uint16_t channelId;
+  uint32_t sequence;
+  std::string data;
+};
+
+Canonical canonical(const MessageView& mv) {
+  return Canonical{
+    mv.message.logTime, uint16_t(mv.message.channelId), mv.message.sequence,
+    std::string(reinterpret_cast<const char*>(mv.message.data), mv.message.dataSize)};
+}
+
+bool sameSequence(const std::vector<Canonical>& a, const std::vector<Canonical>& b,
+                  std::string& detail) {
+  if (a.size() != b.size()) {
+    detail = "size " + std::to_string(a.size()) + " != " + std::to_string(b.size());
+    return false;
+  }
+  for (size_t i = 0; i < a.size(); i++) {
+    if (a[i].logTime != b[i].logTime || a[i].channelId != b[i].channelId ||
+        a[i].sequence != b[i].sequence || a[i].data != b[i].data) {
+      detail = "first divergence at index " + std::to_string(i);
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<Canonical> serialMessages(const std::string& path, const ReadMessageOptions& opts) {
+  std::FILE* fp = std::fopen(path.c_str(), "rb");
+  REQUIRE(fp != nullptr);
+  FileReader src(fp);
+  McapReader reader;
+  REQUIRE(reader.open(src).ok());
+  REQUIRE(reader.readSummary(ReadSummaryMethod::AllowFallbackScan).ok());
+  std::vector<Canonical> out;
+  auto view = reader.readMessages([](const Status&) {}, opts);
+  for (const auto& mv : view) out.push_back(canonical(mv));
+  std::fclose(fp);
+  return out;
+}
+
+std::vector<Canonical> parallelMessages(const std::string& path, const ParallelReadOptions& opts) {
+  ParallelReader pr;
+  REQUIRE(pr.open(path).ok());
+  std::vector<Canonical> out;
+  auto view = pr.readMessages([](const Status&) {}, opts);
+  for (const auto& mv : view) out.push_back(canonical(mv));
+  REQUIRE(view.status().ok());
+  return out;
+}
+
+ParallelReadOptions parallelOpts(Order order, unsigned threads) {
+  ParallelReadOptions o;
+  o.read.readOrder = order;
+  o.threadCount = threads;
+  o.maxBytesInFlight = 16ull * 1024 * 1024;
+  o.lookaheadBytes = 16ull * 1024 * 1024;
+  return o;
+}
+
+}  // namespace
+
+TEST_CASE("ParallelReader matches the serial reader", "[parallel][parity]") {
+  auto dir = uniqueTempDir("mcap_par_");
+
+  std::vector<Spec> specs;
+  specs.push_back({"none_overlap", Compression::None, 8 * 1024, 6, 300, 256, true});
+  specs.push_back({"none_disjoint", Compression::None, 8 * 1024, 6, 300, 256, false});
+#ifndef MCAP_COMPRESSION_NO_ZSTD
+  specs.push_back({"zstd_overlap", Compression::Zstd, 8 * 1024, 8, 300, 256, true});
+  specs.push_back({"zstd_disjoint", Compression::Zstd, 8 * 1024, 8, 300, 256, false});
+  specs.push_back({"zstd_single_chunk", Compression::Zstd, 64 * 1024 * 1024, 8, 300, 256, true});
+  specs.push_back({"zstd_many_small", Compression::Zstd, 4 * 1024, 12, 500, 64, true});
+  specs.push_back({"zstd_ties", Compression::Zstd, 8 * 1024, 8, 300, 256, true, /*tie*/ true});
+#endif
+#ifndef MCAP_COMPRESSION_NO_LZ4
+  specs.push_back({"lz4_overlap", Compression::Lz4, 8 * 1024, 6, 300, 256, true});
+  specs.push_back({"lz4_ties", Compression::Lz4, 8 * 1024, 6, 300, 256, true, /*tie*/ true});
+#endif
+
+  const std::vector<Order> orders = {Order::LogTimeOrder, Order::ReverseLogTimeOrder};
+  const std::vector<unsigned> threadCounts = {1, 2, 4, 8};
+
+  for (const auto& spec : specs) {
+    const auto path = writeFile(dir, spec);
+    for (Order order : orders) {
+      ReadMessageOptions sOpts;
+      sOpts.readOrder = order;
+      const auto expected = serialMessages(path, sOpts);
+      for (unsigned threads : threadCounts) {
+        DYNAMIC_SECTION(spec.name << " order=" << int(order) << " threads=" << threads) {
+          const auto got = parallelMessages(path, parallelOpts(order, threads));
+          std::string detail;
+          const bool equal = sameSequence(expected, got, detail);
+          INFO(detail);
+          REQUIRE(equal);
+        }
+      }
+    }
+  }
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("ParallelReader is deterministic across repeated runs", "[parallel][parity]") {
+  auto dir = uniqueTempDir("mcap_par_det_");
+  const auto path = writeFile(dir, {"det", Compression::None, 8 * 1024, 8, 400, 256, true});
+  const auto base = parallelMessages(path, parallelOpts(Order::LogTimeOrder, 8));
+  for (int run = 0; run < 8; run++) {
+    const auto again = parallelMessages(path, parallelOpts(Order::LogTimeOrder, 8));
+    std::string detail;
+    INFO("run " << run << ": " << detail);
+    REQUIRE(sameSequence(base, again, detail));
+  }
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("ParallelReader honors time-range and topic filters", "[parallel][parity]") {
+  auto dir = uniqueTempDir("mcap_par_flt_");
+  const auto path = writeFile(dir, {"flt", Compression::None, 8 * 1024, 8, 400, 256, true});
+
+  ReadMessageOptions allOpts;
+  allOpts.readOrder = Order::LogTimeOrder;
+  const auto all = serialMessages(path, allOpts);
+  REQUIRE_FALSE(all.empty());
+  const Timestamp mid = all[all.size() / 2].logTime;
+
+  SECTION("time range") {
+    ReadMessageOptions sOpts;
+    sOpts.readOrder = Order::LogTimeOrder;
+    sOpts.endTime = mid;
+    const auto expected = serialMessages(path, sOpts);
+
+    auto pOpts = parallelOpts(Order::LogTimeOrder, 4);
+    pOpts.read.endTime = mid;
+    const auto got = parallelMessages(path, pOpts);
+
+    std::string detail;
+    INFO(detail);
+    REQUIRE(sameSequence(expected, got, detail));
+  }
+
+  SECTION("topic filter") {
+    auto topic0 = [](std::string_view t) {
+      return t == "/t0";
+    };
+    ReadMessageOptions sOpts;
+    sOpts.readOrder = Order::LogTimeOrder;
+    sOpts.topicFilter = topic0;
+    const auto expected = serialMessages(path, sOpts);
+
+    auto pOpts = parallelOpts(Order::LogTimeOrder, 4);
+    pOpts.read.topicFilter = topic0;
+    const auto got = parallelMessages(path, pOpts);
+
+    std::string detail;
+    INFO(detail);
+    REQUIRE(sameSequence(expected, got, detail));
+    REQUIRE(got.size() < all.size());
+  }
+
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("ParallelReader rejects a non-concurrent source", "[parallel][robust]") {
+  auto dir = uniqueTempDir("mcap_par_nc_");
+  const auto path = writeFile(dir, {"nc", Compression::None, 8 * 1024, 4, 100, 256, true});
+
+  // A FileReader is single-cursor (supportsConcurrentRead() == false), so the view
+  // must surface an error and yield nothing rather than read unsafely.
+  std::FILE* fp = std::fopen(path.c_str(), "rb");
+  REQUIRE(fp != nullptr);
+  FileReader src(fp);
+  ParallelReader pr;
+  REQUIRE(pr.open(src).ok());  // open succeeds (summary read serially)
+  ParallelReadOptions opts = parallelOpts(Order::LogTimeOrder, 4);
+  size_t n = 0;
+  auto view = pr.readMessages([](const Status&) {}, opts);
+  for (auto it = view.begin(); it != view.end(); ++it) n++;
+  CHECK(n == 0);
+  CHECK_FALSE(view.status().ok());
+  std::fclose(fp);
+
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("ParallelReader early teardown is clean", "[parallel][robust]") {
+  auto dir = uniqueTempDir("mcap_par_et_");
+  const auto path = writeFile(dir, {"et", Compression::None, 8 * 1024, 8, 400, 256, true});
+  {
+    ParallelReader pr;
+    REQUIRE(pr.open(path).ok());
+    auto opts = parallelOpts(Order::LogTimeOrder, 8);
+    auto view = pr.readMessages([](const Status&) {}, opts);
+    auto it = view.begin();
+    for (int i = 0; i < 5 && it != view.end(); i++) ++it;
+    // pr destroyed mid-iteration here: workers cancelled, pool joined, no hang.
+  }
+  SUCCEED("early teardown completed");
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+}
+
+// ---- memory-cap unit tests ----------------------------------------------------
+
+namespace {
+
+ChunkIndex mkChunk(Timestamp start, Timestamp end, uint64_t uncompressed, ChannelId ch = 1) {
+  ChunkIndex c;
+  c.messageStartTime = start;
+  c.messageEndTime = end;
+  c.uncompressedSize = uncompressed;
+  c.compressedSize = uncompressed / 2;
+  c.messageIndexOffsets[ch] = 0;
+  return c;
+}
+
+struct BruteResult {
+  uint64_t maxChunks = 0;
+  uint64_t maxBytes = 0;
+};
+
+BruteResult bruteForce(const std::vector<ChunkIndex>& cs) {
+  std::vector<Timestamp> instants;
+  for (const auto& c : cs) {
+    instants.push_back(c.messageStartTime);
+    instants.push_back(c.messageEndTime);
+  }
+  BruteResult r;
+  for (Timestamp t : instants) {
+    uint64_t n = 0, b = 0;
+    for (const auto& c : cs) {
+      if (c.messageStartTime <= t && t <= c.messageEndTime) {
+        n++;
+        b += c.uncompressedSize;
+      }
+    }
+    r.maxChunks = std::max(r.maxChunks, n);
+    r.maxBytes = std::max(r.maxBytes, b);
+  }
+  return r;
+}
+
+}  // namespace
+
+TEST_CASE("residency profile matches a brute-force oracle", "[parallel][cap]") {
+  std::mt19937 rng(12345);
+  std::uniform_int_distribution<uint64_t> startD(0, 1000);
+  std::uniform_int_distribution<uint64_t> lenD(0, 200);
+  std::uniform_int_distribution<uint64_t> sizeD(1, 5000);
+  for (int trial = 0; trial < 200; trial++) {
+    std::vector<ChunkIndex> cs;
+    const int n = int(rng() % 40);
+    for (int i = 0; i < n; i++) {
+      const Timestamp s = startD(rng);
+      cs.push_back(mkChunk(s, s + lenD(rng), sizeD(rng)));
+    }
+    const auto p = computeResidencyProfile(cs);
+    const auto b = bruteForce(cs);
+    INFO("trial " << trial << " n=" << n);
+    REQUIRE(p.maxDepthChunks == b.maxChunks);
+    REQUIRE(p.maxDepthBytes == b.maxBytes);
+  }
+}
+
+TEST_CASE("byte semaphore never exceeds capacity under concurrency", "[parallel][cap]") {
+  const uint64_t cap = 1u << 20;
+  internal::ByteSemaphore sem(cap);
+  std::atomic<int64_t> live{0};
+  std::atomic<bool> violated{false};
+  std::vector<std::thread> threads;
+  for (unsigned t = 0; t < 8; t++) {
+    threads.emplace_back([&, t] {
+      std::mt19937 rng(t + 1);
+      std::uniform_int_distribution<uint64_t> sizeD(1, cap);
+      for (int i = 0; i < 2000; i++) {
+        const uint64_t k = sizeD(rng);
+        sem.acquire(k);
+        const int64_t now = live.fetch_add(int64_t(k)) + int64_t(k);
+        if (now > int64_t(cap)) violated.store(true);
+        live.fetch_sub(int64_t(k));
+        sem.release(k);
+      }
+    });
+  }
+  for (auto& th : threads) th.join();
+  REQUIRE_FALSE(violated.load());
+}
+
+TEST_CASE("byte semaphore admits an oversized chunk without deadlock", "[parallel][cap]") {
+  internal::ByteSemaphore sem(100);
+  sem.acquire(250);  // oversized: drives available negative, never blocks on a fresh pool
+  CHECK(sem.outstanding() == 250);
+  CHECK_FALSE(sem.tryAcquire(50));  // no room while the oversized chunk is held
+  sem.release(250);
+  CHECK(sem.tryAcquire(50));
+  sem.release(50);
+}
+
+TEST_CASE("budget resolver enforces the log-time overlap floor", "[parallel][cap]") {
+  ResidencyProfile prof;
+  prof.consideredChunks = 200;
+  prof.maxDepthChunks = 30;
+  prof.maxDepthBytes = 30ull << 20;
+  prof.uMaxBytes = 1ull << 20;
+  prof.totalUncompressed = 150ull << 20;
+  const uint64_t MiB = 1ull << 20;
+
+  SECTION("file order floor is the largest chunk; log-time floor is the overlap depth") {
+    const auto file = resolveBudget(prof, Order::FileOrder, /*cap*/ 0);
+    const auto log = resolveBudget(prof, Order::LogTimeOrder, /*cap*/ 0);
+    CHECK(file.floorBytes == prof.uMaxBytes);
+    CHECK(log.floorBytes == prof.maxDepthBytes);
+    CHECK(log.floorBytes > file.floorBytes);
+  }
+
+  SECTION("cap above floor is honored and used for look-ahead") {
+    const auto d =
+      resolveBudget(prof, Order::LogTimeOrder, 64 * MiB, MemoryCapPolicy::Adapt, 8 * MiB);
+    CHECK(d.feasibleWithoutEviction);
+    CHECK_FALSE(d.exceedsUserCap);
+    CHECK(d.effectiveBudgetBytes == prof.maxDepthBytes + 8 * MiB);
+  }
+
+  SECTION("Adapt raises a sub-floor cap to the floor and flags it") {
+    const auto d = resolveBudget(prof, Order::LogTimeOrder, 8 * MiB, MemoryCapPolicy::Adapt);
+    CHECK(d.effectiveBudgetBytes == prof.maxDepthBytes);
+    CHECK(d.exceedsUserCap);
+    CHECK(d.feasibleWithoutEviction);
+    CHECK_FALSE(d.note.empty());
+  }
+
+  SECTION("Strict reports infeasible without exceeding the cap") {
+    const auto d = resolveBudget(prof, Order::LogTimeOrder, 8 * MiB, MemoryCapPolicy::Strict);
+    CHECK(d.effectiveBudgetBytes == 8 * MiB);
+    CHECK_FALSE(d.feasibleWithoutEviction);
+  }
+
+  SECTION("EvictAndReDecompress honors a sub-floor cap, never below one chunk") {
+    const auto d =
+      resolveBudget(prof, Order::LogTimeOrder, 8 * MiB, MemoryCapPolicy::EvictAndReDecompress);
+    CHECK(d.requiresEviction);
+    CHECK(d.effectiveBudgetBytes == 8 * MiB);
+    CHECK(d.effectiveBudgetBytes >= prof.uMaxBytes);
+    CHECK(d.estReDecompressionFactor > 1.0);
+    const auto tiny =
+      resolveBudget(prof, Order::LogTimeOrder, 256 * 1024, MemoryCapPolicy::EvictAndReDecompress);
+    CHECK(tiny.effectiveBudgetBytes == prof.uMaxBytes);
+  }
+
+  SECTION("FallBackToSerial signals the caller when the cap is below floor") {
+    const auto d =
+      resolveBudget(prof, Order::LogTimeOrder, 8 * MiB, MemoryCapPolicy::FallBackToSerial);
+    CHECK(d.fallBackToSerial);
+  }
+}


### PR DESCRIPTION
## Summary

Adds **`mcap::ParallelReader`** to the C++ library: it decompresses chunks on a thread pool ahead of a k-way merge and emits messages in **exactly the same order as the serial reader**, so time-ordered reads of zstd/lz4 files become bound by cores/IO instead of a single decompression thread.

```cpp
mcap::ParallelReader pr;
if (!pr.open("file.mcap").ok()) { /* handle */ }
mcap::ParallelReadOptions opts;
opts.read.readOrder = mcap::ReadMessageOptions::ReadOrder::LogTimeOrder;
opts.threadCount = 4;
opts.maxBytesInFlight = 1ull << 30;   // soft memory cap
opts.lookaheadBytes   = 1ull << 30;
for (const auto& mv : pr.readMessages(onProblem, opts)) {
  decode(mv.message, mv.channel, mv.schema);
}
```

## Motivation / results

On a real 17 GB zstd recording (562,580 messages), output is **byte-identical** to `McapReader::readMessages` (order + payload hash) while scaling:

| threads | wall time | speedup |
|--:|--:|--:|
| serial | 23.4 s | 1.0× |
| 2 | 11.6 s | 2.0× |
| 4 | 6.0 s | 3.9× |
| 8 | 3.3 s | 7.1× |

Peak **resident decompressed** memory stays at a few MiB (bounded by the byte budget), not the full uncompressed size.

## Design

- **`ParallelReader`** composes a `McapReader` (used only through its public API — `readSummary`/`channels`/`schemas`/`chunkIndexes`/static `Parse*`) and owns the concurrent-safe source. `ParallelMessageView` is the ordered, range-for view. It reuses `RecordOffset`'s comparison operators so tie-breaks match the serial reader exactly.
- **`MmapReader`** — a concurrent-safe `IReadable` (POSIX `mmap` + Windows `CreateFileMapping`/`MapViewOfFile`). `ParallelReader::open(IReadable&)` also accepts a caller-provided concurrent source.
- Memory is capped by a byte-budget semaphore; decompressed chunks are RAII-released as the merge drains them, so prefetch never exceeds the budget (no deadlock: required chunks force-acquire).
- zstd decompresses into an uninitialized buffer via a thread-local `ZSTD_DCtx` (avoids per-chunk context alloc + a redundant zero-fill).

## Footprint on existing code

Intentionally minimal. The **only** change to an existing type is a defaulted virtual:

```cpp
// IReadable
virtual bool supportsConcurrentRead() const { return false; }
```

`MmapReader` overrides it `true`; `FileReader`/`FileStreamReader` inherit `false` (they have a single shared cursor and can't back concurrent reads). Everything else is new headers, all gated by **`MCAP_NO_PARALLEL`** (define it to compile the feature out entirely, e.g. for toolchains without threads).

New headers under `cpp/mcap/include/mcap/`: `parallel_reader.hpp`, `parallel_budget.hpp`, `byte_semaphore.hpp`, `thread_pool.hpp`, `mmap_reader.hpp`.

## Tests

`cpp/test/parallel_reader_test.cpp` (Catch2, ~1.66M assertions): parity vs the serial reader across compression {none, zstd, lz4} × overlap/disjoint × duplicate-timestamp ties × orders {forward, reverse} × threads {1,2,4,8}, plus time-range/topic filters, determinism under repeated runs, non-concurrent-source rejection, early-teardown, and the residency-profile/semaphore/budget unit tests. Wired into `test/CMakeLists.txt` with `-nocompress` and a `unit-tests-noparallel` variant (proves the serial API builds with the feature compiled out), and added to `make test-host`.

## Notes for reviewers

- The new headers are currently **header-only inline** (consistent with `intervaltree.hpp` / `read_job_queue.hpp` / `crc32.hpp`). If you'd prefer the `.hpp`/`.inl` split used by `reader`/`writer`/`types`, I'm happy to split `parallel_reader.hpp`.
- The `IReadable` virtual is source- and behaviour-compatible; it adds one vtable slot (no ABI guarantee is made by the library today, and callers compile from source).
- Windows mmap uses `CreateFileMapping`/`MapViewOfFile`; CI (`cpp-windows`) builds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)