### PR TITLE
rust cli: require flag for remote scans

### DIFF
--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -88,42 +88,26 @@ port is still pre-production:
      `.mcap` when no explicit output is provided.
    - This would also allow `mcap convert` to accept multiple input paths in one
      invocation, including wildcard-expanded paths from the user's shell.
-7. Remote read policy:
-   - Rust CLI remote full scans now require `--allow-remote-scan`. This includes
-     full-object downloads, linear fallbacks when summary/index data is
-     unavailable, remote `convert` inputs, and remote message chunk payload reads
-     such as `cat` output.
-   - Summary/index-only remote operations may run without the flag. Exact indexed
-     non-message record reads such as attachments and metadata can also use
-     bounded ranges without a full-scan opt-in. Large remote summary sections and
-     multi-record metadata reads have conservative no-opt-in byte caps; exceeding
-     those caps requires `--allow-remote-scan`.
-   - Allowed full remote scans should continue to materialize remote inputs to a
-     temporary local file before reading, rather than buffering whole remote files
-     in memory. Commands with multiple remote inputs materialize each remote input
-     independently, so peak temporary disk usage can approach the sum of remote
-     input sizes.
-   - Before Rust CLI 1.0, apply the same policy consistently to future
-     object-store inputs such as S3, GCS, and Azure Blob Storage.
-8. Remote indexed read performance:
-   - The CLI coalesces HTTP(S) footer and summary-section range reads for remote
-     summary discovery without changing the public `mcap` crate API.
-   - Before Rust CLI 1.0, consider moving this into reusable `mcap` crate reader
-     APIs so HTTP(S), S3, GCS, and Azure Blob Storage backends can share
-     coalesced tail/summary range reads instead of each transport adding its own
-     read-ahead workaround.
+7. Future object-store remote input policy:
+   - Before Rust CLI 1.0, apply the remote scan opt-in policy consistently to
+     future object-store inputs such as S3, GCS, and Azure Blob Storage.
+   - Preserve the current HTTP(S) behavior for those backends: summary/index-only
+     operations should not require opt-in, while full-object scans/downloads and
+     message chunk payload reads should require `--allow-remote-scan`.
+8. Shared remote range-read APIs:
+   - Before Rust CLI 1.0, consider moving the CLI-local coalesced summary range
+     reads into reusable `mcap` crate reader APIs so HTTP(S), S3, GCS, and Azure
+     Blob Storage backends can share tail/summary range reads instead of each
+     transport adding its own read-ahead workaround.
    - A future `mcap` crate API should also make range-backed parsing of exact
      indexed records ergonomic without requiring callers to duplicate record
      parsing logic in the CLI.
-9. Range-backed metadata and attachment reads:
-   - Current metadata and attachment convenience helpers, such as
-     `mcap::read::metadata` and `mcap::read::attachment`, require a full MCAP
-     byte slice.
-   - Before Rust CLI 1.0, add CLI or `mcap` crate helpers that can read
-     metadata and attachment records from indexed byte ranges so `get metadata`,
-     `list metadata`, `get attachment`, and metadata/attachment-preserving
-     transforms do not need whole-file fallback for HTTP(S) and future
-     object-store inputs.
+9. Range-backed metadata and attachment transforms:
+   - The CLI can read exact indexed metadata and attachment records for direct
+     `get` / `list` commands without whole-file fallback for HTTP(S) inputs.
+   - Before Rust CLI 1.0, extend this pattern to metadata/attachment-preserving
+     transforms so those commands do not need whole-file fallback for HTTP(S) and
+     future object-store inputs.
 
 ## Intentional divergences from Go CLI
 

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -102,6 +102,11 @@ port is still pre-production:
    - A future `mcap` crate API should also make range-backed parsing of exact
      indexed records ergonomic without requiring callers to duplicate record
      parsing logic in the CLI.
+   - Avoid double-touching summaryless remote inputs when `--allow-remote-scan`
+     is set. Today the CLI attempts indexed discovery with a range probe and
+     footer read before falling back to full-file materialization; a future
+     implementation could share probe/footer state with materialization or skip
+     indexed discovery for commands that already know they must scan.
 9. Range-backed metadata and attachment transforms:
    - The CLI can read exact indexed metadata and attachment records for direct
      `get` / `list` commands without whole-file fallback for HTTP(S) inputs.

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -89,23 +89,28 @@ port is still pre-production:
    - This would also allow `mcap convert` to accept multiple input paths in one
      invocation, including wildcard-expanded paths from the user's shell.
 7. Remote read policy:
-   - Current Go-compatible behavior allows remote reads without an opt-in flag,
-     including commands or inputs that require reading the entire remote file.
-   - Before Rust CLI 1.0, decide whether to keep this behavior or reintroduce an
-     explicit opt-in such as `--allow-remote-scan` for commands that cannot use
-     indexed range reads.
-   - Apply the chosen policy consistently across HTTP(S) and future object-store
-     inputs such as S3, GCS, and Azure Blob Storage.
+   - Rust CLI remote full scans now require `--allow-remote-scan`. This includes
+     full-object downloads, linear fallbacks when summary/index data is
+     unavailable, remote `convert` inputs, and remote message chunk payload reads
+     such as `cat` output.
+   - Summary/index-only remote operations may run without the flag. Exact indexed
+     non-message record reads such as attachments and metadata can also use
+     bounded ranges without a full-scan opt-in.
+   - Allowed full remote scans should continue to materialize remote inputs to a
+     temporary local file before reading, rather than buffering whole remote files
+     in memory.
+   - Before Rust CLI 1.0, apply the same policy consistently to future
+     object-store inputs such as S3, GCS, and Azure Blob Storage.
 8. Remote indexed read performance:
-   - Current HTTP(S) range reads use the generic seek/read interface, which can
-     issue several small range requests while reading MCAP headers, footers, and
-     summaries.
-   - If a remote MCAP has no summary, the CLI currently attempts indexed
-     discovery with range requests and then falls back to a whole-file read.
-   - Before Rust CLI 1.0, optimize summary/index reading in the underlying MCAP
-     reader APIs so HTTP(S), S3, GCS, and Azure Blob Storage backends can share
+   - The CLI coalesces HTTP(S) footer and summary-section range reads for remote
+     summary discovery without changing the public `mcap` crate API.
+   - Before Rust CLI 1.0, consider moving this into reusable `mcap` crate reader
+     APIs so HTTP(S), S3, GCS, and Azure Blob Storage backends can share
      coalesced tail/summary range reads instead of each transport adding its own
      read-ahead workaround.
+   - A future `mcap` crate API should also make range-backed parsing of exact
+     indexed records ergonomic without requiring callers to duplicate record
+     parsing logic in the CLI.
 9. Range-backed metadata and attachment reads:
    - Current metadata and attachment convenience helpers, such as
      `mcap::read::metadata` and `mcap::read::attachment`, require a full MCAP

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -95,7 +95,9 @@ port is still pre-production:
      such as `cat` output.
    - Summary/index-only remote operations may run without the flag. Exact indexed
      non-message record reads such as attachments and metadata can also use
-     bounded ranges without a full-scan opt-in.
+     bounded ranges without a full-scan opt-in. Large remote summary sections and
+     multi-record metadata reads have conservative no-opt-in byte caps; exceeding
+     those caps requires `--allow-remote-scan`.
    - Allowed full remote scans should continue to materialize remote inputs to a
      temporary local file before reading, rather than buffering whole remote files
      in memory. Commands with multiple remote inputs materialize each remote input

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -105,6 +105,9 @@ port is still pre-production:
 9. Range-backed metadata and attachment transforms:
    - The CLI can read exact indexed metadata and attachment records for direct
      `get` / `list` commands without whole-file fallback for HTTP(S) inputs.
+     Single indexed attachment and metadata reads are allowed as bounded range
+     reads without a full-scan opt-in; multi-record metadata reads have a
+     conservative no-opt-in byte cap.
    - Before Rust CLI 1.0, extend this pattern to metadata/attachment-preserving
      transforms so those commands do not need whole-file fallback for HTTP(S) and
      future object-store inputs.
@@ -120,6 +123,8 @@ port is still pre-production:
 3. Remote read policy:
    - Rust CLI requires `--allow-remote-scan` for remote full-object downloads,
      linear fallbacks, remote `convert` inputs, and remote message chunk payload
-     reads such as `cat` output.
+     reads such as `cat` output. Commands with multiple remote inputs materialize
+     each remote input independently, so peak temporary disk usage can approach
+     the sum of remote input sizes.
    - Go-compatible behavior allowed those remote reads without an explicit
      opt-in.

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -117,3 +117,10 @@ port is still pre-production:
 2. `mcap convert` ROS 2 db3 schema discovery:
    - Rust CLI converts self-contained db3 files using embedded message definitions, including non-`/msg/` topics such as service event topics. It fails the conversion if any topic is missing an embedded definition.
    - Go CLI ignores embedded db3 schemas and emulates ament resource lookup with `--ament-prefix-path`, which can miss schemas or silently use definitions from the wrong workspace.
+3. Remote read policy:
+   - Rust CLI requires `--allow-remote-scan` for remote full-object downloads,
+     linear fallbacks, remote `convert` inputs, and remote message chunk payload
+     reads such as `cat` output.
+   - Go-compatible behavior allowed those remote reads without an explicit
+     opt-in.
+

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -123,4 +123,3 @@ port is still pre-production:
      reads such as `cat` output.
    - Go-compatible behavior allowed those remote reads without an explicit
      opt-in.
-

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -98,7 +98,9 @@ port is still pre-production:
      bounded ranges without a full-scan opt-in.
    - Allowed full remote scans should continue to materialize remote inputs to a
      temporary local file before reading, rather than buffering whole remote files
-     in memory.
+     in memory. Commands with multiple remote inputs materialize each remote input
+     independently, so peak temporary disk usage can approach the sum of remote
+     input sizes.
    - Before Rust CLI 1.0, apply the same policy consistently to future
      object-store inputs such as S3, GCS, and Azure Blob Storage.
 8. Remote indexed read performance:

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -28,6 +28,10 @@ pub struct Args {
     #[arg(long, default_value_t = false, global = true)]
     pub pprof_profile: bool,
 
+    /// Allow commands to download or scan remote inputs when indexed range reads are insufficient
+    #[arg(long, default_value_t = false, global = true)]
+    pub allow_remote_scan: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Args {
     #[arg(long, default_value_t = false, global = true)]
     pub pprof_profile: bool,
 
-    /// Allow commands to download or scan remote inputs when indexed range reads are insufficient
+    /// Allow commands to download/scan remote inputs or fetch remote message chunk payloads
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -46,9 +46,14 @@ fn cat_file(
 ) -> Result<bool> {
     if let Some(remote) = common::try_open_remote_mcap(file, source_options)? {
         let mut json_transcoders = JsonTranscoders::default();
-        if let Some(broken_pipe) =
-            cat_remote_indexed(writer, &remote, opts, source_options, &mut json_transcoders)?
-        {
+        if let Some(broken_pipe) = cat_remote_indexed(
+            writer,
+            file,
+            &remote,
+            opts,
+            source_options,
+            &mut json_transcoders,
+        )? {
             return Ok(broken_pipe);
         }
         if !source_options.allow_remote_scan {
@@ -187,6 +192,7 @@ fn cat_indexed(
 
 fn cat_remote_indexed(
     writer: &mut impl std::io::Write,
+    file: &std::path::Path,
     remote: &common::RemoteMcap,
     opts: &CatOptions,
     source_options: common::SourceOptions,
@@ -194,6 +200,12 @@ fn cat_remote_indexed(
 ) -> Result<Option<bool>> {
     let summary = remote.summary();
     if summary.chunk_indexes.is_empty() {
+        if !source_options.allow_remote_scan {
+            bail!(
+                "{}: remote file has no chunk index; reading messages requires --allow-remote-scan",
+                common::redacted_display(file)
+            );
+        }
         return Ok(None);
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -203,7 +203,7 @@ fn cat_remote_indexed(
                 common::redacted_display(file)
             );
         }
-        return Ok(None);
+        return Ok(Some(false));
     }
 
     let included_topics: BTreeSet<String> = summary

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1283,6 +1283,25 @@ mod tests {
     }
 
     #[test]
+    fn remote_cat_with_scan_opt_in_falls_back_for_unchunked_messages() {
+        let body: &'static [u8] =
+            Box::leak(build_out_of_order_linear_mcap_without_summary().into_boxed_slice());
+        let url = serve_http(body);
+        let mut out = Vec::new();
+        let broken_pipe = super::cat_file(
+            &mut out,
+            Path::new(&url),
+            &CatOptions::default(),
+            super::common::SourceOptions::new(true),
+        )
+        .expect("remote cat should scan unchunked messages with opt-in");
+        assert!(!broken_pipe);
+        let output = String::from_utf8(out).expect("cat output should be utf8");
+        assert!(output.contains("30 /demo [Example] [1]"));
+        assert!(output.contains("10 /demo [Example] [2]"));
+    }
+
+    #[test]
     fn remote_cat_no_chunk_index_error_includes_redacted_url() {
         let mut buffer = Vec::new();
         {

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -136,7 +136,7 @@ fn cat_indexed(
         .map(|channel| channel.topic.clone())
         .collect();
     if !opts.topics.is_empty() && included_topics.is_empty() {
-        return Ok(Some(false));
+        return Ok(None);
     }
 
     let mut indexed_opts =
@@ -203,7 +203,7 @@ fn cat_remote_indexed(
                 common::redacted_display(file)
             );
         }
-        return Ok(Some(false));
+        return Ok(None);
     }
 
     let included_topics: BTreeSet<String> = summary
@@ -222,7 +222,8 @@ fn cat_remote_indexed(
             .map(|chunk| chunk.compressed_size)
             .sum::<u64>();
         bail!(
-            "remote cat would read {} message chunks ({} compressed); pass --allow-remote-scan to continue",
+            "{}: remote cat would read {} message chunks ({} compressed); pass --allow-remote-scan to continue",
+            common::redacted_display(file),
             planned_chunks.len(),
             common::human_bytes(compressed_bytes)
         );

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -199,8 +199,9 @@ fn cat_remote_indexed(
     if summary.chunk_indexes.is_empty() {
         if !source_options.allow_remote_scan {
             bail!(
-                "{}: remote file has no chunk index; reading messages requires opt-in; pass --allow-remote-scan to continue",
-                common::redacted_display(file)
+                "{}: remote file has no chunk index; reading messages requires opt-in; {}",
+                common::redacted_display(file),
+                common::remote_scan_opt_in_suffix()
             );
         }
         return Ok(None);
@@ -222,10 +223,11 @@ fn cat_remote_indexed(
             .map(|chunk| chunk.compressed_size)
             .sum::<u64>();
         bail!(
-            "{}: remote cat would read {} message chunks ({} compressed); pass --allow-remote-scan to continue",
+            "{}: remote cat would read {} message chunks ({} compressed); {}",
             common::redacted_display(file),
             planned_chunks.len(),
-            common::human_bytes(compressed_bytes)
+            common::human_bytes(compressed_bytes),
+            common::remote_scan_opt_in_suffix()
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -46,13 +46,9 @@ fn cat_file(
 ) -> Result<bool> {
     if let Some(remote) = common::try_open_remote_mcap(file)? {
         let mut json_transcoders = JsonTranscoders::default();
-        if let Some(broken_pipe) = cat_remote_indexed(
-            writer,
-            &remote,
-            opts,
-            source_options,
-            &mut json_transcoders,
-        )? {
+        if let Some(broken_pipe) =
+            cat_remote_indexed(writer, &remote, opts, source_options, &mut json_transcoders)?
+        {
             return Ok(broken_pipe);
         }
     }
@@ -991,11 +987,16 @@ fn write_payload_preview(
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::Cow, collections::BTreeMap, io::Cursor, sync::Arc};
+    use std::{
+        borrow::Cow,
+        collections::{BTreeMap, BTreeSet},
+        io::Cursor,
+        sync::Arc,
+    };
 
     use super::{
-        cat_mcap, cat_streaming, parse_ros1_field_type, write_payload_preview, write_ros1_float,
-        write_signed_decimal_time, CatOptions, JsonTranscoders, Ros1MessageDef,
+        cat_mcap, cat_streaming, parse_ros1_field_type, planned_chunk_reads, write_payload_preview,
+        write_ros1_float, write_signed_decimal_time, CatOptions, JsonTranscoders, Ros1MessageDef,
     };
 
     fn sample_message(schema_name: Option<&str>, data: Vec<u8>) -> mcap::Message<'static> {
@@ -1211,6 +1212,25 @@ mod tests {
         assert_eq!(
             message_line_string(&message, 10),
             "42 /demo [no schema] [1 2 3]"
+        );
+    }
+
+    #[test]
+    fn remote_chunk_plan_identifies_message_chunk_reads() {
+        let mcap = build_multi_topic_mcap();
+        let summary = mcap::Summary::read(&mcap)
+            .expect("summary read")
+            .expect("summary should exist");
+        let opts = CatOptions::default();
+        let included_topics: BTreeSet<String> = summary
+            .channels
+            .values()
+            .map(|channel| channel.topic.clone())
+            .collect();
+        let chunks = planned_chunk_reads(&summary, &opts, &included_topics);
+        assert!(
+            !chunks.is_empty(),
+            "cat would need remote chunk payload reads"
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -136,7 +136,7 @@ fn cat_indexed(
         .map(|channel| channel.topic.clone())
         .collect();
     if !opts.topics.is_empty() && included_topics.is_empty() {
-        return Ok(None);
+        return Ok(Some(false));
     }
 
     let mut indexed_opts =

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -46,7 +46,7 @@ fn cat_file(
 ) -> Result<bool> {
     if let Some(remote) = common::try_open_remote_mcap(file, source_options)? {
         let mut json_transcoders = JsonTranscoders::default();
-        if let Some(broken_pipe) = cat_remote_indexed(
+        match cat_remote_indexed(
             writer,
             file,
             &remote,
@@ -54,7 +54,9 @@ fn cat_file(
             source_options,
             &mut json_transcoders,
         )? {
-            return Ok(broken_pipe);
+            RemoteCatResult::BrokenPipe => return Ok(true),
+            RemoteCatResult::Done => return Ok(false),
+            RemoteCatResult::NeedsFullScan => {}
         }
     }
     let mcap = common::load_path(file, source_options)?;
@@ -187,6 +189,13 @@ fn cat_indexed(
     Ok(Some(false))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteCatResult {
+    BrokenPipe,
+    Done,
+    NeedsFullScan,
+}
+
 fn cat_remote_indexed(
     writer: &mut impl std::io::Write,
     file: &std::path::Path,
@@ -194,7 +203,7 @@ fn cat_remote_indexed(
     opts: &CatOptions,
     source_options: common::SourceOptions,
     json_transcoders: &mut JsonTranscoders,
-) -> Result<Option<bool>> {
+) -> Result<RemoteCatResult> {
     let summary = remote.summary();
     if summary.chunk_indexes.is_empty() {
         if !source_options.allow_remote_scan {
@@ -204,7 +213,7 @@ fn cat_remote_indexed(
                 common::remote_scan_opt_in_suffix()
             );
         }
-        return Ok(None);
+        return Ok(RemoteCatResult::NeedsFullScan);
     }
 
     let included_topics: BTreeSet<String> = summary
@@ -214,7 +223,7 @@ fn cat_remote_indexed(
         .map(|channel| channel.topic.clone())
         .collect();
     if !opts.topics.is_empty() && included_topics.is_empty() {
-        return Ok(Some(false));
+        return Ok(RemoteCatResult::Done);
     }
     let planned_chunks = planned_chunk_reads(summary, opts, &included_topics);
     if !planned_chunks.is_empty() && !source_options.allow_remote_scan {
@@ -263,13 +272,13 @@ fn cat_remote_indexed(
                     data,
                 };
                 if write_message(writer, message, opts, json_transcoders)? {
-                    return Ok(Some(true));
+                    return Ok(RemoteCatResult::BrokenPipe);
                 }
             }
         }
     }
 
-    Ok(Some(false))
+    Ok(RemoteCatResult::Done)
 }
 
 // Keep this planner conservative: it intentionally mirrors IndexedReader chunk filtering as an

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -13,8 +13,9 @@ use crate::context::CommandContext;
 
 const MESSAGE_PREVIEW_LEN: usize = 10;
 
-pub fn run(_ctx: &CommandContext, args: CatCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: CatCommand) -> Result<()> {
     let opts = CatOptions::from_args(&args)?;
+    let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
     let stdout = std::io::stdout();
     let mut writer = std::io::BufWriter::new(stdout.lock());
 
@@ -28,7 +29,7 @@ pub fn run(_ctx: &CommandContext, args: CatCommand) -> Result<()> {
         }
     } else {
         for file in args.files {
-            if cat_file(&mut writer, &file, &opts)? {
+            if cat_file(&mut writer, &file, &opts, source_options)? {
                 return Ok(());
             }
         }
@@ -41,15 +42,21 @@ fn cat_file(
     writer: &mut impl std::io::Write,
     file: &std::path::Path,
     opts: &CatOptions,
+    source_options: common::SourceOptions,
 ) -> Result<bool> {
     if let Some(remote) = common::try_open_remote_mcap(file)? {
         let mut json_transcoders = JsonTranscoders::default();
-        if let Some(broken_pipe) = cat_remote_indexed(writer, &remote, opts, &mut json_transcoders)?
-        {
+        if let Some(broken_pipe) = cat_remote_indexed(
+            writer,
+            &remote,
+            opts,
+            source_options,
+            &mut json_transcoders,
+        )? {
             return Ok(broken_pipe);
         }
     }
-    let mcap = common::load_path(file)?;
+    let mcap = common::load_path(file, source_options)?;
     cat_mcap(writer, &mcap, opts)
 }
 
@@ -183,6 +190,7 @@ fn cat_remote_indexed(
     writer: &mut impl std::io::Write,
     remote: &common::RemoteMcap,
     opts: &CatOptions,
+    source_options: common::SourceOptions,
     json_transcoders: &mut JsonTranscoders,
 ) -> Result<Option<bool>> {
     let summary = remote.summary();
@@ -198,6 +206,18 @@ fn cat_remote_indexed(
         .collect();
     if !opts.topics.is_empty() && included_topics.is_empty() {
         return Ok(Some(false));
+    }
+    let planned_chunks = planned_chunk_reads(summary, opts, &included_topics);
+    if !planned_chunks.is_empty() && !source_options.allow_remote_scan {
+        let compressed_bytes = planned_chunks
+            .iter()
+            .map(|chunk| chunk.compressed_size)
+            .sum::<u64>();
+        bail!(
+            "remote cat would read {} message chunks ({} compressed); pass --allow-remote-scan to continue",
+            planned_chunks.len(),
+            common::human_bytes(compressed_bytes)
+        );
     }
 
     let mut indexed_opts =
@@ -239,6 +259,48 @@ fn cat_remote_indexed(
     }
 
     Ok(Some(false))
+}
+
+fn planned_chunk_reads<'a>(
+    summary: &'a mcap::Summary,
+    opts: &CatOptions,
+    included_topics: &BTreeSet<String>,
+) -> Vec<&'a mcap::records::ChunkIndex> {
+    let channel_ids: BTreeSet<u16> = if opts.topics.is_empty() {
+        BTreeSet::new()
+    } else {
+        summary
+            .channels
+            .iter()
+            .filter(|(_, channel)| included_topics.contains(&channel.topic))
+            .map(|(id, _)| *id)
+            .collect()
+    };
+
+    summary
+        .chunk_indexes
+        .iter()
+        .filter(|chunk| {
+            if opts.start != 0 && chunk.message_end_time < opts.start {
+                return false;
+            }
+            if let Some(end) = opts.end {
+                if chunk.message_start_time >= end {
+                    return false;
+                }
+            }
+            if channel_ids.is_empty() {
+                return true;
+            }
+            if chunk.message_index_offsets.is_empty() {
+                return true;
+            }
+            chunk
+                .message_index_offsets
+                .keys()
+                .any(|channel_id| channel_ids.contains(channel_id))
+        })
+        .collect()
 }
 
 fn cat_linear(

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1007,8 +1007,11 @@ mod tests {
     use std::{
         borrow::Cow,
         collections::{BTreeMap, BTreeSet},
-        io::Cursor,
+        io::{Cursor, Read, Write},
+        net::TcpListener,
+        path::Path,
         sync::Arc,
+        thread,
     };
 
     use super::{
@@ -1162,6 +1165,55 @@ mod tests {
         cursor.into_inner()
     }
 
+    fn serve_http(body: &'static [u8]) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        thread::spawn(move || {
+            for stream in listener.incoming().take(64) {
+                let mut stream = stream.expect("accept test connection");
+                let mut request = [0u8; 4096];
+                let read = stream.read(&mut request).expect("read request");
+                let request = String::from_utf8_lossy(&request[..read]);
+                let requested_range = request
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Range: bytes="))
+                    .or_else(|| {
+                        request
+                            .lines()
+                            .find_map(|line| line.strip_prefix("range: bytes="))
+                    })
+                    .and_then(|range| range.split_once('-'))
+                    .and_then(|(start, end)| {
+                        Some((start.parse::<usize>().ok()?, end.parse::<usize>().ok()?))
+                    });
+                if let Some((start, end)) = requested_range {
+                    let end = end.min(body.len().saturating_sub(1));
+                    let start = start.min(end);
+                    let content = &body[start..=end];
+                    let response = format!(
+                        "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {start}-{end}/{}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        content.len(),
+                        body.len(),
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write headers");
+                    stream.write_all(content).expect("write range body");
+                } else {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write headers");
+                    stream.write_all(body).expect("write body");
+                }
+            }
+        });
+        format!("http://{addr}/demo.mcap")
+    }
+
     fn build_multi_topic_mcap() -> Vec<u8> {
         let mut cursor = Cursor::new(Vec::new());
         {
@@ -1230,6 +1282,22 @@ mod tests {
             message_line_string(&message, 10),
             "42 /demo [no schema] [1 2 3]"
         );
+    }
+
+    #[test]
+    fn remote_cat_requires_allow_remote_scan_before_chunk_reads() {
+        let body: &'static [u8] = Box::leak(build_multi_topic_mcap().into_boxed_slice());
+        let url = serve_http(body);
+        let mut out = Vec::new();
+        let err = super::cat_file(
+            &mut out,
+            Path::new(&url),
+            &CatOptions::default(),
+            super::common::SourceOptions::default(),
+        )
+        .expect_err("remote cat should require opt-in before reading chunks");
+        assert!(err.to_string().contains("remote cat would read"));
+        assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
     #[test]

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -56,9 +56,6 @@ fn cat_file(
         )? {
             return Ok(broken_pipe);
         }
-        if !source_options.allow_remote_scan {
-            bail!("remote file has no chunk index; reading messages requires --allow-remote-scan");
-        }
     }
     let mcap = common::load_path(file, source_options)?;
     cat_mcap(writer, &mcap, opts)
@@ -1282,6 +1279,29 @@ mod tests {
             message_line_string(&message, 10),
             "42 /demo [no schema] [1 2 3]"
         );
+    }
+
+    #[test]
+    fn remote_cat_no_chunk_index_error_includes_redacted_url() {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = mcap::Writer::new(Cursor::new(&mut buffer)).expect("writer");
+            writer.finish().expect("finish writer");
+        }
+        let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
+        let url = serve_http(body) + "?token=secret";
+        let mut out = Vec::new();
+        let err = super::cat_file(
+            &mut out,
+            Path::new(&url),
+            &CatOptions::default(),
+            super::common::SourceOptions::default(),
+        )
+        .expect_err("remote cat without chunk indexes should require opt-in");
+        let message = err.to_string();
+        assert!(message.contains("--allow-remote-scan"));
+        assert!(message.contains("/demo.mcap"));
+        assert!(!message.contains("secret"));
     }
 
     #[test]

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1351,22 +1351,80 @@ mod tests {
         assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
+    fn planned_chunks_for_opts<'a>(
+        summary: &'a mcap::Summary,
+        opts: &CatOptions,
+    ) -> Vec<&'a mcap::records::ChunkIndex> {
+        let included_topics: BTreeSet<String> = summary
+            .channels
+            .values()
+            .filter(|channel| opts.include_topic(&channel.topic))
+            .map(|channel| channel.topic.clone())
+            .collect();
+        if !opts.topics.is_empty() && included_topics.is_empty() {
+            return Vec::new();
+        }
+        planned_chunk_reads(summary, opts, &included_topics)
+    }
+
     #[test]
-    fn remote_chunk_plan_identifies_message_chunk_reads() {
+    fn remote_chunk_plan_is_conservative_for_representative_filters() {
         let mcap = build_multi_topic_mcap();
         let summary = mcap::Summary::read(&mcap)
             .expect("summary read")
             .expect("summary should exist");
-        let opts = CatOptions::default();
-        let included_topics: BTreeSet<String> = summary
-            .channels
-            .values()
-            .map(|channel| channel.topic.clone())
-            .collect();
-        let chunks = planned_chunk_reads(&summary, &opts, &included_topics);
+
         assert!(
-            !chunks.is_empty(),
-            "cat would need remote chunk payload reads"
+            !planned_chunks_for_opts(&summary, &CatOptions::default()).is_empty(),
+            "unfiltered cat would need remote chunk payload reads"
+        );
+
+        assert!(
+            !planned_chunks_for_opts(
+                &summary,
+                &CatOptions {
+                    topics: vec!["/camera".to_string()],
+                    ..CatOptions::default()
+                },
+            )
+            .is_empty(),
+            "matching topic filter would still need remote chunk payload reads"
+        );
+
+        assert!(
+            planned_chunks_for_opts(
+                &summary,
+                &CatOptions {
+                    topics: vec!["/missing".to_string()],
+                    ..CatOptions::default()
+                },
+            )
+            .is_empty(),
+            "non-matching topic filter should not plan remote chunk reads"
+        );
+
+        assert!(
+            !planned_chunks_for_opts(
+                &summary,
+                &CatOptions {
+                    start: 20,
+                    ..CatOptions::default()
+                },
+            )
+            .is_empty(),
+            "overlapping time filter would need remote chunk payload reads"
+        );
+
+        assert!(
+            planned_chunks_for_opts(
+                &summary,
+                &CatOptions {
+                    start: 100,
+                    ..CatOptions::default()
+                },
+            )
+            .is_empty(),
+            "non-overlapping time filter should not plan remote chunk reads"
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -260,6 +260,8 @@ fn cat_remote_indexed(
     Ok(Some(false))
 }
 
+// Keep this planner conservative: it intentionally mirrors IndexedReader chunk filtering as an
+// upper bound so the remote-scan gate fires before any possible chunk payload fetch.
 fn planned_chunk_reads<'a>(
     summary: &'a mcap::Summary,
     opts: &CatOptions,

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -199,7 +199,7 @@ fn cat_remote_indexed(
     if summary.chunk_indexes.is_empty() {
         if !source_options.allow_remote_scan {
             bail!(
-                "{}: remote file has no chunk index; reading messages requires --allow-remote-scan",
+                "{}: remote file has no chunk index; reading messages requires opt-in; pass --allow-remote-scan to continue",
                 common::redacted_display(file)
             );
         }

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -44,12 +44,15 @@ fn cat_file(
     opts: &CatOptions,
     source_options: common::SourceOptions,
 ) -> Result<bool> {
-    if let Some(remote) = common::try_open_remote_mcap(file)? {
+    if let Some(remote) = common::try_open_remote_mcap(file, source_options)? {
         let mut json_transcoders = JsonTranscoders::default();
         if let Some(broken_pipe) =
             cat_remote_indexed(writer, &remote, opts, source_options, &mut json_transcoders)?
         {
             return Ok(broken_pipe);
+        }
+        if remote.summary().chunk_indexes.is_empty() && !source_options.allow_remote_scan {
+            bail!("remote file has no chunk index; reading messages requires --allow-remote-scan");
         }
     }
     let mcap = common::load_path(file, source_options)?;

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -51,7 +51,7 @@ fn cat_file(
         {
             return Ok(broken_pipe);
         }
-        if remote.summary().chunk_indexes.is_empty() && !source_options.allow_remote_scan {
+        if !source_options.allow_remote_scan {
             bail!("remote file has no chunk index; reading messages requires --allow-remote-scan");
         }
     }

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -21,7 +21,13 @@ const REMOTE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const REMOTE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_BODY_TIMEOUT: Duration = Duration::from_secs(60);
 const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
+// Guards remote summary discovery against corrupt or hostile footers that point
+// `summary_start` near the beginning of a large file, which would otherwise turn
+// an index-only operation into a near-full-file range read without opt-in.
 const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 16 * 1024 * 1024;
+// Bounds aggregate metadata body reads for list/multi-match metadata commands.
+// Single indexed metadata/attachment records are deliberately uncapped beyond
+// the remote file size because they are explicit user-selected record reads.
 pub(crate) const MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN: u64 = 64 * 1024 * 1024;
 
 pub enum InputData {

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -22,6 +22,7 @@ const REMOTE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_BODY_TIMEOUT: Duration = Duration::from_secs(60);
 const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
 const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 16 * 1024 * 1024;
+pub(crate) const MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN: u64 = 64 * 1024 * 1024;
 
 pub enum InputData {
     Mapped(Mmap),
@@ -184,6 +185,11 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
             let header = read_header_from_seekable(&mut reader)?;
             if let Some(summary) = read_summary_from_remote(&reader, options)? {
                 return Ok(parsed_mcap_from_summary_ref(header, &summary));
+            }
+            if !options.allow_remote_scan {
+                bail!(
+                    "remote file has no summary section; reading without one requires --allow-remote-scan"
+                );
             }
         }
     } else if let Some(mut source) = open_seekable_mcap_source(path)? {
@@ -484,6 +490,20 @@ fn validate_identity_content_encoding(
     }
     bail!(
         "remote server returned Content-Encoding: {value} for {display_url}; MCAP remote reads require identity encoding"
+    );
+}
+
+pub(crate) fn require_remote_metadata_budget(
+    total_bytes: u64,
+    options: SourceOptions,
+    description: &str,
+) -> Result<()> {
+    if options.allow_remote_scan || total_bytes <= MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN {
+        return Ok(());
+    }
+    bail!(
+        "remote {description} would read {}; pass --allow-remote-scan to continue",
+        human_bytes(total_bytes)
     );
 }
 

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -524,7 +524,7 @@ fn validate_identity_content_encoding(
     );
 }
 
-fn remote_scan_opt_in_suffix() -> &'static str {
+pub(crate) fn remote_scan_opt_in_suffix() -> &'static str {
     "pass --allow-remote-scan to continue"
 }
 

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -96,12 +96,6 @@ impl RemoteMcap {
     pub fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
         self.reader.read_range(offset, length)
     }
-
-    pub fn read_indexed_record_range(&self, offset: u64, length: u64) -> Result<Vec<u8>> {
-        let length = usize::try_from(length)
-            .context("indexed record is too large to read on this platform")?;
-        self.reader.read_range(offset, length)
-    }
 }
 
 impl std::io::Read for McapSource {

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -22,11 +22,6 @@ const REMOTE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_BODY_TIMEOUT: Duration = Duration::from_secs(60);
 const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
 const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 16 * 1024 * 1024;
-// Exact indexed records are bounded by the remote file size, but corrupt or hostile indexes can
-// still turn a targeted attachment/metadata lookup into an unexpectedly large transfer. Keep the
-// no-opt-in path generous for legitimate large attachments while requiring explicit consent for
-// GiB-scale single-record reads.
-const MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN: usize = 1024 * 1024 * 1024;
 
 pub enum InputData {
     Mapped(Mmap),
@@ -105,17 +100,10 @@ impl RemoteMcap {
         &self,
         offset: u64,
         length: u64,
-        options: SourceOptions,
         description: &str,
     ) -> Result<Vec<u8>> {
         let length = usize::try_from(length)
             .with_context(|| format!("{description} is too large to read on this platform"))?;
-        if length > MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN && !options.allow_remote_scan {
-            bail!(
-                "remote {description} is {}; pass --allow-remote-scan to read it",
-                human_bytes(length as u64)
-            );
-        }
         self.reader.read_range(offset, length)
     }
 }
@@ -1150,30 +1138,6 @@ mod tests {
                 Err(err) => err,
             };
         assert!(err.to_string().contains("remote summary section"));
-        assert!(err.to_string().contains("--allow-remote-scan"));
-    }
-
-    #[test]
-    fn indexed_record_range_requires_scan_for_oversized_record() {
-        let remote = super::RemoteMcap {
-            reader: super::HttpRangeReader {
-                agent: super::remote_agent(),
-                url: "http://127.0.0.1:1/demo.mcap".to_string(),
-                display_url: "http://127.0.0.1:1/demo.mcap".to_string(),
-                size: (super::MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN + 1) as u64,
-                offset: 0,
-            },
-            summary: mcap::Summary::default(),
-        };
-        let err = remote
-            .read_indexed_record_range(
-                0,
-                (super::MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN + 1) as u64,
-                super::SourceOptions::default(),
-                "attachment record",
-            )
-            .expect_err("oversized indexed record should require opt-in");
-        assert!(err.to_string().contains("attachment record"));
         assert!(err.to_string().contains("--allow-remote-scan"));
     }
 

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -182,8 +182,8 @@ pub fn open_seekable_mcap_source(path: &Path) -> Result<Option<McapSource>> {
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
     if is_http_url(path) {
         if let Some(mut reader) = HttpRangeReader::open(path)? {
-            let header = read_header_from_seekable(&mut reader)?;
             if let Some(summary) = read_summary_from_remote(&reader, options)? {
+                let header = read_header_from_seekable(&mut reader)?;
                 return Ok(parsed_mcap_from_summary_ref(header, &summary));
             }
             if !options.allow_remote_scan {
@@ -270,6 +270,11 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
         return Ok(None);
     };
     let Some(summary) = read_summary_from_remote(&reader, options)? else {
+        if !options.allow_remote_scan {
+            bail!(
+                "remote file has no summary section; reading without one requires --allow-remote-scan"
+            );
+        }
         return Ok(None);
     };
     Ok(Some(RemoteMcap { reader, summary }))
@@ -502,8 +507,9 @@ pub(crate) fn require_remote_metadata_budget(
         return Ok(());
     }
     bail!(
-        "remote {description} would read {}; pass --allow-remote-scan to continue",
-        human_bytes(total_bytes)
+        "remote {description} would read {} (exceeds {} cap without --allow-remote-scan); pass --allow-remote-scan to continue",
+        human_bytes(total_bytes),
+        human_bytes(MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN)
     );
 }
 
@@ -559,8 +565,9 @@ fn read_summary_from_remote(
         .context("remote summary section is too large to read on this platform")?;
     if summary_len > MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN && !options.allow_remote_scan {
         bail!(
-            "remote summary section is {}; pass --allow-remote-scan to read it",
-            human_bytes(summary_len as u64)
+            "remote summary section is {} (exceeds {} cap without --allow-remote-scan); pass --allow-remote-scan to read it",
+            human_bytes(summary_len as u64),
+            human_bytes(MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN as u64)
         );
     }
     let summary_bytes = reader.read_range(footer.summary_start, summary_len)?;

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -21,11 +21,15 @@ const REMOTE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const REMOTE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_BODY_TIMEOUT: Duration = Duration::from_secs(60);
 const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
+const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 16 * 1024 * 1024;
+const MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN: usize = 64 * 1024 * 1024;
 
 pub enum InputData {
     Mapped(Mmap),
     TempMapped {
-        _temp_file: NamedTempFile,
+        // Keep the temporary file alive for at least as long as the mmap.
+        #[allow(dead_code)]
+        temp_file: NamedTempFile,
         mmap: Mmap,
     },
     Buffered(Vec<u8>),
@@ -89,6 +93,24 @@ impl RemoteMcap {
     }
 
     pub fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
+        self.reader.read_range(offset, length)
+    }
+
+    pub fn read_indexed_record_range(
+        &self,
+        offset: u64,
+        length: u64,
+        options: SourceOptions,
+        description: &str,
+    ) -> Result<Vec<u8>> {
+        let length = usize::try_from(length)
+            .with_context(|| format!("{description} is too large to read on this platform"))?;
+        if length > MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN && !options.allow_remote_scan {
+            bail!(
+                "remote {description} is {}; pass --allow-remote-scan to read it",
+                human_bytes(length as u64)
+            );
+        }
         self.reader.read_range(offset, length)
     }
 }
@@ -167,7 +189,7 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
     if is_http_url(path) {
         if let Some(mut reader) = HttpRangeReader::open(path)? {
             let header = read_header_from_seekable(&mut reader)?;
-            if let Some(summary) = read_summary_from_remote(&reader)? {
+            if let Some(summary) = read_summary_from_remote(&reader, options)? {
                 return Ok(parsed_mcap_from_summary_ref(header, &summary));
             }
         }
@@ -189,10 +211,7 @@ pub fn load_path(path: &Path, options: SourceOptions) -> Result<InputData> {
         let temp_file = materialized
             .temp_file
             .expect("remote materialized input should have a temp file");
-        return Ok(InputData::TempMapped {
-            _temp_file: temp_file,
-            mmap,
-        });
+        return Ok(InputData::TempMapped { temp_file, mmap });
     }
     Ok(InputData::Mapped(map_file(path)?))
 }
@@ -244,14 +263,14 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
     })
 }
 
-pub fn try_open_remote_mcap(path: &Path) -> Result<Option<RemoteMcap>> {
+pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Option<RemoteMcap>> {
     if !is_http_url(path) {
         return Ok(None);
     }
     let Some(reader) = HttpRangeReader::open(path)? else {
         return Ok(None);
     };
-    let Some(summary) = read_summary_from_remote(&reader)? else {
+    let Some(summary) = read_summary_from_remote(&reader, options)? else {
         return Ok(None);
     };
     Ok(Some(RemoteMcap { reader, summary }))
@@ -488,7 +507,10 @@ fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()
     );
 }
 
-fn read_summary_from_remote(reader: &HttpRangeReader) -> Result<Option<mcap::Summary>> {
+fn read_summary_from_remote(
+    reader: &HttpRangeReader,
+    options: SourceOptions,
+) -> Result<Option<mcap::Summary>> {
     let file_size = reader.size();
     let tail_len = FOOTER_RECORD_AND_END_MAGIC_LEN as u64;
     if file_size < tail_len + mcap::MAGIC.len() as u64 {
@@ -522,6 +544,12 @@ fn read_summary_from_remote(reader: &HttpRangeReader) -> Result<Option<mcap::Sum
     }
     let summary_len = usize::try_from(footer_start - footer.summary_start)
         .context("remote summary section is too large to read on this platform")?;
+    if summary_len > MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN && !options.allow_remote_scan {
+        bail!(
+            "remote summary section is {}; pass --allow-remote-scan to read it",
+            human_bytes(summary_len as u64)
+        );
+    }
     let summary_bytes = reader.read_range(footer.summary_start, summary_len)?;
     if summary_bytes.len() != summary_len {
         return Err(mcap::McapError::UnexpectedEof.into());
@@ -529,6 +557,8 @@ fn read_summary_from_remote(reader: &HttpRangeReader) -> Result<Option<mcap::Sum
     Ok(Some(parse_summary_section(&summary_bytes)?))
 }
 
+// TODO: keep this in sync with mcap::sans_io::SummaryReader and mcap::read::ChannelAccumulator.
+// A future mcap crate range-summary API should replace this CLI-local parser.
 fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
     let mut out = mcap::Summary::default();
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
@@ -606,6 +636,36 @@ fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
     }
     out.schemas = schemas;
     Ok(out)
+}
+
+pub(crate) fn parse_metadata_record(bytes: &[u8]) -> Result<mcap::records::Metadata> {
+    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
+    let metadata = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
+        mcap::records::Record::Metadata(metadata) => metadata,
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+    if reader.next().is_some() {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    Ok(metadata)
+}
+
+pub(crate) fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'static>> {
+    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
+    let attachment = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
+        mcap::records::Record::Attachment { header, data, .. } => mcap::Attachment {
+            log_time: header.log_time,
+            create_time: header.create_time,
+            name: header.name,
+            media_type: header.media_type,
+            data: Cow::Owned(data.into_owned()),
+        },
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+    if reader.next().is_some() {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    Ok(attachment)
 }
 
 fn read_summary_from_seekable(
@@ -1051,10 +1111,11 @@ mod tests {
         }
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let url = serve_http_with_headers(body, true, &[("Content-Encoding", "gzip")]);
-        let err = match super::try_open_remote_mcap(Path::new(&url)) {
-            Ok(_) => panic!("gzip-encoded range probe should fail"),
-            Err(err) => err,
-        };
+        let err =
+            match super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default()) {
+                Ok(_) => panic!("gzip-encoded range probe should fail"),
+                Err(err) => err,
+            };
         assert!(err
             .to_string()
             .contains("MCAP remote reads require identity encoding"));
@@ -1076,7 +1137,7 @@ mod tests {
         };
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let url = serve_http(body, true);
-        let remote = super::try_open_remote_mcap(Path::new(&url))
+        let remote = super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default())
             .expect("remote summary read")
             .expect("summary should be present");
 

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -22,7 +22,11 @@ const REMOTE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_BODY_TIMEOUT: Duration = Duration::from_secs(60);
 const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
 const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 16 * 1024 * 1024;
-const MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN: usize = 64 * 1024 * 1024;
+// Exact indexed records are bounded by the remote file size, but corrupt or hostile indexes can
+// still turn a targeted attachment/metadata lookup into an unexpectedly large transfer. Keep the
+// no-opt-in path generous for legitimate large attachments while requiring explicit consent for
+// GiB-scale single-record reads.
+const MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN: usize = 1024 * 1024 * 1024;
 
 pub enum InputData {
     Mapped(Mmap),
@@ -1119,6 +1123,57 @@ mod tests {
         assert!(err
             .to_string()
             .contains("MCAP remote reads require identity encoding"));
+    }
+
+    #[test]
+    fn remote_summary_read_requires_scan_for_oversized_summary_section() {
+        let len = super::MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN
+            + super::FOOTER_RECORD_AND_END_MAGIC_LEN
+            + mcap::MAGIC.len()
+            + 1;
+        let mut body = vec![0u8; len];
+        body[..mcap::MAGIC.len()].copy_from_slice(mcap::MAGIC);
+        let footer_start = len - super::FOOTER_RECORD_AND_END_MAGIC_LEN;
+        body[footer_start] = records::op::FOOTER;
+        body[footer_start + 1..footer_start + 9].copy_from_slice(&20u64.to_le_bytes());
+        body[footer_start + 9..footer_start + 17]
+            .copy_from_slice(&(mcap::MAGIC.len() as u64).to_le_bytes());
+        body[footer_start + 17..footer_start + 25].copy_from_slice(&0u64.to_le_bytes());
+        body[footer_start + 25..footer_start + 29].copy_from_slice(&0u32.to_le_bytes());
+        body[len - mcap::MAGIC.len()..].copy_from_slice(mcap::MAGIC);
+
+        let url = serve_http(Box::leak(body.into_boxed_slice()), true);
+        let err =
+            match super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default()) {
+                Ok(_) => panic!("oversized remote summary should require scan opt-in"),
+                Err(err) => err,
+            };
+        assert!(err.to_string().contains("remote summary section"));
+        assert!(err.to_string().contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn indexed_record_range_requires_scan_for_oversized_record() {
+        let remote = super::RemoteMcap {
+            reader: super::HttpRangeReader {
+                agent: super::remote_agent(),
+                url: "http://127.0.0.1:1/demo.mcap".to_string(),
+                display_url: "http://127.0.0.1:1/demo.mcap".to_string(),
+                size: (super::MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN + 1) as u64,
+                offset: 0,
+            },
+            summary: mcap::Summary::default(),
+        };
+        let err = remote
+            .read_indexed_record_range(
+                0,
+                (super::MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN + 1) as u64,
+                super::SourceOptions::default(),
+                "attachment record",
+            )
+            .expect_err("oversized indexed record should require opt-in");
+        assert!(err.to_string().contains("attachment record"));
+        assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
     #[test]

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -511,9 +511,8 @@ fn read_summary_from_remote(reader: &HttpRangeReader) -> Result<Option<mcap::Sum
         return Err(mcap::McapError::BadMagic.into());
     }
 
-    let mut cursor = std::io::Cursor::new(
-        &tail[9..FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()],
-    );
+    let mut cursor =
+        std::io::Cursor::new(&tail[9..FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()]);
     let footer = records::Footer::read_le(&mut cursor)?;
     if footer.summary_start == 0 {
         return Ok(None);
@@ -558,7 +557,7 @@ fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
                             || existing.data.as_ref() != schema.data.as_ref()
                         {
                             return Err(
-                                mcap::McapError::ConflictingSchemas(schema.name.clone()).into(),
+                                mcap::McapError::ConflictingSchemas(schema.name.clone()).into()
                             );
                         }
                     }
@@ -591,9 +590,10 @@ fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
                             || existing.message_encoding != resolved.message_encoding
                             || existing.metadata != resolved.metadata
                         {
-                            return Err(
-                                mcap::McapError::ConflictingChannels(resolved.topic.clone()).into(),
-                            );
+                            return Err(mcap::McapError::ConflictingChannels(
+                                resolved.topic.clone(),
+                            )
+                            .into());
                         }
                     }
                     std::collections::hash_map::Entry::Vacant(entry) => {
@@ -1000,8 +1000,8 @@ mod tests {
     #[test]
     fn remote_errors_redact_query_strings() {
         let url = "http://127.0.0.1:1/demo.mcap?X-Amz-Signature=secret-token";
-        let err =
-            load_path(Path::new(url)).expect_err("connection failure should report redacted URL");
+        let err = load_path(Path::new(url), super::SourceOptions::default())
+            .expect_err("remote scan rejection should report redacted URL");
         assert!(!err.to_string().contains("secret-token"));
         assert!(!err.to_string().contains("X-Amz-Signature"));
     }
@@ -1009,24 +1009,34 @@ mod tests {
     #[test]
     fn remote_errors_redact_userinfo() {
         let url = "http://AKIA:secret@127.0.0.1:1/demo.mcap";
-        let err =
-            load_path(Path::new(url)).expect_err("connection failure should report redacted URL");
+        let err = load_path(Path::new(url), super::SourceOptions::default())
+            .expect_err("remote scan rejection should report redacted URL");
         assert!(!err.to_string().contains("AKIA"));
         assert!(!err.to_string().contains("secret"));
         assert!(err.to_string().contains("http://127.0.0.1:1/demo.mcap"));
     }
 
     #[test]
+    fn remote_http_input_requires_remote_scan_opt_in() {
+        let url = serve_http(b"hello remote", true);
+        let err = load_path(Path::new(&url), super::SourceOptions::default())
+            .expect_err("remote full read should require opt-in");
+        assert!(err.to_string().contains("--allow-remote-scan"));
+    }
+
+    #[test]
     fn remote_http_input_reads_entire_file() {
         let url = serve_http(b"hello remote", true);
-        let input = load_path(Path::new(&url)).expect("remote read");
+        let input =
+            load_path(Path::new(&url), super::SourceOptions::new(true)).expect("remote read");
         assert_eq!(input.as_slice(), b"hello remote");
     }
 
     #[test]
     fn remote_http_input_rejects_gzip_content_encoding() {
         let url = serve_http_with_headers(b"hello remote", false, &[("Content-Encoding", "gzip")]);
-        let err = load_path(Path::new(&url)).expect_err("gzip-encoded remote read should fail");
+        let err = load_path(Path::new(&url), super::SourceOptions::new(true))
+            .expect_err("gzip-encoded remote read should fail");
         assert!(err
             .to_string()
             .contains("MCAP remote reads require identity encoding"));

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -1,9 +1,13 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::io::{IsTerminal as _, Read as _, SeekFrom};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
+use binrw::BinRead;
 use mcap::records::{self, Record};
 use mcap::sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions};
 use memmap2::Mmap;
@@ -16,10 +20,26 @@ pub const PLEASE_SUPPLY_FILE: &str = "please supply a file. see --help for usage
 const REMOTE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const REMOTE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_BODY_TIMEOUT: Duration = Duration::from_secs(60);
+const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
 
 pub enum InputData {
     Mapped(Mmap),
+    TempMapped {
+        _temp_file: NamedTempFile,
+        mmap: Mmap,
+    },
     Buffered(Vec<u8>),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SourceOptions {
+    pub allow_remote_scan: bool,
+}
+
+impl SourceOptions {
+    pub fn new(allow_remote_scan: bool) -> Self {
+        Self { allow_remote_scan }
+    }
 }
 
 impl std::fmt::Debug for InputData {
@@ -42,6 +62,7 @@ impl InputData {
     pub fn as_slice(&self) -> &[u8] {
         match self {
             InputData::Mapped(mmap) => mmap.as_ref(),
+            InputData::TempMapped { mmap, .. } => mmap.as_ref(),
             InputData::Buffered(buf) => buf.as_slice(),
         }
     }
@@ -142,28 +163,43 @@ pub fn open_seekable_mcap_source(path: &Path) -> Result<Option<McapSource>> {
     Ok(Some(McapSource::Local(file)))
 }
 
-pub fn parse_mcap_from_path(path: &Path) -> Result<ParsedMcap> {
-    if let Some(mut source) = open_seekable_mcap_source(path)? {
+pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
+    if is_http_url(path) {
+        if let Some(mut reader) = HttpRangeReader::open(path)? {
+            let header = read_header_from_seekable(&mut reader)?;
+            if let Some(summary) = read_summary_from_remote(&reader)? {
+                return Ok(parsed_mcap_from_summary_ref(header, &summary));
+            }
+        }
+    } else if let Some(mut source) = open_seekable_mcap_source(path)? {
         let header = read_header_from_seekable(&mut source)?;
         if let Some(summary) = read_summary_from_seekable(&mut source)? {
             return Ok(parsed_mcap_from_summary_ref(header, &summary));
         }
     }
 
-    let mcap = load_path(path)?;
+    let mcap = load_path(path, options)?;
     parse_mcap(&mcap)
 }
 
-pub fn load_path(path: &Path) -> Result<InputData> {
+pub fn load_path(path: &Path, options: SourceOptions) -> Result<InputData> {
     if is_http_url(path) {
-        return Ok(InputData::Buffered(read_remote_input(path)?));
+        let materialized = materialize_input(path, options)?;
+        let mmap = map_file(materialized.path())?;
+        let temp_file = materialized
+            .temp_file
+            .expect("remote materialized input should have a temp file");
+        return Ok(InputData::TempMapped {
+            _temp_file: temp_file,
+            mmap,
+        });
     }
     Ok(InputData::Mapped(map_file(path)?))
 }
 
-pub fn load_input(file: Option<&Path>) -> Result<InputData> {
+pub fn load_input(file: Option<&Path>, options: SourceOptions) -> Result<InputData> {
     if let Some(path) = file {
-        return load_path(path);
+        return load_path(path, options);
     }
 
     let stdin = std::io::stdin();
@@ -179,7 +215,7 @@ pub fn load_input(file: Option<&Path>) -> Result<InputData> {
     Ok(InputData::Buffered(buf))
 }
 
-pub fn materialize_input(path: &Path) -> Result<MaterializedInput> {
+pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<MaterializedInput> {
     if !is_http_url(path) {
         return Ok(MaterializedInput {
             temp_file: None,
@@ -187,6 +223,7 @@ pub fn materialize_input(path: &Path) -> Result<MaterializedInput> {
         });
     }
 
+    require_remote_scan_allowed(path, options)?;
     let suffix = remote_or_local_extension(path)
         .filter(|extension| !extension.is_empty())
         .map(|extension| format!(".{extension}"));
@@ -211,10 +248,10 @@ pub fn try_open_remote_mcap(path: &Path) -> Result<Option<RemoteMcap>> {
     if !is_http_url(path) {
         return Ok(None);
     }
-    let Some(mut reader) = HttpRangeReader::open(path)? else {
+    let Some(reader) = HttpRangeReader::open(path)? else {
         return Ok(None);
     };
-    let Some(summary) = read_summary_from_seekable(&mut reader)? else {
+    let Some(summary) = read_summary_from_remote(&reader)? else {
         return Ok(None);
     };
     Ok(Some(RemoteMcap { reader, summary }))
@@ -241,12 +278,6 @@ pub fn remote_or_local_extension(path: &Path) -> Option<String> {
     path.extension()
         .and_then(|extension| extension.to_str())
         .map(str::to_string)
-}
-
-fn read_remote_input(path: &Path) -> Result<Vec<u8>> {
-    let mut bytes = Vec::new();
-    read_remote_input_to_writer(path, &mut bytes)?;
-    Ok(bytes)
 }
 
 impl HttpRangeReader {
@@ -299,6 +330,10 @@ impl HttpRangeReader {
         )
         .with_context(|| format!("failed to read range from {}", self.display_url))?;
         Ok(bytes)
+    }
+
+    fn size(&self) -> u64 {
+        self.size
     }
 }
 
@@ -438,6 +473,139 @@ fn validate_identity_content_encoding(
     bail!(
         "remote server returned Content-Encoding: {value} for {display_url}; MCAP remote reads require identity encoding"
     );
+}
+
+fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()> {
+    if options.allow_remote_scan {
+        return Ok(());
+    }
+    let display = path
+        .to_str()
+        .map(redact_url)
+        .unwrap_or_else(|| path.display().to_string());
+    bail!(
+        "remote input {display} requires --allow-remote-scan because this command must download or scan remote data"
+    );
+}
+
+fn read_summary_from_remote(reader: &HttpRangeReader) -> Result<Option<mcap::Summary>> {
+    let file_size = reader.size();
+    let tail_len = FOOTER_RECORD_AND_END_MAGIC_LEN as u64;
+    if file_size < tail_len + mcap::MAGIC.len() as u64 {
+        return Err(mcap::McapError::UnexpectedEof.into());
+    }
+
+    let footer_start = file_size - tail_len;
+    let tail = reader.read_range(footer_start, FOOTER_RECORD_AND_END_MAGIC_LEN)?;
+    if tail.len() != FOOTER_RECORD_AND_END_MAGIC_LEN {
+        return Err(mcap::McapError::UnexpectedEof.into());
+    }
+    if tail[0] != records::op::FOOTER {
+        return Err(mcap::McapError::BadFooter.into());
+    }
+    let record_len = u64::from_le_bytes(tail[1..9].try_into().expect("footer length slice"));
+    if record_len != 20 {
+        return Err(mcap::McapError::BadFooter.into());
+    }
+    if &tail[FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()..] != mcap::MAGIC {
+        return Err(mcap::McapError::BadMagic.into());
+    }
+
+    let mut cursor = std::io::Cursor::new(
+        &tail[9..FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()],
+    );
+    let footer = records::Footer::read_le(&mut cursor)?;
+    if footer.summary_start == 0 {
+        return Ok(None);
+    }
+    if footer.summary_start > footer_start {
+        return Err(mcap::McapError::UnexpectedEof.into());
+    }
+    let summary_len = usize::try_from(footer_start - footer.summary_start)
+        .context("remote summary section is too large to read on this platform")?;
+    let summary_bytes = reader.read_range(footer.summary_start, summary_len)?;
+    if summary_bytes.len() != summary_len {
+        return Err(mcap::McapError::UnexpectedEof.into());
+    }
+    Ok(Some(parse_summary_section(&summary_bytes)?))
+}
+
+fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
+    let mut out = mcap::Summary::default();
+    let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
+
+    for record in mcap::read::LinearReader::sans_magic(summary) {
+        match record? {
+            Record::AttachmentIndex(index) => out.attachment_indexes.push(index),
+            Record::MetadataIndex(index) => out.metadata_indexes.push(index),
+            Record::Statistics(statistics) => out.stats = Some(statistics),
+            Record::ChunkIndex(index) => out.chunk_indexes.push(index),
+            Record::Schema { header, data } => {
+                if header.id == 0 {
+                    return Err(mcap::McapError::InvalidSchemaId.into());
+                }
+                let schema = Arc::new(mcap::Schema {
+                    id: header.id,
+                    name: header.name,
+                    encoding: header.encoding,
+                    data: Cow::Owned(data.into_owned()),
+                });
+                match schemas.entry(schema.id) {
+                    std::collections::hash_map::Entry::Occupied(entry) => {
+                        let existing = entry.get();
+                        if existing.name != schema.name
+                            || existing.encoding != schema.encoding
+                            || existing.data.as_ref() != schema.data.as_ref()
+                        {
+                            return Err(
+                                mcap::McapError::ConflictingSchemas(schema.name.clone()).into(),
+                            );
+                        }
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(schema);
+                    }
+                }
+            }
+            Record::Channel(channel) => {
+                let schema = if channel.schema_id == 0 {
+                    None
+                } else {
+                    Some(schemas.get(&channel.schema_id).cloned().ok_or_else(|| {
+                        mcap::McapError::UnknownSchema(channel.topic.clone(), channel.schema_id)
+                    })?)
+                };
+                let resolved = Arc::new(mcap::Channel {
+                    id: channel.id,
+                    topic: channel.topic,
+                    schema,
+                    message_encoding: channel.message_encoding,
+                    metadata: channel.metadata,
+                });
+                match out.channels.entry(resolved.id) {
+                    std::collections::hash_map::Entry::Occupied(entry) => {
+                        let existing = entry.get();
+                        if existing.topic != resolved.topic
+                            || existing.schema.as_ref().map(|schema| schema.id)
+                                != resolved.schema.as_ref().map(|schema| schema.id)
+                            || existing.message_encoding != resolved.message_encoding
+                            || existing.metadata != resolved.metadata
+                        {
+                            return Err(
+                                mcap::McapError::ConflictingChannels(resolved.topic.clone()).into(),
+                            );
+                        }
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(resolved);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out.schemas = schemas;
+    Ok(out)
 }
 
 fn read_summary_from_seekable(

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -188,7 +188,8 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
             }
             if !options.allow_remote_scan {
                 bail!(
-                    "remote file has no summary section; reading without one requires --allow-remote-scan"
+                    "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
+                    redacted_display(path)
                 );
             }
         }
@@ -272,7 +273,8 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
     let Some(summary) = read_summary_from_remote(&reader, options)? else {
         if !options.allow_remote_scan {
             bail!(
-                "remote file has no summary section; reading without one requires --allow-remote-scan"
+                "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
+                redacted_display(path)
             );
         }
         return Ok(None);
@@ -415,6 +417,12 @@ fn probe_range_size(agent: &Agent, url: &str, display_url: &str) -> Result<Optio
     }
 }
 
+pub(crate) fn redacted_display(path: &Path) -> String {
+    path.to_str()
+        .map(redact_url)
+        .unwrap_or_else(|| path.display().to_string())
+}
+
 fn read_remote_input_to_writer(path: &Path, writer: &mut impl std::io::Write) -> Result<()> {
     let url = path
         .to_str()
@@ -517,10 +525,7 @@ fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()
     if options.allow_remote_scan {
         return Ok(());
     }
-    let display = path
-        .to_str()
-        .map(redact_url)
-        .unwrap_or_else(|| path.display().to_string());
+    let display = redacted_display(path);
     bail!(
         "remote input {display} requires --allow-remote-scan because this command must download or scan remote data"
     );
@@ -1165,6 +1170,21 @@ mod tests {
                 Err(err) => err,
             };
         assert!(err.to_string().contains("remote summary section"));
+        assert!(err.to_string().contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn remote_metadata_budget_requires_scan_for_oversized_total() {
+        let err = super::require_remote_metadata_budget(
+            super::MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN + 1,
+            super::SourceOptions::default(),
+            "metadata records",
+        )
+        .expect_err("oversized metadata range total should require scan opt-in");
+        assert!(err.to_string().contains("metadata records"));
+        assert!(err.to_string().contains(&super::human_bytes(
+            super::MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN
+        )));
         assert!(err.to_string().contains("--allow-remote-scan"));
     }
 

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -85,7 +85,6 @@ pub struct RemoteMcap {
 
 pub enum McapSource {
     Local(std::fs::File),
-    Remote(HttpRangeReader),
 }
 
 impl RemoteMcap {
@@ -102,7 +101,6 @@ impl std::io::Read for McapSource {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
             Self::Local(file) => file.read(buf),
-            Self::Remote(reader) => reader.read(buf),
         }
     }
 }
@@ -111,7 +109,6 @@ impl std::io::Seek for McapSource {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
         match self {
             Self::Local(file) => file.seek(pos),
-            Self::Remote(reader) => reader.seek(pos),
         }
     }
 }
@@ -161,7 +158,7 @@ pub fn map_file(path: &Path) -> anyhow::Result<Mmap> {
 
 pub fn open_seekable_mcap_source(path: &Path) -> Result<Option<McapSource>> {
     if is_http_url(path) {
-        return Ok(HttpRangeReader::open(path)?.map(McapSource::Remote));
+        return Ok(None);
     }
     let file =
         std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))?;
@@ -185,15 +182,17 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
                 }
                 if !options.allow_remote_scan {
                     bail!(
-                        "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
-                        redacted_display(path)
+                        "{}: remote file has no summary section; reading without one requires opt-in; {}",
+                        redacted_display(path),
+                        remote_scan_opt_in_suffix()
                     );
                 }
             }
             None if !options.allow_remote_scan => {
                 bail!(
-                    "{}: remote server does not support HTTP range requests; pass --allow-remote-scan to download the full file",
-                    redacted_display(path)
+                    "{}: remote server does not support HTTP range requests; {}",
+                    redacted_display(path),
+                    remote_scan_opt_in_suffix()
                 );
             }
             None => {}
@@ -275,8 +274,9 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
     let Some(reader) = HttpRangeReader::open(path)? else {
         if !options.allow_remote_scan {
             bail!(
-                "{}: remote server does not support HTTP range requests; pass --allow-remote-scan to download the full file",
-                redacted_display(path)
+                "{}: remote server does not support HTTP range requests; {}",
+                redacted_display(path),
+                remote_scan_opt_in_suffix()
             );
         }
         return Ok(None);
@@ -290,8 +290,9 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
     else {
         if !options.allow_remote_scan {
             bail!(
-                "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
-                redacted_display(path)
+                "{}: remote file has no summary section; reading without one requires opt-in; {}",
+                redacted_display(path),
+                remote_scan_opt_in_suffix()
             );
         }
         return Ok(None);
@@ -523,6 +524,10 @@ fn validate_identity_content_encoding(
     );
 }
 
+fn remote_scan_opt_in_suffix() -> &'static str {
+    "pass --allow-remote-scan to continue"
+}
+
 pub(crate) fn require_remote_metadata_budget(
     total_bytes: u64,
     options: SourceOptions,
@@ -532,9 +537,10 @@ pub(crate) fn require_remote_metadata_budget(
         return Ok(());
     }
     bail!(
-        "remote {description} would read {} (exceeds {} cap without --allow-remote-scan); pass --allow-remote-scan to continue",
+        "remote {description} would read {} (exceeds {} cap without --allow-remote-scan); {}",
         human_bytes(total_bytes),
-        human_bytes(MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN)
+        human_bytes(MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN),
+        remote_scan_opt_in_suffix()
     );
 }
 
@@ -544,7 +550,8 @@ fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()
     }
     let display = redacted_display(path);
     bail!(
-        "remote input {display} requires --allow-remote-scan because this command must download or scan remote data"
+        "remote input {display} requires opt-in because this command must download or scan remote data; {}",
+        remote_scan_opt_in_suffix()
     );
 }
 
@@ -587,9 +594,10 @@ fn read_summary_from_remote(
         .context("remote summary section is too large to read on this platform")?;
     if summary_len > MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN && !options.allow_remote_scan {
         bail!(
-            "remote summary section is {} (exceeds {} cap without --allow-remote-scan); pass --allow-remote-scan to read it",
+            "remote summary section is {} (exceeds {} cap without --allow-remote-scan); {}",
             human_bytes(summary_len as u64),
-            human_bytes(MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN as u64)
+            human_bytes(MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN as u64),
+            remote_scan_opt_in_suffix()
         );
     }
     let summary_bytes = reader.read_range(footer.summary_start, summary_len)?;

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -97,14 +97,9 @@ impl RemoteMcap {
         self.reader.read_range(offset, length)
     }
 
-    pub fn read_indexed_record_range(
-        &self,
-        offset: u64,
-        length: u64,
-        description: &str,
-    ) -> Result<Vec<u8>> {
+    pub fn read_indexed_record_range(&self, offset: u64, length: u64) -> Result<Vec<u8>> {
         let length = usize::try_from(length)
-            .with_context(|| format!("{description} is too large to read on this platform"))?;
+            .context("indexed record is too large to read on this platform")?;
         self.reader.read_range(offset, length)
     }
 }

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -181,17 +181,26 @@ pub fn open_seekable_mcap_source(path: &Path) -> Result<Option<McapSource>> {
 
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
     if is_http_url(path) {
-        if let Some(mut reader) = HttpRangeReader::open(path)? {
-            if let Some(summary) = read_summary_from_remote(&reader, options)? {
-                let header = read_header_from_seekable(&mut reader)?;
-                return Ok(parsed_mcap_from_summary_ref(header, &summary));
+        match HttpRangeReader::open(path)? {
+            Some(mut reader) => {
+                if let Some(summary) = read_summary_from_remote(&reader, options)? {
+                    let header = read_header_from_seekable(&mut reader)?;
+                    return Ok(parsed_mcap_from_summary_ref(header, &summary));
+                }
+                if !options.allow_remote_scan {
+                    bail!(
+                        "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
+                        redacted_display(path)
+                    );
+                }
             }
-            if !options.allow_remote_scan {
+            None if !options.allow_remote_scan => {
                 bail!(
-                    "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
+                    "{}: remote server does not support HTTP range requests; pass --allow-remote-scan to download the full file",
                     redacted_display(path)
                 );
             }
+            None => {}
         }
     } else if let Some(mut source) = open_seekable_mcap_source(path)? {
         let header = read_header_from_seekable(&mut source)?;
@@ -268,6 +277,12 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
         return Ok(None);
     }
     let Some(reader) = HttpRangeReader::open(path)? else {
+        if !options.allow_remote_scan {
+            bail!(
+                "{}: remote server does not support HTTP range requests; pass --allow-remote-scan to download the full file",
+                redacted_display(path)
+            );
+        }
         return Ok(None);
     };
     let Some(summary) = read_summary_from_remote(&reader, options)? else {
@@ -663,6 +678,9 @@ fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
     Ok(out)
 }
 
+// TODO: keep these exact-record parsers in sync with mcap::read::metadata and
+// mcap::read::attachment. They duplicate the mcap crate helpers so remote range callers can
+// parse owned records without holding a full-file byte slice alive.
 pub(crate) fn parse_metadata_record(bytes: &[u8]) -> Result<mcap::records::Metadata> {
     let mut reader = mcap::read::LinearReader::sans_magic(bytes);
     let metadata = match reader.next().ok_or(mcap::McapError::BadIndex)?? {

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -89,10 +89,6 @@ pub struct RemoteMcap {
     summary: mcap::Summary,
 }
 
-pub enum McapSource {
-    Local(std::fs::File),
-}
-
 impl RemoteMcap {
     pub fn summary(&self) -> &mcap::Summary {
         &self.summary
@@ -100,22 +96,6 @@ impl RemoteMcap {
 
     pub fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
         self.reader.read_range(offset, length)
-    }
-}
-
-impl std::io::Read for McapSource {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        match self {
-            Self::Local(file) => file.read(buf),
-        }
-    }
-}
-
-impl std::io::Seek for McapSource {
-    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        match self {
-            Self::Local(file) => file.seek(pos),
-        }
     }
 }
 
@@ -162,10 +142,8 @@ pub fn map_file(path: &Path) -> anyhow::Result<Mmap> {
     unsafe { Mmap::map(&file) }.with_context(|| format!("couldn't map '{}'", path.display()))
 }
 
-pub fn open_seekable_mcap_source(path: &Path) -> Result<Option<McapSource>> {
-    let file =
-        std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))?;
-    Ok(Some(McapSource::Local(file)))
+pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
+    std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))
 }
 
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
@@ -200,7 +178,8 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
             }
             None => {}
         }
-    } else if let Some(mut source) = open_seekable_mcap_source(path)? {
+    } else {
+        let mut source = open_seekable_mcap_source(path)?;
         let header = read_header_from_seekable(&mut source)?;
         if let Some(summary) = read_summary_from_seekable(&mut source)? {
             return Ok(parsed_mcap_from_summary_ref(header, &summary));

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -31,10 +31,11 @@ const MAX_REMOTE_INDEXED_RECORD_BYTES_WITHOUT_SCAN: usize = 1024 * 1024 * 1024;
 pub enum InputData {
     Mapped(Mmap),
     TempMapped {
-        // Keep the temporary file alive for at least as long as the mmap.
+        mmap: Mmap,
+        // Keep the temporary file alive for at least as long as the mmap. Fields drop in
+        // declaration order, so this is dropped after `mmap`.
         #[allow(dead_code)]
         temp_file: NamedTempFile,
-        mmap: Mmap,
     },
     Buffered(Vec<u8>),
 }

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -163,9 +163,6 @@ pub fn map_file(path: &Path) -> anyhow::Result<Mmap> {
 }
 
 pub fn open_seekable_mcap_source(path: &Path) -> Result<Option<McapSource>> {
-    if is_http_url(path) {
-        return Ok(None);
-    }
     let file =
         std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))?;
     Ok(Some(McapSource::Local(file)))

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -172,7 +172,14 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
     if is_http_url(path) {
         match HttpRangeReader::open(path)? {
             Some(mut reader) => {
-                if let Some(summary) = read_summary_from_remote(&reader, options)? {
+                if let Some(summary) =
+                    read_summary_from_remote(&reader, options).with_context(|| {
+                        format!(
+                            "failed to read remote summary from {}",
+                            redacted_display(path)
+                        )
+                    })?
+                {
                     let header = read_header_from_seekable(&mut reader)?;
                     return Ok(parsed_mcap_from_summary_ref(header, &summary));
                 }
@@ -274,7 +281,13 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
         }
         return Ok(None);
     };
-    let Some(summary) = read_summary_from_remote(&reader, options)? else {
+    let Some(summary) = read_summary_from_remote(&reader, options).with_context(|| {
+        format!(
+            "failed to read remote summary from {}",
+            redacted_display(path)
+        )
+    })?
+    else {
         if !options.allow_remote_scan {
             bail!(
                 "{}: remote file has no summary section; reading without one requires --allow-remote-scan",
@@ -1176,8 +1189,9 @@ mod tests {
                 Ok(_) => panic!("oversized remote summary should require scan opt-in"),
                 Err(err) => err,
             };
-        assert!(err.to_string().contains("remote summary section"));
-        assert!(err.to_string().contains("--allow-remote-scan"));
+        let message = format!("{err:#}");
+        assert!(message.contains("remote summary section"));
+        assert!(message.contains("--allow-remote-scan"));
     }
 
     #[test]

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -12,9 +12,9 @@ pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
         .compression(args.compression)
         .use_chunks(!args.unchunked)
         .include_metadata(true)
-        .include_attachments(true)
-        .source_options(crate::commands::common::SourceOptions::new(
-            ctx.allow_remote_scan(),
-        ));
-    filter::run_transcode(options)
+        .include_attachments(true);
+    filter::run_transcode(
+        options,
+        crate::commands::common::SourceOptions::new(ctx.allow_remote_scan()),
+    )
 }

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -4,7 +4,7 @@ use crate::cli::CompressCommand;
 use crate::commands::filter::{self, TranscodeCommandOptions};
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: CompressCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
     // Intentionally keep accepting --chunk-size/--compression with --unchunked to
     // match Go CLI flag behavior. With unchunked output there are no chunk records,
     // so these settings are effectively ignored by the writer.
@@ -12,6 +12,9 @@ pub fn run(_ctx: &CommandContext, args: CompressCommand) -> Result<()> {
         .compression(args.compression)
         .use_chunks(!args.unchunked)
         .include_metadata(true)
-        .include_attachments(true);
+        .include_attachments(true)
+        .source_options(crate::commands::common::SourceOptions::new(
+            ctx.allow_remote_scan(),
+        ));
     filter::run_transcode(options)
 }

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -13,13 +13,16 @@ use crate::context::CommandContext;
 
 const GIT_LFS_POINTER_PREFIX: &[u8] = b"version https://git-lfs.github.com";
 
-pub fn run(_ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
     let input = ConvertInput::detect(&args.input)?;
     let is_remote = crate::commands::common::is_http_url(&args.input);
     if !is_remote {
         reject_lfs_pointer(&args.input)?;
     }
-    let materialized_input = crate::commands::common::materialize_input(&args.input)?;
+    let materialized_input = crate::commands::common::materialize_input(
+        &args.input,
+        crate::commands::common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     if !is_remote {
         ensure_distinct_paths(materialized_input.path(), &args.output)?;
     }

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -350,6 +350,25 @@ size 123\n",
     }
 
     #[test]
+    fn remote_input_requires_allow_remote_scan_before_download() {
+        let err = super::run(
+            &CommandContext::default(),
+            ConvertCommand {
+                input: PathBuf::from("https://example.com/demo.bag?token=secret"),
+                output: PathBuf::from("/tmp/mcap-cli-remote-output.mcap"),
+                compression: CompressionFormat::None,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: false,
+                chunked: true,
+            },
+        )
+        .expect_err("remote convert should require opt-in");
+
+        assert!(err.to_string().contains("--allow-remote-scan"));
+        assert!(!err.to_string().contains("token=secret"));
+    }
+
+    #[test]
     fn include_crc_false_zeros_data_end_and_footer_crc() {
         let bytes = build_sample_mcap(false);
 

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -9,9 +9,9 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
         .compression("none")
         .include_metadata(true)
         .include_attachments(true)
-        .use_chunks(true)
-        .source_options(crate::commands::common::SourceOptions::new(
-            ctx.allow_remote_scan(),
-        ));
-    filter::run_transcode(options)
+        .use_chunks(true);
+    filter::run_transcode(
+        options,
+        crate::commands::common::SourceOptions::new(ctx.allow_remote_scan()),
+    )
 }

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -4,11 +4,14 @@ use crate::cli::DecompressCommand;
 use crate::commands::filter::{self, TranscodeCommandOptions};
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
     let options = TranscodeCommandOptions::new(args.file, args.output, args.chunk_size)
         .compression("none")
         .include_metadata(true)
         .include_attachments(true)
-        .use_chunks(true);
+        .use_chunks(true)
+        .source_options(crate::commands::common::SourceOptions::new(
+            ctx.allow_remote_scan(),
+        ));
     filter::run_transcode(options)
 }

--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -8,7 +8,10 @@ use crate::commands::common;
 use crate::context::CommandContext;
 
 pub fn run(ctx: &CommandContext, args: DoctorCommand) -> Result<()> {
-    let mcap = common::load_path(&args.file)?;
+    let mcap = common::load_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     if ctx.verbose() > 0 {
         println!("Examining {}", args.file.display());
     }

--- a/rust/cli/src/commands/du.rs
+++ b/rust/cli/src/commands/du.rs
@@ -31,8 +31,11 @@ struct OffsetEntry {
     channel_id: u16,
 }
 
-pub fn run(_ctx: &CommandContext, args: DuCommand) -> Result<()> {
-    let mcap = common::load_path(&args.file)?;
+pub fn run(ctx: &CommandContext, args: DuCommand) -> Result<()> {
+    let mcap = common::load_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
 
     let (usage, used_approximate) = if args.approximate {
         match collect_usage_approximate(&mcap)? {

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -45,6 +45,7 @@ pub(crate) struct TranscodeCommandOptions {
     pub(crate) output_compression: String,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
+    pub(crate) source_options: common::SourceOptions,
 }
 
 impl From<&FilterCommand> for TranscodeCommandOptions {
@@ -66,6 +67,7 @@ impl From<&FilterCommand> for TranscodeCommandOptions {
             output_compression: args.output_compression.clone(),
             chunk_size: args.chunk_size,
             use_chunks: true,
+            source_options: common::SourceOptions::default(),
         }
     }
 }
@@ -89,6 +91,7 @@ impl TranscodeCommandOptions {
             output_compression: "zstd".to_string(),
             chunk_size,
             use_chunks: true,
+            source_options: common::SourceOptions::default(),
         }
     }
 
@@ -111,6 +114,11 @@ impl TranscodeCommandOptions {
         self.include_attachments = value;
         self
     }
+
+    pub(crate) fn source_options(mut self, value: common::SourceOptions) -> Self {
+        self.source_options = value;
+        self
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -122,13 +130,16 @@ struct PreStartMessage {
     data: Vec<u8>,
 }
 
-pub fn run(_ctx: &CommandContext, args: FilterCommand) -> Result<()> {
-    run_transcode(TranscodeCommandOptions::from(&args))
+pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
+    run_transcode(
+        TranscodeCommandOptions::from(&args)
+            .source_options(common::SourceOptions::new(ctx.allow_remote_scan())),
+    )
 }
 
 pub(crate) fn run_transcode(args: TranscodeCommandOptions) -> Result<()> {
     let opts = build_filter_options_from_transcode_options(&args)?;
-    let input = common::load_input(args.file.as_deref())?;
+    let input = common::load_input(args.file.as_deref(), args.source_options)?;
 
     if let Some(output) = &opts.output {
         let writer = std::fs::File::create(output)

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -45,7 +45,6 @@ pub(crate) struct TranscodeCommandOptions {
     pub(crate) output_compression: String,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
-    pub(crate) source_options: common::SourceOptions,
 }
 
 impl From<&FilterCommand> for TranscodeCommandOptions {
@@ -67,7 +66,6 @@ impl From<&FilterCommand> for TranscodeCommandOptions {
             output_compression: args.output_compression.clone(),
             chunk_size: args.chunk_size,
             use_chunks: true,
-            source_options: common::SourceOptions::default(),
         }
     }
 }
@@ -91,7 +89,6 @@ impl TranscodeCommandOptions {
             output_compression: "zstd".to_string(),
             chunk_size,
             use_chunks: true,
-            source_options: common::SourceOptions::default(),
         }
     }
 
@@ -114,11 +111,6 @@ impl TranscodeCommandOptions {
         self.include_attachments = value;
         self
     }
-
-    pub(crate) fn source_options(mut self, value: common::SourceOptions) -> Self {
-        self.source_options = value;
-        self
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -132,14 +124,17 @@ struct PreStartMessage {
 
 pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
     run_transcode(
-        TranscodeCommandOptions::from(&args)
-            .source_options(common::SourceOptions::new(ctx.allow_remote_scan())),
+        TranscodeCommandOptions::from(&args),
+        common::SourceOptions::new(ctx.allow_remote_scan()),
     )
 }
 
-pub(crate) fn run_transcode(args: TranscodeCommandOptions) -> Result<()> {
+pub(crate) fn run_transcode(
+    args: TranscodeCommandOptions,
+    source_options: common::SourceOptions,
+) -> Result<()> {
     let opts = build_filter_options_from_transcode_options(&args)?;
-    let input = common::load_input(args.file.as_deref(), args.source_options)?;
+    let input = common::load_input(args.file.as_deref(), source_options)?;
 
     if let Some(output) = &opts.output {
         let writer = std::fs::File::create(output)
@@ -968,7 +963,8 @@ mod tests {
         options.use_chunks = false;
         options.output_compression = "none".to_string();
 
-        super::run_transcode(options).expect("transcode should succeed");
+        super::run_transcode(options, super::common::SourceOptions::default())
+            .expect("transcode should succeed");
         let output = std::fs::read(&output_path).expect("read output");
         let summary = mcap::Summary::read(&output)
             .expect("summary read should succeed")

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -12,8 +12,7 @@ const PLEASE_REDIRECT: &str =
 
 pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
-    let attachment = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)?
-    {
+    if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
         let index = select_attachment_index(
             &remote.summary().attachment_indexes,
             &args.name,
@@ -24,12 +23,13 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
             usize::try_from(index.length)
                 .context("indexed record is too large to read on this platform")?,
         )?;
-        common::parse_attachment_record(&bytes).with_context(|| {
+        let attachment = common::parse_attachment_record(&bytes).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",
                 args.name, index.offset
             )
-        })?
+        })?;
+        write_attachment_data(attachment.data.as_ref(), args.output.as_deref())?;
     } else {
         let mcap = common::load_path(&args.file, source_options)?;
         let parsed = common::parse_mcap(&mcap)?;
@@ -40,31 +40,24 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
                 args.name, index.offset
             )
         })?;
-        own_attachment(attachment)
-    };
-
-    if let Some(output) = args.output {
-        std::fs::write(&output, &attachment.data)
-            .with_context(|| format!("failed to write attachment to '{}'", output.display()))?;
-    } else if std::io::stdout().is_terminal() {
-        anyhow::bail!("{PLEASE_REDIRECT}");
-    } else {
-        std::io::stdout()
-            .write_all(&attachment.data)
-            .context("failed to write attachment to stdout")?;
+        write_attachment_data(attachment.data.as_ref(), args.output.as_deref())?;
     }
 
     Ok(())
 }
 
-fn own_attachment(attachment: mcap::Attachment<'_>) -> mcap::Attachment<'static> {
-    mcap::Attachment {
-        log_time: attachment.log_time,
-        create_time: attachment.create_time,
-        name: attachment.name,
-        media_type: attachment.media_type,
-        data: std::borrow::Cow::Owned(attachment.data.into_owned()),
+fn write_attachment_data(data: &[u8], output: Option<&std::path::Path>) -> Result<()> {
+    if let Some(output) = output {
+        std::fs::write(output, data)
+            .with_context(|| format!("failed to write attachment to '{}'", output.display()))?;
+    } else if std::io::stdout().is_terminal() {
+        anyhow::bail!("{PLEASE_REDIRECT}");
+    } else {
+        std::io::stdout()
+            .write_all(data)
+            .context("failed to write attachment to stdout")?;
     }
+    Ok(())
 }
 
 fn select_attachment_index<'a>(

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -10,16 +10,31 @@ use crate::context::CommandContext;
 const PLEASE_REDIRECT: &str =
     "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
 
-pub fn run(_ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
-    let mcap = common::load_path(&args.file)?;
-    let parsed = common::parse_mcap(&mcap)?;
-    let index = select_attachment_index(&parsed.attachment_indexes, &args.name, args.offset)?;
-    let attachment = mcap::read::attachment(&mcap, index).with_context(|| {
-        format!(
-            "failed to read attachment {} at offset {}",
-            args.name, index.offset
-        )
-    })?;
+pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
+    let attachment = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
+        let index = select_attachment_index(&remote.summary().attachment_indexes, &args.name, args.offset)?;
+        let bytes = remote.read_range(index.offset, usize::try_from(index.length).context("attachment record is too large to read on this platform")?)?;
+        parse_attachment_record(&bytes).with_context(|| {
+            format!(
+                "failed to read attachment {} at offset {}",
+                args.name, index.offset
+            )
+        })?
+    } else {
+        let mcap = common::load_path(
+            &args.file,
+            common::SourceOptions::new(ctx.allow_remote_scan()),
+        )?;
+        let parsed = common::parse_mcap(&mcap)?;
+        let index = select_attachment_index(&parsed.attachment_indexes, &args.name, args.offset)?;
+        let attachment = mcap::read::attachment(&mcap, index).with_context(|| {
+            format!(
+                "failed to read attachment {} at offset {}",
+                args.name, index.offset
+            )
+        })?;
+        own_attachment(attachment)
+    };
 
     if let Some(output) = args.output {
         std::fs::write(&output, &attachment.data)
@@ -33,6 +48,36 @@ pub fn run(_ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     }
 
     Ok(())
+}
+
+
+
+fn own_attachment(attachment: mcap::Attachment<'_>) -> mcap::Attachment<'static> {
+    mcap::Attachment {
+        log_time: attachment.log_time,
+        create_time: attachment.create_time,
+        name: attachment.name,
+        media_type: attachment.media_type,
+        data: std::borrow::Cow::Owned(attachment.data.into_owned()),
+    }
+}
+
+fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'static>> {
+    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
+    let attachment = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
+        mcap::records::Record::Attachment { header, data, .. } => mcap::Attachment {
+            log_time: header.log_time,
+            create_time: header.create_time,
+            name: header.name,
+            media_type: header.media_type,
+            data: std::borrow::Cow::Owned(data.into_owned()),
+        },
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+    if reader.next().is_some() {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    Ok(attachment)
 }
 
 fn select_attachment_index<'a>(

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -11,28 +11,28 @@ const PLEASE_REDIRECT: &str =
     "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
 
 pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
-    let attachment = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
+    let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
+    let attachment = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)?
+    {
         let index = select_attachment_index(
             &remote.summary().attachment_indexes,
             &args.name,
             args.offset,
         )?;
-        let bytes = remote.read_range(
+        let bytes = remote.read_indexed_record_range(
             index.offset,
-            usize::try_from(index.length)
-                .context("attachment record is too large to read on this platform")?,
+            index.length,
+            source_options,
+            "attachment record",
         )?;
-        parse_attachment_record(&bytes).with_context(|| {
+        common::parse_attachment_record(&bytes).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",
                 args.name, index.offset
             )
         })?
     } else {
-        let mcap = common::load_path(
-            &args.file,
-            common::SourceOptions::new(ctx.allow_remote_scan()),
-        )?;
+        let mcap = common::load_path(&args.file, source_options)?;
         let parsed = common::parse_mcap(&mcap)?;
         let index = select_attachment_index(&parsed.attachment_indexes, &args.name, args.offset)?;
         let attachment = mcap::read::attachment(&mcap, index).with_context(|| {
@@ -66,24 +66,6 @@ fn own_attachment(attachment: mcap::Attachment<'_>) -> mcap::Attachment<'static>
         media_type: attachment.media_type,
         data: std::borrow::Cow::Owned(attachment.data.into_owned()),
     }
-}
-
-fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'static>> {
-    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
-    let attachment = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
-        mcap::records::Record::Attachment { header, data, .. } => mcap::Attachment {
-            log_time: header.log_time,
-            create_time: header.create_time,
-            name: header.name,
-            media_type: header.media_type,
-            data: std::borrow::Cow::Owned(data.into_owned()),
-        },
-        _ => return Err(mcap::McapError::BadIndex.into()),
-    };
-    if reader.next().is_some() {
-        return Err(mcap::McapError::BadIndex.into());
-    }
-    Ok(attachment)
 }
 
 fn select_attachment_index<'a>(

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -19,8 +19,7 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
             &args.name,
             args.offset,
         )?;
-        let bytes =
-            remote.read_indexed_record_range(index.offset, index.length, "attachment record")?;
+        let bytes = remote.read_indexed_record_range(index.offset, index.length)?;
         common::parse_attachment_record(&bytes).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -12,8 +12,16 @@ const PLEASE_REDIRECT: &str =
 
 pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     let attachment = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
-        let index = select_attachment_index(&remote.summary().attachment_indexes, &args.name, args.offset)?;
-        let bytes = remote.read_range(index.offset, usize::try_from(index.length).context("attachment record is too large to read on this platform")?)?;
+        let index = select_attachment_index(
+            &remote.summary().attachment_indexes,
+            &args.name,
+            args.offset,
+        )?;
+        let bytes = remote.read_range(
+            index.offset,
+            usize::try_from(index.length)
+                .context("attachment record is too large to read on this platform")?,
+        )?;
         parse_attachment_record(&bytes).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",
@@ -49,8 +57,6 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
 
     Ok(())
 }
-
-
 
 fn own_attachment(attachment: mcap::Attachment<'_>) -> mcap::Attachment<'static> {
     mcap::Attachment {

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -19,7 +19,11 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
             &args.name,
             args.offset,
         )?;
-        let bytes = remote.read_indexed_record_range(index.offset, index.length)?;
+        let bytes = remote.read_range(
+            index.offset,
+            usize::try_from(index.length)
+                .context("indexed record is too large to read on this platform")?,
+        )?;
         common::parse_attachment_record(&bytes).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",

--- a/rust/cli/src/commands/get_attachment.rs
+++ b/rust/cli/src/commands/get_attachment.rs
@@ -19,12 +19,8 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
             &args.name,
             args.offset,
         )?;
-        let bytes = remote.read_indexed_record_range(
-            index.offset,
-            index.length,
-            source_options,
-            "attachment record",
-        )?;
+        let bytes =
+            remote.read_indexed_record_range(index.offset, index.length, "attachment record")?;
         common::parse_attachment_record(&bytes).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -9,7 +9,7 @@ use crate::context::CommandContext;
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
     let metadata = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
-        merged_remote_metadata_for_name(&remote, &args.name, source_options)?
+        merged_remote_metadata_for_name(&remote, &args.name)?
     } else {
         let mcap = common::load_path(&args.file, source_options)?;
         let parsed = common::parse_mcap(&mcap)?;
@@ -24,7 +24,6 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
 fn merged_remote_metadata_for_name(
     remote: &common::RemoteMcap,
     name: &str,
-    source_options: common::SourceOptions,
 ) -> Result<BTreeMap<String, String>> {
     let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
         .summary()
@@ -39,12 +38,8 @@ fn merged_remote_metadata_for_name(
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {
-        let bytes = remote.read_indexed_record_range(
-            index.offset,
-            index.length,
-            source_options,
-            "metadata record",
-        )?;
+        let bytes =
+            remote.read_indexed_record_range(index.offset, index.length, "metadata record")?;
         let record = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         for (key, value) in record.metadata {

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -36,11 +36,13 @@ fn merged_remote_metadata_for_name(
         anyhow::bail!("metadata {name} does not exist");
     }
     matching_indexes.sort_by_key(|index| index.offset);
-    let total_bytes = matching_indexes
-        .iter()
-        .map(|index| index.length)
-        .sum::<u64>();
-    common::require_remote_metadata_budget(total_bytes, source_options, "metadata records")?;
+    if matching_indexes.len() > 1 {
+        let total_bytes = matching_indexes
+            .iter()
+            .map(|index| index.length)
+            .sum::<u64>();
+        common::require_remote_metadata_budget(total_bytes, source_options, "metadata records")?;
+    }
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -6,14 +6,64 @@ use crate::cli::GetMetadataCommand;
 use crate::commands::common;
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
-    let mcap = common::load_path(&args.file)?;
-    let parsed = common::parse_mcap(&mcap)?;
-    let metadata = merged_metadata_for_name(&mcap, &parsed.metadata_indexes, &args.name)?;
+pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
+    let metadata = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
+        merged_remote_metadata_for_name(&remote, &args.name)?
+    } else {
+        let mcap = common::load_path(
+            &args.file,
+            common::SourceOptions::new(ctx.allow_remote_scan()),
+        )?;
+        let parsed = common::parse_mcap(&mcap)?;
+        merged_metadata_for_name(&mcap, &parsed.metadata_indexes, &args.name)?
+    };
     let pretty =
         serde_json::to_string_pretty(&metadata).context("failed to serialize metadata to JSON")?;
     println!("{pretty}");
     Ok(())
+}
+
+
+fn merged_remote_metadata_for_name(
+    remote: &common::RemoteMcap,
+    name: &str,
+) -> Result<BTreeMap<String, String>> {
+    let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
+        .summary()
+        .metadata_indexes
+        .iter()
+        .filter(|index| index.name == name)
+        .collect();
+    if matching_indexes.is_empty() {
+        anyhow::bail!("metadata {name} does not exist");
+    }
+    matching_indexes.sort_by_key(|index| index.offset);
+
+    let mut output = BTreeMap::new();
+    for index in matching_indexes {
+        let bytes = remote.read_range(
+            index.offset,
+            usize::try_from(index.length).context("metadata record is too large to read on this platform")?,
+        )?;
+        let record = parse_metadata_record(&bytes)
+            .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
+        for (key, value) in record.metadata {
+            output.insert(key, value);
+        }
+    }
+    Ok(output)
+}
+
+fn parse_metadata_record(bytes: &[u8]) -> Result<mcap::records::Metadata> {
+    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
+    let metadata = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
+        mcap::records::Record::Metadata(metadata) => metadata,
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+    if reader.next().is_some() {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    Ok(metadata)
 }
 
 fn merged_metadata_for_name(

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -46,8 +46,7 @@ fn merged_remote_metadata_for_name(
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {
-        let bytes =
-            remote.read_indexed_record_range(index.offset, index.length, "metadata record")?;
+        let bytes = remote.read_indexed_record_range(index.offset, index.length)?;
         let record = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         for (key, value) in record.metadata {

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -7,13 +7,11 @@ use crate::commands::common;
 use crate::context::CommandContext;
 
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
-    let metadata = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
-        merged_remote_metadata_for_name(&remote, &args.name)?
+    let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
+    let metadata = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
+        merged_remote_metadata_for_name(&remote, &args.name, source_options)?
     } else {
-        let mcap = common::load_path(
-            &args.file,
-            common::SourceOptions::new(ctx.allow_remote_scan()),
-        )?;
+        let mcap = common::load_path(&args.file, source_options)?;
         let parsed = common::parse_mcap(&mcap)?;
         merged_metadata_for_name(&mcap, &parsed.metadata_indexes, &args.name)?
     };
@@ -26,6 +24,7 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
 fn merged_remote_metadata_for_name(
     remote: &common::RemoteMcap,
     name: &str,
+    source_options: common::SourceOptions,
 ) -> Result<BTreeMap<String, String>> {
     let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
         .summary()
@@ -40,30 +39,19 @@ fn merged_remote_metadata_for_name(
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {
-        let bytes = remote.read_range(
+        let bytes = remote.read_indexed_record_range(
             index.offset,
-            usize::try_from(index.length)
-                .context("metadata record is too large to read on this platform")?,
+            index.length,
+            source_options,
+            "metadata record",
         )?;
-        let record = parse_metadata_record(&bytes)
+        let record = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         for (key, value) in record.metadata {
             output.insert(key, value);
         }
     }
     Ok(output)
-}
-
-fn parse_metadata_record(bytes: &[u8]) -> Result<mcap::records::Metadata> {
-    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
-    let metadata = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
-        mcap::records::Record::Metadata(metadata) => metadata,
-        _ => return Err(mcap::McapError::BadIndex.into()),
-    };
-    if reader.next().is_some() {
-        return Err(mcap::McapError::BadIndex.into());
-    }
-    Ok(metadata)
 }
 
 fn merged_metadata_for_name(

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -23,7 +23,6 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     Ok(())
 }
 
-
 fn merged_remote_metadata_for_name(
     remote: &common::RemoteMcap,
     name: &str,
@@ -43,7 +42,8 @@ fn merged_remote_metadata_for_name(
     for index in matching_indexes {
         let bytes = remote.read_range(
             index.offset,
-            usize::try_from(index.length).context("metadata record is too large to read on this platform")?,
+            usize::try_from(index.length)
+                .context("metadata record is too large to read on this platform")?,
         )?;
         let record = parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -46,7 +46,11 @@ fn merged_remote_metadata_for_name(
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {
-        let bytes = remote.read_indexed_record_range(index.offset, index.length)?;
+        let bytes = remote.read_range(
+            index.offset,
+            usize::try_from(index.length)
+                .context("indexed record is too large to read on this platform")?,
+        )?;
         let record = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         for (key, value) in record.metadata {

--- a/rust/cli/src/commands/get_metadata.rs
+++ b/rust/cli/src/commands/get_metadata.rs
@@ -9,7 +9,7 @@ use crate::context::CommandContext;
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
     let metadata = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
-        merged_remote_metadata_for_name(&remote, &args.name)?
+        merged_remote_metadata_for_name(&remote, &args.name, source_options)?
     } else {
         let mcap = common::load_path(&args.file, source_options)?;
         let parsed = common::parse_mcap(&mcap)?;
@@ -24,6 +24,7 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
 fn merged_remote_metadata_for_name(
     remote: &common::RemoteMcap,
     name: &str,
+    source_options: common::SourceOptions,
 ) -> Result<BTreeMap<String, String>> {
     let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
         .summary()
@@ -35,6 +36,11 @@ fn merged_remote_metadata_for_name(
         anyhow::bail!("metadata {name} does not exist");
     }
     matching_indexes.sort_by_key(|index| index.offset);
+    let total_bytes = matching_indexes
+        .iter()
+        .map(|index| index.length)
+        .sum::<u64>();
+    common::require_remote_metadata_budget(total_bytes, source_options, "metadata records")?;
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -7,8 +7,11 @@ use crate::cli::InfoCommand;
 use crate::commands::common;
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: InfoCommand) -> Result<()> {
-    let parsed = common::parse_mcap_from_path(&args.file)?;
+pub fn run(ctx: &CommandContext, args: InfoCommand) -> Result<()> {
+    let parsed = common::parse_mcap_from_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     print!("{}", render_info(&parsed));
     Ok(())
 }

--- a/rust/cli/src/commands/list_attachments.rs
+++ b/rust/cli/src/commands/list_attachments.rs
@@ -4,8 +4,11 @@ use crate::cli::ListAttachmentsCommand;
 use crate::commands::common;
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
-    let parsed = common::parse_mcap_from_path(&args.file)?;
+pub fn run(ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
+    let parsed = common::parse_mcap_from_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     let mut indexes = parsed.attachment_indexes;
     indexes.sort_by_key(|index| index.offset);
     common::print_table(&render_attachment_rows(&indexes));

--- a/rust/cli/src/commands/list_channels.rs
+++ b/rust/cli/src/commands/list_channels.rs
@@ -4,8 +4,11 @@ use crate::cli::ListChannelsCommand;
 use crate::commands::common;
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: ListChannelsCommand) -> Result<()> {
-    let parsed = common::parse_mcap_from_path(&args.file)?;
+pub fn run(ctx: &CommandContext, args: ListChannelsCommand) -> Result<()> {
+    let parsed = common::parse_mcap_from_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     common::print_table(&render_channel_rows(&parsed.channels)?);
     Ok(())
 }

--- a/rust/cli/src/commands/list_chunks.rs
+++ b/rust/cli/src/commands/list_chunks.rs
@@ -4,8 +4,11 @@ use crate::cli::ListChunksCommand;
 use crate::commands::common;
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: ListChunksCommand) -> Result<()> {
-    let parsed = common::parse_mcap_from_path(&args.file)?;
+pub fn run(ctx: &CommandContext, args: ListChunksCommand) -> Result<()> {
+    let parsed = common::parse_mcap_from_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     common::print_table(&render_chunk_rows(&parsed.chunk_indexes));
     Ok(())
 }

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -4,11 +4,47 @@ use crate::cli::ListMetadataCommand;
 use crate::commands::common;
 use crate::context::CommandContext;
 
-pub fn run(_ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
-    let mcap = common::load_path(&args.file)?;
-    let records = collect_metadata_records(&mcap)?;
+pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
+    let records = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
+        collect_remote_metadata_records(&remote)?
+    } else {
+        let mcap = common::load_path(
+            &args.file,
+            common::SourceOptions::new(ctx.allow_remote_scan()),
+        )?;
+        collect_metadata_records(&mcap)?
+    };
     common::print_table(&render_metadata_rows(&records)?);
     Ok(())
+}
+
+
+fn collect_remote_metadata_records(
+    remote: &common::RemoteMcap,
+) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
+    let mut records = Vec::new();
+    for index in remote.summary().metadata_indexes.clone() {
+        let bytes = remote.read_range(
+            index.offset,
+            usize::try_from(index.length).context("metadata record is too large to read on this platform")?,
+        )?;
+        let metadata = parse_metadata_record(&bytes)
+            .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
+        records.push((index, metadata));
+    }
+    Ok(records)
+}
+
+fn parse_metadata_record(bytes: &[u8]) -> Result<mcap::records::Metadata> {
+    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
+    let metadata = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
+        mcap::records::Record::Metadata(metadata) => metadata,
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+    if reader.next().is_some() {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    Ok(metadata)
 }
 
 fn collect_metadata_records(

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -30,8 +30,7 @@ fn collect_remote_metadata_records(
 
     let mut records = Vec::new();
     for index in &remote.summary().metadata_indexes {
-        let bytes =
-            remote.read_indexed_record_range(index.offset, index.length, "metadata record")?;
+        let bytes = remote.read_indexed_record_range(index.offset, index.length)?;
         let metadata = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         records.push((index.clone(), metadata));

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -7,7 +7,7 @@ use crate::context::CommandContext;
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
     let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
     let records = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
-        collect_remote_metadata_records(&remote, source_options)?
+        collect_remote_metadata_records(&remote)?
     } else {
         let mcap = common::load_path(&args.file, source_options)?;
         collect_metadata_records(&mcap)?
@@ -18,16 +18,11 @@ pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
 
 fn collect_remote_metadata_records(
     remote: &common::RemoteMcap,
-    source_options: common::SourceOptions,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
     let mut records = Vec::new();
     for index in &remote.summary().metadata_indexes {
-        let bytes = remote.read_indexed_record_range(
-            index.offset,
-            index.length,
-            source_options,
-            "metadata record",
-        )?;
+        let bytes =
+            remote.read_indexed_record_range(index.offset, index.length, "metadata record")?;
         let metadata = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         records.push((index.clone(), metadata));

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -18,7 +18,6 @@ pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
     Ok(())
 }
 
-
 fn collect_remote_metadata_records(
     remote: &common::RemoteMcap,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
@@ -26,7 +25,8 @@ fn collect_remote_metadata_records(
     for index in remote.summary().metadata_indexes.clone() {
         let bytes = remote.read_range(
             index.offset,
-            usize::try_from(index.length).context("metadata record is too large to read on this platform")?,
+            usize::try_from(index.length)
+                .context("metadata record is too large to read on this platform")?,
         )?;
         let metadata = parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -30,7 +30,11 @@ fn collect_remote_metadata_records(
 
     let mut records = Vec::new();
     for index in &remote.summary().metadata_indexes {
-        let bytes = remote.read_indexed_record_range(index.offset, index.length)?;
+        let bytes = remote.read_range(
+            index.offset,
+            usize::try_from(index.length)
+                .context("indexed record is too large to read on this platform")?,
+        )?;
         let metadata = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         records.push((index.clone(), metadata));

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -7,7 +7,7 @@ use crate::context::CommandContext;
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
     let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
     let records = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
-        collect_remote_metadata_records(&remote)?
+        collect_remote_metadata_records(&remote, source_options)?
     } else {
         let mcap = common::load_path(&args.file, source_options)?;
         collect_metadata_records(&mcap)?
@@ -18,7 +18,16 @@ pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
 
 fn collect_remote_metadata_records(
     remote: &common::RemoteMcap,
+    source_options: common::SourceOptions,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
+    let total_bytes = remote
+        .summary()
+        .metadata_indexes
+        .iter()
+        .map(|index| index.length)
+        .sum::<u64>();
+    common::require_remote_metadata_budget(total_bytes, source_options, "metadata records")?;
+
     let mut records = Vec::new();
     for index in &remote.summary().metadata_indexes {
         let bytes =

--- a/rust/cli/src/commands/list_metadata.rs
+++ b/rust/cli/src/commands/list_metadata.rs
@@ -5,13 +5,11 @@ use crate::commands::common;
 use crate::context::CommandContext;
 
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
-    let records = if let Some(remote) = common::try_open_remote_mcap(&args.file)? {
-        collect_remote_metadata_records(&remote)?
+    let source_options = common::SourceOptions::new(ctx.allow_remote_scan());
+    let records = if let Some(remote) = common::try_open_remote_mcap(&args.file, source_options)? {
+        collect_remote_metadata_records(&remote, source_options)?
     } else {
-        let mcap = common::load_path(
-            &args.file,
-            common::SourceOptions::new(ctx.allow_remote_scan()),
-        )?;
+        let mcap = common::load_path(&args.file, source_options)?;
         collect_metadata_records(&mcap)?
     };
     common::print_table(&render_metadata_rows(&records)?);
@@ -20,31 +18,21 @@ pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
 
 fn collect_remote_metadata_records(
     remote: &common::RemoteMcap,
+    source_options: common::SourceOptions,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
     let mut records = Vec::new();
-    for index in remote.summary().metadata_indexes.clone() {
-        let bytes = remote.read_range(
+    for index in &remote.summary().metadata_indexes {
+        let bytes = remote.read_indexed_record_range(
             index.offset,
-            usize::try_from(index.length)
-                .context("metadata record is too large to read on this platform")?,
+            index.length,
+            source_options,
+            "metadata record",
         )?;
-        let metadata = parse_metadata_record(&bytes)
+        let metadata = common::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
-        records.push((index, metadata));
+        records.push((index.clone(), metadata));
     }
     Ok(records)
-}
-
-fn parse_metadata_record(bytes: &[u8]) -> Result<mcap::records::Metadata> {
-    let mut reader = mcap::read::LinearReader::sans_magic(bytes);
-    let metadata = match reader.next().ok_or(mcap::McapError::BadIndex)?? {
-        mcap::records::Record::Metadata(metadata) => metadata,
-        _ => return Err(mcap::McapError::BadIndex.into()),
-    };
-    if reader.next().is_some() {
-        return Err(mcap::McapError::BadIndex.into());
-    }
-    Ok(metadata)
 }
 
 fn collect_metadata_records(

--- a/rust/cli/src/commands/list_schemas.rs
+++ b/rust/cli/src/commands/list_schemas.rs
@@ -3,8 +3,11 @@ use crate::commands::common;
 use crate::context::CommandContext;
 use anyhow::Result;
 
-pub fn run(_ctx: &CommandContext, args: ListSchemasCommand) -> Result<()> {
-    let parsed = common::parse_mcap_from_path(&args.file)?;
+pub fn run(ctx: &CommandContext, args: ListSchemasCommand) -> Result<()> {
+    let parsed = common::parse_mcap_from_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     common::print_table(&render_schema_rows(&parsed.schemas));
     Ok(())
 }

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -110,9 +110,9 @@ struct IdMaps {
     next_output_channel_id: u16,
 }
 
-pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: MergeCommand) -> Result<()> {
     let opts = build_merge_options(args);
-    let source_options = crate::commands::common::SourceOptions::new(_ctx.allow_remote_scan());
+    let source_options = crate::commands::common::SourceOptions::new(ctx.allow_remote_scan());
 
     let mut mapped_inputs = Vec::with_capacity(opts.files.len());
     let mut input_names = Vec::with_capacity(opts.files.len());

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -119,7 +119,7 @@ pub fn run(ctx: &CommandContext, args: MergeCommand) -> Result<()> {
     for path in &opts.files {
         let mapped = crate::commands::common::load_path(path, source_options)?;
         mapped_inputs.push(mapped);
-        input_names.push(path.display().to_string());
+        input_names.push(crate::commands::common::redacted_display(path));
     }
 
     let input_refs: Vec<InputRef<'_>> = mapped_inputs

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -112,8 +112,7 @@ struct IdMaps {
 
 pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
     let opts = build_merge_options(args);
-    let source_options =
-        crate::commands::common::SourceOptions::new(_ctx.allow_remote_scan());
+    let source_options = crate::commands::common::SourceOptions::new(_ctx.allow_remote_scan());
 
     let mut mapped_inputs = Vec::with_capacity(opts.files.len());
     let mut input_names = Vec::with_capacity(opts.files.len());
@@ -792,14 +791,11 @@ mod tests {
     }
 
     #[test]
-    fn run_rejects_multiple_remote_inputs() {
+    fn run_rejects_remote_input_without_scan_opt_in() {
         let err = run(
             &CommandContext::default(),
             MergeCommand {
-                files: vec![
-                    "http://example.com/a.mcap".into(),
-                    "https://example.com/b.mcap".into(),
-                ],
+                files: vec!["http://example.com/a.mcap".into()],
                 output_file: Some("out.mcap".into()),
                 compression: CompressionFormat::Zstd,
                 chunk_size: 1024,
@@ -809,11 +805,9 @@ mod tests {
                 coalesce_channels: CoalesceChannels::Auto,
             },
         )
-        .expect_err("multiple remote merge inputs should be rejected");
+        .expect_err("remote merge input should require opt-in");
 
-        assert!(err
-            .to_string()
-            .contains("supports at most one remote HTTP(S) input"));
+        assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
     #[test]

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -112,19 +112,13 @@ struct IdMaps {
 
 pub fn run(_ctx: &CommandContext, args: MergeCommand) -> Result<()> {
     let opts = build_merge_options(args);
-    let remote_inputs = opts
-        .files
-        .iter()
-        .filter(|path| crate::commands::common::is_http_url(path))
-        .count();
-    if remote_inputs > 1 {
-        bail!("mcap merge currently supports at most one remote HTTP(S) input");
-    }
+    let source_options =
+        crate::commands::common::SourceOptions::new(_ctx.allow_remote_scan());
 
     let mut mapped_inputs = Vec::with_capacity(opts.files.len());
     let mut input_names = Vec::with_capacity(opts.files.len());
     for path in &opts.files {
-        let mapped = crate::commands::common::load_path(path)?;
+        let mapped = crate::commands::common::load_path(path, source_options)?;
         mapped_inputs.push(mapped);
         input_names.push(path.display().to_string());
     }

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -39,13 +39,16 @@ struct RecoveryState {
     warned_missing_channels: BTreeSet<u16>,
 }
 
-pub fn run(_ctx: &CommandContext, args: RecoverCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: RecoverCommand) -> Result<()> {
     let opts = RecoverOptions {
         compression: crate::commands::common::parse_output_compression(&args.compression)?,
         chunk_size: args.chunk_size,
         always_decode_chunk: args.always_decode_chunk,
     };
-    let input = crate::commands::common::load_input(args.file.as_deref())?;
+    let input = crate::commands::common::load_input(
+        args.file.as_deref(),
+        crate::commands::common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
 
     let stats = if let Some(output) = &args.output {
         let writer = std::fs::File::create(output)

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -16,9 +16,12 @@ struct SortOptions {
     chunked: bool,
 }
 
-pub fn run(_ctx: &CommandContext, args: SortCommand) -> Result<()> {
+pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
     let opts = build_sort_options(&args);
-    let input = common::load_path(&args.file)?;
+    let input = common::load_path(
+        &args.file,
+        common::SourceOptions::new(ctx.allow_remote_scan()),
+    )?;
     if !common::is_http_url(&args.file) {
         ensure_distinct_input_output(&args.file, &args.output_file)?;
     }

--- a/rust/cli/src/context.rs
+++ b/rust/cli/src/context.rs
@@ -13,6 +13,7 @@ pub struct CommandContext {
     color: Color,
     config: Option<PathBuf>,
     pprof_profile: bool,
+    allow_remote_scan: bool,
 }
 
 impl Default for CommandContext {
@@ -22,18 +23,26 @@ impl Default for CommandContext {
             color: Color::Auto,
             config: None,
             pprof_profile: false,
+            allow_remote_scan: false,
         }
     }
 }
 
 #[allow(dead_code)]
 impl CommandContext {
-    pub fn new(verbose: u8, color: Color, config: Option<PathBuf>, pprof_profile: bool) -> Self {
+    pub fn new(
+        verbose: u8,
+        color: Color,
+        config: Option<PathBuf>,
+        pprof_profile: bool,
+        allow_remote_scan: bool,
+    ) -> Self {
         Self {
             verbose,
             color,
             config,
             pprof_profile,
+            allow_remote_scan,
         }
     }
 
@@ -51,5 +60,9 @@ impl CommandContext {
 
     pub fn pprof_profile(&self) -> bool {
         self.pprof_profile
+    }
+
+    pub fn allow_remote_scan(&self) -> bool {
+        self.allow_remote_scan
     }
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -18,7 +18,13 @@ fn run() -> Result<()> {
     if args.pprof_profile {
         anyhow::bail!("'--pprof-profile' is not implemented yet");
     }
-    let ctx = CommandContext::new(args.verbose, args.color, args.config, args.pprof_profile);
+    let ctx = CommandContext::new(
+        args.verbose,
+        args.color,
+        args.config,
+        args.pprof_profile,
+        args.allow_remote_scan,
+    );
 
     commands::dispatch(&ctx, args.command)
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -171,6 +171,23 @@ mod tests {
     }
 
     #[test]
+    fn parses_global_allow_remote_scan_flag() {
+        let args = Args::try_parse_from(["mcap", "--allow-remote-scan", "info", "demo.mcap"])
+            .expect("allow remote scan should parse before subcommand");
+        assert!(args.allow_remote_scan);
+        assert_eq!(
+            args.command,
+            Command::Info(InfoCommand {
+                file: "demo.mcap".into(),
+            })
+        );
+
+        let args = Args::try_parse_from(["mcap", "info", "--allow-remote-scan", "demo.mcap"])
+            .expect("allow remote scan should parse after subcommand");
+        assert!(args.allow_remote_scan);
+    }
+
+    #[test]
     fn parses_global_verbosity_flag() {
         let args = Args::try_parse_from(["mcap", "-vv", "info", "demo.mcap"])
             .expect("verbosity should parse");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

This PR tightens Rust CLI remote input handling around an explicit `--allow-remote-scan` policy and standardizes the helper paths commands use to open remote MCAP/source files.

### Remote scan policy

- Adds a global `--allow-remote-scan` flag.
- Allows summary/index-only HTTP(S) reads without opt-in.
- Requires `--allow-remote-scan` before operations that would download/scan remote data, including:
  - full-object remote downloads/materialization,
  - linear fallbacks when a remote MCAP has no usable summary/index,
  - remote `convert` inputs (`.bag` / `.db3`),
  - remote message chunk payload reads such as `mcap cat` output.
- Keeps exact indexed non-message record reads as bounded-range operations that do not require a full-scan opt-in, including direct metadata/attachment `get`/`list` paths. Multi-record metadata reads have a conservative no-opt-in byte budget.

### Remote source implementation

- Allowed remote full scans stream to a temporary file and mmap it, instead of buffering the whole remote file in a heap `Vec<u8>`.
- Remote `convert` uses the same materialization path so `.db3` remains sqlite-compatible and `.bag`/`.db3` downloads require opt-in.
- HTTP(S) remote summary discovery uses coalesced footer/summary range reads in CLI-local code without changing public `mcap` crate APIs.
- Remote errors redact query strings/userinfo before displaying URLs.

### Command behavior

- `cat` can inspect remote summaries/indexes without the flag, but refuses to fetch message chunks unless `--allow-remote-scan` is set.
- `info` and summary-backed `list` operations continue to work without the flag when the remote MCAP has usable summary data.
- `get attachment`, `get metadata`, and `list metadata` can use indexed record ranges without whole-file fallback when summary indexes are present.
- `merge` now permits multiple remote inputs when scan opt-in is present; each remote input is materialized independently, so temporary disk usage can approach the sum of remote input sizes.

### README updates

- Removes implemented remote-read cleanup items from the pre-1.0 list.
- Keeps remaining pre-1.0 follow-ups for future object-store policy, shared `mcap` range-read APIs, summaryless remote double-touch optimization, and metadata/attachment-preserving transforms.
- Documents the remote read policy as an intentional divergence from Go CLI behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mcap-cli`
- `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`
- `yarn prettier --check rust/cli/README.md`

## Notes / deliberate tradeoffs

- This intentionally avoids changing public `mcap` crate APIs. CLI-local summary/range parsing is documented as pre-1.0 follow-up work to move into shared reader APIs later.
- In the `no summary + --allow-remote-scan` case, the CLI still does a range probe/footer read before falling back to full-file materialization. That keeps indexed/summary-backed remote reads fast by default; avoiding the extra probe would either skip the useful summary fast path whenever scan opt-in is present or require more state plumbing between range probing and materialization.
- Exact named attachment reads intentionally remain a bounded-range carve-out without a metadata-style byte budget because they fetch one explicitly selected indexed record.

## Release note

This is an intentional behavior change from the Go-compatible default: Rust CLI commands that would download/scan remote inputs or fetch remote message chunk payloads now require `--allow-remote-scan`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af9ea03b-3241-4c39-be2e-294d275c0d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af9ea03b-3241-4c39-be2e-294d275c0d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

