### PR TITLE
docs: link to MCAP spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log file format, with implementations in TypeScript, Python, Go, Rust, C++, and Swift. There are no running services — this is purely a library/SDK project. The core functionality is writing and reading MCAP files.
 
-**MCAP** is a modular container file format for recording timestamped [pub/sub](https://en.wikipedia.org/wiki/Publish–subscribe_pattern) messages with arbitrary serialization formats. It is designed to work well under various workloads, resource constraints, and durability requirements. The format specification lives in [`website/docs/spec/index.md`](./website/docs/spec/index.md), with the well-known registry in [`website/docs/spec/registry.md`](./website/docs/spec/registry.md), feature notes in [`website/docs/spec/notes.md`](./website/docs/spec/notes.md), and a [Kaitai Struct](http://kaitai.io) description in [`website/docs/spec/mcap.ksy`](./website/docs/spec/mcap.ksy).
+**MCAP** is a modular container file format for recording timestamped pub/sub messages with arbitrary serialization formats. It is designed to work well under various workloads, resource constraints, and durability requirements. The format specification lives in [`website/docs/spec/index.md`](./website/docs/spec/index.md), with the well-known registry in [`website/docs/spec/registry.md`](./website/docs/spec/registry.md), and feature notes in [`website/docs/spec/notes.md`](./website/docs/spec/notes.md).
 
 ## General prerequisites
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log file format, with implementations in TypeScript, Python, Go, Rust, C++, and Swift. There are no running services — this is purely a library/SDK project. The core functionality is writing and reading MCAP files.
 
-**MCAP** is a modular container file format for recording timestamped pub/sub messages with arbitrary serialization formats. It is designed to work well under various workloads, resource constraints, and durability requirements. The format specification lives in [`website/docs/spec/index.md`](./website/docs/spec/index.md), with the well-known registry in [`website/docs/spec/registry.md`](./website/docs/spec/registry.md), and feature notes in [`website/docs/spec/notes.md`](./website/docs/spec/notes.md).
+**MCAP** is a modular container file format for recording timestamped pub/sub messages with arbitrary serialization formats. It is designed to work well under various workloads, resource constraints, and durability requirements. The format specification lives in `website/docs/spec/index.md`, with the well-known registry in `website/docs/spec/registry.md`, and feature notes in `website/docs/spec/notes.md`.
 
 ## General prerequisites
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log file format, with implementations in TypeScript, Python, Go, Rust, C++, and Swift. There are no running services — this is purely a library/SDK project. The core functionality is writing and reading MCAP files.
 
+**MCAP** is a modular container file format for recording timestamped [pub/sub](https://en.wikipedia.org/wiki/Publish–subscribe_pattern) messages with arbitrary serialization formats. It is designed to work well under various workloads, resource constraints, and durability requirements. The format specification lives in [`website/docs/spec/index.md`](./website/docs/spec/index.md), with the well-known registry in [`website/docs/spec/registry.md`](./website/docs/spec/registry.md), feature notes in [`website/docs/spec/notes.md`](./website/docs/spec/notes.md), and a [Kaitai Struct](http://kaitai.io) description in [`website/docs/spec/mcap.ksy`](./website/docs/spec/mcap.ksy).
+
 ## General prerequisites
 
 - **Git LFS** — test data under `tests/conformance/data/` and `rust/mcap/tests/data/` is stored in Git LFS. Tests will fail with `InvalidMagic` errors if LFS pointers haven't been pulled. Run `git lfs pull` before running tests.


### PR DESCRIPTION
## Summary

Adds a concise description of the MCAP file format and a pointer to the spec to the `## Overview` section of `AGENTS.md`.