### PR TITLE
Remove Rust CLI short version flag

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -5,11 +5,20 @@ use clap::{ArgAction, Parser, Subcommand};
 use crate::logsetup;
 
 #[derive(Parser, Debug, PartialEq, Eq)]
-#[command(name = "mcap", bin_name = "mcap", version = env!("CARGO_PKG_VERSION"))]
+#[command(
+    name = "mcap",
+    bin_name = "mcap",
+    version = env!("CARGO_PKG_VERSION"),
+    disable_version_flag = true
+)]
 pub struct Args {
     /// Verbosity (-v, -vv, -vvv, etc.)
     #[arg(short, long, action = ArgAction::Count, global = true)]
     pub verbose: u8,
+
+    /// Print version
+    #[arg(long = "version", action = ArgAction::Version, global = true)]
+    pub version: bool,
 
     #[arg(
         short,

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -65,6 +65,20 @@ mod tests {
     }
 
     #[test]
+    fn displays_long_version_flag() {
+        let parse_err =
+            Args::try_parse_from(["mcap", "--version"]).expect_err("version should display");
+        assert_eq!(parse_err.kind(), clap::error::ErrorKind::DisplayVersion);
+    }
+
+    #[test]
+    fn rejects_short_version_flag() {
+        let parse_err =
+            Args::try_parse_from(["mcap", "-V"]).expect_err("short version should not parse");
+        assert_eq!(parse_err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
     fn parses_cat_subcommand_with_files() {
         let args =
             Args::try_parse_from(["mcap", "cat", "a.mcap", "b.mcap"]).expect("cat should parse");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep `mcap --version` available while removing the `-V` shorthand from the Rust CLI.
- Add parser coverage for long version display and short version rejection.

## Testing
- Pending local Rust CLI validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1da568b-8f11-45e7-b6c1-0522805dc09f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1da568b-8f11-45e7-b6c1-0522805dc09f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

