### PR TITLE
rust cli: Add git sha to version string

### DIFF
--- a/rust/cli/build.rs
+++ b/rust/cli/build.rs
@@ -11,5 +11,5 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=GIT_SHA={git_sha}");
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
 }

--- a/rust/cli/build.rs
+++ b/rust/cli/build.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+
+fn main() {
+    let git_sha = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|sha| !sha.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_SHA={git_sha}");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+}

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -7,8 +7,9 @@ use crate::logsetup;
 
 pub(crate) static VERSION: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "{} (mcap-rust {})",
+        "{} ({}) mcap-rust/{}",
         env!("CARGO_PKG_VERSION"),
+        env!("GIT_SHA"),
         mcap::VERSION
     )
 });


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description

Add git sha to cli version output.

```sh
$ target/debug/mcap --version
mcap 0.0.1 (6edbb0c) mcap-rust/0.24.0
```