### PR TITLE
rust cli: Build linux binaries with musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,7 +580,10 @@ jobs:
         uses: mlugg/setup-zig@v2
       - name: Install cargo-zigbuild
         if: matrix.os == 'linux'
-        run: cargo install cargo-zigbuild --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-zigbuild@0.22.3
+          fallback: none
       - name: Build binary
         run: |
           if [[ "${{ matrix.os }}" == "linux" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,47 +512,39 @@ jobs:
             arch: amd64
             target: x86_64-unknown-linux-musl
             exe: ""
-            env: {}
           - os: linux
             image: ubuntu-latest
             arch: arm64
             target: aarch64-unknown-linux-musl
             exe: ""
-            env: {}
           - os: linux
             image: ubuntu-latest
             arch: arm
             target: armv7-unknown-linux-musleabihf
             exe: ""
-            env: {}
           - os: macos
             image: macos-latest
             arch: amd64
             target: x86_64-apple-darwin
             exe: ""
-            env: {}
           - os: macos
             image: macos-latest
             arch: arm64
             target: aarch64-apple-darwin
             exe: ""
-            env: {}
           - os: windows
             image: windows-latest
             arch: amd64
             target: x86_64-pc-windows-msvc
             exe: ".exe"
-            env: {}
           - os: windows
             image: windows-latest
             arch: arm64
             target: aarch64-pc-windows-msvc
             exe: ".exe"
-            env: {}
 
     name: rust-cli (${{ matrix.os }}/${{ matrix.arch }})
     runs-on: ${{ matrix.image }}
-    env: ${{ matrix.env }}
     defaults:
       run:
         working-directory: rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,49 +511,42 @@ jobs:
             image: ubuntu-latest
             arch: amd64
             target: x86_64-unknown-linux-musl
-            setup: ""
             exe: ""
             env: {}
           - os: linux
             image: ubuntu-latest
             arch: arm64
             target: aarch64-unknown-linux-musl
-            setup: ""
             exe: ""
             env: {}
           - os: linux
             image: ubuntu-latest
             arch: arm
             target: armv7-unknown-linux-musleabihf
-            setup: ""
             exe: ""
             env: {}
           - os: macos
             image: macos-latest
             arch: amd64
             target: x86_64-apple-darwin
-            setup: ""
             exe: ""
             env: {}
           - os: macos
             image: macos-latest
             arch: arm64
             target: aarch64-apple-darwin
-            setup: ""
             exe: ""
             env: {}
           - os: windows
             image: windows-latest
             arch: amd64
             target: x86_64-pc-windows-msvc
-            setup: ""
             exe: ".exe"
             env: {}
           - os: windows
             image: windows-latest
             arch: arm64
             target: aarch64-pc-windows-msvc
-            setup: ""
             exe: ".exe"
             env: {}
 
@@ -572,9 +565,6 @@ jobs:
           toolchain: stable
           default: true
       - run: rustup target add ${{ matrix.target }}
-      - name: Setup environment
-        if: matrix.setup != ''
-        run: ${{ matrix.setup }}
       - name: Setup Zig
         if: matrix.os == 'linux'
         uses: mlugg/setup-zig@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,36 +511,43 @@ jobs:
             image: ubuntu-latest
             arch: amd64
             target: x86_64-unknown-linux-musl
+            build: cargo zigbuild
             exe: ""
           - os: linux
             image: ubuntu-latest
             arch: arm64
             target: aarch64-unknown-linux-musl
+            build: cargo zigbuild
             exe: ""
           - os: linux
             image: ubuntu-latest
             arch: arm
             target: armv7-unknown-linux-musleabihf
+            build: cargo zigbuild
             exe: ""
           - os: macos
             image: macos-latest
             arch: amd64
             target: x86_64-apple-darwin
+            build: cargo build
             exe: ""
           - os: macos
             image: macos-latest
             arch: arm64
             target: aarch64-apple-darwin
+            build: cargo build
             exe: ""
           - os: windows
             image: windows-latest
             arch: amd64
             target: x86_64-pc-windows-msvc
+            build: cargo build
             exe: ".exe"
           - os: windows
             image: windows-latest
             arch: arm64
             target: aarch64-pc-windows-msvc
+            build: cargo build
             exe: ".exe"
 
     name: rust-cli (${{ matrix.os }}/${{ matrix.arch }})
@@ -568,11 +575,7 @@ jobs:
           fallback: none
       - name: Build binary
         run: |
-          if [[ "${{ matrix.os }}" == "linux" ]]; then
-            cargo zigbuild -p mcap-cli --release --target "${{ matrix.target }}"
-          else
-            cargo build -p mcap-cli --release --target "${{ matrix.target }}"
-          fi
+          ${{ matrix.build }} -p mcap-cli --release --target "${{ matrix.target }}"
           mkdir -p bin
           cp \
             "target/${{ matrix.target }}/release/mcap${{ matrix.exe }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,30 +510,24 @@ jobs:
           - os: linux
             image: ubuntu-latest
             arch: amd64
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             setup: ""
             exe: ""
             env: {}
           - os: linux
             image: ubuntu-latest
             arch: arm64
-            target: aarch64-unknown-linux-gnu
-            setup: sudo apt-get update && sudo apt-get install -qq gcc-aarch64-linux-gnu
+            target: aarch64-unknown-linux-musl
+            setup: ""
             exe: ""
-            env:
-              CC: aarch64-linux-gnu-gcc
-              CXX: aarch64-linux-gnu-g++
-              CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+            env: {}
           - os: linux
             image: ubuntu-latest
             arch: arm
-            target: armv7-unknown-linux-gnueabihf
-            setup: sudo apt-get update && sudo apt-get install -qq gcc-arm-linux-gnueabihf
+            target: armv7-unknown-linux-musleabihf
+            setup: ""
             exe: ""
-            env:
-              CC: arm-linux-gnueabihf-gcc
-              CXX: arm-linux-gnueabihf-g++
-              CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+            env: {}
           - os: macos
             image: macos-latest
             arch: amd64
@@ -581,9 +575,19 @@ jobs:
       - name: Setup environment
         if: matrix.setup != ''
         run: ${{ matrix.setup }}
+      - name: Setup Zig
+        if: matrix.os == 'linux'
+        uses: mlugg/setup-zig@v2
+      - name: Install cargo-zigbuild
+        if: matrix.os == 'linux'
+        run: cargo install cargo-zigbuild --locked
       - name: Build binary
         run: |
-          cargo build -p mcap-cli --release --target "${{ matrix.target }}"
+          if [[ "${{ matrix.os }}" == "linux" ]]; then
+            cargo zigbuild -p mcap-cli --release --target "${{ matrix.target }}"
+          else
+            cargo build -p mcap-cli --release --target "${{ matrix.target }}"
+          fi
           mkdir -p bin
           cp \
             "target/${{ matrix.target }}/release/mcap${{ matrix.exe }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,8 @@ jobs:
       - name: Setup Zig
         if: matrix.os == 'linux'
         uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
       - name: Install cargo-zigbuild
         if: matrix.os == 'linux'
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
None

### Docs
None

### Description
Switch the Rust CLI Linux release matrix to musl target triples, using `cargo-zigbuild` for cross-compilation. This matches the Go CLI's static Linux release behavior while keeping macOS and Windows builds on the standard Cargo path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eed07d6-4b9d-4b8e-b2fc-91867ea98e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eed07d6-4b9d-4b8e-b2fc-91867ea98e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

