### PR TITLE
cli: More conformance tests

### DIFF
--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -367,12 +367,59 @@ export const cases: CliTestCase[] = [
     },
   },
   {
+    id: "get-attachment-by-offset",
+    description: "Attachment extraction by record offset writes identical payload bytes.",
+    tags: ["get", "attachments", "bytes", "offset"],
+    invocation: {
+      args: ["get", "attachment", ONE_ATTACHMENT, "--offset", "25", "-o", "attachment.bin"],
+    },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text" },
+      files: [{ path: "attachment.bin", comparator: { kind: "bytes" } }],
+    },
+  },
+  {
     id: "doctor-valid-file-exits-successfully",
     description:
       "Doctor accepts a representative valid MCAP; warning stream differences are covered separately.",
     tags: ["doctor"],
     invocation: { args: ["doctor", ONE_MESSAGE] },
     comparison: EXIT_CODE_ONLY,
+  },
+  {
+    id: "doctor-strict-message-order-detects-out-of-order-log-time",
+    description: "Doctor strict message ordering rejects messages whose log times move backward.",
+    tags: ["doctor", "strict-message-order"],
+    setup: [
+      {
+        type: "writeProtobufJsonMcap",
+        to: "{caseWorkDir}/out-of-order.mcap",
+        messages: [
+          {
+            sequence: 1,
+            logTime: 3,
+            publishTime: 1,
+            snakeCase: "later",
+            count: 1,
+          },
+          {
+            sequence: 2,
+            logTime: 2,
+            publishTime: 2,
+            snakeCase: "earlier",
+            count: 2,
+          },
+        ],
+      },
+    ],
+    invocation: { args: ["doctor", "--strict-message-order", "out-of-order.mcap"] },
+    comparison: {
+      exitCode: 1,
+      stdout: { kind: "ignore" },
+      stderr: { kind: "ignore" },
+    },
   },
   ...[
     {
@@ -448,6 +495,117 @@ export const cases: CliTestCase[] = [
     },
   },
   {
+    id: "filter-exclude-topic-output-messages",
+    description: "Filtering with an exclude topic regex removes matching messages from output.",
+    tags: ["filter", "mcap-output", "topics"],
+    invocation: {
+      args: [
+        "filter",
+        TEN_MESSAGES,
+        "-o",
+        "filtered.mcap",
+        "-n",
+        "example",
+        "--output-compression",
+        "none",
+      ],
+    },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text", collapseWhitespace: true },
+      files: [
+        {
+          path: "filtered.mcap",
+          comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
+        },
+      ],
+    },
+  },
+  {
+    id: "filter-rfc3339-time-range-output-messages",
+    description: "Filtering with RFC3339 start/end bounds preserves the same message stream.",
+    tags: ["filter", "mcap-output", "time"],
+    invocation: {
+      args: [
+        "filter",
+        ONE_MESSAGE,
+        "-o",
+        "filtered.mcap",
+        "-S",
+        "1970-01-01T00:00:00.000000002Z",
+        "-E",
+        "1970-01-01T00:00:00.000000003Z",
+        "--output-compression",
+        "none",
+      ],
+    },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text", collapseWhitespace: true },
+      files: [
+        {
+          path: "filtered.mcap",
+          comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
+        },
+      ],
+    },
+  },
+  {
+    id: "filter-includes-metadata-and-attachments",
+    description: "Filtering with metadata and attachment flags preserves non-message records.",
+    tags: ["filter", "mcap-output", "metadata", "attachments"],
+    setup: [
+      {
+        type: "writeProtobufJsonMcap",
+        to: "{caseWorkDir}/content.mcap",
+        messages: [
+          {
+            sequence: 1,
+            logTime: 2,
+            publishTime: 1,
+            snakeCase: "hello",
+            count: 7,
+          },
+        ],
+        metadata: [{ name: "cli-conformance", metadata: { key: "value" } }],
+        attachments: [
+          {
+            name: "payload.bin",
+            mediaType: "application/octet-stream",
+            logTime: 4,
+            createTime: 3,
+            data: [1, 1, 2, 3, 5, 8],
+          },
+        ],
+      },
+    ],
+    invocation: {
+      args: [
+        "filter",
+        "content.mcap",
+        "-o",
+        "filtered.mcap",
+        "--include-metadata",
+        "--include-attachments",
+        "--output-compression",
+        "none",
+      ],
+    },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text", collapseWhitespace: true },
+      files: [
+        {
+          path: "filtered.mcap",
+          comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
+        },
+      ],
+    },
+  },
+  {
     id: "compress-none-output-messages",
     description: "Rewriting an MCAP with no output compression preserves the same message stream.",
     tags: ["compress", "mcap-output"],
@@ -505,6 +663,25 @@ export const cases: CliTestCase[] = [
     },
   },
   {
+    id: "compress-unchunked-output-content",
+    description: "Rewriting an MCAP with unchunked output preserves content.",
+    tags: ["compress", "mcap-output", "unchunked"],
+    invocation: {
+      args: ["compress", TEN_MESSAGES, "-o", "compressed-unchunked.mcap", "--unchunked"],
+    },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text", collapseWhitespace: true },
+      files: [
+        {
+          path: "compressed-unchunked.mcap",
+          comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
+        },
+      ],
+    },
+  },
+  {
     id: "decompress-output-messages",
     description: "Decompressing an MCAP preserves the same message stream.",
     tags: ["decompress", "mcap-output"],
@@ -556,6 +733,35 @@ export const cases: CliTestCase[] = [
       files: [
         {
           path: "merged.mcap",
+          comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
+        },
+      ],
+    },
+  },
+  {
+    id: "merge-coalesce-channels-none-output-messages",
+    description: "Merging with channel coalescing disabled preserves the same combined message stream.",
+    tags: ["merge", "mcap-output", "coalesce-channels"],
+    invocation: {
+      args: [
+        "merge",
+        ONE_MESSAGE,
+        ONE_MESSAGE,
+        "-o",
+        "merged-no-coalesce.mcap",
+        "--compression",
+        "none",
+        "--coalesce-channels",
+        "none",
+      ],
+    },
+    comparison: {
+      exitCode: 0,
+      stdout: { kind: "text" },
+      stderr: { kind: "text", collapseWhitespace: true },
+      files: [
+        {
+          path: "merged-no-coalesce.mcap",
           comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
         },
       ],
@@ -803,6 +1009,38 @@ export const cases: CliTestCase[] = [
       rustBehavior: {
         exitCode: "nonzero",
         stderr: { kind: "contains", value: "unsupported input file extension" },
+      },
+    },
+  },
+  {
+    id: "known-difference-convert-bool-space-values",
+    description:
+      "Convert rejects space-separated explicit bool values with implementation-specific parse errors.",
+    tags: ["known-difference", "convert", "surface"],
+    invocation: {
+      args: [
+        "convert",
+        NOETIC_MULTITOPIC_NONE,
+        "converted.mcap",
+        "--include-crc",
+        "false",
+      ],
+    },
+    knownDifference: {
+      id: "convert-bool-space-values",
+      summary:
+        "Go and Rust both reject 'convert --include-crc false', but report different parse failures.",
+      reason:
+        "The Rust CLI requires explicit bool values to use the '--flag=<value>' form, while the Go CLI's Cobra parser leaves the trailing value as an extra positional argument for this command.",
+      desiredBehavior:
+        "Keep requiring '--include-crc=false' for explicit Rust bool values unless the CLI parser policy changes before v1.0.",
+      goBehavior: {
+        exitCode: 1,
+        stderr: { kind: "contains", value: "accepts 2 arg(s), received 3" },
+      },
+      rustBehavior: {
+        exitCode: 2,
+        stderr: { kind: "contains", value: "unexpected argument 'false'" },
       },
     },
   },

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -378,6 +378,7 @@ export const cases: CliTestCase[] = [
         "--name",
         "myFile",
         "--offset",
+        // 8-byte magic + 1-byte header opcode + 8-byte header length + two empty MCAP strings.
         "25",
         "-o",
         "attachment.bin",
@@ -406,6 +407,7 @@ export const cases: CliTestCase[] = [
       {
         type: "writeProtobufJsonMcap",
         to: "{caseWorkDir}/out-of-order.mcap",
+        chunkedMessages: true,
         messages: [
           {
             sequence: 1,

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -9,6 +9,8 @@ const ONE_SCHEMALESS =
   "{dataDir}/OneSchemalessMessage/OneSchemalessMessage-ch-chx-mx-pad-rch-st.mcap";
 const TEN_MESSAGES = "{dataDir}/TenMessages/TenMessages-ch-chx-mx-pad-rch-rsh-st-sum.mcap";
 const ONE_ATTACHMENT = "{dataDir}/OneAttachment/OneAttachment-ax-st-sum.mcap";
+// 8-byte magic + 1-byte header opcode + 8-byte header length + two empty MCAP strings.
+const ONE_ATTACHMENT_RECORD_OFFSET = "25";
 const ONE_METADATA = "{dataDir}/OneMetadata/OneMetadata-mdx-st-sum.mcap";
 const ROS2_EMBEDDED_SCHEMA_DB3 = "{repoRoot}/testdata/db3/talker-iron.db3";
 const NOETIC_MULTITOPIC_NONE = "{repoRoot}/testdata/bags/generated/noetic-multitopic-none.bag";
@@ -378,8 +380,7 @@ export const cases: CliTestCase[] = [
         "--name",
         "myFile",
         "--offset",
-        // 8-byte magic + 1-byte header opcode + 8-byte header length + two empty MCAP strings.
-        "25",
+        ONE_ATTACHMENT_RECORD_OFFSET,
         "-o",
         "attachment.bin",
       ],

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -371,7 +371,17 @@ export const cases: CliTestCase[] = [
     description: "Attachment extraction by record offset writes identical payload bytes.",
     tags: ["get", "attachments", "bytes", "offset"],
     invocation: {
-      args: ["get", "attachment", ONE_ATTACHMENT, "--offset", "25", "-o", "attachment.bin"],
+      args: [
+        "get",
+        "attachment",
+        ONE_ATTACHMENT,
+        "--name",
+        "myFile",
+        "--offset",
+        "25",
+        "-o",
+        "attachment.bin",
+      ],
     },
     comparison: {
       exitCode: 0,
@@ -497,7 +507,7 @@ export const cases: CliTestCase[] = [
   {
     id: "filter-exclude-topic-output-messages",
     description: "Filtering with an exclude topic regex removes matching messages from output.",
-    tags: ["filter", "mcap-output", "topics"],
+    tags: ["known-difference", "filter", "mcap-output", "topics"],
     invocation: {
       args: [
         "filter",
@@ -510,16 +520,34 @@ export const cases: CliTestCase[] = [
         "none",
       ],
     },
-    comparison: {
-      exitCode: 0,
-      stdout: { kind: "text" },
-      stderr: { kind: "text", collapseWhitespace: true },
-      files: [
-        {
-          path: "filtered.mcap",
-          comparator: { kind: "mcap", mode: "content", allowSemanticFallback: true },
-        },
-      ],
+    knownDifference: {
+      id: "filter-exclude-topic-regex",
+      summary:
+        "Rust filter excludes matching topics with -n/--exclude-topic-regex; Go currently leaves matching messages in place.",
+      reason:
+        "The Rust CLI applies exclude regexes when rewriting the MCAP, while the legacy Go CLI's current output for this fixture still contains the excluded topic.",
+      desiredBehavior:
+        "Both CLIs should remove messages whose topics match -n/--exclude-topic-regex before Rust CLI v1.0.",
+      goBehavior: {
+        exitCode: 0,
+        files: [
+          {
+            path: "filtered.mcap",
+            exists: true,
+            mcapSummary: { messageCount: 10, channelCount: 1, schemaCount: 1 },
+          },
+        ],
+      },
+      rustBehavior: {
+        exitCode: 0,
+        files: [
+          {
+            path: "filtered.mcap",
+            exists: true,
+            mcapSummary: { messageCount: 0, channelCount: 0, schemaCount: 0 },
+          },
+        ],
+      },
     },
   },
   {
@@ -740,7 +768,8 @@ export const cases: CliTestCase[] = [
   },
   {
     id: "merge-coalesce-channels-none-output-messages",
-    description: "Merging with channel coalescing disabled preserves the same combined message stream.",
+    description:
+      "Merging with channel coalescing disabled preserves the same combined message stream.",
     tags: ["merge", "mcap-output", "coalesce-channels"],
     invocation: {
       args: [
@@ -1018,13 +1047,7 @@ export const cases: CliTestCase[] = [
       "Convert rejects space-separated explicit bool values with implementation-specific parse errors.",
     tags: ["known-difference", "convert", "surface"],
     invocation: {
-      args: [
-        "convert",
-        NOETIC_MULTITOPIC_NONE,
-        "converted.mcap",
-        "--include-crc",
-        "false",
-      ],
+      args: ["convert", NOETIC_MULTITOPIC_NONE, "converted.mcap", "--include-crc", "false"],
     },
     knownDifference: {
       id: "convert-bool-space-values",

--- a/tests/cli-conformance/src/protobufJsonFixture.ts
+++ b/tests/cli-conformance/src/protobufJsonFixture.ts
@@ -36,10 +36,12 @@ export type ProtobufJsonFixtureOptions = {
   messages: ProtobufJsonMessage[];
   metadata?: ProtobufJsonMetadata[];
   attachments?: ProtobufJsonAttachment[];
+  chunkedMessages?: boolean;
 };
 
 export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffer {
   const descriptor = sampleDescriptorSet();
+  const messageRecords = options.messages.map(messageRecord);
   const records = [
     record(0x01, Buffer.concat([mcapString(""), mcapString("")])),
     record(
@@ -55,18 +57,7 @@ export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffe
       0x04,
       Buffer.concat([uint16(1), uint16(1), mcapString("proto"), mcapString("protobuf"), uint32(0)]),
     ),
-    ...options.messages.map((message) =>
-      record(
-        0x05,
-        Buffer.concat([
-          uint16(1),
-          uint32(message.sequence),
-          uint64(message.logTime),
-          uint64(message.publishTime),
-          sampleMessage(message),
-        ]),
-      ),
-    ),
+    ...(options.chunkedMessages ? [chunkRecord(messageRecords, options.messages)] : messageRecords),
     ...(options.metadata ?? []).map((metadata) =>
       record(0x0c, Buffer.concat([mcapString(metadata.name), mcapStringMap(metadata.metadata)])),
     ),
@@ -89,6 +80,45 @@ export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffe
     record(0x02, Buffer.concat([uint64(0), uint64(0), uint32(0)])),
   ];
   return Buffer.concat([MCAP_MAGIC, ...records, MCAP_MAGIC]);
+}
+
+function messageRecord(message: ProtobufJsonMessage): Buffer {
+  return record(
+    0x05,
+    Buffer.concat([
+      uint16(1),
+      uint32(message.sequence),
+      uint64(message.logTime),
+      uint64(message.publishTime),
+      sampleMessage(message),
+    ]),
+  );
+}
+
+function chunkRecord(records: Buffer[], messages: ProtobufJsonMessage[]): Buffer {
+  const chunkRecords = Buffer.concat(records);
+  const logTimes = messages.map((message) => BigInt(message.logTime));
+  const messageStartTime = logTimes.reduce(
+    (min, value) => (value < min ? value : min),
+    logTimes[0] ?? 0n,
+  );
+  const messageEndTime = logTimes.reduce(
+    (max, value) => (value > max ? value : max),
+    logTimes[0] ?? 0n,
+  );
+
+  return record(
+    0x06,
+    Buffer.concat([
+      uint64(messageStartTime),
+      uint64(messageEndTime),
+      uint64(chunkRecords.length),
+      uint32(0),
+      mcapString(""),
+      uint64(chunkRecords.length),
+      chunkRecords,
+    ]),
+  );
 }
 
 function mcapStringMap(values: Record<string, string>): Buffer {

--- a/tests/cli-conformance/src/protobufJsonFixture.ts
+++ b/tests/cli-conformance/src/protobufJsonFixture.ts
@@ -19,8 +19,23 @@ type ProtobufJsonMessage = {
   count: number;
 };
 
+type ProtobufJsonMetadata = {
+  name: string;
+  metadata: Record<string, string>;
+};
+
+type ProtobufJsonAttachment = {
+  name: string;
+  mediaType: string;
+  logTime: bigint | number;
+  createTime: bigint | number;
+  data: number[];
+};
+
 export type ProtobufJsonFixtureOptions = {
   messages: ProtobufJsonMessage[];
+  metadata?: ProtobufJsonMetadata[];
+  attachments?: ProtobufJsonAttachment[];
 };
 
 export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffer {
@@ -52,10 +67,35 @@ export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffe
         ]),
       ),
     ),
+    ...(options.metadata ?? []).map((metadata) =>
+      record(0x0c, Buffer.concat([mcapString(metadata.name), mcapStringMap(metadata.metadata)])),
+    ),
+    ...(options.attachments ?? []).map((attachment) => {
+      const data = Buffer.from(attachment.data);
+      return record(
+        0x09,
+        Buffer.concat([
+          uint64(attachment.logTime),
+          uint64(attachment.createTime),
+          mcapString(attachment.name),
+          mcapString(attachment.mediaType),
+          uint64(data.length),
+          data,
+          uint32(0),
+        ]),
+      );
+    }),
     record(0x0f, uint32(0)),
     record(0x02, Buffer.concat([uint64(0), uint64(0), uint32(0)])),
   ];
   return Buffer.concat([MCAP_MAGIC, ...records, MCAP_MAGIC]);
+}
+
+function mcapStringMap(values: Record<string, string>): Buffer {
+  const entries = Object.entries(values).map(([key, value]) =>
+    Buffer.concat([mcapString(key), mcapString(value)]),
+  );
+  return prefixedBytes(Buffer.concat(entries));
 }
 
 function sampleDescriptorSet(): Buffer {

--- a/tests/cli-conformance/src/protobufJsonFixture.ts
+++ b/tests/cli-conformance/src/protobufJsonFixture.ts
@@ -57,7 +57,9 @@ export function makeProtobufJsonMcap(options: ProtobufJsonFixtureOptions): Buffe
       0x04,
       Buffer.concat([uint16(1), uint16(1), mcapString("proto"), mcapString("protobuf"), uint32(0)]),
     ),
-    ...(options.chunkedMessages ? [chunkRecord(messageRecords, options.messages)] : messageRecords),
+    ...(options.chunkedMessages === true
+      ? [chunkRecord(messageRecords, options.messages)]
+      : messageRecords),
     ...(options.metadata ?? []).map((metadata) =>
       record(0x0c, Buffer.concat([mcapString(metadata.name), mcapStringMap(metadata.metadata)])),
     ),

--- a/tests/cli-conformance/src/types.ts
+++ b/tests/cli-conformance/src/types.ts
@@ -36,6 +36,17 @@ export type FixtureAction =
         zeroValue?: number;
         count: number;
       }>;
+      metadata?: Array<{
+        name: string;
+        metadata: Record<string, string>;
+      }>;
+      attachments?: Array<{
+        name: string;
+        mediaType: string;
+        logTime: bigint | number;
+        createTime: bigint | number;
+        data: number[];
+      }>;
     }
   | {
       type: "writeRos1JsonMcap";

--- a/tests/cli-conformance/src/types.ts
+++ b/tests/cli-conformance/src/types.ts
@@ -47,6 +47,7 @@ export type FixtureAction =
         createTime: bigint | number;
         data: number[];
       }>;
+      chunkedMessages?: boolean;
     }
   | {
       type: "writeRos1JsonMcap";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
None

### Docs
None

### Description
Adds CLI conformance coverage for Rust flag surfaces that were previously thinly tested: attachment lookup by offset, strict doctor ordering, filter RFC3339/content flags, unchunked compression, merge channel coalescing, and documented differences for filter exclusion plus convert bool parsing.

### Testing
- [x] Run `yarn workspace @foxglove/mcap-cli-conformance lint:ci` and verify lint/typecheck passes.
- [x] Run `yarn test:cli-conformance --go-bin "$(pwd)/go/cli/mcap/bin/mcap" --rust-bin "$(pwd)/rust/target/debug/mcap"` and verify the suite passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3d5ba3-02af-4d1f-a633-0f5b013feacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3d5ba3-02af-4d1f-a633-0f5b013feacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

