### PR TITLE
demo: align CompressedImage format with docs

### DIFF
--- a/website/src/components/McapRecordingDemo/Recorder.ts
+++ b/website/src/components/McapRecordingDemo/Recorder.ts
@@ -213,7 +213,7 @@ export class Recorder extends EventEmitter<RecorderEvents> {
         timestamp: toProtobufTime(fromNanoSec(now)),
         frame_id: "camera",
         data: new Uint8Array(await blob.arrayBuffer()),
-        format: blob.type,
+        format: "jpeg",
       };
       await this.#writer.addMessage({
         sequence: this.#jpegChannelSeq++,


### PR DESCRIPTION
### Changelog
The demo on https://mcap.dev now writes JPEG images with format `"jpeg"` instead of `"image/jpeg"`, to align with https://docs.foxglove.dev/docs/sdk/schemas/compressed-image.

### Docs

None

### Description

See https://docs.foxglove.dev/docs/sdk/schemas/compressed-image