### PR TITLE
cli: Fix cat on chunked files with no schema in summary section

### DIFF
--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -130,6 +130,18 @@ fn cat_indexed(
     if summary.chunk_indexes.is_empty() {
         return Ok(None);
     }
+    if summary
+        .chunk_indexes
+        .iter()
+        .any(|chunk| chunk.message_index_offsets.is_empty())
+    {
+        return Ok(None);
+    }
+
+    let chunk_indexes_by_data_offset = chunk_indexes_by_data_offset(&summary)?;
+    let mut schemas = summary.schemas.clone();
+    let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
+    let mut channels = summary.channels.clone();
 
     let included_topics: BTreeSet<String> = summary
         .channels
@@ -137,7 +149,7 @@ fn cat_indexed(
         .filter(|channel| opts.include_topic(&channel.topic))
         .map(|channel| channel.topic.clone())
         .collect();
-    if !opts.topics.is_empty() && included_topics.is_empty() {
+    if !opts.topics.is_empty() && included_topics.is_empty() && !summary.channels.is_empty() {
         return Ok(Some(false));
     }
 
@@ -149,7 +161,7 @@ fn cat_indexed(
     if let Some(end) = opts.end {
         indexed_opts = indexed_opts.log_time_before(end);
     }
-    if !opts.topics.is_empty() {
+    if !opts.topics.is_empty() && !included_topics.is_empty() {
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
 
@@ -158,6 +170,15 @@ fn cat_indexed(
     while let Some(event) = reader.next_event() {
         match event? {
             mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
+                let chunk_index = chunk_indexes_by_data_offset.get(&offset).ok_or_else(|| {
+                    anyhow::anyhow!("chunk index missing for data offset {offset}")
+                })?;
+                collect_chunk_definitions_from_mcap(
+                    mcap,
+                    chunk_index,
+                    &mut schemas,
+                    &mut channel_defs,
+                )?;
                 let start = offset as usize;
                 let end = start
                     .checked_add(length)
@@ -168,12 +189,13 @@ fn cat_indexed(
                 reader.insert_chunk_record_data(offset, &mcap[start..end])?;
             }
             mcap::sans_io::IndexedReadEvent::Message { header, data } => {
-                let channel = summary
-                    .channels
-                    .get(&header.channel_id)
-                    .ok_or_else(|| anyhow::anyhow!("unknown channel {}", header.channel_id))?;
+                let channel =
+                    resolve_channel(header.channel_id, &schemas, &channel_defs, &mut channels)?;
+                if !opts.include_topic(&channel.topic) {
+                    continue;
+                }
                 let message = CatMessage {
-                    channel,
+                    channel: &channel,
                     sequence: header.sequence,
                     log_time: header.log_time,
                     publish_time: header.publish_time,
@@ -215,6 +237,25 @@ fn cat_remote_indexed(
         }
         return Ok(RemoteCatResult::NeedsFullScan);
     }
+    if summary
+        .chunk_indexes
+        .iter()
+        .any(|chunk| chunk.message_index_offsets.is_empty())
+    {
+        if !source_options.allow_remote_scan {
+            bail!(
+                "{}: remote file has chunk indexes without message indexes; reading messages requires opt-in; {}",
+                source::redacted_display(file),
+                source::remote_scan_opt_in_suffix()
+            );
+        }
+        return Ok(RemoteCatResult::NeedsFullScan);
+    }
+
+    let chunk_indexes_by_data_offset = chunk_indexes_by_data_offset(summary)?;
+    let mut schemas = summary.schemas.clone();
+    let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
+    let mut channels = summary.channels.clone();
 
     let included_topics: BTreeSet<String> = summary
         .channels
@@ -222,7 +263,7 @@ fn cat_remote_indexed(
         .filter(|channel| opts.include_topic(&channel.topic))
         .map(|channel| channel.topic.clone())
         .collect();
-    if !opts.topics.is_empty() && included_topics.is_empty() {
+    if !opts.topics.is_empty() && included_topics.is_empty() && !summary.channels.is_empty() {
         return Ok(RemoteCatResult::Done);
     }
     let planned_chunks = planned_chunk_reads(summary, opts, &included_topics);
@@ -248,7 +289,7 @@ fn cat_remote_indexed(
     if let Some(end) = opts.end {
         indexed_opts = indexed_opts.log_time_before(end);
     }
-    if !opts.topics.is_empty() {
+    if !opts.topics.is_empty() && !included_topics.is_empty() {
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
 
@@ -256,16 +297,44 @@ fn cat_remote_indexed(
     while let Some(event) = reader.next_event() {
         match event? {
             mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                let chunk = remote.read_range(offset, length)?;
-                reader.insert_chunk_record_data(offset, &chunk)?;
+                let chunk_index = chunk_indexes_by_data_offset.get(&offset).ok_or_else(|| {
+                    anyhow::anyhow!("chunk index missing for data offset {offset}")
+                })?;
+                let chunk_len = usize::try_from(chunk_index.chunk_length).with_context(|| {
+                    format!(
+                        "chunk length out of range for this platform: {}",
+                        chunk_index.chunk_length
+                    )
+                })?;
+                let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
+                collect_chunk_definitions_from_record_bytes(
+                    &chunk,
+                    &mut schemas,
+                    &mut channel_defs,
+                )?;
+                let compressed_start = usize::try_from(offset - chunk_index.chunk_start_offset)
+                    .with_context(|| {
+                        format!("chunk data offset out of range for this platform: {offset}")
+                    })?;
+                let compressed_end = compressed_start
+                    .checked_add(length)
+                    .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
+                let compressed_data =
+                    chunk.get(compressed_start..compressed_end).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "chunk read out of bounds at offset {offset} length {length}"
+                        )
+                    })?;
+                reader.insert_chunk_record_data(offset, compressed_data)?;
             }
             mcap::sans_io::IndexedReadEvent::Message { header, data } => {
-                let channel = summary
-                    .channels
-                    .get(&header.channel_id)
-                    .ok_or_else(|| anyhow::anyhow!("unknown channel {}", header.channel_id))?;
+                let channel =
+                    resolve_channel(header.channel_id, &schemas, &channel_defs, &mut channels)?;
+                if !opts.include_topic(&channel.topic) {
+                    continue;
+                }
                 let message = CatMessage {
-                    channel,
+                    channel: &channel,
                     sequence: header.sequence,
                     log_time: header.log_time,
                     publish_time: header.publish_time,
@@ -279,6 +348,113 @@ fn cat_remote_indexed(
     }
 
     Ok(RemoteCatResult::Done)
+}
+
+fn chunk_indexes_by_data_offset(
+    summary: &mcap::Summary,
+) -> Result<HashMap<u64, &mcap::records::ChunkIndex>> {
+    summary
+        .chunk_indexes
+        .iter()
+        .map(|index| Ok((index.compressed_data_offset()?, index)))
+        .collect()
+}
+
+fn collect_chunk_definitions_from_mcap(
+    mcap: &[u8],
+    index: &mcap::records::ChunkIndex,
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
+) -> Result<()> {
+    let start = usize::try_from(index.chunk_start_offset).with_context(|| {
+        format!(
+            "chunk offset out of range for this platform: {}",
+            index.chunk_start_offset
+        )
+    })?;
+    let length = usize::try_from(index.chunk_length).with_context(|| {
+        format!(
+            "chunk length out of range for this platform: {}",
+            index.chunk_length
+        )
+    })?;
+    let end = start.checked_add(length).ok_or_else(|| {
+        anyhow::anyhow!("chunk read overflow at offset {}", index.chunk_start_offset)
+    })?;
+    let chunk = mcap.get(start..end).ok_or_else(|| {
+        anyhow::anyhow!(
+            "chunk read out of bounds at offset {} length {}",
+            index.chunk_start_offset,
+            length
+        )
+    })?;
+    collect_chunk_definitions_from_record_bytes(chunk, schemas, channel_defs)
+}
+
+fn collect_chunk_definitions_from_record_bytes(
+    chunk: &[u8],
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
+) -> Result<()> {
+    if chunk.len() < 9 || chunk[0] != mcap::records::op::CHUNK {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    let body_len = usize::try_from(u64::from_le_bytes(chunk[1..9].try_into()?))
+        .context("chunk body length out of range for this platform")?;
+    if chunk.len() != 9 + body_len {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+
+    let (header, data) = match mcap::parse_record(mcap::records::op::CHUNK, &chunk[9..])? {
+        mcap::records::Record::Chunk { header, data } => (header, data),
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+
+    for record in mcap::read::ChunkReader::new(header, data.as_ref())? {
+        collect_definition_record(record?, schemas, channel_defs);
+    }
+    Ok(())
+}
+
+fn collect_definition_record(
+    record: mcap::records::Record<'_>,
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
+) {
+    match record {
+        mcap::records::Record::Schema { header, data } => {
+            schemas.entry(header.id).or_insert_with(|| {
+                Arc::new(mcap::Schema {
+                    id: header.id,
+                    name: header.name,
+                    encoding: header.encoding,
+                    data: Cow::Owned(data.into_owned()),
+                })
+            });
+        }
+        mcap::records::Record::Channel(channel) => {
+            channel_defs.entry(channel.id).or_insert(channel);
+        }
+        _ => {}
+    }
+}
+
+fn resolve_channel(
+    channel_id: u16,
+    schemas: &HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &HashMap<u16, mcap::records::Channel>,
+    channels: &mut HashMap<u16, Arc<mcap::Channel<'static>>>,
+) -> Result<Arc<mcap::Channel<'static>>> {
+    if let Some(channel) = channels.get(&channel_id) {
+        return Ok(channel.clone());
+    }
+
+    let channel_def = channel_defs
+        .get(&channel_id)
+        .ok_or_else(|| anyhow::anyhow!("unknown channel {channel_id}"))?;
+    let channel = build_channel(channel_def, schemas)?;
+    channels.insert(channel_id, channel.clone());
+    Ok(channel)
 }
 
 // Keep this planner conservative: it intentionally mirrors IndexedReader chunk filtering as an
@@ -1024,8 +1200,9 @@ mod tests {
     };
 
     use super::{
-        cat_mcap, cat_streaming, parse_ros1_field_type, planned_chunk_reads, write_payload_preview,
-        write_ros1_float, write_signed_decimal_time, CatOptions, JsonTranscoders, Ros1MessageDef,
+        cat_indexed, cat_mcap, cat_streaming, parse_ros1_field_type, planned_chunk_reads,
+        write_payload_preview, write_ros1_float, write_signed_decimal_time, CatOptions,
+        JsonTranscoders, Ros1MessageDef, MESSAGE_PREVIEW_LEN,
     };
 
     fn sample_message(schema_name: Option<&str>, data: Vec<u8>) -> mcap::Message<'static> {
@@ -1080,6 +1257,18 @@ mod tests {
             .expect("message line should be utf8")
             .trim_end_matches('\n')
             .to_string()
+    }
+
+    fn message_lines_from_stream(mcap: &[u8]) -> Vec<String> {
+        mcap::MessageStream::new(mcap)
+            .expect("message stream should open")
+            .map(|message| {
+                message_line_string(
+                    &message.expect("message stream should read"),
+                    MESSAGE_PREVIEW_LEN,
+                )
+            })
+            .collect()
     }
 
     fn build_out_of_order_chunked_mcap() -> Vec<u8> {
@@ -1472,6 +1661,67 @@ mod tests {
             lines,
             vec!["30 /demo [Example] [1]", "10 /demo [Example] [2]"]
         );
+    }
+
+    #[test]
+    fn cat_falls_back_for_chunk_index_without_message_indexes_and_in_chunk_channels() {
+        let mcap =
+            include_bytes!("../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx.mcap");
+        let expected = message_lines_from_stream(mcap);
+        assert_eq!(expected.len(), 1);
+
+        let mut indexed_out = Vec::new();
+        let mut json_transcoders = JsonTranscoders::default();
+        let indexed_result = cat_indexed(
+            &mut indexed_out,
+            mcap,
+            &CatOptions::default(),
+            &mut json_transcoders,
+        )
+        .expect("indexed planner should fall back");
+        assert_eq!(indexed_result, None);
+        assert!(indexed_out.is_empty());
+
+        let mut out = Vec::new();
+        let broken_pipe = cat_mcap(&mut out, mcap, &CatOptions::default())
+            .expect("cat should succeed through linear fallback");
+        assert!(!broken_pipe);
+
+        let output = String::from_utf8(out).expect("valid utf8 output");
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines, expected);
+    }
+
+    #[test]
+    fn cat_indexed_reads_message_index_with_in_chunk_channels() {
+        let mcap = include_bytes!(
+            "../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx.mcap"
+        );
+        let expected = message_lines_from_stream(mcap);
+        assert_eq!(expected.len(), 1);
+        let summary = mcap::Summary::read(mcap)
+            .expect("summary read")
+            .expect("summary should exist");
+        assert!(summary.channels.is_empty());
+        assert!(summary
+            .chunk_indexes
+            .iter()
+            .all(|chunk| !chunk.message_index_offsets.is_empty()));
+
+        let mut out = Vec::new();
+        let mut json_transcoders = JsonTranscoders::default();
+        let indexed_result = cat_indexed(
+            &mut out,
+            mcap,
+            &CatOptions::default(),
+            &mut json_transcoders,
+        )
+        .expect("indexed cat should succeed");
+        assert_eq!(indexed_result, Some(false));
+
+        let output = String::from_utf8(out).expect("valid utf8 output");
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines, expected);
     }
 
     #[test]

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -1887,6 +1887,55 @@ mod tests {
     }
 
     #[test]
+    fn cat_indexed_applies_topic_filter_to_chunk_local_channels() {
+        // The channel is defined only inside the chunk, so reader-level topic filtering is disabled
+        // and the per-message `include_topic` check is the sole filter. Exercise both a matching and
+        // a non-matching topic end-to-end through `cat_indexed` (not the linear fallback).
+        let mcap = include_bytes!(
+            "../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx.mcap"
+        );
+        let summary = mcap::Summary::read(mcap)
+            .expect("summary read")
+            .expect("summary should exist");
+        assert!(summary.channels.is_empty());
+        assert!(needs_in_chunk_definitions(&summary));
+
+        // Matching topic keeps the chunk-local channel's message.
+        let mut matched = Vec::new();
+        let mut json_transcoders = JsonTranscoders::default();
+        let result = cat_indexed(
+            &mut matched,
+            mcap,
+            &CatOptions {
+                topics: vec!["example".to_string()],
+                ..CatOptions::default()
+            },
+            &mut json_transcoders,
+        )
+        .expect("indexed cat should succeed");
+        assert_eq!(result, Some(false));
+        let matched = String::from_utf8(matched).expect("valid utf8 output");
+        assert_eq!(matched.lines().count(), 1);
+
+        // Non-matching topic drops the message via the per-message check (not silently via
+        // reader-level filtering), and the indexed path still completes without a linear fallback.
+        let mut filtered = Vec::new();
+        let mut json_transcoders = JsonTranscoders::default();
+        let result = cat_indexed(
+            &mut filtered,
+            mcap,
+            &CatOptions {
+                topics: vec!["nope".to_string()],
+                ..CatOptions::default()
+            },
+            &mut json_transcoders,
+        )
+        .expect("indexed cat should succeed");
+        assert_eq!(result, Some(false));
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
     fn cat_applies_topic_and_time_filters() {
         let mcap = build_multi_topic_mcap();
         let opts = CatOptions {

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -280,14 +280,31 @@ fn cat_remote_indexed(
     let planned_chunks =
         planned_chunk_reads(summary, opts, &included_topics, needs_in_chunk_definitions);
     if !planned_chunks.is_empty() && !source_options.allow_remote_scan {
-        let compressed_bytes = planned_chunks
-            .iter()
-            .map(|chunk| chunk.compressed_size)
-            .sum::<u64>();
+        // When chunk-local definitions must be collected, every chunk is read up front (a
+        // definition can live in a chunk the filter would otherwise skip), so size the warning from
+        // the full set rather than the filtered plan to avoid under-quoting the bytes fetched.
+        let (chunk_count, compressed_bytes) = if needs_in_chunk_definitions {
+            (
+                summary.chunk_indexes.len(),
+                summary
+                    .chunk_indexes
+                    .iter()
+                    .map(|chunk| chunk.compressed_size)
+                    .sum::<u64>(),
+            )
+        } else {
+            (
+                planned_chunks.len(),
+                planned_chunks
+                    .iter()
+                    .map(|chunk| chunk.compressed_size)
+                    .sum::<u64>(),
+            )
+        };
         bail!(
             "{}: remote cat would read {} message chunks ({} compressed); {}",
             source::redacted_display(file),
-            planned_chunks.len(),
+            chunk_count,
             render::human_bytes(compressed_bytes),
             source::remote_scan_opt_in_suffix()
         );

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -560,16 +560,7 @@ fn handle_linear_record(
                 return Ok(false);
             }
 
-            let channel = if let Some(channel) = channels.get(&header.channel_id) {
-                channel.clone()
-            } else {
-                let Some(channel_def) = channel_defs.get(&header.channel_id) else {
-                    bail!("message references unknown channel {}", header.channel_id);
-                };
-                let resolved = build_channel(channel_def, schemas)?;
-                channels.insert(header.channel_id, resolved.clone());
-                resolved
-            };
+            let channel = resolve_channel(header.channel_id, schemas, channel_defs, channels)?;
 
             if !opts.include_topic(&channel.topic) {
                 return Ok(false);

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -9,7 +9,7 @@ use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
 
 use crate::cli::CatCommand;
 use crate::context::CommandContext;
-use crate::{render, source};
+use crate::{parse, render, source};
 
 const MESSAGE_PREVIEW_LEN: usize = 10;
 
@@ -175,7 +175,7 @@ fn cat_indexed(
                     anyhow::anyhow!("chunk index missing for data offset {offset}")
                 })?;
                 if needs_in_chunk_definitions {
-                    collect_chunk_definitions_from_mcap(
+                    parse::collect_chunk_definitions_from_mcap(
                         mcap,
                         chunk_index,
                         &mut schemas,
@@ -314,7 +314,7 @@ fn cat_remote_indexed(
                             )
                         })?;
                     let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
-                    collect_chunk_definitions_from_record_bytes(
+                    parse::collect_chunk_definitions_from_record_bytes(
                         &chunk,
                         &mut schemas,
                         &mut channel_defs,
@@ -379,85 +379,6 @@ fn needs_in_chunk_definitions(summary: &mcap::Summary) -> bool {
             .keys()
             .any(|channel_id| !summary.channels.contains_key(channel_id))
     })
-}
-
-fn collect_chunk_definitions_from_mcap(
-    mcap: &[u8],
-    index: &mcap::records::ChunkIndex,
-    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
-    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
-) -> Result<()> {
-    let start = usize::try_from(index.chunk_start_offset).with_context(|| {
-        format!(
-            "chunk offset out of range for this platform: {}",
-            index.chunk_start_offset
-        )
-    })?;
-    let length = usize::try_from(index.chunk_length).with_context(|| {
-        format!(
-            "chunk length out of range for this platform: {}",
-            index.chunk_length
-        )
-    })?;
-    let end = start.checked_add(length).ok_or_else(|| {
-        anyhow::anyhow!("chunk read overflow at offset {}", index.chunk_start_offset)
-    })?;
-    let chunk = mcap.get(start..end).ok_or_else(|| {
-        anyhow::anyhow!(
-            "chunk read out of bounds at offset {} length {}",
-            index.chunk_start_offset,
-            length
-        )
-    })?;
-    collect_chunk_definitions_from_record_bytes(chunk, schemas, channel_defs)
-}
-
-fn collect_chunk_definitions_from_record_bytes(
-    chunk: &[u8],
-    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
-    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
-) -> Result<()> {
-    if chunk.len() < 9 || chunk[0] != mcap::records::op::CHUNK {
-        return Err(mcap::McapError::BadIndex.into());
-    }
-    let body_len = usize::try_from(u64::from_le_bytes(chunk[1..9].try_into()?))
-        .context("chunk body length out of range for this platform")?;
-    if chunk.len() != 9 + body_len {
-        return Err(mcap::McapError::BadIndex.into());
-    }
-
-    let (header, data) = match mcap::parse_record(mcap::records::op::CHUNK, &chunk[9..])? {
-        mcap::records::Record::Chunk { header, data } => (header, data),
-        _ => return Err(mcap::McapError::BadIndex.into()),
-    };
-
-    for record in mcap::read::ChunkReader::new(header, data.as_ref())? {
-        collect_definition_record(record?, schemas, channel_defs);
-    }
-    Ok(())
-}
-
-fn collect_definition_record(
-    record: mcap::records::Record<'_>,
-    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
-    channel_defs: &mut HashMap<u16, mcap::records::Channel>,
-) {
-    match record {
-        mcap::records::Record::Schema { header, data } => {
-            schemas.entry(header.id).or_insert_with(|| {
-                Arc::new(mcap::Schema {
-                    id: header.id,
-                    name: header.name,
-                    encoding: header.encoding,
-                    data: Cow::Owned(data.into_owned()),
-                })
-            });
-        }
-        mcap::records::Record::Channel(channel) => {
-            channel_defs.entry(channel.id).or_insert(channel);
-        }
-        _ => {}
-    }
 }
 
 fn resolve_channel(

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -124,8 +124,14 @@ fn cat_indexed(
     opts: &CatOptions,
     json_transcoders: &mut JsonTranscoders,
 ) -> Result<Option<bool>> {
-    let Some(summary) = mcap::Summary::read(mcap)? else {
-        return Ok(None);
+    let summary = match mcap::Summary::read(mcap) {
+        Ok(Some(summary)) => summary,
+        Ok(None) => return Ok(None),
+        // A spec-valid file may repeat a channel in the summary without repeating its schema,
+        // leaving the schema defined only inside a chunk. That can't be resolved from the summary
+        // alone, so fall back to a linear scan, which registers in-chunk definitions as it reads.
+        Err(mcap::McapError::UnknownSchema(..)) => return Ok(None),
+        Err(err) => return Err(err.into()),
     };
     if summary.chunk_indexes.is_empty() {
         return Ok(None);
@@ -138,11 +144,24 @@ fn cat_indexed(
         return Ok(None);
     }
 
-    let chunk_indexes_by_data_offset = chunk_indexes_by_data_offset(&summary)?;
     let needs_in_chunk_definitions = needs_in_chunk_definitions(&summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = summary.channels.clone();
+    // When channels/schemas are defined only inside chunks (not repeated in the summary), collect
+    // their definitions from every chunk up front. Collecting lazily per requested chunk would miss
+    // a definition that lives in a chunk skipped by a topic or time filter (e.g. a channel defined
+    // in an early chunk but referenced by messages in a later one).
+    if needs_in_chunk_definitions {
+        for chunk_index in &summary.chunk_indexes {
+            parse::collect_chunk_definitions_from_mcap(
+                mcap,
+                chunk_index,
+                &mut schemas,
+                &mut channel_defs,
+            )?;
+        }
+    }
 
     let included_topics: BTreeSet<String> = summary
         .channels
@@ -171,17 +190,6 @@ fn cat_indexed(
     while let Some(event) = reader.next_event() {
         match event? {
             mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                let chunk_index = chunk_indexes_by_data_offset.get(&offset).ok_or_else(|| {
-                    anyhow::anyhow!("chunk index missing for data offset {offset}")
-                })?;
-                if needs_in_chunk_definitions {
-                    parse::collect_chunk_definitions_from_mcap(
-                        mcap,
-                        chunk_index,
-                        &mut schemas,
-                        &mut channel_defs,
-                    )?;
-                }
                 let start = offset as usize;
                 let end = start
                     .checked_add(length)
@@ -255,7 +263,6 @@ fn cat_remote_indexed(
         return Ok(RemoteCatResult::NeedsFullScan);
     }
 
-    let chunk_indexes_by_data_offset = chunk_indexes_by_data_offset(summary)?;
     let needs_in_chunk_definitions = needs_in_chunk_definitions(summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
@@ -286,6 +293,38 @@ fn cat_remote_indexed(
         );
     }
 
+    // When channels/schemas are defined only inside chunks, fetch every chunk once up front to
+    // collect their definitions, caching the compressed data so the indexed read below doesn't
+    // re-fetch. Lazy per-chunk collection would miss a definition in a chunk skipped by a topic or
+    // time filter. The remote-scan gate above already required opt-in to reach here.
+    let mut chunk_data_cache: HashMap<u64, Vec<u8>> = HashMap::new();
+    if needs_in_chunk_definitions && !planned_chunks.is_empty() {
+        for chunk_index in &summary.chunk_indexes {
+            let chunk_len = usize::try_from(chunk_index.chunk_length).with_context(|| {
+                format!(
+                    "chunk length out of range for this platform: {}",
+                    chunk_index.chunk_length
+                )
+            })?;
+            let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
+            parse::collect_chunk_definitions_from_record_bytes(
+                &chunk,
+                &mut schemas,
+                &mut channel_defs,
+            )?;
+            let data_offset = chunk_index.compressed_data_offset()?;
+            let compressed_start = usize::try_from(data_offset - chunk_index.chunk_start_offset)
+                .with_context(|| {
+                    format!("chunk data offset out of range for this platform: {data_offset}")
+                })?;
+            let compressed = chunk
+                .get(compressed_start..)
+                .ok_or_else(|| anyhow::anyhow!("chunk data out of bounds at offset {data_offset}"))?
+                .to_vec();
+            chunk_data_cache.insert(data_offset, compressed);
+        }
+    }
+
     let mut indexed_opts =
         mcap::sans_io::IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
     if opts.start != 0 {
@@ -302,42 +341,17 @@ fn cat_remote_indexed(
     while let Some(event) = reader.next_event() {
         match event? {
             mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                let chunk_index = chunk_indexes_by_data_offset.get(&offset).ok_or_else(|| {
-                    anyhow::anyhow!("chunk index missing for data offset {offset}")
-                })?;
-                let compressed_data = if needs_in_chunk_definitions {
-                    let chunk_len =
-                        usize::try_from(chunk_index.chunk_length).with_context(|| {
-                            format!(
-                                "chunk length out of range for this platform: {}",
-                                chunk_index.chunk_length
-                            )
-                        })?;
-                    let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
-                    parse::collect_chunk_definitions_from_record_bytes(
-                        &chunk,
-                        &mut schemas,
-                        &mut channel_defs,
-                    )?;
-                    let compressed_start = usize::try_from(offset - chunk_index.chunk_start_offset)
-                        .with_context(|| {
-                            format!("chunk data offset out of range for this platform: {offset}")
-                        })?;
-                    let compressed_end = compressed_start
-                        .checked_add(length)
-                        .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
-                    chunk
-                        .get(compressed_start..compressed_end)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "chunk read out of bounds at offset {offset} length {length}"
-                            )
-                        })?
-                        .to_vec()
+                if let Some(cached) = chunk_data_cache.get(&offset) {
+                    let compressed = cached.get(..length).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "chunk read out of bounds at offset {offset} length {length}"
+                        )
+                    })?;
+                    reader.insert_chunk_record_data(offset, compressed)?;
                 } else {
-                    remote.read_range(offset, length)?
-                };
-                reader.insert_chunk_record_data(offset, &compressed_data)?;
+                    let chunk = remote.read_range(offset, length)?;
+                    reader.insert_chunk_record_data(offset, &chunk)?;
+                }
             }
             mcap::sans_io::IndexedReadEvent::Message { header, data } => {
                 let channel =
@@ -360,16 +374,6 @@ fn cat_remote_indexed(
     }
 
     Ok(RemoteCatResult::Done)
-}
-
-fn chunk_indexes_by_data_offset(
-    summary: &mcap::Summary,
-) -> Result<HashMap<u64, &mcap::records::ChunkIndex>> {
-    summary
-        .chunk_indexes
-        .iter()
-        .map(|index| Ok((index.compressed_data_offset()?, index)))
-        .collect()
 }
 
 fn needs_in_chunk_definitions(summary: &mcap::Summary) -> bool {
@@ -1745,6 +1749,124 @@ mod tests {
         let output = String::from_utf8(out).expect("valid utf8 output");
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines, expected);
+    }
+
+    #[test]
+    fn cat_falls_back_for_summary_channel_with_in_chunk_schema() {
+        // Spec-valid file: the channel is repeated in the summary, but its schema is defined only
+        // inside the chunk. The indexed planner can't resolve the schema from the summary, so it
+        // defers to the linear scan, which registers the in-chunk schema and resolves the message.
+        let mcap = include_bytes!(
+            "../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-rch-st-sum.mcap"
+        );
+        let expected = message_lines_from_stream(mcap);
+        assert_eq!(expected.len(), 1);
+
+        let mut indexed_out = Vec::new();
+        let mut json_transcoders = JsonTranscoders::default();
+        let indexed_result = cat_indexed(
+            &mut indexed_out,
+            mcap,
+            &CatOptions::default(),
+            &mut json_transcoders,
+        )
+        .expect("indexed planner should fall back");
+        assert_eq!(indexed_result, None);
+        assert!(indexed_out.is_empty());
+
+        let mut out = Vec::new();
+        let broken_pipe = cat_mcap(&mut out, mcap, &CatOptions::default())
+            .expect("cat should succeed through linear fallback");
+        assert!(!broken_pipe);
+
+        let output = String::from_utf8(out).expect("valid utf8 output");
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines, expected);
+    }
+
+    fn build_multi_chunk_chunk_local_mcap() -> Vec<u8> {
+        let mut buffer = Vec::new();
+        {
+            // A small schema/channel plus large messages and a mid-size chunk target keeps the
+            // schema+channel+first message together in chunk 0, then forces the second message into
+            // chunk 1. The chunk-flush check runs before each message, so the threshold must exceed
+            // the schema+channel size (to avoid a message-less chunk) but be smaller than chunk 0
+            // once the first message is added.
+            let mut writer = mcap::WriteOptions::new()
+                .chunk_size(Some(150))
+                .repeat_channels(false)
+                .repeat_schemas(false)
+                .create(Cursor::new(&mut buffer))
+                .expect("writer");
+            let schema_id = writer.add_schema("Example", "json", b"x").expect("schema");
+            let channel_id = writer
+                .add_channel(schema_id, "/topic", "json", &BTreeMap::new())
+                .expect("channel");
+            let payload = vec![0u8; 200];
+            for (sequence, log_time) in [(1u32, 10u64), (2, 20)] {
+                writer
+                    .write_to_known_channel(
+                        &mcap::records::MessageHeader {
+                            channel_id,
+                            sequence,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        &payload,
+                    )
+                    .expect("write message");
+            }
+            writer.finish().expect("finish writer");
+        }
+        buffer
+    }
+
+    #[test]
+    fn cat_indexed_resolves_chunk_local_channel_defined_in_filtered_out_chunk() {
+        // Multiple chunks, channels defined only inside chunks. The channel is defined in the first
+        // chunk, but a start-time filter excludes that chunk while keeping a later chunk's message.
+        // The channel must still resolve from the up-front in-chunk definition collection.
+        let mcap = build_multi_chunk_chunk_local_mcap();
+        let summary = mcap::Summary::read(&mcap)
+            .expect("summary read")
+            .expect("summary should exist");
+        assert!(summary.channels.is_empty());
+        assert!(
+            summary.chunk_indexes.len() >= 2,
+            "expected multiple chunks, got {}",
+            summary.chunk_indexes.len()
+        );
+        assert!(summary
+            .chunk_indexes
+            .iter()
+            .all(|chunk| !chunk.message_index_offsets.is_empty()));
+        assert!(needs_in_chunk_definitions(&summary));
+        // The first chunk (which defines the channel) is fully before the start filter.
+        assert!(summary.chunk_indexes[0].message_end_time < 15);
+
+        let opts = CatOptions {
+            start: 15,
+            ..CatOptions::default()
+        };
+        let mut out = Vec::new();
+        let mut json_transcoders = JsonTranscoders::default();
+        let indexed_result = cat_indexed(&mut out, &mcap, &opts, &mut json_transcoders)
+            .expect("indexed cat should resolve chunk-local channel");
+        assert_eq!(indexed_result, Some(false));
+
+        let output = String::from_utf8(out).expect("valid utf8 output");
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "only the second message is within the window"
+        );
+        assert!(lines[0].contains("/topic"), "unexpected line: {}", lines[0]);
+        assert!(
+            lines[0].contains("Example"),
+            "schema should resolve from the defining chunk: {}",
+            lines[0]
+        );
     }
 
     #[test]

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -139,6 +139,7 @@ fn cat_indexed(
     }
 
     let chunk_indexes_by_data_offset = chunk_indexes_by_data_offset(&summary)?;
+    let needs_in_chunk_definitions = needs_in_chunk_definitions(&summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = summary.channels.clone();
@@ -149,7 +150,7 @@ fn cat_indexed(
         .filter(|channel| opts.include_topic(&channel.topic))
         .map(|channel| channel.topic.clone())
         .collect();
-    if !opts.topics.is_empty() && included_topics.is_empty() && !summary.channels.is_empty() {
+    if !opts.topics.is_empty() && included_topics.is_empty() && !needs_in_chunk_definitions {
         return Ok(Some(false));
     }
 
@@ -161,7 +162,7 @@ fn cat_indexed(
     if let Some(end) = opts.end {
         indexed_opts = indexed_opts.log_time_before(end);
     }
-    if !opts.topics.is_empty() && !included_topics.is_empty() {
+    if !opts.topics.is_empty() && !included_topics.is_empty() && !needs_in_chunk_definitions {
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
 
@@ -173,12 +174,14 @@ fn cat_indexed(
                 let chunk_index = chunk_indexes_by_data_offset.get(&offset).ok_or_else(|| {
                     anyhow::anyhow!("chunk index missing for data offset {offset}")
                 })?;
-                collect_chunk_definitions_from_mcap(
-                    mcap,
-                    chunk_index,
-                    &mut schemas,
-                    &mut channel_defs,
-                )?;
+                if needs_in_chunk_definitions {
+                    collect_chunk_definitions_from_mcap(
+                        mcap,
+                        chunk_index,
+                        &mut schemas,
+                        &mut channel_defs,
+                    )?;
+                }
                 let start = offset as usize;
                 let end = start
                     .checked_add(length)
@@ -253,6 +256,7 @@ fn cat_remote_indexed(
     }
 
     let chunk_indexes_by_data_offset = chunk_indexes_by_data_offset(summary)?;
+    let needs_in_chunk_definitions = needs_in_chunk_definitions(summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = summary.channels.clone();
@@ -263,10 +267,11 @@ fn cat_remote_indexed(
         .filter(|channel| opts.include_topic(&channel.topic))
         .map(|channel| channel.topic.clone())
         .collect();
-    if !opts.topics.is_empty() && included_topics.is_empty() && !summary.channels.is_empty() {
+    if !opts.topics.is_empty() && included_topics.is_empty() && !needs_in_chunk_definitions {
         return Ok(RemoteCatResult::Done);
     }
-    let planned_chunks = planned_chunk_reads(summary, opts, &included_topics);
+    let planned_chunks =
+        planned_chunk_reads(summary, opts, &included_topics, needs_in_chunk_definitions);
     if !planned_chunks.is_empty() && !source_options.allow_remote_scan {
         let compressed_bytes = planned_chunks
             .iter()
@@ -289,7 +294,7 @@ fn cat_remote_indexed(
     if let Some(end) = opts.end {
         indexed_opts = indexed_opts.log_time_before(end);
     }
-    if !opts.topics.is_empty() && !included_topics.is_empty() {
+    if !opts.topics.is_empty() && !included_topics.is_empty() && !needs_in_chunk_definitions {
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
 
@@ -300,32 +305,39 @@ fn cat_remote_indexed(
                 let chunk_index = chunk_indexes_by_data_offset.get(&offset).ok_or_else(|| {
                     anyhow::anyhow!("chunk index missing for data offset {offset}")
                 })?;
-                let chunk_len = usize::try_from(chunk_index.chunk_length).with_context(|| {
-                    format!(
-                        "chunk length out of range for this platform: {}",
-                        chunk_index.chunk_length
-                    )
-                })?;
-                let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
-                collect_chunk_definitions_from_record_bytes(
-                    &chunk,
-                    &mut schemas,
-                    &mut channel_defs,
-                )?;
-                let compressed_start = usize::try_from(offset - chunk_index.chunk_start_offset)
-                    .with_context(|| {
-                        format!("chunk data offset out of range for this platform: {offset}")
-                    })?;
-                let compressed_end = compressed_start
-                    .checked_add(length)
-                    .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
-                let compressed_data =
-                    chunk.get(compressed_start..compressed_end).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "chunk read out of bounds at offset {offset} length {length}"
-                        )
-                    })?;
-                reader.insert_chunk_record_data(offset, compressed_data)?;
+                let compressed_data = if needs_in_chunk_definitions {
+                    let chunk_len =
+                        usize::try_from(chunk_index.chunk_length).with_context(|| {
+                            format!(
+                                "chunk length out of range for this platform: {}",
+                                chunk_index.chunk_length
+                            )
+                        })?;
+                    let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
+                    collect_chunk_definitions_from_record_bytes(
+                        &chunk,
+                        &mut schemas,
+                        &mut channel_defs,
+                    )?;
+                    let compressed_start = usize::try_from(offset - chunk_index.chunk_start_offset)
+                        .with_context(|| {
+                            format!("chunk data offset out of range for this platform: {offset}")
+                        })?;
+                    let compressed_end = compressed_start
+                        .checked_add(length)
+                        .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
+                    chunk
+                        .get(compressed_start..compressed_end)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "chunk read out of bounds at offset {offset} length {length}"
+                            )
+                        })?
+                        .to_vec()
+                } else {
+                    remote.read_range(offset, length)?
+                };
+                reader.insert_chunk_record_data(offset, &compressed_data)?;
             }
             mcap::sans_io::IndexedReadEvent::Message { header, data } => {
                 let channel =
@@ -358,6 +370,15 @@ fn chunk_indexes_by_data_offset(
         .iter()
         .map(|index| Ok((index.compressed_data_offset()?, index)))
         .collect()
+}
+
+fn needs_in_chunk_definitions(summary: &mcap::Summary) -> bool {
+    summary.chunk_indexes.iter().any(|chunk| {
+        chunk
+            .message_index_offsets
+            .keys()
+            .any(|channel_id| !summary.channels.contains_key(channel_id))
+    })
 }
 
 fn collect_chunk_definitions_from_mcap(
@@ -463,8 +484,9 @@ fn planned_chunk_reads<'a>(
     summary: &'a mcap::Summary,
     opts: &CatOptions,
     included_topics: &BTreeSet<String>,
+    needs_in_chunk_definitions: bool,
 ) -> Vec<&'a mcap::records::ChunkIndex> {
-    let channel_ids: BTreeSet<u16> = if opts.topics.is_empty() {
+    let channel_ids: BTreeSet<u16> = if opts.topics.is_empty() || needs_in_chunk_definitions {
         BTreeSet::new()
     } else {
         summary
@@ -1200,9 +1222,9 @@ mod tests {
     };
 
     use super::{
-        cat_indexed, cat_mcap, cat_streaming, parse_ros1_field_type, planned_chunk_reads,
-        write_payload_preview, write_ros1_float, write_signed_decimal_time, CatOptions,
-        JsonTranscoders, Ros1MessageDef, MESSAGE_PREVIEW_LEN,
+        cat_indexed, cat_mcap, cat_streaming, needs_in_chunk_definitions, parse_ros1_field_type,
+        planned_chunk_reads, write_payload_preview, write_ros1_float, write_signed_decimal_time,
+        CatOptions, JsonTranscoders, Ros1MessageDef, MESSAGE_PREVIEW_LEN,
     };
 
     fn sample_message(schema_name: Option<&str>, data: Vec<u8>) -> mcap::Message<'static> {
@@ -1269,6 +1291,40 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    fn summary_with_channels(
+        summary_channel_ids: &[u16],
+        indexed_channel_ids: &[u16],
+    ) -> mcap::Summary {
+        let mut summary = mcap::Summary::default();
+        for channel_id in summary_channel_ids {
+            summary.channels.insert(
+                *channel_id,
+                Arc::new(mcap::Channel {
+                    id: *channel_id,
+                    topic: format!("/topic_{channel_id}"),
+                    schema: None,
+                    message_encoding: "json".to_string(),
+                    metadata: BTreeMap::new(),
+                }),
+            );
+        }
+        summary.chunk_indexes.push(mcap::records::ChunkIndex {
+            message_start_time: 0,
+            message_end_time: 10,
+            chunk_start_offset: 0,
+            chunk_length: 0,
+            message_index_offsets: indexed_channel_ids
+                .iter()
+                .map(|channel_id| (*channel_id, 0))
+                .collect(),
+            message_index_length: 0,
+            compression: String::new(),
+            compressed_size: 0,
+            uncompressed_size: 0,
+        });
+        summary
     }
 
     fn build_out_of_order_chunked_mcap() -> Vec<u8> {
@@ -1558,16 +1614,17 @@ mod tests {
         summary: &'a mcap::Summary,
         opts: &CatOptions,
     ) -> Vec<&'a mcap::records::ChunkIndex> {
+        let needs_in_chunk_definitions = needs_in_chunk_definitions(summary);
         let included_topics: BTreeSet<String> = summary
             .channels
             .values()
             .filter(|channel| opts.include_topic(&channel.topic))
             .map(|channel| channel.topic.clone())
             .collect();
-        if !opts.topics.is_empty() && included_topics.is_empty() {
+        if !opts.topics.is_empty() && included_topics.is_empty() && !needs_in_chunk_definitions {
             return Vec::new();
         }
-        planned_chunk_reads(summary, opts, &included_topics)
+        planned_chunk_reads(summary, opts, &included_topics, needs_in_chunk_definitions)
     }
 
     #[test]
@@ -1576,6 +1633,7 @@ mod tests {
         let summary = mcap::Summary::read(&mcap)
             .expect("summary read")
             .expect("summary should exist");
+        assert!(!needs_in_chunk_definitions(&summary));
 
         assert!(
             !planned_chunks_for_opts(&summary, &CatOptions::default()).is_empty(),
@@ -1628,6 +1686,50 @@ mod tests {
             )
             .is_empty(),
             "non-overlapping time filter should not plan remote chunk reads"
+        );
+    }
+
+    #[test]
+    fn mixed_chunk_local_channels_disable_summary_topic_pruning() {
+        let summary = summary_with_channels(&[1], &[1, 2]);
+        assert!(needs_in_chunk_definitions(&summary));
+
+        assert!(
+            !planned_chunks_for_opts(
+                &summary,
+                &CatOptions {
+                    topics: vec!["/topic_1".to_string()],
+                    ..CatOptions::default()
+                },
+            )
+            .is_empty(),
+            "mixed summaries still need chunk reads because chunk-local topics are unknown"
+        );
+
+        let complete_summary = summary_with_channels(&[1, 2], &[1, 2]);
+        assert!(!needs_in_chunk_definitions(&complete_summary));
+    }
+
+    #[test]
+    fn chunk_local_channels_keep_remote_topic_plan_conservative() {
+        let mcap = include_bytes!(
+            "../../../../tests/conformance/data/OneMessage/OneMessage-ch-chx-mx.mcap"
+        );
+        let summary = mcap::Summary::read(mcap)
+            .expect("summary read")
+            .expect("summary should exist");
+        assert!(needs_in_chunk_definitions(&summary));
+
+        assert!(
+            !planned_chunks_for_opts(
+                &summary,
+                &CatOptions {
+                    topics: vec!["example".to_string()],
+                    ..CatOptions::default()
+                },
+            )
+            .is_empty(),
+            "topic filters cannot safely prune chunks before reading chunk-local channels"
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -181,6 +181,9 @@ fn cat_indexed(
     if let Some(end) = opts.end {
         indexed_opts = indexed_opts.log_time_before(end);
     }
+    // Reader-level topic filtering keys on `summary.channels`, so skip it when chunk-local channels
+    // may exist (see `needs_in_chunk_definitions`) and let the per-message `include_topic` check
+    // below filter instead, to avoid silently dropping matching chunk-local messages.
     if !opts.topics.is_empty() && !included_topics.is_empty() && !needs_in_chunk_definitions {
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
@@ -350,6 +353,9 @@ fn cat_remote_indexed(
     if let Some(end) = opts.end {
         indexed_opts = indexed_opts.log_time_before(end);
     }
+    // Reader-level topic filtering keys on `summary.channels`, so skip it when chunk-local channels
+    // may exist (see `needs_in_chunk_definitions`) and let the per-message `include_topic` check
+    // below filter instead, to avoid silently dropping matching chunk-local messages.
     if !opts.topics.is_empty() && !included_topics.is_empty() && !needs_in_chunk_definitions {
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
@@ -393,6 +399,18 @@ fn cat_remote_indexed(
     Ok(RemoteCatResult::Done)
 }
 
+/// Returns whether any chunk references channels that aren't repeated in the summary, so their
+/// definitions (and topics) must be read from the chunks themselves.
+///
+/// When true, callers must (a) collect in-chunk definitions before resolving messages, and (b) skip
+/// reader-level topic filtering — which keys on `summary.channels` only — and filter per message
+/// instead, otherwise a chunk-local channel matching a `--topics` filter would be silently dropped.
+///
+/// Note: a file mixing summary channels with chunk-local ones can't be produced by the standard
+/// writer (its `repeat_channels`/`repeat_schemas` options are all-or-nothing: either every channel
+/// is in the summary, making this false, or none is, making `included_topics` empty). So the mixed +
+/// `--topics` path this guards is defensive against partial-repetition files from other tools and
+/// isn't covered by an `mcap::Writer`-based regression test.
 fn needs_in_chunk_definitions(summary: &mcap::Summary) -> bool {
     summary.chunk_indexes.iter().any(|chunk| {
         chunk

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use mcap::records::{self, Record};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -274,6 +274,85 @@ pub(crate) fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'
         return Err(mcap::McapError::BadIndex.into());
     }
     Ok(attachment)
+}
+
+pub(crate) fn collect_chunk_definitions_from_mcap(
+    mcap: &[u8],
+    index: &records::ChunkIndex,
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, records::Channel>,
+) -> Result<()> {
+    let start = usize::try_from(index.chunk_start_offset).with_context(|| {
+        format!(
+            "chunk offset out of range for this platform: {}",
+            index.chunk_start_offset
+        )
+    })?;
+    let length = usize::try_from(index.chunk_length).with_context(|| {
+        format!(
+            "chunk length out of range for this platform: {}",
+            index.chunk_length
+        )
+    })?;
+    let end = start.checked_add(length).ok_or_else(|| {
+        anyhow::anyhow!("chunk read overflow at offset {}", index.chunk_start_offset)
+    })?;
+    let chunk = mcap.get(start..end).ok_or_else(|| {
+        anyhow::anyhow!(
+            "chunk read out of bounds at offset {} length {}",
+            index.chunk_start_offset,
+            length
+        )
+    })?;
+    collect_chunk_definitions_from_record_bytes(chunk, schemas, channel_defs)
+}
+
+pub(crate) fn collect_chunk_definitions_from_record_bytes(
+    chunk: &[u8],
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, records::Channel>,
+) -> Result<()> {
+    if chunk.len() < 9 || chunk[0] != records::op::CHUNK {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+    let body_len = usize::try_from(u64::from_le_bytes(chunk[1..9].try_into()?))
+        .context("chunk body length out of range for this platform")?;
+    if chunk.len() != 9 + body_len {
+        return Err(mcap::McapError::BadIndex.into());
+    }
+
+    let (header, data) = match mcap::parse_record(records::op::CHUNK, &chunk[9..])? {
+        Record::Chunk { header, data } => (header, data),
+        _ => return Err(mcap::McapError::BadIndex.into()),
+    };
+
+    for record in mcap::read::ChunkReader::new(header, data.as_ref())? {
+        collect_definition_record(record?, schemas, channel_defs);
+    }
+    Ok(())
+}
+
+fn collect_definition_record(
+    record: Record<'_>,
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel_defs: &mut HashMap<u16, records::Channel>,
+) {
+    match record {
+        Record::Schema { header, data } => {
+            schemas.entry(header.id).or_insert_with(|| {
+                Arc::new(mcap::Schema {
+                    id: header.id,
+                    name: header.name,
+                    encoding: header.encoding,
+                    data: Cow::Owned(data.into_owned()),
+                })
+            });
+        }
+        Record::Channel(channel) => {
+            channel_defs.entry(channel.id).or_insert(channel);
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

The MCAP spec makes repeating schema/channel records in the summary section optional, so a file may define them only inside its chunks. The Rust `mcap cat` assumed the summary listed everything and failed with `unknown channel` / `unknown schema` on these spec-valid files. This makes `cat` read them correctly, matching the reference readers and the graceful handling added for `info`/`list` in #1695.

### Changes
- **Resolve in-chunk definitions on indexed reads.** Schema/channel records defined inside chunks are now collected (up front, from every chunk) so a definition that lives in a chunk a `--start`/`--end`/`--topics` filter would skip still resolves. Summary-complete files (the common case) skip this and are unaffected.
- **Fall back to a linear scan** when an indexed read can't work: chunk indexes without message indexes, or a summary that repeats a channel but not its schema. The linear scan registers in-chunk definitions and resolves the message (including its schema name).
- **Keep topic filtering correct with chunk-local channels.** Reader-level filtering keys on the summary, so it's disabled when chunk-local channels may exist and filtering falls to the per-message check, avoiding silent drops.
- **Remote:** the `--allow-remote-scan` opt-in warning is sized from the chunks actually read, and each fetched chunk is cached so the up-front collection adds no extra requests.

### Testing
Regression coverage for the two #1692 fixtures (`OneMessage-ch-chx`, `OneMessage-ch-chx-mx`), the summary-channel/in-chunk-schema fixture (`OneMessage-ch-chx-mx-rch-st-sum.mcap`), a multi-chunk chunk-local file read under a start-time filter, and `cat --topics` (matching + non-matching) through the chunk-local indexed path.

Fixes #1692