### PR TITLE
rust cli: Add shell completion command

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -354,6 +354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap 4.6.0",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1344,7 @@ dependencies = [
  "bzip2",
  "chrono",
  "clap 4.6.0",
+ "clap_complete",
  "crc32fast",
  "futures-util",
  "log",

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -17,6 +17,7 @@ lz4 = "1"
 binrw = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 crc32fast = "1"
 log = "0.4"
 memmap2 = "0.9"

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -12,6 +12,7 @@ Status legend: 🟢 implemented, 🟡 partial, 🔴 not implemented.
 | ------------ | ------ | ----- |
 | `add`        | 🟢     |       |
 | `cat`        | 🟢     |       |
+| `completion` | 🟢     |       |
 | `compress`   | 🟢     |       |
 | `convert`    | 🟢     |       |
 | `decompress` | 🟢     |       |

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 
 use anyhow::{bail, Context, Result};
 use clap::{ArgAction, Parser, Subcommand};
+use clap_complete::Shell;
 
 use crate::logsetup;
 
@@ -57,6 +58,8 @@ pub enum Command {
     Add(AddCommand),
     /// Concatenate the messages in one or more MCAP files to stdout
     Cat(CatCommand),
+    /// Generate shell completion scripts
+    Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file
     Compress(CompressCommand),
     /// Convert supported input files to MCAP
@@ -106,6 +109,20 @@ pub struct CompressCommand {
     /// Do not chunk the output file
     #[arg(long = "unchunked", default_value_t = false)]
     pub unchunked: bool,
+}
+
+/// Generate a shell completion script and print it to stdout.
+///
+/// To load completions in the current shell session:
+///   bash:       source <(mcap completion bash)
+///   zsh:        source <(mcap completion zsh)
+///   fish:       mcap completion fish | source
+///   powershell: mcap completion powershell | Out-String | Invoke-Expression
+#[derive(clap::Args, Debug, PartialEq, Eq)]
+pub struct CompletionCommand {
+    /// Shell to generate a completion script for
+    #[arg(value_enum)]
+    pub shell: Shell,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -59,6 +59,13 @@ pub enum Command {
     /// Concatenate the messages in one or more MCAP files to stdout
     Cat(CatCommand),
     /// Generate shell completion scripts
+    ///
+    /// To load completions in the current shell session:
+    ///   bash:       source <(mcap completion bash)
+    ///   zsh:        source <(mcap completion zsh)
+    ///   fish:       mcap completion fish | source
+    ///   powershell: mcap completion powershell | Out-String | Invoke-Expression
+    #[command(verbatim_doc_comment)]
     Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file
     Compress(CompressCommand),
@@ -89,13 +96,6 @@ pub enum Command {
     Sort(SortCommand),
 }
 
-/// Generate a shell completion script and print it to stdout.
-///
-/// To load completions in the current shell session:
-///   bash:       source <(mcap completion bash)
-///   zsh:        source <(mcap completion zsh)
-///   fish:       mcap completion fish | source
-///   powershell: mcap completion powershell | Out-String | Invoke-Expression
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CompletionCommand {
     /// Shell to generate a completion script for

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -89,6 +89,20 @@ pub enum Command {
     Sort(SortCommand),
 }
 
+/// Generate a shell completion script and print it to stdout.
+///
+/// To load completions in the current shell session:
+///   bash:       source <(mcap completion bash)
+///   zsh:        source <(mcap completion zsh)
+///   fish:       mcap completion fish | source
+///   powershell: mcap completion powershell | Out-String | Invoke-Expression
+#[derive(clap::Args, Debug, PartialEq, Eq)]
+pub struct CompletionCommand {
+    /// Shell to generate a completion script for
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CompressCommand {
     /// Input MCAP file path. If omitted, reads from stdin.
@@ -109,20 +123,6 @@ pub struct CompressCommand {
     /// Do not chunk the output file
     #[arg(long = "unchunked", default_value_t = false)]
     pub unchunked: bool,
-}
-
-/// Generate a shell completion script and print it to stdout.
-///
-/// To load completions in the current shell session:
-///   bash:       source <(mcap completion bash)
-///   zsh:        source <(mcap completion zsh)
-///   fish:       mcap completion fish | source
-///   powershell: mcap completion powershell | Out-String | Invoke-Expression
-#[derive(clap::Args, Debug, PartialEq, Eq)]
-pub struct CompletionCommand {
-    /// Shell to generate a completion script for
-    #[arg(value_enum)]
-    pub shell: Shell,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -1,5 +1,6 @@
 mod add;
 mod cat;
+mod completion;
 mod compress;
 mod convert;
 mod decompress;
@@ -63,6 +64,7 @@ pub fn dispatch(ctx: &CommandContext, command: Command) -> Result<CommandOutcome
         .map(|()| CommandOutcome::Success),
 
         Command::Cat(args) => cat::run(ctx, args).map(|()| CommandOutcome::Success),
+        Command::Completion(args) => completion::run(args).map(|()| CommandOutcome::Success),
         Command::Compress(args) => compress::run(ctx, args).map(|()| CommandOutcome::Success),
         Command::Convert(args) => convert::run(ctx, args).map(|()| CommandOutcome::Success),
         Command::Decompress(args) => decompress::run(ctx, args).map(|()| CommandOutcome::Success),

--- a/rust/cli/src/commands/completion.rs
+++ b/rust/cli/src/commands/completion.rs
@@ -1,0 +1,15 @@
+use std::io;
+
+use anyhow::Result;
+use clap::CommandFactory;
+use clap_complete::generate;
+
+use crate::cli::{Args, CompletionCommand};
+
+/// Generate a shell completion script for the requested shell and write it to stdout.
+pub fn run(args: CompletionCommand) -> Result<()> {
+    let mut cmd = Args::command();
+    let bin_name = cmd.get_name().to_string();
+    generate(args.shell, &mut cmd, bin_name, &mut io::stdout());
+    Ok(())
+}

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -48,14 +48,16 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use clap_complete::Shell;
 
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
-        CoalesceChannels, Command, CompressCommand, CompressionFormat, ConvertCommand,
-        DecompressCommand, DoctorCommand, DuCommand, FilterCommand, GetAttachmentCommand,
-        GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand, ListAttachmentsCommand,
-        ListChannelsCommand, ListChunksCommand, ListCommand, ListMetadataCommand,
-        ListSchemasCommand, ListSubcommand, MergeCommand, RecoverCommand, SortCommand,
+        CoalesceChannels, Command, CompletionCommand, CompressCommand, CompressionFormat,
+        ConvertCommand, DecompressCommand, DoctorCommand, DuCommand, FilterCommand,
+        GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand,
+        ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
+        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, RecoverCommand,
+        SortCommand,
     };
 
     #[test]
@@ -67,24 +69,6 @@ mod tests {
                 file: "demo.mcap".into(),
             })
         );
-    }
-
-    #[test]
-    fn parses_completion_subcommand() {
-        let args =
-            Args::try_parse_from(["mcap", "completion", "bash"]).expect("completion should parse");
-        assert_eq!(
-            args.command,
-            Command::Completion(crate::cli::CompletionCommand {
-                shell: clap_complete::Shell::Bash,
-            })
-        );
-    }
-
-    #[test]
-    fn completion_requires_known_shell() {
-        Args::try_parse_from(["mcap", "completion", "notashell"])
-            .expect_err("completion should reject unknown shells");
     }
 
     #[test]
@@ -176,6 +160,22 @@ mod tests {
         ])
         .expect_err("end seconds and nanoseconds should conflict");
         assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn parses_completion_subcommand() {
+        let args =
+            Args::try_parse_from(["mcap", "completion", "bash"]).expect("completion should parse");
+        assert_eq!(
+            args.command,
+            Command::Completion(CompletionCommand { shell: Shell::Bash })
+        );
+    }
+
+    #[test]
+    fn completion_requires_known_shell() {
+        Args::try_parse_from(["mcap", "completion", "notashell"])
+            .expect_err("completion should reject unknown shells");
     }
 
     #[test]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -70,6 +70,24 @@ mod tests {
     }
 
     #[test]
+    fn parses_completion_subcommand() {
+        let args =
+            Args::try_parse_from(["mcap", "completion", "bash"]).expect("completion should parse");
+        assert_eq!(
+            args.command,
+            Command::Completion(crate::cli::CompletionCommand {
+                shell: clap_complete::Shell::Bash,
+            })
+        );
+    }
+
+    #[test]
+    fn completion_requires_known_shell() {
+        Args::try_parse_from(["mcap", "completion", "notashell"])
+            .expect_err("completion should reject unknown shells");
+    }
+
+    #[test]
     fn parses_cat_subcommand_with_files() {
         let args =
             Args::try_parse_from(["mcap", "cat", "a.mcap", "b.mcap"]).expect("cat should parse");

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -74,6 +74,17 @@ export const cases: CliTestCase[] = [
     comparison: HELP_EXISTS,
   })),
   {
+    id: "completion-command",
+    description: "Both CLIs generate a shell completion script for a requested shell.",
+    tags: ["surface", "completion"],
+    invocation: { args: ["completion", "bash"] },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "nonempty" },
+      stderr: { kind: "ignore" },
+    },
+  },
+  {
     id: "known-difference-version-flag",
     description: "Rust CLI exposes a --version flag; Go CLI exposes a version subcommand.",
     tags: ["known-difference", "surface", "version"],
@@ -678,17 +689,6 @@ export const cases: CliTestCase[] = [
         exitCode: "nonzero",
         stderr: { kind: "contains", value: "--always-decode-chunk" },
       },
-    },
-  },
-  {
-    id: "completion-command",
-    description: "Both CLIs generate a shell completion script for a requested shell.",
-    tags: ["surface", "completion"],
-    invocation: { args: ["completion", "bash"] },
-    comparison: {
-      exitCode: 0,
-      stdout: { kind: "nonempty" },
-      stderr: { kind: "ignore" },
     },
   },
   {

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -681,24 +681,14 @@ export const cases: CliTestCase[] = [
     },
   },
   {
-    id: "known-difference-completion-command",
-    description: "The Go CLI exposes Cobra-generated shell completion; Rust CLI does not yet.",
-    tags: ["known-difference", "surface"],
+    id: "completion-command",
+    description: "Both CLIs generate a shell completion script for a requested shell.",
+    tags: ["surface", "completion"],
     invocation: { args: ["completion", "bash"] },
-    knownDifference: {
-      id: "completion-command",
-      summary: "Go CLI exposes a completion command; Rust CLI currently has no completion command.",
-      reason: "Rust CLI is still being prepared for v1.0 parity.",
-      desiredBehavior:
-        "Rust CLI should either provide completion behavior compatible with Go CLI or document an intentional replacement.",
-      goBehavior: {
-        exitCode: 0,
-        stdout: { kind: "nonempty" },
-      },
-      rustBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "unrecognized" },
-      },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "nonempty" },
+      stderr: { kind: "ignore" },
     },
   },
   {

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -57,12 +57,12 @@ export const cases: CliTestCase[] = [
   {
     id: "root-help-command-list",
     description:
-      "Root help advertises the same supported command list, ignoring Go-only completion.",
+      "Root help advertises the same supported command list, ignoring the Go-only version subcommand.",
     tags: ["surface", "help"],
     invocation: { args: ["--help"] },
     comparison: {
       exitCode: 0,
-      stdout: { kind: "command-list", ignoreCommands: ["completion", "version"] },
+      stdout: { kind: "command-list", ignoreCommands: ["version"] },
       stderr: { kind: "text" },
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Adds a `completion` subcommand to the Rust `mcap` CLI that generates shell completion scripts, matching the behavior provided by the Go CLI (cobra auto-generates an equivalent `completion` command).

- Adds the `clap_complete` dependency.
- Adds a `completion <SHELL>` subcommand supporting `bash`, `zsh`, `fish`, `powershell`, and `elvish`.
- Writes the generated script to stdout so users can `source` it.

### Usage

```
# bash
source <(mcap completion bash)
# zsh
source <(mcap completion zsh)
# fish
mcap completion fish | source
# powershell
mcap completion powershell | Out-String | Invoke-Expression
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93ef82fc-f0fa-4ab5-824c-c5634491fad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93ef82fc-f0fa-4ab5-824c-c5634491fad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

