### PR TITLE
cli: Handle missing summary schemas in info/list

### DIFF
--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1544,6 +1544,34 @@ mod tests {
     }
 
     #[test]
+    fn cat_json_passes_schemaless_json_messages() {
+        let message = sample_message(None, br#"{"value":1}"#.to_vec());
+        let mut out = Vec::new();
+        let mut transcoders = JsonTranscoders::default();
+        let opts = CatOptions {
+            json: true,
+            ..CatOptions::default()
+        };
+        let cat_message = super::CatMessage {
+            channel: &message.channel,
+            sequence: message.sequence,
+            log_time: message.log_time,
+            publish_time: message.publish_time,
+            data: message.data.as_ref(),
+        };
+        let broken_pipe = super::write_message(&mut out, cat_message, &opts, &mut transcoders)
+            .expect("schemaless json message should write");
+        assert!(!broken_pipe);
+
+        assert_eq!(
+            String::from_utf8(out).expect("valid utf8 output"),
+            r#"{"topic":"/demo","sequence":1,"log_time":0.000000042,"publish_time":0.000000043,"data":{"value":1}}"#
+                .to_string()
+                + "\n"
+        );
+    }
+
+    #[test]
     fn protobuf_json_uses_lower_camel_case_and_omits_zero_values() {
         let descriptor = vec![
             10, 122, 10, 12, 115, 97, 109, 112, 108, 101, 46, 112, 114, 111, 116, 111, 18, 4, 116,

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Context, Result};
 use mcap::records::{self, Record};
 
 const FOOTER_RECORD_LEN: usize = 1 + 8 + 8 + 8 + 4;
-const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = FOOTER_RECORD_LEN + mcap::MAGIC.len();
+pub(crate) const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = FOOTER_RECORD_LEN + mcap::MAGIC.len();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedSchema {
@@ -265,7 +265,7 @@ pub(crate) fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::{parse_mcap, parse_mcap_from_summary};
+    use super::{parse_mcap, parse_mcap_from_summary, parse_summary_section};
     use mcap::records;
 
     #[test]
@@ -373,6 +373,49 @@ mod tests {
             .expect("channel should be read from summary");
         assert_eq!(channel.schema_id, schema_id);
         assert!(!parsed.schemas.contains_key(&schema_id));
+    }
+
+    #[test]
+    fn parse_summary_section_accepts_channel_with_missing_schema() {
+        let mut buffer = Vec::new();
+        let (schema_id, channel_id) = {
+            let mut writer = mcap::WriteOptions::new()
+                .repeat_schemas(false)
+                .repeat_channels(true)
+                .create(std::io::Cursor::new(&mut buffer))
+                .expect("writer");
+            let schema_id = writer
+                .add_schema("demo_schema", "jsonschema", br#"{"type":"object"}"#)
+                .expect("schema");
+            let channel_id = writer
+                .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
+                .expect("channel");
+            writer
+                .write_to_known_channel(
+                    &records::MessageHeader {
+                        channel_id,
+                        sequence: 1,
+                        log_time: 10,
+                        publish_time: 11,
+                    },
+                    br#"{"k":"v"}"#,
+                )
+                .expect("write message");
+            writer.finish().expect("finish writer");
+            (schema_id, channel_id)
+        };
+
+        let footer = mcap::read::footer(&buffer).expect("footer");
+        let footer_start = buffer.len() - super::FOOTER_RECORD_AND_END_MAGIC_LEN;
+        let summary = parse_summary_section(&buffer[footer.summary_start as usize..footer_start])
+            .expect("summary should parse without repeated schema");
+        let channel = summary
+            .channels
+            .get(&channel_id)
+            .expect("channel should be preserved");
+        assert_eq!(channel.id, channel_id);
+        assert!(channel.schema.is_none());
+        assert!(!summary.schemas.contains_key(&schema_id));
     }
 
     #[test]

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -2,8 +2,11 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use mcap::records::{self, Record};
+
+const FOOTER_RECORD_LEN: usize = 1 + 8 + 8 + 8 + 4;
+const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = FOOTER_RECORD_LEN + mcap::MAGIC.len();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedSchema {
@@ -47,56 +50,39 @@ fn parse_mcap_from_summary(
     mcap: &[u8],
     header: Option<records::Header>,
 ) -> Result<Option<ParsedMcap>> {
-    let Some(summary) = mcap::Summary::read(mcap)? else {
+    let footer = mcap::read::footer(mcap)?;
+    if footer.summary_start == 0 {
         return Ok(None);
-    };
-    Ok(Some(parsed_mcap_from_summary_ref(header, &summary)))
+    }
+
+    let footer_start = mcap
+        .len()
+        .checked_sub(FOOTER_RECORD_AND_END_MAGIC_LEN)
+        .context("input is too short to contain a footer")?;
+    let summary_start =
+        usize::try_from(footer.summary_start).context("summary offset is too large")?;
+    if summary_start > footer_start {
+        return Err(mcap::McapError::UnexpectedEof.into());
+    }
+
+    Ok(Some(parsed_mcap_from_summary_section(
+        header,
+        &mcap[summary_start..footer_start],
+    )?))
 }
 
-pub(crate) fn parsed_mcap_from_summary_ref(
+pub(crate) fn parsed_mcap_from_summary_section(
     header: Option<records::Header>,
-    summary: &mcap::Summary,
-) -> ParsedMcap {
+    summary: &[u8],
+) -> Result<ParsedMcap> {
     let mut out = ParsedMcap {
         header,
-        statistics: summary.stats.clone(),
-        channels: std::collections::BTreeMap::new(),
-        schemas: std::collections::BTreeMap::new(),
-        chunk_indexes: summary.chunk_indexes.clone(),
-        attachment_indexes: summary.attachment_indexes.clone(),
-        metadata_indexes: summary.metadata_indexes.clone(),
+        ..ParsedMcap::default()
     };
-
-    for schema in summary.schemas.values() {
-        let schema = schema.as_ref();
-        out.schemas.insert(
-            schema.id,
-            ParsedSchema {
-                header: records::SchemaHeader {
-                    id: schema.id,
-                    name: schema.name.clone(),
-                    encoding: schema.encoding.clone(),
-                },
-                data: schema.data.clone().into_owned(),
-            },
-        );
+    for record in mcap::read::LinearReader::sans_magic(summary) {
+        collect_record(&mut out, record?)?;
     }
-
-    for channel in summary.channels.values() {
-        let channel = channel.as_ref();
-        out.channels.insert(
-            channel.id,
-            records::Channel {
-                id: channel.id,
-                schema_id: channel.schema.as_ref().map(|schema| schema.id).unwrap_or(0),
-                topic: channel.topic.clone(),
-                message_encoding: channel.message_encoding.clone(),
-                metadata: channel.metadata.clone(),
-            },
-        );
-    }
-
-    out
+    Ok(out)
 }
 
 fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<ParsedMcap> {
@@ -167,6 +153,7 @@ fn collect_record(out: &mut ParsedMcap, record: Record<'_>) -> Result<()> {
 pub(crate) fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
     let mut out = mcap::Summary::default();
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
+    let mut channel_defs = HashMap::<u16, records::Channel>::new();
 
     for record in mcap::read::LinearReader::sans_magic(summary) {
         match record? {
@@ -201,44 +188,42 @@ pub(crate) fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
                     }
                 }
             }
-            Record::Channel(channel) => {
-                let schema = if channel.schema_id == 0 {
-                    None
-                } else {
-                    Some(schemas.get(&channel.schema_id).cloned().ok_or_else(|| {
-                        mcap::McapError::UnknownSchema(channel.topic.clone(), channel.schema_id)
-                    })?)
-                };
-                let resolved = Arc::new(mcap::Channel {
+            Record::Channel(channel) => match channel_defs.entry(channel.id) {
+                std::collections::hash_map::Entry::Occupied(entry) => {
+                    let existing = entry.get();
+                    if existing != &channel {
+                        return Err(
+                            mcap::McapError::ConflictingChannels(channel.topic.clone()).into()
+                        );
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(channel);
+                }
+            },
+            _ => {}
+        }
+    }
+    out.channels = channel_defs
+        .into_iter()
+        .map(|(id, channel)| {
+            let schema = if channel.schema_id == 0 {
+                None
+            } else {
+                schemas.get(&channel.schema_id).cloned()
+            };
+            (
+                id,
+                Arc::new(mcap::Channel {
                     id: channel.id,
                     topic: channel.topic,
                     schema,
                     message_encoding: channel.message_encoding,
                     metadata: channel.metadata,
-                });
-                match out.channels.entry(resolved.id) {
-                    std::collections::hash_map::Entry::Occupied(entry) => {
-                        let existing = entry.get();
-                        if existing.topic != resolved.topic
-                            || existing.schema.as_ref().map(|schema| schema.id)
-                                != resolved.schema.as_ref().map(|schema| schema.id)
-                            || existing.message_encoding != resolved.message_encoding
-                            || existing.metadata != resolved.metadata
-                        {
-                            return Err(mcap::McapError::ConflictingChannels(
-                                resolved.topic.clone(),
-                            )
-                            .into());
-                        }
-                    }
-                    std::collections::hash_map::Entry::Vacant(entry) => {
-                        entry.insert(resolved);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
+                }),
+            )
+        })
+        .collect();
     out.schemas = schemas;
     Ok(out)
 }
@@ -349,6 +334,45 @@ mod tests {
         assert!(parsed.header.is_some());
         assert!(parsed.channels.contains_key(&channel_id));
         assert!(parsed.schemas.contains_key(&schema_id));
+    }
+
+    #[test]
+    fn parse_mcap_preserves_missing_summary_schema_id() {
+        let mut buffer = Vec::new();
+        let (schema_id, channel_id) = {
+            let mut writer = mcap::WriteOptions::new()
+                .repeat_schemas(false)
+                .repeat_channels(true)
+                .create(std::io::Cursor::new(&mut buffer))
+                .expect("writer");
+            let schema_id = writer
+                .add_schema("demo_schema", "jsonschema", br#"{"type":"object"}"#)
+                .expect("schema");
+            let channel_id = writer
+                .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
+                .expect("channel");
+            writer
+                .write_to_known_channel(
+                    &records::MessageHeader {
+                        channel_id,
+                        sequence: 1,
+                        log_time: 10,
+                        publish_time: 11,
+                    },
+                    br#"{"k":"v"}"#,
+                )
+                .expect("write message");
+            writer.finish().expect("finish writer");
+            (schema_id, channel_id)
+        };
+
+        let parsed = parse_mcap(&buffer).expect("parse mcap");
+        let channel = parsed
+            .channels
+            .get(&channel_id)
+            .expect("channel should be read from summary");
+        assert_eq!(channel.schema_id, schema_id);
+        assert!(!parsed.schemas.contains_key(&schema_id));
     }
 
     #[test]

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -19,7 +19,6 @@ use crate::render::human_bytes;
 pub const PLEASE_REDIRECT: &str =
     "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
 pub const PLEASE_SUPPLY_FILE: &str = "please supply a file. see --help for usage details.";
-const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = 37;
 // Size of the single range request issued from the end of a remote file to discover
 // the summary section. One read proves range support (for HTTP), discovers the file
 // size via `Content-Range`, and in the common case already contains the whole summary
@@ -947,7 +946,7 @@ fn read_summary_bytes_from_remote(
     options: SourceOptions,
 ) -> Result<Option<Vec<u8>>> {
     let file_size = reader.size();
-    let tail_len = FOOTER_RECORD_AND_END_MAGIC_LEN as u64;
+    let tail_len = parse::FOOTER_RECORD_AND_END_MAGIC_LEN as u64;
     if file_size < tail_len + mcap::MAGIC.len() as u64 {
         return Err(classify_remote_summary_error(
             reader,
@@ -976,7 +975,7 @@ fn read_summary_bytes_from_remote(
     );
 
     let footer_start = file_size - tail_len;
-    let footer_bytes = &tail.bytes[tail.bytes.len() - FOOTER_RECORD_AND_END_MAGIC_LEN..];
+    let footer_bytes = &tail.bytes[tail.bytes.len() - parse::FOOTER_RECORD_AND_END_MAGIC_LEN..];
     if footer_bytes[0] != records::op::FOOTER {
         return Err(classify_remote_summary_error(
             reader,
@@ -991,15 +990,16 @@ fn read_summary_bytes_from_remote(
             mcap::McapError::BadFooter.into(),
         ));
     }
-    if &footer_bytes[FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()..] != mcap::MAGIC {
+    if &footer_bytes[parse::FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()..] != mcap::MAGIC {
         return Err(classify_remote_summary_error(
             reader,
             mcap::McapError::BadMagic.into(),
         ));
     }
 
-    let mut cursor =
-        std::io::Cursor::new(&footer_bytes[9..FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()]);
+    let mut cursor = std::io::Cursor::new(
+        &footer_bytes[9..parse::FOOTER_RECORD_AND_END_MAGIC_LEN - mcap::MAGIC.len()],
+    );
     let footer = records::Footer::read_le(&mut cursor)
         .map_err(|err| classify_remote_summary_error(reader, err.into()))?;
     if footer.summary_start == 0 {
@@ -1595,12 +1595,12 @@ mod tests {
     #[test]
     fn remote_summary_read_requires_scan_for_oversized_summary_section() {
         let len = super::MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN
-            + super::FOOTER_RECORD_AND_END_MAGIC_LEN
+            + crate::parse::FOOTER_RECORD_AND_END_MAGIC_LEN
             + mcap::MAGIC.len()
             + 1;
         let mut body = vec![0u8; len];
         body[..mcap::MAGIC.len()].copy_from_slice(mcap::MAGIC);
-        let footer_start = len - super::FOOTER_RECORD_AND_END_MAGIC_LEN;
+        let footer_start = len - crate::parse::FOOTER_RECORD_AND_END_MAGIC_LEN;
         body[footer_start] = records::op::FOOTER;
         body[footer_start + 1..footer_start + 9].copy_from_slice(&20u64.to_le_bytes());
         body[footer_start + 9..footer_start + 17]
@@ -1893,7 +1893,7 @@ mod tests {
         // Simulate a summary larger than the prefetched tail: the tail starts after
         // `summary_start`, so discovery must issue one back-fill read for the prefix.
         let (buffer, channel_id) = summary_mcap_with_channel();
-        let footer_start = buffer.len() - super::FOOTER_RECORD_AND_END_MAGIC_LEN;
+        let footer_start = buffer.len() - crate::parse::FOOTER_RECORD_AND_END_MAGIC_LEN;
         let summary_start = u64::from_le_bytes(
             buffer[footer_start + 9..footer_start + 17]
                 .try_into()

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -6,7 +6,6 @@ use anyhow::{bail, Context, Result};
 use binrw::BinRead;
 use futures_util::TryStreamExt;
 use mcap::records::{self, Record};
-use mcap::sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions};
 use memmap2::Mmap;
 use object_store::{
     path::Path as ObjectStorePath, Attribute, GetOptions, GetRange, ObjectStore, ObjectStoreExt,
@@ -153,11 +152,14 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
     if is_remote_url(path) {
         match open_remote_range_reader(path)? {
             Some(mut reader) => {
-                if let Some(summary) = read_summary_from_remote(&mut reader, options)
+                if let Some(summary_bytes) = read_summary_bytes_from_remote(&mut reader, options)
                     .map_err(|err| remote_read_error(path, err))?
                 {
                     let header = read_header_from_seekable(&mut reader)?;
-                    return Ok(parse::parsed_mcap_from_summary_ref(header, &summary));
+                    return parse::parsed_mcap_from_summary_section(header, &summary_bytes)
+                        .map_err(|err| {
+                            remote_read_error(path, classify_remote_summary_error(&reader, err))
+                        });
                 }
                 if !options.allow_remote_scan {
                     bail!(
@@ -175,12 +177,6 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
                 );
             }
             None => {}
-        }
-    } else {
-        let mut source = open_seekable_mcap_source(path)?;
-        let header = read_header_from_seekable(&mut source)?;
-        if let Some(summary) = read_summary_from_seekable(&mut source)? {
-            return Ok(parse::parsed_mcap_from_summary_ref(header, &summary));
         }
     }
 
@@ -938,6 +934,18 @@ fn read_summary_from_remote(
     reader: &mut RemoteRangeReader,
     options: SourceOptions,
 ) -> Result<Option<mcap::Summary>> {
+    let Some(summary_bytes) = read_summary_bytes_from_remote(reader, options)? else {
+        return Ok(None);
+    };
+    parse::parse_summary_section(&summary_bytes)
+        .map(Some)
+        .map_err(|err| classify_remote_summary_error(reader, err))
+}
+
+fn read_summary_bytes_from_remote(
+    reader: &mut RemoteRangeReader,
+    options: SourceOptions,
+) -> Result<Option<Vec<u8>>> {
     let file_size = reader.size();
     let tail_len = FOOTER_RECORD_AND_END_MAGIC_LEN as u64;
     if file_size < tail_len + mcap::MAGIC.len() as u64 {
@@ -1039,9 +1047,7 @@ fn read_summary_from_remote(
             mcap::McapError::UnexpectedEof.into(),
         ));
     }
-    parse::parse_summary_section(&summary_bytes)
-        .map(Some)
-        .map_err(|err| classify_remote_summary_error(reader, err))
+    Ok(Some(summary_bytes))
 }
 
 fn classify_remote_summary_error(reader: &RemoteRangeReader, err: anyhow::Error) -> anyhow::Error {
@@ -1089,27 +1095,6 @@ fn remote_range_matches_magic(reader: &RemoteRangeReader, offset: u64) -> Option
 
 fn recoverable_mcap_error() -> &'static str {
     "MCAP file appears truncated or incomplete (try running `mcap --allow-remote-scan recover`)"
-}
-
-fn read_summary_from_seekable(
-    reader: &mut (impl std::io::Read + std::io::Seek),
-) -> Result<Option<mcap::Summary>> {
-    let file_size = reader.seek(SeekFrom::End(0))?;
-    let mut summary_reader =
-        SummaryReader::new_with_options(SummaryReaderOptions::default().with_file_size(file_size));
-    while let Some(event) = summary_reader.next_event() {
-        match event? {
-            SummaryReadEvent::ReadRequest(n) => {
-                let read = reader.read(summary_reader.insert(n))?;
-                summary_reader.notify_read(read);
-            }
-            SummaryReadEvent::SeekRequest(to) => {
-                let pos = reader.seek(to)?;
-                summary_reader.notify_seeked(pos);
-            }
-        }
-    }
-    Ok(summary_reader.finish())
 }
 
 fn read_header_from_seekable(


### PR DESCRIPTION
## Description
- Preserve raw channel schema IDs when the Rust CLI parses summary sections.
- Allow summary channel records to omit repeated schema records without aborting `info`/`list`.
- Share the footer length constant between local and remote summary parsing.
- Add regression coverage for both `ParsedMcap` and `mcap::Summary` missing-schema summary paths, plus schemaless `cat --json` output.

Fixes https://github.com/foxglove/mcap/issues/1691