### PR TITLE
rust cli: Add remote object storage support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +175,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -224,12 +259,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -345,6 +400,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,7 +446,7 @@ dependencies = [
  "criterion-plot",
  "futures",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -388,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -421,6 +501,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -463,6 +553,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -551,6 +662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +707,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,9 +736,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -617,8 +762,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -628,9 +775,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -642,8 +791,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -728,10 +897,205 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "id-arena"
@@ -744,6 +1108,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -768,6 +1153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +1180,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -849,10 +1249,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4"
@@ -888,7 +1309,7 @@ dependencies = [
  "crc32fast",
  "criterion",
  "enumset",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "lz4",
  "memmap2",
@@ -915,17 +1336,31 @@ dependencies = [
  "chrono",
  "clap 4.6.0",
  "crc32fast",
+ "futures-util",
  "log",
  "lz4",
  "mcap",
  "memmap2",
+ "object_store",
  "prost-reflect",
  "regex",
  "rusqlite",
  "serde_json",
  "simplelog",
  "tempfile",
+ "tokio",
  "ureq",
+ "url",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -941,6 +1376,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -978,6 +1424,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1480,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -1015,6 +1507,29 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "paste"
@@ -1069,10 +1584,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1134,7 +1667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1163,6 +1696,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1782,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1845,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1231,6 +1884,48 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -1272,6 +1967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,11 +2001,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1326,12 +2040,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1394,6 +2152,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,10 +2181,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -1427,6 +2213,12 @@ dependencies = [
  "rsqlite-vfs",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1472,6 +2264,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1576,6 +2388,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,26 +2408,156 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1654,10 +2606,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1685,6 +2655,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1722,6 +2701,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1779,6 +2772,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +2801,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1841,10 +2857,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2017,6 +3086,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,10 +3135,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -29,6 +29,6 @@ rusqlite = { version = "0.39.0", features = ["bundled"] }
 ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 tempfile = "3.27.0"
 object_store = { version = "0.13.2", features = ["aws", "gcp", "azure"] }
-tokio = { version = "1.52.3", features = ["rt"] }
+tokio = { version = "1.52.3", features = ["net", "rt", "time"] }
 url = "2.5.8"
 futures-util = "0.3.32"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -28,3 +28,7 @@ prost-reflect = { version = "0.16.4", features = ["serde"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 tempfile = "3.27.0"
+object_store = { version = "0.13.2", features = ["aws", "gcp", "azure"] }
+tokio = { version = "1.52.3", features = ["rt"] }
+url = "2.5.8"
+futures-util = "0.3.32"

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -128,6 +128,8 @@ After the Rust CLI is in production, the following is a list of potential improv
     - Before Rust CLI 1.0, remove the direct `ureq` HTTP implementation and route
       HTTP(S) remote inputs through the same `reqwest`/`object_store` stack used
       for object stores, preserving the current remote scan opt-in behavior.
+      Prefer the platform's native certificate store for this unified stack
+      rather than shipping a separate bundled web PKI root set.
 11. `recover` chunk recompression optimization (deferred for valid chunks):
     - `recover` currently decodes every chunk, validates its records, and
       re-writes all records through the writer (which rebuilds chunks, indexes,

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -214,7 +214,9 @@ After the Rust CLI is in production, the following is a list of potential improv
 
 1. Remote read opt-in:
    - The Rust CLI requires `--allow-remote-scan` whenever a command would scan or
-     download a remote (HTTP/S3) file in full, rather than a bounded indexed read.
+     download a remote file in full, rather than a bounded indexed read. Remote
+     inputs include HTTP(S) URLs and object-store URLs (`s3://`, `gs://`, and
+     Azure `az://`/`abfs://` and friends).
      This covers whole-file commands such as `merge`, `filter`, and `convert`
      (including remote `convert` inputs and full-object downloads), as well as scan
      fallbacks for otherwise-indexed commands (for example, a remote file with no

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -91,13 +91,7 @@ After the Rust CLI is in production, the following is a list of potential improv
      `.mcap` when no explicit output is provided.
    - This would also allow `mcap convert` to accept multiple input paths in one
      invocation, including wildcard-expanded paths from the user's shell.
-7. Future object-store remote input policy:
-   - Before Rust CLI 1.0, apply the remote scan opt-in policy consistently to
-     future object-store inputs such as S3, GCS, and Azure Blob Storage.
-   - Preserve the current HTTP(S) behavior for those backends: summary/index-only
-     operations should not require opt-in, while full-object scans/downloads and
-     message chunk payload reads should require `--allow-remote-scan`.
-8. Shared remote range-read APIs:
+7. Shared remote range-read APIs:
    - Before Rust CLI 1.0, consider moving the CLI-local coalesced summary range
      reads into reusable `mcap` crate reader APIs so HTTP(S), S3, GCS, and Azure
      Blob Storage backends can share tail/summary range reads instead of each
@@ -110,7 +104,7 @@ After the Rust CLI is in production, the following is a list of potential improv
      footer read before falling back to full-file materialization; a future
      implementation could share probe/footer state with materialization or skip
      indexed discovery for commands that already know they must scan.
-9. Range-backed metadata and attachment transforms:
+8. Range-backed metadata and attachment transforms:
    - The CLI can read exact indexed metadata and attachment records for direct
      `get` / `list` commands without whole-file fallback for HTTP(S) inputs.
      Single indexed attachment and metadata reads are allowed as bounded range
@@ -119,7 +113,7 @@ After the Rust CLI is in production, the following is a list of potential improv
    - Before Rust CLI 1.0, extend this pattern to metadata/attachment-preserving
      transforms so those commands do not need whole-file fallback for HTTP(S) and
      future object-store inputs.
-10. Use one HTTP client stack:
+9. Use one HTTP client stack:
     - The CLI currently uses `ureq` for HTTP(S) remote inputs and `reqwest`
       through `object_store` for S3, GCS, and Azure Blob Storage inputs. Both use
       rustls, but maintaining two HTTP client stacks increases binary size,
@@ -130,7 +124,7 @@ After the Rust CLI is in production, the following is a list of potential improv
       for object stores, preserving the current remote scan opt-in behavior.
       Prefer the platform's native certificate store for this unified stack
       rather than shipping a separate bundled web PKI root set.
-11. `recover` chunk recompression optimization (deferred for valid chunks):
+10. `recover` chunk recompression optimization (deferred for valid chunks):
     - `recover` currently decodes every chunk, validates its records, and
       re-writes all records through the writer (which rebuilds chunks, indexes,
       the summary section, and CRCs). This guarantees a valid, readable output
@@ -163,7 +157,7 @@ After the Rust CLI is in production, the following is a list of potential improv
       compression.
       Adding this later is purely additive, so we ship the always-re-encode
       version now and revisit if recompression cost matters in practice.
-12. `recover` out-of-order schema/channel handling:
+11. `recover` out-of-order schema/channel handling:
     - `recover` registers each channel with the writer as soon as it is read, so a
       channel that appears before the schema it references is dropped (along with
       every message on that channel) and the recovery is reported as lossy.
@@ -174,7 +168,7 @@ After the Rust CLI is in production, the following is a list of potential improv
     - Before Rust CLI 1.0, decide whether `recover` should buffer channels with a
       not-yet-seen schema id and flush them once the schema is recovered, rather
       than discarding them on first sight.
-13. Shared lenient-scan infrastructure for `recover` and `doctor`:
+12. Shared lenient-scan infrastructure for `recover` and `doctor`:
     - `recover` and `doctor` independently implement the same lenient, single-pass
       scan of the data section: same permissive `LinearReader` options
       (`emit_chunks`, record-length limit), the same chunk decode via
@@ -194,7 +188,7 @@ After the Rust CLI is in production, the following is a list of potential improv
       `mcap::sans_io`), keeping summary validation and the write path
       command-specific. This would remove the most error-prone duplication and
       force the `doctor`/`recover` policy differences to be stated explicitly.
-14. `recover` attachment-CRC tolerance:
+13. `recover` attachment-CRC tolerance:
     - `recover` tolerates a bad chunk CRC (`with_validate_chunk_crcs(false)`, plus
       explicit `BadChunkCrc` handling) and recomputes a correct CRC on re-encode,
       but it has no equivalent path for a loose attachment: `mcap::parse_record`

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -114,16 +114,16 @@ After the Rust CLI is in production, the following is a list of potential improv
      transforms so those commands do not need whole-file fallback for HTTP(S) and
      future object-store inputs.
 9. Use one HTTP client stack:
-    - The CLI currently uses `ureq` for HTTP(S) remote inputs and `reqwest`
-      through `object_store` for S3, GCS, and Azure Blob Storage inputs. Both use
-      rustls, but maintaining two HTTP client stacks increases binary size,
-      dependency surface area, and subtle behavior differences (for example root
-      certificate handling).
-    - Before Rust CLI 1.0, remove the direct `ureq` HTTP implementation and route
-      HTTP(S) remote inputs through the same `reqwest`/`object_store` stack used
-      for object stores, preserving the current remote scan opt-in behavior.
-      Prefer the platform's native certificate store for this unified stack
-      rather than shipping a separate bundled web PKI root set.
+   - The CLI currently uses `ureq` for HTTP(S) remote inputs and `reqwest`
+     through `object_store` for S3, GCS, and Azure Blob Storage inputs. Both use
+     rustls, but maintaining two HTTP client stacks increases binary size,
+     dependency surface area, and subtle behavior differences (for example root
+     certificate handling).
+   - Before Rust CLI 1.0, remove the direct `ureq` HTTP implementation and route
+     HTTP(S) remote inputs through the same `reqwest`/`object_store` stack used
+     for object stores, preserving the current remote scan opt-in behavior.
+     Prefer the platform's native certificate store for this unified stack
+     rather than shipping a separate bundled web PKI root set.
 10. `recover` chunk recompression optimization (deferred for valid chunks):
     - `recover` currently decodes every chunk, validates its records, and
       re-writes all records through the writer (which rebuilds chunks, indexes,

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -119,7 +119,16 @@ After the Rust CLI is in production, the following is a list of potential improv
    - Before Rust CLI 1.0, extend this pattern to metadata/attachment-preserving
      transforms so those commands do not need whole-file fallback for HTTP(S) and
      future object-store inputs.
-10. `recover` chunk recompression optimization (deferred for valid chunks):
+10. Use one HTTP client stack:
+    - The CLI currently uses `ureq` for HTTP(S) remote inputs and `reqwest`
+      through `object_store` for S3, GCS, and Azure Blob Storage inputs. Both use
+      rustls, but maintaining two HTTP client stacks increases binary size,
+      dependency surface area, and subtle behavior differences (for example root
+      certificate handling).
+    - Before Rust CLI 1.0, remove the direct `ureq` HTTP implementation and route
+      HTTP(S) remote inputs through the same `reqwest`/`object_store` stack used
+      for object stores, preserving the current remote scan opt-in behavior.
+11. `recover` chunk recompression optimization (deferred for valid chunks):
     - `recover` currently decodes every chunk, validates its records, and
       re-writes all records through the writer (which rebuilds chunks, indexes,
       the summary section, and CRCs). This guarantees a valid, readable output
@@ -152,7 +161,7 @@ After the Rust CLI is in production, the following is a list of potential improv
       compression.
       Adding this later is purely additive, so we ship the always-re-encode
       version now and revisit if recompression cost matters in practice.
-11. `recover` out-of-order schema/channel handling:
+12. `recover` out-of-order schema/channel handling:
     - `recover` registers each channel with the writer as soon as it is read, so a
       channel that appears before the schema it references is dropped (along with
       every message on that channel) and the recovery is reported as lossy.
@@ -163,7 +172,7 @@ After the Rust CLI is in production, the following is a list of potential improv
     - Before Rust CLI 1.0, decide whether `recover` should buffer channels with a
       not-yet-seen schema id and flush them once the schema is recovered, rather
       than discarding them on first sight.
-12. Shared lenient-scan infrastructure for `recover` and `doctor`:
+13. Shared lenient-scan infrastructure for `recover` and `doctor`:
     - `recover` and `doctor` independently implement the same lenient, single-pass
       scan of the data section: same permissive `LinearReader` options
       (`emit_chunks`, record-length limit), the same chunk decode via
@@ -183,7 +192,7 @@ After the Rust CLI is in production, the following is a list of potential improv
       `mcap::sans_io`), keeping summary validation and the write path
       command-specific. This would remove the most error-prone duplication and
       force the `doctor`/`recover` policy differences to be stated explicitly.
-13. `recover` attachment-CRC tolerance:
+14. `recover` attachment-CRC tolerance:
     - `recover` tolerates a bad chunk CRC (`with_validate_chunk_crcs(false)`, plus
       explicit `BadChunkCrc` handling) and recomputes a correct CRC on re-encode,
       but it has no equivalent path for a loose attachment: `mcap::parse_record`

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -468,6 +468,12 @@ impl ObjectStoreSource {
     }
 }
 
+// object_store config keys accept unprefixed aliases (for example `endpoint`,
+// `region`, and `token`), so forwarding the whole environment would let unrelated
+// shell variables silently reconfigure the store. Restrict to the prefixes the
+// object_store builders themselves read in their `from_env` constructors.
+const OBJECT_STORE_ENV_PREFIXES: [&str; 3] = ["AWS_", "GOOGLE_", "AZURE_"];
+
 fn object_store_env_options() -> Vec<(String, String)> {
     object_store_options_from_env_vars(std::env::vars_os())
 }
@@ -477,6 +483,11 @@ fn object_store_options_from_env_vars(
 ) -> Vec<(String, String)> {
     vars.into_iter()
         .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+        .filter(|(key, _)| {
+            OBJECT_STORE_ENV_PREFIXES
+                .iter()
+                .any(|prefix| key.starts_with(prefix))
+        })
         .collect()
 }
 
@@ -1392,6 +1403,39 @@ mod tests {
         assert_eq!(
             options,
             vec![("AWS_REGION".to_string(), "us-east-1".to_string())]
+        );
+    }
+
+    #[test]
+    fn object_store_env_options_only_forward_recognized_prefixes() {
+        use std::ffi::OsString;
+
+        let options = super::object_store_options_from_env_vars([
+            (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
+            (OsString::from("GOOGLE_BUCKET"), OsString::from("bucket")),
+            (
+                OsString::from("AZURE_STORAGE_ACCOUNT_NAME"),
+                OsString::from("account"),
+            ),
+            // Unprefixed aliases like `endpoint`/`region`/`token` would otherwise
+            // be applied by object_store; they must not be forwarded.
+            (
+                OsString::from("ENDPOINT"),
+                OsString::from("http://attacker"),
+            ),
+            (OsString::from("REGION"), OsString::from("elsewhere")),
+            (OsString::from("TOKEN"), OsString::from("unrelated")),
+        ]);
+        assert_eq!(
+            options,
+            vec![
+                ("AWS_ACCESS_KEY_ID".to_string(), "akid".to_string()),
+                ("GOOGLE_BUCKET".to_string(), "bucket".to_string()),
+                (
+                    "AZURE_STORAGE_ACCOUNT_NAME".to_string(),
+                    "account".to_string()
+                ),
+            ]
         );
     }
 

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -460,7 +460,7 @@ impl ObjectStoreSource {
             object_store::parse_url_opts(&url, object_store_env_options())
                 .with_context(|| format!("failed to configure object store for {display_url}"))?;
         Ok(Self {
-            runtime: Arc::new(object_store_runtime()?),
+            runtime: object_store_runtime()?,
             store: Arc::from(store),
             path: object_path,
             display_url,
@@ -510,7 +510,7 @@ impl ObjectStoreRangeReader {
     fn new_for_test(store: Arc<dyn ObjectStore>, path: ObjectStorePath, size: u64) -> Result<Self> {
         Ok(Self {
             source: ObjectStoreSource {
-                runtime: Arc::new(object_store_runtime()?),
+                runtime: object_store_runtime()?,
                 store,
                 path,
                 display_url: "memory:///test".to_string(),
@@ -791,11 +791,18 @@ fn remote_agent() -> Agent {
         .into()
 }
 
-fn object_store_runtime() -> Result<tokio::runtime::Runtime> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("failed to create object store runtime")
+fn object_store_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
+    static RUNTIME: std::sync::OnceLock<Arc<tokio::runtime::Runtime>> = std::sync::OnceLock::new();
+    if let Some(runtime) = RUNTIME.get() {
+        return Ok(runtime.clone());
+    }
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to create object store runtime")?,
+    );
+    Ok(RUNTIME.get_or_init(|| runtime).clone())
 }
 
 fn redact_url(url: &str) -> String {

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -1382,70 +1382,6 @@ mod tests {
             .expect("memory range reader")
     }
 
-    #[test]
-    fn object_store_source_open_uses_url_parser() {
-        let source = super::ObjectStoreSource::open(Path::new("memory:///demo.mcap?token=secret"))
-            .expect("memory object store URL should parse");
-        assert_eq!(source.path.as_ref(), "demo.mcap");
-        assert_eq!(source.display_url, "memory:///demo.mcap");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn object_store_env_options_ignore_non_utf8_values() {
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-
-        let options = super::object_store_options_from_env_vars([
-            (OsString::from("AWS_REGION"), OsString::from("us-east-1")),
-            (
-                OsString::from_vec(vec![0xFF, b'B', b'A', b'D']),
-                OsString::from("ignored-key"),
-            ),
-            (
-                OsString::from("IGNORED_VALUE"),
-                OsString::from_vec(vec![0xFF, b'v']),
-            ),
-        ]);
-        assert_eq!(
-            options,
-            vec![("AWS_REGION".to_string(), "us-east-1".to_string())]
-        );
-    }
-
-    #[test]
-    fn object_store_env_options_only_forward_recognized_prefixes() {
-        use std::ffi::OsString;
-
-        let options = super::object_store_options_from_env_vars([
-            (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
-            (OsString::from("GOOGLE_BUCKET"), OsString::from("bucket")),
-            (
-                OsString::from("AZURE_STORAGE_ACCOUNT_NAME"),
-                OsString::from("account"),
-            ),
-            // Unprefixed aliases like `endpoint`/`region`/`token` would otherwise
-            // be applied by object_store; they must not be forwarded.
-            (
-                OsString::from("ENDPOINT"),
-                OsString::from("http://attacker"),
-            ),
-            (OsString::from("REGION"), OsString::from("elsewhere")),
-            (OsString::from("TOKEN"), OsString::from("unrelated")),
-        ]);
-        assert_eq!(
-            options,
-            vec![
-                ("AWS_ACCESS_KEY_ID".to_string(), "akid".to_string()),
-                ("GOOGLE_BUCKET".to_string(), "bucket".to_string()),
-                (
-                    "AZURE_STORAGE_ACCOUNT_NAME".to_string(),
-                    "account".to_string()
-                ),
-            ]
-        );
-    }
-
     fn serve_http_with_headers(
         body: &'static [u8],
         supports_ranges: bool,
@@ -1511,12 +1447,6 @@ mod tests {
             }
         });
         format!("http://{addr}/demo.mcap")
-    }
-
-    #[test]
-    fn table_printer_handles_empty_input() {
-        print_table(&[]);
-        assert!(format_table(&[]).is_empty());
     }
 
     #[test]
@@ -1748,6 +1678,76 @@ mod tests {
         assert_eq!(reader.seek(SeekFrom::End(1)).expect("seek past end"), 20);
         let mut byte = [0_u8; 1];
         assert_eq!(reader.read(&mut byte).expect("eof"), 0);
+    }
+
+    #[test]
+    fn object_store_source_open_uses_url_parser() {
+        let source = super::ObjectStoreSource::open(Path::new("memory:///demo.mcap?token=secret"))
+            .expect("memory object store URL should parse");
+        assert_eq!(source.path.as_ref(), "demo.mcap");
+        assert_eq!(source.display_url, "memory:///demo.mcap");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn object_store_env_options_ignore_non_utf8_values() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let options = super::object_store_options_from_env_vars([
+            (OsString::from("AWS_REGION"), OsString::from("us-east-1")),
+            (
+                OsString::from_vec(vec![0xFF, b'B', b'A', b'D']),
+                OsString::from("ignored-key"),
+            ),
+            (
+                OsString::from("IGNORED_VALUE"),
+                OsString::from_vec(vec![0xFF, b'v']),
+            ),
+        ]);
+        assert_eq!(
+            options,
+            vec![("AWS_REGION".to_string(), "us-east-1".to_string())]
+        );
+    }
+
+    #[test]
+    fn object_store_env_options_only_forward_recognized_prefixes() {
+        use std::ffi::OsString;
+
+        let options = super::object_store_options_from_env_vars([
+            (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
+            (OsString::from("GOOGLE_BUCKET"), OsString::from("bucket")),
+            (
+                OsString::from("AZURE_STORAGE_ACCOUNT_NAME"),
+                OsString::from("account"),
+            ),
+            // Unprefixed aliases like `endpoint`/`region`/`token` would otherwise
+            // be applied by object_store; they must not be forwarded.
+            (
+                OsString::from("ENDPOINT"),
+                OsString::from("http://attacker"),
+            ),
+            (OsString::from("REGION"), OsString::from("elsewhere")),
+            (OsString::from("TOKEN"), OsString::from("unrelated")),
+        ]);
+        assert_eq!(
+            options,
+            vec![
+                ("AWS_ACCESS_KEY_ID".to_string(), "akid".to_string()),
+                ("GOOGLE_BUCKET".to_string(), "bucket".to_string()),
+                (
+                    "AZURE_STORAGE_ACCOUNT_NAME".to_string(),
+                    "account".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn table_printer_handles_empty_input() {
+        print_table(&[]);
+        assert!(format_table(&[]).is_empty());
     }
 
     #[test]

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -268,6 +268,10 @@ pub(crate) fn open_streaming_input(
             )?));
         }
         if is_object_store_url(path) {
+            // Object store clients are async, while recover's reader pipeline is synchronous.
+            // Materializing keeps the recovery path simple and consistent with other full-scan
+            // object-store commands. Like every full remote scan, this is gated by
+            // `--allow-remote-scan` in `materialize_input`.
             let materialized = materialize_input(path, options)?;
             let file = open_seekable_mcap_source(materialized.path())?;
             let temp_file = materialized
@@ -452,8 +456,9 @@ impl ObjectStoreSource {
         })?;
         let display_url = redact_url(url);
         let url = Url::parse(url).with_context(|| format!("failed to parse {display_url}"))?;
-        let (store, object_path) = object_store::parse_url_opts(&url, std::env::vars())
-            .with_context(|| format!("failed to configure object store for {display_url}"))?;
+        let (store, object_path) =
+            object_store::parse_url_opts(&url, object_store_env_options())
+                .with_context(|| format!("failed to configure object store for {display_url}"))?;
         Ok(Self {
             runtime: Arc::new(object_store_runtime()?),
             store: Arc::from(store),
@@ -461,6 +466,18 @@ impl ObjectStoreSource {
             display_url,
         })
     }
+}
+
+fn object_store_env_options() -> Vec<(String, String)> {
+    object_store_options_from_env_vars(std::env::vars_os())
+}
+
+fn object_store_options_from_env_vars(
+    vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+) -> Vec<(String, String)> {
+    vars.into_iter()
+        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+        .collect()
 }
 
 impl ObjectStoreRangeReader {
@@ -1345,6 +1362,37 @@ mod tests {
             .expect("put memory object");
         super::ObjectStoreRangeReader::new_for_test(store, path, bytes.len() as u64)
             .expect("memory range reader")
+    }
+
+    #[test]
+    fn object_store_source_open_uses_url_parser() {
+        let source = super::ObjectStoreSource::open(Path::new("memory:///demo.mcap?token=secret"))
+            .expect("memory object store URL should parse");
+        assert_eq!(source.path.as_ref(), "demo.mcap");
+        assert_eq!(source.display_url, "memory:///demo.mcap");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn object_store_env_options_ignore_non_utf8_values() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let options = super::object_store_options_from_env_vars([
+            (OsString::from("AWS_REGION"), OsString::from("us-east-1")),
+            (
+                OsString::from_vec(vec![0xFF, b'B', b'A', b'D']),
+                OsString::from("ignored-key"),
+            ),
+            (
+                OsString::from("IGNORED_VALUE"),
+                OsString::from_vec(vec![0xFF, b'v']),
+            ),
+        ]);
+        assert_eq!(
+            options,
+            vec![("AWS_REGION".to_string(), "us-east-1".to_string())]
+        );
     }
 
     fn serve_http_with_headers(

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -8,11 +8,14 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use binrw::BinRead;
+use futures_util::TryStreamExt;
 use mcap::records::{self, Record};
 use mcap::sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions};
 use memmap2::Mmap;
+use object_store::{path::Path as ObjectStorePath, ObjectStore, ObjectStoreExt};
 use tempfile::NamedTempFile;
 use ureq::Agent;
+use url::Url;
 
 pub const PLEASE_REDIRECT: &str =
     "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
@@ -85,7 +88,7 @@ pub struct MaterializedInput {
 }
 
 pub struct RemoteMcap {
-    reader: HttpRangeReader,
+    reader: RemoteRangeReader,
     summary: mcap::Summary,
 }
 
@@ -107,10 +110,33 @@ pub struct HttpRangeReader {
     offset: u64,
 }
 
+pub struct ObjectStoreRangeReader {
+    source: ObjectStoreSource,
+    size: u64,
+    offset: u64,
+}
+
+struct ObjectStoreSource {
+    runtime: Arc<tokio::runtime::Runtime>,
+    store: Arc<dyn ObjectStore>,
+    path: ObjectStorePath,
+    display_url: String,
+}
+
+pub enum RemoteRangeReader {
+    Http(HttpRangeReader),
+    ObjectStore(ObjectStoreRangeReader),
+}
+
 pub(crate) enum StreamingInput {
     Local(std::fs::File),
     Stdin(std::io::Stdin),
     Remote(HttpBodyReader),
+    RemoteMaterialized {
+        file: std::fs::File,
+        #[allow(dead_code)]
+        temp_file: NamedTempFile,
+    },
 }
 
 pub(crate) struct HttpBodyReader {
@@ -158,8 +184,8 @@ pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
 }
 
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
-    if is_http_url(path) {
-        match HttpRangeReader::open(path)? {
+    if is_remote_url(path) {
+        match open_remote_range_reader(path)? {
             Some(mut reader) => {
                 if let Some(summary) =
                     read_summary_from_remote(&reader, options).with_context(|| {
@@ -182,7 +208,7 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
             }
             None if !options.allow_remote_scan => {
                 bail!(
-                    "{}: remote server does not support HTTP range requests; {}",
+                    "{}: remote server does not support range requests; {}",
                     redacted_display(path),
                     remote_scan_opt_in_suffix()
                 );
@@ -202,7 +228,7 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
 }
 
 pub fn load_path(path: &Path, options: SourceOptions) -> Result<InputData> {
-    if is_http_url(path) {
+    if is_remote_url(path) {
         let materialized = materialize_input(path, options)?;
         let mmap = map_file(materialized.path())?;
         let temp_file = materialized
@@ -241,6 +267,14 @@ pub(crate) fn open_streaming_input(
                 path, options,
             )?));
         }
+        if is_object_store_url(path) {
+            let materialized = materialize_input(path, options)?;
+            let file = open_seekable_mcap_source(materialized.path())?;
+            let temp_file = materialized
+                .temp_file
+                .expect("object store streaming input should have a temp file");
+            return Ok(StreamingInput::RemoteMaterialized { file, temp_file });
+        }
         return Ok(StreamingInput::Local(open_seekable_mcap_source(path)?));
     }
 
@@ -252,7 +286,7 @@ pub(crate) fn open_streaming_input(
 }
 
 pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<MaterializedInput> {
-    if !is_http_url(path) {
+    if !is_remote_url(path) {
         return Ok(MaterializedInput {
             temp_file: None,
             local_path: Some(path.to_path_buf()),
@@ -271,7 +305,11 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
     let mut temp_file = builder
         .tempfile()
         .context("failed to create temporary remote input file")?;
-    read_remote_input_to_writer(path, temp_file.as_file_mut())?;
+    if is_http_url(path) {
+        read_remote_input_to_writer(path, temp_file.as_file_mut())?;
+    } else {
+        read_object_store_input_to_writer(path, temp_file.as_file_mut())?;
+    }
     std::io::Write::flush(temp_file.as_file_mut())
         .context("failed to flush temporary remote input file")?;
     Ok(MaterializedInput {
@@ -281,13 +319,13 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
 }
 
 pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Option<RemoteMcap>> {
-    if !is_http_url(path) {
+    if !is_remote_url(path) {
         return Ok(None);
     }
-    let Some(reader) = HttpRangeReader::open(path)? else {
+    let Some(reader) = open_remote_range_reader(path)? else {
         if !options.allow_remote_scan {
             bail!(
-                "{}: remote server does not support HTTP range requests; {}",
+                "{}: remote server does not support range requests; {}",
                 redacted_display(path),
                 remote_scan_opt_in_suffix()
             );
@@ -314,17 +352,31 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
 }
 
 pub fn is_http_url(path: &Path) -> bool {
-    let Some(text) = path.to_str() else {
-        return false;
-    };
-    let Some((scheme, _)) = text.split_once("://") else {
-        return false;
-    };
-    scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+    scheme_of(path).is_some_and(|scheme| {
+        scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+    })
+}
+
+pub fn is_object_store_url(path: &Path) -> bool {
+    scheme_of(path).is_some_and(|scheme| {
+        matches!(
+            scheme.to_ascii_lowercase().as_str(),
+            "s3" | "s3a" | "gs" | "az" | "adl" | "azure" | "abfs" | "abfss"
+        )
+    })
+}
+
+pub fn is_remote_url(path: &Path) -> bool {
+    is_http_url(path) || is_object_store_url(path)
+}
+
+fn scheme_of(path: &Path) -> Option<&str> {
+    let text = path.to_str()?;
+    text.split_once("://").map(|(scheme, _)| scheme)
 }
 
 pub fn remote_or_local_extension(path: &Path) -> Option<String> {
-    if is_http_url(path) {
+    if is_remote_url(path) {
         let text = remote_url_without_fragment_or_query(path.to_str()?);
         return Path::new(text)
             .extension()
@@ -393,6 +445,102 @@ impl HttpRangeReader {
     }
 }
 
+impl ObjectStoreSource {
+    fn open(path: &Path) -> Result<Self> {
+        let url = path.to_str().ok_or_else(|| {
+            anyhow::anyhow!("remote URL is not valid UTF-8: '{}'", path.display())
+        })?;
+        let display_url = redact_url(url);
+        let url = Url::parse(url).with_context(|| format!("failed to parse {display_url}"))?;
+        let (store, object_path) = object_store::parse_url_opts(&url, std::env::vars())
+            .with_context(|| format!("failed to configure object store for {display_url}"))?;
+        Ok(Self {
+            runtime: Arc::new(object_store_runtime()?),
+            store: Arc::from(store),
+            path: object_path,
+            display_url,
+        })
+    }
+}
+
+impl ObjectStoreRangeReader {
+    fn open(path: &Path) -> Result<Self> {
+        let source = ObjectStoreSource::open(path)?;
+        let size = source
+            .runtime
+            .block_on(source.store.head(&source.path))
+            .with_context(|| format!("failed to stat {}", source.display_url))?
+            .size;
+        Ok(Self {
+            source,
+            size,
+            offset: 0,
+        })
+    }
+
+    #[cfg(test)]
+    fn new_for_test(store: Arc<dyn ObjectStore>, path: ObjectStorePath, size: u64) -> Result<Self> {
+        Ok(Self {
+            source: ObjectStoreSource {
+                runtime: Arc::new(object_store_runtime()?),
+                store,
+                path,
+                display_url: "memory:///test".to_string(),
+            },
+            size,
+            offset: 0,
+        })
+    }
+
+    fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
+        if length == 0 || offset >= self.size {
+            return Ok(Vec::new());
+        }
+        let end = offset
+            .checked_add(length as u64)
+            .map(|end| end.min(self.size))
+            .ok_or_else(|| anyhow::anyhow!("remote range overflow"))?;
+        let bytes = self
+            .source
+            .runtime
+            .block_on(self.source.store.get_range(&self.source.path, offset..end))
+            .with_context(|| format!("failed to fetch range from {}", self.source.display_url))?;
+        Ok(bytes.to_vec())
+    }
+
+    fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+impl RemoteRangeReader {
+    fn open(path: &Path) -> Result<Option<Self>> {
+        if is_http_url(path) {
+            return HttpRangeReader::open(path).map(|reader| reader.map(Self::Http));
+        }
+        if is_object_store_url(path) {
+            return ObjectStoreRangeReader::open(path)
+                .map(Self::ObjectStore)
+                .map(Some);
+        }
+        Ok(None)
+    }
+
+    fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
+        match self {
+            RemoteRangeReader::Http(reader) => reader.read_range(offset, length),
+            RemoteRangeReader::ObjectStore(reader) => reader.read_range(offset, length),
+        }
+    }
+
+    fn size(&self) -> u64 {
+        match self {
+            RemoteRangeReader::Http(reader) => reader.size(),
+            RemoteRangeReader::ObjectStore(reader) => reader.size(),
+        }
+    }
+}
+
 impl std::io::Read for HttpRangeReader {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self.read_range(self.offset, buf.len()) {
@@ -407,12 +555,36 @@ impl std::io::Read for HttpRangeReader {
     }
 }
 
+impl std::io::Read for ObjectStoreRangeReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self.read_range(self.offset, buf.len()) {
+            Ok(bytes) => {
+                let n = bytes.len();
+                buf[..n].copy_from_slice(&bytes);
+                self.offset = self.offset.saturating_add(n as u64);
+                Ok(n)
+            }
+            Err(err) => Err(std::io::Error::other(err)),
+        }
+    }
+}
+
+impl std::io::Read for RemoteRangeReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            RemoteRangeReader::Http(reader) => reader.read(buf),
+            RemoteRangeReader::ObjectStore(reader) => reader.read(buf),
+        }
+    }
+}
+
 impl std::io::Read for StreamingInput {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
             StreamingInput::Local(file) => file.read(buf),
             StreamingInput::Stdin(stdin) => stdin.read(buf),
             StreamingInput::Remote(reader) => reader.read(buf),
+            StreamingInput::RemoteMaterialized { file, .. } => file.read(buf),
         }
     }
 }
@@ -448,6 +620,37 @@ impl std::io::Seek for HttpRangeReader {
         self.offset = target as u64;
         Ok(self.offset)
     }
+}
+
+impl std::io::Seek for ObjectStoreRangeReader {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let target = match pos {
+            SeekFrom::Start(offset) => offset as i128,
+            SeekFrom::End(offset) => self.size as i128 + offset as i128,
+            SeekFrom::Current(offset) => self.offset as i128 + offset as i128,
+        };
+        if target < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "remote seek out of bounds",
+            ));
+        }
+        self.offset = target as u64;
+        Ok(self.offset)
+    }
+}
+
+impl std::io::Seek for RemoteRangeReader {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        match self {
+            RemoteRangeReader::Http(reader) => reader.seek(pos),
+            RemoteRangeReader::ObjectStore(reader) => reader.seek(pos),
+        }
+    }
+}
+
+fn open_remote_range_reader(path: &Path) -> Result<Option<RemoteRangeReader>> {
+    RemoteRangeReader::open(path)
 }
 
 fn probe_range_size(agent: &Agent, url: &str, display_url: &str) -> Result<Option<u64>> {
@@ -501,6 +704,31 @@ fn read_remote_input_to_writer(path: &Path, writer: &mut impl std::io::Write) ->
     Ok(())
 }
 
+fn read_object_store_input_to_writer(path: &Path, writer: &mut impl std::io::Write) -> Result<()> {
+    let source = ObjectStoreSource::open(path)?;
+    eprintln!("Warning: reading entire remote file {}", source.display_url);
+
+    source.runtime.block_on(async {
+        let response = source
+            .store
+            .get(&source.path)
+            .await
+            .with_context(|| format!("failed to read remote input {}", source.display_url))?;
+        let mut stream = response.into_stream();
+        while let Some(bytes) = stream
+            .try_next()
+            .await
+            .with_context(|| format!("failed to read remote input {}", source.display_url))?
+        {
+            std::io::Write::write_all(writer, bytes.as_ref())
+                .with_context(|| format!("failed to write remote input {}", source.display_url))?;
+        }
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
 fn open_remote_body_reader(path: &Path, options: SourceOptions) -> Result<HttpBodyReader> {
     require_remote_scan_allowed(path, options)?;
     let url = path
@@ -533,6 +761,13 @@ fn remote_agent() -> Agent {
         .timeout_recv_body(Some(REMOTE_BODY_TIMEOUT))
         .build()
         .into()
+}
+
+fn object_store_runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to create object store runtime")
 }
 
 fn redact_url(url: &str) -> String {
@@ -618,7 +853,7 @@ fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()
 }
 
 fn read_summary_from_remote(
-    reader: &HttpRangeReader,
+    reader: &RemoteRangeReader,
     options: SourceOptions,
 ) -> Result<Option<mcap::Summary>> {
     let file_size = reader.size();
@@ -1084,9 +1319,10 @@ pub fn print_table(rows: &[Vec<String>]) {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::io::{Read, SeekFrom, Write};
+    use std::io::{Read, Seek, SeekFrom, Write};
     use std::net::TcpListener;
     use std::path::Path;
+    use std::sync::Arc;
     use std::thread;
 
     use super::{
@@ -1094,9 +1330,21 @@ mod tests {
         parse_mcap_from_summary, print_table, write_raw_time,
     };
     use mcap::records;
+    use object_store::ObjectStoreExt;
 
     fn serve_http(body: &'static [u8], supports_ranges: bool) -> String {
         serve_http_with_headers(body, supports_ranges, &[])
+    }
+
+    fn object_store_memory_reader(bytes: Vec<u8>) -> super::ObjectStoreRangeReader {
+        let store = Arc::new(object_store::memory::InMemory::new());
+        let path = object_store::path::Path::from("demo.mcap");
+        let runtime = super::object_store_runtime().expect("runtime");
+        runtime
+            .block_on(store.put(&path, bytes.clone().into()))
+            .expect("put memory object");
+        super::ObjectStoreRangeReader::new_for_test(store, path, bytes.len() as u64)
+            .expect("memory range reader")
     }
 
     fn serve_http_with_headers(
@@ -1197,6 +1445,18 @@ mod tests {
         let err = load_path(Path::new(&url), super::SourceOptions::default())
             .expect_err("remote full read should require opt-in");
         assert!(err.to_string().contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn remote_object_store_input_requires_remote_scan_opt_in_before_network() {
+        let err = load_path(
+            Path::new("s3://bucket/demo.mcap?X-Amz-Signature=secret-token"),
+            super::SourceOptions::default(),
+        )
+        .expect_err("cloud remote full read should require opt-in");
+        assert!(err.to_string().contains("--allow-remote-scan"));
+        assert!(!err.to_string().contains("secret-token"));
+        assert!(!err.to_string().contains("X-Amz-Signature"));
     }
 
     #[test]
@@ -1313,6 +1573,23 @@ mod tests {
     }
 
     #[test]
+    fn remote_url_recognizes_cloud_schemes() {
+        for url in [
+            "s3://bucket/demo.mcap",
+            "s3a://bucket/demo.mcap",
+            "gs://bucket/demo.mcap",
+            "az://container@account.blob.core.windows.net/demo.mcap",
+            "azure://container@account.blob.core.windows.net/demo.mcap",
+            "adl://container@account.dfs.core.windows.net/demo.mcap",
+            "abfs://container@account.dfs.core.windows.net/demo.mcap",
+            "abfss://container@account.dfs.core.windows.net/demo.mcap",
+        ] {
+            assert!(super::is_object_store_url(Path::new(url)), "{url}");
+            assert!(super::is_remote_url(Path::new(url)), "{url}");
+        }
+    }
+
+    #[test]
     fn remote_extension_ignores_query_and_fragment() {
         assert_eq!(
             super::remote_or_local_extension(Path::new(
@@ -1320,6 +1597,13 @@ mod tests {
             ))
             .as_deref(),
             Some("bag")
+        );
+        assert_eq!(
+            super::remote_or_local_extension(Path::new(
+                "s3://bucket/path/demo.db3?X-Amz-Signature=secret#fragment"
+            ))
+            .as_deref(),
+            Some("db3")
         );
     }
 
@@ -1339,6 +1623,32 @@ mod tests {
         );
         let mut byte = [0_u8; 1];
         assert_eq!(std::io::Read::read(&mut reader, &mut byte).unwrap(), 0);
+    }
+
+    #[test]
+    fn object_store_range_reader_reads_and_seeks() {
+        let mut reader = object_store_memory_reader(b"hello remote object".to_vec());
+
+        assert_eq!(reader.read_range(0, 5).expect("range"), b"hello");
+        assert_eq!(reader.read_range(13, 20).expect("clamped range"), b"object");
+
+        let mut buf = [0_u8; 6];
+        assert_eq!(reader.read(&mut buf).expect("read"), 6);
+        assert_eq!(&buf, b"hello ");
+
+        assert_eq!(reader.seek(SeekFrom::Current(1)).expect("seek"), 7);
+        let mut buf = [0_u8; 6];
+        assert_eq!(reader.read(&mut buf).expect("read"), 6);
+        assert_eq!(&buf, b"emote ");
+
+        assert_eq!(reader.seek(SeekFrom::End(-6)).expect("seek end"), 13);
+        let mut tail = Vec::new();
+        reader.read_to_end(&mut tail).expect("read tail");
+        assert_eq!(tail, b"object");
+
+        assert_eq!(reader.seek(SeekFrom::End(1)).expect("seek past end"), 20);
+        let mut byte = [0_u8; 1];
+        assert_eq!(reader.read(&mut byte).expect("eof"), 0);
     }
 
     #[test]

--- a/rust/cli/src/commands/common.rs
+++ b/rust/cli/src/commands/common.rs
@@ -110,17 +110,17 @@ pub struct HttpRangeReader {
     offset: u64,
 }
 
-pub struct ObjectStoreRangeReader {
-    source: ObjectStoreSource,
-    size: u64,
-    offset: u64,
-}
-
 struct ObjectStoreSource {
     runtime: Arc<tokio::runtime::Runtime>,
     store: Arc<dyn ObjectStore>,
     path: ObjectStorePath,
     display_url: String,
+}
+
+pub struct ObjectStoreRangeReader {
+    source: ObjectStoreSource,
+    size: u64,
+    offset: u64,
 }
 
 pub enum RemoteRangeReader {
@@ -468,29 +468,6 @@ impl ObjectStoreSource {
     }
 }
 
-// object_store config keys accept unprefixed aliases (for example `endpoint`,
-// `region`, and `token`), so forwarding the whole environment would let unrelated
-// shell variables silently reconfigure the store. Restrict to the prefixes the
-// object_store builders themselves read in their `from_env` constructors.
-const OBJECT_STORE_ENV_PREFIXES: [&str; 3] = ["AWS_", "GOOGLE_", "AZURE_"];
-
-fn object_store_env_options() -> Vec<(String, String)> {
-    object_store_options_from_env_vars(std::env::vars_os())
-}
-
-fn object_store_options_from_env_vars(
-    vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
-) -> Vec<(String, String)> {
-    vars.into_iter()
-        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
-        .filter(|(key, _)| {
-            OBJECT_STORE_ENV_PREFIXES
-                .iter()
-                .any(|prefix| key.starts_with(prefix))
-        })
-        .collect()
-}
-
 impl ObjectStoreRangeReader {
     fn open(path: &Path) -> Result<Self> {
         let source = ObjectStoreSource::open(path)?;
@@ -539,6 +516,29 @@ impl ObjectStoreRangeReader {
     fn size(&self) -> u64 {
         self.size
     }
+}
+
+// object_store config keys accept unprefixed aliases (for example `endpoint`,
+// `region`, and `token`), so forwarding the whole environment would let unrelated
+// shell variables silently reconfigure the store. Restrict to the prefixes the
+// object_store builders themselves read in their `from_env` constructors.
+const OBJECT_STORE_ENV_PREFIXES: [&str; 3] = ["AWS_", "GOOGLE_", "AZURE_"];
+
+fn object_store_env_options() -> Vec<(String, String)> {
+    object_store_options_from_env_vars(std::env::vars_os())
+}
+
+fn object_store_options_from_env_vars(
+    vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+) -> Vec<(String, String)> {
+    vars.into_iter()
+        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+        .filter(|(key, _)| {
+            OBJECT_STORE_ENV_PREFIXES
+                .iter()
+                .any(|prefix| key.starts_with(prefix))
+        })
+        .collect()
 }
 
 impl RemoteRangeReader {

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -15,7 +15,7 @@ const GIT_LFS_POINTER_PREFIX: &[u8] = b"version https://git-lfs.github.com";
 
 pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
     let input = ConvertInput::detect(&args.input)?;
-    let is_remote = crate::commands::common::is_http_url(&args.input);
+    let is_remote = crate::commands::common::is_remote_url(&args.input);
     if !is_remote {
         reject_lfs_pointer(&args.input)?;
     }
@@ -287,6 +287,20 @@ mod tests {
     }
 
     #[test]
+    fn detects_remote_cloud_extensions() {
+        assert!(matches!(
+            ConvertInput::detect(Path::new("s3://bucket/path/demo.bag?token=secret"))
+                .expect("detect s3 bag"),
+            ConvertInput::Ros1Bag
+        ));
+        assert!(matches!(
+            ConvertInput::detect(Path::new("gs://bucket/path/demo.db3#fragment"))
+                .expect("detect gcs db3"),
+            ConvertInput::Ros2Db3
+        ));
+    }
+
+    #[test]
     fn rejects_unknown_extension() {
         let path = temp_input("unknown", b"not an mcap input");
         let err = ConvertInput::detect(&path).expect_err("unknown input should fail");
@@ -363,6 +377,25 @@ size 123\n",
             },
         )
         .expect_err("remote convert should require opt-in");
+
+        assert!(err.to_string().contains("--allow-remote-scan"));
+        assert!(!err.to_string().contains("token=secret"));
+    }
+
+    #[test]
+    fn cloud_input_requires_allow_remote_scan_before_download() {
+        let err = super::run(
+            &CommandContext::default(),
+            ConvertCommand {
+                input: PathBuf::from("s3://bucket/demo.bag?token=secret"),
+                output: PathBuf::from("/tmp/mcap-cli-cloud-output.mcap"),
+                compression: CompressionFormat::None,
+                chunk_size: 8 * 1024 * 1024,
+                include_crc: false,
+                chunked: true,
+            },
+        )
+        .expect_err("cloud convert should require opt-in");
 
         assert!(err.to_string().contains("--allow-remote-scan"));
         assert!(!err.to_string().contains("token=secret"));

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -22,7 +22,7 @@ pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
         &args.file,
         common::SourceOptions::new(ctx.allow_remote_scan()),
     )?;
-    if !common::is_http_url(&args.file) {
+    if !common::is_remote_url(&args.file) {
         ensure_distinct_input_output(&args.file, &args.output_file)?;
     }
     let summary = validate_sort_input(input.as_slice())?;
@@ -239,6 +239,7 @@ fn checked_slice(input: &[u8], offset: u64, length: usize) -> Result<&[u8]> {
 mod tests {
     use std::collections::BTreeMap;
     use std::io::Cursor;
+    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{sort_to_writer, validate_sort_input, SortOptions};
@@ -469,6 +470,24 @@ mod tests {
             .contains("input and output paths resolve to the same file"));
 
         let _ = std::fs::remove_file(file_path);
+    }
+
+    #[test]
+    fn run_treats_cloud_input_as_remote() {
+        let err = super::run(
+            &CommandContext::default(),
+            SortCommand {
+                file: PathBuf::from("s3://bucket/input.mcap?token=secret"),
+                output_file: PathBuf::from("/tmp/mcap-cli-cloud-sort-output.mcap"),
+                compression: CompressionFormat::Zstd,
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                include_crc: true,
+                chunked: true,
+            },
+        )
+        .expect_err("cloud input should require scan opt-in before download");
+        assert!(err.to_string().contains("--allow-remote-scan"));
+        assert!(!err.to_string().contains("token=secret"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Rust CLI input support for S3, GCS, and Azure Blob/Data Lake URLs via the `object_store` crate.
- Preserve existing HTTP(S) behavior while generalizing remote range reads for cloud-backed summaries/indexes.
- Keep full-object scans/downloads gated behind `--allow-remote-scan`; no remote output/write support or new credential flags are added.

## Supported input schemes
- S3: `s3://`, `s3a://`
- GCS: `gs://`
- Azure: `az://`, `adl://`, `azure://`, `abfs://`, `abfss://`

## Notes
- Authentication and provider-specific configuration are delegated to `object_store` and its standard environment/default credential mechanisms.
- Remote outputs/writes are intentionally out of scope for this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31398764-c8c8-472d-8fe9-533d3b52bdef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31398764-c8c8-472d-8fe9-533d3b52bdef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

