### PR TITLE
rust cli: Shorten --allow-remote-scan help text

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -38,7 +38,7 @@ pub struct Args {
     #[arg(long, default_value_t = false, global = true)]
     pub pprof_profile: bool,
 
-    /// Allow commands to download/scan remote inputs or fetch remote message chunk payloads
+    /// Allow commands to download/scan remote inputs
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 


### PR DESCRIPTION
### Changelog

None

### Description

Shorten the `--allow-remote-scan` help text in the Rust CLI so that it doesn't wrap onto another line.