### PR TITLE
rust: Update GitHub Actions toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,21 +553,11 @@ jobs:
           echo "rust/cli/Cargo.toml version ($cargo_version) matches release tag"
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup target add ${{ matrix.target }}
-      - name: Install Zig
+      - name: Setup Zig
         if: matrix.os == 'linux'
-        run: |
-          zig_version=0.16.0
-          zig_sha256=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
-          zig_dir="${RUNNER_TEMP}/zig-${zig_version}"
-          zig_archive="${RUNNER_TEMP}/zig-${zig_version}.tar.xz"
-          mkdir -p "$zig_dir"
-          curl --fail --location --retry 3 \
-            --output "$zig_archive" \
-            "https://ziglang.org/download/${zig_version}/zig-x86_64-linux-${zig_version}.tar.xz"
-          echo "${zig_sha256}  ${zig_archive}" | sha256sum --check
-          tar -xJf "$zig_archive" --strip-components=1 -C "$zig_dir"
-          echo "$zig_dir" >> "$GITHUB_PATH"
-          "$zig_dir/zig" version
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
       - name: Install cargo-zigbuild
         if: matrix.os == 'linux'
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,7 @@ jobs:
         with:
           node-version: 24.x
           cache: yarn
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo build -p mcap --example=conformance_reader --example=conformance_reader_async --example=conformance_writer --example=conformance_indexed_reader --features=tokio
         working-directory: rust
       - run: yarn install --immutable
@@ -184,10 +181,7 @@ jobs:
         with:
           go-version-file: go/go.work
           cache: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: yarn install --immutable
       - run: make -C go/cli/mcap build
       - run: cargo build -p mcap-cli
@@ -557,16 +551,23 @@ jobs:
             exit 1
           fi
           echo "rust/cli/Cargo.toml version ($cargo_version) matches release tag"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: rustup target add ${{ matrix.target }}
-      - name: Setup Zig
+      - name: Install Zig
         if: matrix.os == 'linux'
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
+        run: |
+          zig_version=0.16.0
+          zig_sha256=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
+          zig_dir="${RUNNER_TEMP}/zig-${zig_version}"
+          zig_archive="${RUNNER_TEMP}/zig-${zig_version}.tar.xz"
+          mkdir -p "$zig_dir"
+          curl --fail --location --retry 3 \
+            --output "$zig_archive" \
+            "https://ziglang.org/download/${zig_version}/zig-x86_64-linux-${zig_version}.tar.xz"
+          echo "${zig_sha256}  ${zig_archive}" | sha256sum --check
+          tar -xJf "$zig_archive" --strip-components=1 -C "$zig_dir"
+          echo "$zig_dir" >> "$GITHUB_PATH"
+          "$zig_dir/zig" version
       - name: Install cargo-zigbuild
         if: matrix.os == 'linux'
         uses: taiki-e/install-action@v2
@@ -622,11 +623,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          components: "rustfmt, clippy"
+          components: rustfmt, clippy
       - run: rustup target add wasm32-unknown-unknown
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- --no-deps -D warnings


### PR DESCRIPTION
Replace the unmaintained `actions-rs/toolchain@v1` usage in Rust CI jobs with `dtolnay/rust-toolchain@stable`.