### PR TITLE
actions: Fix Go cache dependency paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go/go.work
+          cache-dependency-path: |
+            go/go.work
+            go/**/go.mod
+            go/**/go.sum
       - run: cd go && make build-conformance-binaries
       - run: yarn install --immutable
       - run: yarn test:conformance:generate-inputs --verify
@@ -181,6 +185,10 @@ jobs:
         with:
           go-version-file: go/go.work
           cache: true
+          cache-dependency-path: |
+            go/go.work
+            go/**/go.mod
+            go/**/go.sum
       - uses: dtolnay/rust-toolchain@stable
       - run: yarn install --immutable
       - run: make -C go/cli/mcap build
@@ -406,6 +414,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go/go.work
+          cache-dependency-path: |
+            go/go.work
+            go/**/go.mod
+            go/**/go.sum
       - name: install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
       - run: make lint
@@ -467,6 +479,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go/go.work
+          cache-dependency-path: |
+            go/go.work
+            go/**/go.mod
+            go/**/go.sum
       - name: Setup environment
         run: ${{ matrix.setup }}
       - name: Build binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           go-version-file: go/go.work
           cache-dependency-path: |
             go/go.work
+            go/go.work.sum
             go/**/go.mod
             go/**/go.sum
       - run: cd go && make build-conformance-binaries
@@ -187,6 +188,7 @@ jobs:
           cache: true
           cache-dependency-path: |
             go/go.work
+            go/go.work.sum
             go/**/go.mod
             go/**/go.sum
       - uses: dtolnay/rust-toolchain@stable
@@ -416,6 +418,7 @@ jobs:
           go-version-file: go/go.work
           cache-dependency-path: |
             go/go.work
+            go/go.work.sum
             go/**/go.mod
             go/**/go.sum
       - name: install golangci-lint
@@ -481,6 +484,7 @@ jobs:
           go-version-file: go/go.work
           cache-dependency-path: |
             go/go.work
+            go/go.work.sum
             go/**/go.mod
             go/**/go.sum
       - name: Setup environment


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix 9 warnings that were showing up in GitHub Actions:

```
Restore cache failed: Dependencies file is not found in /home/runner/work/mcap/mcap. Supported file pattern: go.mod
```

- Configure GitHub Actions `setup-go` cache dependency paths for the `go/` workspace modules.
- Include `go/go.work`, `go/go.work.sum`, module `go.mod`, and module `go.sum` files in the cache key.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5557f4f2-748d-468f-a997-642b428c241a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5557f4f2-748d-468f-a997-642b428c241a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

