### PR TITLE
rust cli: Remove unsupported flags

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -31,14 +31,6 @@ pub struct Args {
     )]
     pub color: logsetup::Color,
 
-    /// Config file path
-    #[arg(long, global = true)]
-    pub config: Option<PathBuf>,
-
-    /// Record pprof-style profiling output
-    #[arg(long, default_value_t = false, global = true)]
-    pub pprof_profile: bool,
-
     /// Allow commands to download/scan remote inputs
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,

--- a/rust/cli/src/context.rs
+++ b/rust/cli/src/context.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::logsetup::Color;
 
 /// Global CLI execution context shared across command handlers.
@@ -11,8 +9,6 @@ use crate::logsetup::Color;
 pub struct CommandContext {
     verbose: u8,
     color: Color,
-    config: Option<PathBuf>,
-    pprof_profile: bool,
     allow_remote_scan: bool,
 }
 
@@ -21,8 +17,6 @@ impl Default for CommandContext {
         Self {
             verbose: 0,
             color: Color::Auto,
-            config: None,
-            pprof_profile: false,
             allow_remote_scan: false,
         }
     }
@@ -30,18 +24,10 @@ impl Default for CommandContext {
 
 #[allow(dead_code)]
 impl CommandContext {
-    pub fn new(
-        verbose: u8,
-        color: Color,
-        config: Option<PathBuf>,
-        pprof_profile: bool,
-        allow_remote_scan: bool,
-    ) -> Self {
+    pub fn new(verbose: u8, color: Color, allow_remote_scan: bool) -> Self {
         Self {
             verbose,
             color,
-            config,
-            pprof_profile,
             allow_remote_scan,
         }
     }
@@ -52,14 +38,6 @@ impl CommandContext {
 
     pub fn color(&self) -> Color {
         self.color
-    }
-
-    pub fn config(&self) -> Option<&PathBuf> {
-        self.config.as_ref()
-    }
-
-    pub fn pprof_profile(&self) -> bool {
-        self.pprof_profile
     }
 
     pub fn allow_remote_scan(&self) -> bool {

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -16,19 +16,7 @@ use context::CommandContext;
 fn run() -> Result<CommandOutcome> {
     let args = cli::Args::parse();
     logsetup::init_logger(args.verbose, args.color)?;
-    if args.config.is_some() {
-        anyhow::bail!("'--config' is not implemented yet");
-    }
-    if args.pprof_profile {
-        anyhow::bail!("'--pprof-profile' is not implemented yet");
-    }
-    let ctx = CommandContext::new(
-        args.verbose,
-        args.color,
-        args.config,
-        args.pprof_profile,
-        args.allow_remote_scan,
-    );
+    let ctx = CommandContext::new(args.verbose, args.color, args.allow_remote_scan);
 
     commands::dispatch(&ctx, args.command)
 }

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -1,4 +1,4 @@
-/* cspell:words lz4 multitopic ndjson noetic notbag pprof testdata */
+/* cspell:words flamegraph lz4 multitopic ndjson noetic notbag pprof samply testdata */
 
 import type { CliTestCase } from "./types.ts";
 
@@ -820,7 +820,7 @@ export const cases: CliTestCase[] = [
     id: "known-difference-pprof-profile-global",
     description:
       "Go CLI writes pprof profiles; Rust CLI intentionally does not expose --pprof-profile.",
-    tags: ["known-difference", "intentional", "global-options"],
+    tags: ["known-difference", "global-options"],
     invocation: { args: ["--pprof-profile", "info", ONE_MESSAGE] },
     knownDifference: {
       id: "global-pprof-profile",
@@ -839,8 +839,8 @@ export const cases: CliTestCase[] = [
         ],
       },
       rustBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "--pprof-profile" },
+        exitCode: 2,
+        stderr: { kind: "contains", value: "unexpected argument '--pprof-profile'" },
       },
     },
   },
@@ -890,7 +890,7 @@ export const cases: CliTestCase[] = [
   {
     id: "known-difference-config-global",
     description: "Go CLI accepts a config file; Rust CLI intentionally does not expose --config.",
-    tags: ["known-difference", "intentional", "global-options"],
+    tags: ["known-difference", "global-options"],
     setup: [{ type: "writeText", to: "{caseWorkDir}/config.yaml", contents: "{}\n" }],
     invocation: { args: ["--config", "{caseWorkDir}/config.yaml", "info", ONE_MESSAGE] },
     knownDifference: {
@@ -906,8 +906,8 @@ export const cases: CliTestCase[] = [
         stderr: { kind: "contains", value: "Using config file:" },
       },
       rustBehavior: {
-        exitCode: "nonzero",
-        stderr: { kind: "contains", value: "--config" },
+        exitCode: 2,
+        stderr: { kind: "contains", value: "unexpected argument '--config'" },
       },
     },
   },

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -819,16 +819,17 @@ export const cases: CliTestCase[] = [
   {
     id: "known-difference-pprof-profile-global",
     description:
-      "Go CLI writes pprof profiles; Rust CLI parses --pprof-profile but reports it unimplemented.",
-    tags: ["known-difference", "global-options"],
+      "Go CLI writes pprof profiles; Rust CLI intentionally does not expose --pprof-profile.",
+    tags: ["known-difference", "intentional", "global-options"],
     invocation: { args: ["--pprof-profile", "info", ONE_MESSAGE] },
     knownDifference: {
       id: "global-pprof-profile",
       summary:
-        "Go CLI implements --pprof-profile while Rust CLI currently bails out as unimplemented.",
-      reason: "Global option support is incomplete in the Rust CLI.",
+        "Go CLI implements --pprof-profile; the Rust CLI intentionally omits the flag and rejects it as an unknown argument.",
+      reason:
+        "The Go flag is built on Go's runtime/pprof profiler and emits Go-pprof-format artifacts that have no equivalent in Rust. Profiling Rust builds is done with external tooling (for example perf, cargo flamegraph, or samply) rather than a baked-in flag, so the Rust CLI deliberately does not carry it.",
       desiredBehavior:
-        "Rust CLI should either implement Go-compatible profiling or remove the flag.",
+        "Rust CLI should not expose --pprof-profile; the flag remains Go-only by design.",
       goBehavior: {
         exitCode: 0,
         files: [
@@ -888,16 +889,18 @@ export const cases: CliTestCase[] = [
   },
   {
     id: "known-difference-config-global",
-    description: "Go CLI accepts a config file; Rust parses --config but reports it unimplemented.",
-    tags: ["known-difference", "global-options"],
+    description: "Go CLI accepts a config file; Rust CLI intentionally does not expose --config.",
+    tags: ["known-difference", "intentional", "global-options"],
     setup: [{ type: "writeText", to: "{caseWorkDir}/config.yaml", contents: "{}\n" }],
     invocation: { args: ["--config", "{caseWorkDir}/config.yaml", "info", ONE_MESSAGE] },
     knownDifference: {
       id: "global-config",
-      summary: "Go CLI accepts --config but Rust CLI currently bails out as unimplemented.",
-      reason: "Global option support is incomplete in the Rust CLI.",
+      summary:
+        "Go CLI accepts --config; the Rust CLI intentionally omits the flag and rejects it as an unknown argument.",
+      reason:
+        "Go's --config loads a YAML file through viper and prints a confirmation line, but no Go command ever reads a value from it (there are no viper.Get* call sites), so the flag is effectively a no-op. Rather than reproduce a no-op flag, the Rust CLI deliberately omits --config until a real configuration system is designed for both CLIs.",
       desiredBehavior:
-        "Rust CLI should either implement Go-compatible config handling or remove the flag.",
+        "Rust CLI should not expose --config unless a future, intentionally designed configuration system is added to both CLIs.",
       goBehavior: {
         exitCode: 0,
         stderr: { kind: "contains", value: "Using config file:" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Rust CLI parsed two global flags, `--config` and `--pprof-profile`, but `main.rs` bailed with `'... is not implemented yet'` for both. Rather than reproduce Go-specific behavior, this PR removes them and documents both as intentional, Go-only differences.

Why drop rather than implement:

- **`--pprof-profile`** is built on Go's `runtime/pprof` and emits Go-pprof-format artifacts (`mcap-cpu.prof`, `mcap-mem.prof`, `mcap-block.pprof`) that have no equivalent in Rust. Idiomatic Rust profiling uses external tooling (`perf`, `cargo flamegraph`, `samply`), so a baked-in flag can't be made Go-compatible anyway.
- **`--config`** loads a YAML file through viper in the Go CLI and prints `Using config file: ...`, but **no Go command ever reads a value from it** (there are no `viper.Get*` call sites). The flag is effectively a no-op, so reproducing it in Rust would only add a no-op flag.

## Changes

- Remove `config` and `pprof_profile` global args from `rust/cli/src/cli.rs`.
- Remove the corresponding fields, constructor params, and accessors (plus the now-unused `PathBuf` import) from `rust/cli/src/context.rs`.
- Remove the two `bail!` "not implemented yet" guards in `rust/cli/src/main.rs`.
- Update the `known-difference-config-global` and `known-difference-pprof-profile-global` cases in `tests/cli-conformance/src/cases.ts` to describe these as intentional, Go-only differences. The Rust CLI now rejects the flags as unknown arguments (exit 2), while Go still accepts them.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f7c68c1-9cb8-467e-8ae1-5dc8f30e2f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f7c68c1-9cb8-467e-8ae1-5dc8f30e2f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

