### PR TITLE
Standardize writer library strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,21 @@ jobs:
       - run: yarn fmt:check
       - run: yarn workspace @mcap/core lint:ci
       - run: yarn workspace @mcap/core build
+      - name: Check @mcap/core version matches tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/core/v')
+        run: |
+          package_version="$(node -p "require('./typescript/core/package.json').version")"
+          source_version="$(node -e "const fs = require('fs'); const match = fs.readFileSync('typescript/core/src/version.ts', 'utf8').match(/export const VERSION = \"([^\"]+)\"/); if (!match) process.exit(2); console.log(match[1]);")"
+          tag_version="${GITHUB_REF#refs/tags/releases/typescript/core/v}"
+          if [ "$package_version" != "$tag_version" ]; then
+            echo "::error::typescript/core/package.json version ($package_version) does not match release tag ($tag_version)"
+            exit 1
+          fi
+          if [ "$source_version" != "$tag_version" ]; then
+            echo "::error::typescript/core/src/version.ts VERSION ($source_version) does not match release tag ($tag_version)"
+            exit 1
+          fi
+          echo "@mcap/core versions ($tag_version) match release tag"
       - run: yarn workspace @mcap/support lint:ci
       - run: yarn workspace @mcap/support build
       - run: yarn workspace @mcap/nodejs lint:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,7 @@ jobs:
       - run: make lint
       - run: make test
       - name: Check library version
-        if: |
-          !github.event.pull_request.head.repo.fork &&
-          startsWith(github.ref, 'refs/tags/go/mcap/v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/go/mcap/v')
         run: make -C cli/mcap build && ./check_tag.sh cli/mcap/bin/mcap
 
   python:
@@ -131,33 +129,25 @@ jobs:
           attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish mcap to PyPI
-        if: |
-          !github.event.pull_request.head.repo.fork &&
-          startsWith(github.ref, 'refs/tags/releases/python/mcap/v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/python/mcap/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/mcap/dist
 
       - name: Publish mcap-protobuf-support to PyPI
-        if: |
-          !github.event.pull_request.head.repo.fork &&
-          startsWith(github.ref, 'refs/tags/releases/python/mcap-protobuf-support/v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/python/mcap-protobuf-support/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/mcap-protobuf-support/dist
 
       - name: Publish mcap-ros1-support to PyPI
-        if: |
-          !github.event.pull_request.head.repo.fork &&
-          startsWith(github.ref, 'refs/tags/releases/python/mcap-ros1-support/v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/python/mcap-ros1-support/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/mcap-ros1-support/dist
 
       - name: Publish mcap-ros2-support to PyPI
-        if: |
-          !github.event.pull_request.head.repo.fork &&
-          startsWith(github.ref, 'refs/tags/releases/python/mcap-ros2-support/v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/python/mcap-ros2-support/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/mcap-ros2-support/dist
@@ -244,7 +234,7 @@ jobs:
       - run: yarn typescript:test
 
       - name: Check @mcap/core version matches tag
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/core/v')
         run: |
           package_version="$(node -p "require('./typescript/core/package.json').version")"
           source_version="$(node -e "const fs = require('fs'); const match = fs.readFileSync('typescript/core/src/version.ts', 'utf8').match(/export const VERSION = \"([^\"]+)\"/); if (!match) process.exit(2); console.log(match[1]);")"
@@ -259,19 +249,19 @@ jobs:
           fi
           echo "@mcap/core versions ($tag_version) match release tag"
       - name: Publish @mcap/core to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/core/v')
         run: yarn workspace @mcap/core npm publish --provenance --access public
 
       - name: Publish @mcap/support to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/support/v') }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/support/v')
         run: yarn workspace @mcap/support npm publish --provenance --access public
 
       - name: Publish @mcap/nodejs to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/nodejs/v') }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/nodejs/v')
         run: yarn workspace @mcap/nodejs npm publish --provenance --access public
 
       - name: Publish @mcap/browser to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/browser/v') }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/browser/v')
         run: yarn workspace @mcap/browser npm publish --provenance --access public
 
   typescript-examples:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
       - run: yarn typescript:test
 
       - name: Check @mcap/core version matches tag
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/core/v')
+        if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
         run: |
           package_version="$(node -p "require('./typescript/core/package.json').version")"
           source_version="$(node -e "const fs = require('fs'); const match = fs.readFileSync('typescript/core/src/version.ts', 'utf8').match(/export const VERSION = \"([^\"]+)\"/); if (!match) process.exit(2); console.log(match[1]);")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: false
+      - name: Check Swift version matches tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/swift/v')
+        run: |
+          source_version="$(grep -m1 '^public let mcapVersion = ' swift/mcap/Version.swift | sed -E 's/^public let mcapVersion = "(.*)"/\1/')"
+          tag_version="${GITHUB_REF#refs/tags/releases/swift/v}"
+          if [ "$source_version" != "$tag_version" ]; then
+            echo "::error::swift/mcap/Version.swift mcapVersion ($source_version) does not match release tag ($tag_version)"
+            exit 1
+          fi
+          echo "Swift mcapVersion ($source_version) matches release tag"
       - uses: ./.github/actions/setup-swift
         with:
           swift-version: "6.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,14 @@ jobs:
       - run: yarn fmt:check
       - run: yarn workspace @mcap/core lint:ci
       - run: yarn workspace @mcap/core build
+      - run: yarn workspace @mcap/support lint:ci
+      - run: yarn workspace @mcap/support build
+      - run: yarn workspace @mcap/nodejs lint:ci
+      - run: yarn workspace @mcap/nodejs build
+      - run: yarn workspace @mcap/browser lint:ci
+      - run: yarn workspace @mcap/browser build
+      - run: yarn typescript:test
+
       - name: Check @mcap/core version matches tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/typescript/core/v')
         run: |
@@ -240,14 +248,6 @@ jobs:
             exit 1
           fi
           echo "@mcap/core versions ($tag_version) match release tag"
-      - run: yarn workspace @mcap/support lint:ci
-      - run: yarn workspace @mcap/support build
-      - run: yarn workspace @mcap/nodejs lint:ci
-      - run: yarn workspace @mcap/nodejs build
-      - run: yarn workspace @mcap/browser lint:ci
-      - run: yarn workspace @mcap/browser build
-      - run: yarn typescript:test
-
       - name: Publish @mcap/core to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/releases/typescript/core/v') }}
         run: yarn workspace @mcap/core npm publish --provenance --access public

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,7 +51,7 @@ There are several TS packages; updating any follows a similar process.
 
 ## Swift
 
-1. Update `mcapLibraryIdentifier` in `swift/mcap/Records.swift`
+1. Update `mcapVersion` in `swift/mcap/Version.swift`
 2. Tag a release matching the version number `releases/swift/vX.Y.Z`
 
 ## Rust

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,7 +43,7 @@ There are several TS packages; updating any follows a similar process.
 
 1. Check out the version of the code you want to release
 2. Update the version in `typescript/{pkg}/package.json`
-   - For `@mcap/core`, update `LIBRARY_IDENTIFIER` in `typescript/core/src/McapWriter.ts`
+   - For `@mcap/core`, update `VERSION` in `typescript/core/src/version.ts`
 3. Make a PR with your changes to package.json
 4. Wait for the PR to pass CI and merge
 5. Checkout main and tag the merged commit with `releases/typescript/{pkg}/v#.#.#`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,6 +43,7 @@ There are several TS packages; updating any follows a similar process.
 
 1. Check out the version of the code you want to release
 2. Update the version in `typescript/{pkg}/package.json`
+   - For `@mcap/core`, update `LIBRARY_IDENTIFIER` in `typescript/core/src/McapWriter.ts`
 3. Make a PR with your changes to package.json
 4. Wait for the PR to pass CI and merge
 5. Checkout main and tag the merged commit with `releases/typescript/{pkg}/v#.#.#`
@@ -50,7 +51,8 @@ There are several TS packages; updating any follows a similar process.
 
 ## Swift
 
-Tag a release matching the version number `releases/swift/vX.Y.Z`
+1. Update `mcapLibraryIdentifier` in `swift/mcap/Records.swift`
+2. Tag a release matching the version number `releases/swift/vX.Y.Z`
 
 ## Rust
 

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -89,9 +89,9 @@ struct MCAP_PUBLIC McapWriterOptions {
   std::string profile;
   /**
    * @brief A freeform string written by recording libraries. For this library,
-   * the default is "libmcap {Major}.{Minor}.{Patch}".
+   * the default is "mcap-cpp/{Major}.{Minor}.{Patch}".
    */
-  std::string library = "libmcap " MCAP_LIBRARY_VERSION;
+  std::string library = "mcap-cpp/" MCAP_LIBRARY_VERSION;
 
   // The following options are less commonly used, providing more fine-grained
   // control of index records and the Summary section

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -1042,22 +1042,41 @@ TEST_CASE("RecordOffset equality operators", "[reader]") {
 }
 
 TEST_CASE("parsing", "header") {
-  Buffer buffer;
-  mcap::McapWriter writer;
-  mcap::McapWriterOptions opts("my-profile");
-  opts.library = "my-library";
-  writer.open(buffer, opts);
-  writer.close();
+  SECTION("default library") {
+    Buffer buffer;
+    mcap::McapWriter writer;
+    writer.open(buffer, mcap::McapWriterOptions("my-profile"));
+    writer.close();
 
-  mcap::McapReader reader;
-  auto status = reader.open(buffer);
-  requireOk(status);
+    mcap::McapReader reader;
+    auto status = reader.open(buffer);
+    requireOk(status);
 
-  auto header = reader.header();
-  REQUIRE(header != std::nullopt);
+    auto header = reader.header();
+    REQUIRE(header != std::nullopt);
 
-  REQUIRE(header->library == "my-library");
-  REQUIRE(header->profile == "my-profile");
+    REQUIRE(header->library == "mcap-cpp/" MCAP_LIBRARY_VERSION);
+    REQUIRE(header->profile == "my-profile");
+  }
+
+  SECTION("custom library") {
+    Buffer buffer;
+    mcap::McapWriter writer;
+    mcap::McapWriterOptions opts("my-profile");
+    opts.library = "my-library";
+    writer.open(buffer, opts);
+    writer.close();
+
+    mcap::McapReader reader;
+    auto status = reader.open(buffer);
+    requireOk(status);
+
+    auto header = reader.header();
+    REQUIRE(header != std::nullopt);
+
+    REQUIRE(header->library == "my-library");
+    REQUIRE(header->profile == "my-profile");
+  }
 }
 
 TEST_CASE("Schema isolation between files with noRepeatedSchemas=false", "[writer][reader]") {

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -45,11 +45,15 @@ type Writer struct {
 	closed bool
 }
 
+func libraryIdentifier() string {
+	return "mcap-go/" + strings.TrimPrefix(Version, "v")
+}
+
 // WriteHeader writes a header record to the output.
 func (w *Writer) WriteHeader(header *Header) error {
 	var library string
 	if !w.opts.OverrideLibrary {
-		library = fmt.Sprintf("mcap-go/%s", strings.TrimPrefix(Version, "v"))
+		library = libraryIdentifier()
 		if header.Library != "" && header.Library != library {
 			library += "; " + header.Library
 		}

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -48,7 +49,7 @@ type Writer struct {
 func (w *Writer) WriteHeader(header *Header) error {
 	var library string
 	if !w.opts.OverrideLibrary {
-		library = fmt.Sprintf("mcap go %s", Version)
+		library = fmt.Sprintf("mcap-go/%s", strings.TrimPrefix(Version, "v"))
 		if header.Library != "" && header.Library != library {
 			library += "; " + header.Library
 		}

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -529,7 +530,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 }
 
 func TestLibraryString(t *testing.T) {
-	thisLibraryString := fmt.Sprintf("mcap go %s", Version)
+	thisLibraryString := fmt.Sprintf("mcap-go/%s", strings.TrimPrefix(Version, "v"))
 	cases := []struct {
 		input  string
 		output string

--- a/go/mcap/writer_test.go
+++ b/go/mcap/writer_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"strings"
 	"testing"
 	"time"
 
@@ -530,7 +529,7 @@ func TestUnchunkedReadWrite(t *testing.T) {
 }
 
 func TestLibraryString(t *testing.T) {
-	thisLibraryString := fmt.Sprintf("mcap-go/%s", strings.TrimPrefix(Version, "v"))
+	thisLibraryString := libraryIdentifier()
 	cases := []struct {
 		input  string
 		output string

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -2,9 +2,9 @@ import time
 from io import BufferedWriter
 from typing import IO, Any, Dict, Optional, Tuple, Union
 
-import mcap
 from mcap.well_known import MessageEncoding
 from mcap.writer import CompressionType
+from mcap.writer import LIBRARY_IDENTIFIER as MCAP_LIBRARY_IDENTIFIER
 from mcap.writer import Writer as McapWriter
 
 from . import __version__
@@ -13,7 +13,7 @@ from .schema import register_schema
 
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
-    return f"mcap-python/{mcap.__version__} mcap-protobuf-support/{__version__}"
+    return f"{MCAP_LIBRARY_IDENTIFIER} mcap-protobuf-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -14,7 +14,7 @@ from .schema import register_schema
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-protobuf-support/{__version__}; mcap-python/{mcap_version}"
+    return f"mcap-protobuf-support/{__version__} mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -14,7 +14,7 @@ from .schema import register_schema
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-python-protobuf-support/{__version__}; mcap-python/{mcap_version}"
+    return f"mcap-protobuf-support/{__version__}; mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -14,7 +14,7 @@ from .schema import register_schema
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
     mcap_version = getattr(mcap, "__version__", "<=0.0.10")
-    return f"python mcap-protobuf-support {__version__}; mcap {mcap_version}"
+    return f"mcap-python-protobuf-support/{__version__}; mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -3,8 +3,8 @@ from io import BufferedWriter
 from typing import IO, Any, Dict, Optional, Tuple, Union
 
 from mcap.well_known import MessageEncoding
-from mcap.writer import CompressionType
 from mcap.writer import LIBRARY_IDENTIFIER as MCAP_LIBRARY_IDENTIFIER
+from mcap.writer import CompressionType
 from mcap.writer import Writer as McapWriter
 
 from . import __version__

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -13,7 +13,7 @@ from .schema import register_schema
 
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
-    mcap_version = getattr(mcap, "__version__", "<=0.0.10")
+    mcap_version = getattr(mcap, "__version__", "0.0.10")
     return f"mcap-python-protobuf-support/{__version__}; mcap-python/{mcap_version}"
 
 

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -14,7 +14,7 @@ from .schema import register_schema
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-protobuf-support/{__version__} mcap-python/{mcap_version}"
+    return f"mcap-python/{mcap_version} mcap-protobuf-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -13,8 +13,7 @@ from .schema import register_schema
 
 def _library_identifier():
     """the default value written into MCAP headers by this library."""
-    mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-python/{mcap_version} mcap-protobuf-support/{__version__}"
+    return f"mcap-python/{mcap.__version__} mcap-protobuf-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -10,8 +10,7 @@ from . import __version__
 
 
 def _library_identifier():
-    mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-python/{mcap_version} mcap-ros1-support/{__version__}"
+    return f"mcap-python/{mcap.__version__} mcap-ros1-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -2,8 +2,8 @@ import time
 from io import BufferedWriter, BytesIO
 from typing import IO, Any, Dict, Optional, Union
 
-from mcap.writer import CompressionType
 from mcap.writer import LIBRARY_IDENTIFIER as MCAP_LIBRARY_IDENTIFIER
+from mcap.writer import CompressionType
 from mcap.writer import Writer as McapWriter
 
 from . import __version__

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -11,7 +11,7 @@ from . import __version__
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-ros1-support/{__version__}; mcap-python/{mcap_version}"
+    return f"mcap-ros1-support/{__version__} mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -10,7 +10,7 @@ from . import __version__
 
 
 def _library_identifier():
-    mcap_version = getattr(mcap, "__version__", "<=0.0.10")
+    mcap_version = getattr(mcap, "__version__", "0.0.10")
     return f"mcap-python-ros1-support/{__version__}; mcap-python/{mcap_version}"
 
 

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -11,7 +11,7 @@ from . import __version__
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-python-ros1-support/{__version__}; mcap-python/{mcap_version}"
+    return f"mcap-ros1-support/{__version__}; mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -11,7 +11,7 @@ from . import __version__
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "<=0.0.10")
-    return f"mcap-ros1-support {__version__}; mcap {mcap_version}"
+    return f"mcap-python-ros1-support/{__version__}; mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -2,15 +2,15 @@ import time
 from io import BufferedWriter, BytesIO
 from typing import IO, Any, Dict, Optional, Union
 
-import mcap
 from mcap.writer import CompressionType
+from mcap.writer import LIBRARY_IDENTIFIER as MCAP_LIBRARY_IDENTIFIER
 from mcap.writer import Writer as McapWriter
 
 from . import __version__
 
 
 def _library_identifier():
-    return f"mcap-python/{mcap.__version__} mcap-ros1-support/{__version__}"
+    return f"{MCAP_LIBRARY_IDENTIFIER} mcap-ros1-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros1-support/mcap_ros1/writer.py
+++ b/python/mcap-ros1-support/mcap_ros1/writer.py
@@ -11,7 +11,7 @@ from . import __version__
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-ros1-support/{__version__} mcap-python/{mcap_version}"
+    return f"mcap-python/{mcap_version} mcap-ros1-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -21,7 +21,7 @@ class McapROS2WriteError(McapError):
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-python-ros2-support/{__version__}; mcap-python/{mcap_version}"
+    return f"mcap-ros2-support/{__version__}; mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -20,7 +20,7 @@ class McapROS2WriteError(McapError):
 
 
 def _library_identifier():
-    mcap_version = getattr(mcap, "__version__", "<=0.0.10")
+    mcap_version = getattr(mcap, "__version__", "0.0.10")
     return f"mcap-python-ros2-support/{__version__}; mcap-python/{mcap_version}"
 
 

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -21,7 +21,7 @@ class McapROS2WriteError(McapError):
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-ros2-support/{__version__}; mcap-python/{mcap_version}"
+    return f"mcap-ros2-support/{__version__} mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -5,8 +5,8 @@ from typing import IO, Any, Dict, Optional, Union
 from mcap.exceptions import McapError
 from mcap.records import Schema
 from mcap.well_known import SchemaEncoding
-from mcap.writer import CompressionType
 from mcap.writer import LIBRARY_IDENTIFIER as MCAP_LIBRARY_IDENTIFIER
+from mcap.writer import CompressionType
 from mcap.writer import Writer as McapWriter
 
 from . import __version__

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -20,8 +20,7 @@ class McapROS2WriteError(McapError):
 
 
 def _library_identifier():
-    mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-python/{mcap_version} mcap-ros2-support/{__version__}"
+    return f"mcap-python/{mcap.__version__} mcap-ros2-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -2,11 +2,11 @@ import time
 from io import BufferedWriter
 from typing import IO, Any, Dict, Optional, Union
 
-import mcap
 from mcap.exceptions import McapError
 from mcap.records import Schema
 from mcap.well_known import SchemaEncoding
 from mcap.writer import CompressionType
+from mcap.writer import LIBRARY_IDENTIFIER as MCAP_LIBRARY_IDENTIFIER
 from mcap.writer import Writer as McapWriter
 
 from . import __version__
@@ -20,7 +20,7 @@ class McapROS2WriteError(McapError):
 
 
 def _library_identifier():
-    return f"mcap-python/{mcap.__version__} mcap-ros2-support/{__version__}"
+    return f"{MCAP_LIBRARY_IDENTIFIER} mcap-ros2-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -21,7 +21,7 @@ class McapROS2WriteError(McapError):
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "0.0.10")
-    return f"mcap-ros2-support/{__version__} mcap-python/{mcap_version}"
+    return f"mcap-python/{mcap_version} mcap-ros2-support/{__version__}"
 
 
 class Writer:

--- a/python/mcap-ros2-support/mcap_ros2/writer.py
+++ b/python/mcap-ros2-support/mcap_ros2/writer.py
@@ -21,7 +21,7 @@ class McapROS2WriteError(McapError):
 
 def _library_identifier():
     mcap_version = getattr(mcap, "__version__", "<=0.0.10")
-    return f"mcap-ros2-support {__version__}; mcap {mcap_version}"
+    return f"mcap-python-ros2-support/{__version__}; mcap-python/{mcap_version}"
 
 
 class Writer:

--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -39,7 +39,7 @@ from .records import (
 )
 
 MCAP0_MAGIC = struct.pack("<8B", 137, 77, 67, 65, 80, 48, 13, 10)
-LIBRARY_IDENTIFIER = f"python mcap {__version__}"
+LIBRARY_IDENTIFIER = f"mcap-python/{__version__}"
 
 
 class CompressionType(Enum):

--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -499,4 +499,4 @@ class Writer:
             self.__finalize_chunk()
 
 
-__all__ = ["CompressionType", "IndexType", "Writer"]
+__all__ = ["CompressionType", "IndexType", "LIBRARY_IDENTIFIER", "Writer"]

--- a/python/mcap/tests/test_writer.py
+++ b/python/mcap/tests/test_writer.py
@@ -8,9 +8,9 @@ from typing import List
 import lz4.frame
 import pytest
 
-from mcap.records import Chunk, ChunkIndex, Statistics
+from mcap.records import Chunk, ChunkIndex, Header, Statistics
 from mcap.stream_reader import StreamReader
-from mcap.writer import CompressionType, Writer
+from mcap.writer import LIBRARY_IDENTIFIER, CompressionType, Writer
 
 
 @contextlib.contextmanager
@@ -72,6 +72,20 @@ def test_lz4_chunks():
         uncompressed_data: bytes = lz4.frame.decompress(chunk.data)
         assert chunk.uncompressed_size == len(uncompressed_data)
         assert chunk.uncompressed_crc == zlib.crc32(uncompressed_data)
+
+
+def test_default_library_identifier():
+    io = BytesIO()
+    writer = Writer(io)
+    writer.start()
+    writer.finish()
+
+    io.seek(0)
+    records = list(StreamReader(io).records)
+    header = next(r for r in records if isinstance(r, Header))
+
+    assert header.library == LIBRARY_IDENTIFIER
+    assert header.library.startswith("mcap-python/")
 
 
 @pytest.mark.parametrize(

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -391,7 +391,7 @@ mod tests {
         let mut parsed = ParsedMcap {
             header: Some(Header {
                 profile: "demo".to_string(),
-                library: "mcap-rust/0.24.0".to_string(),
+                library: mcap::LIBRARY_IDENTIFIER.to_string(),
             }),
             statistics: Some(Statistics {
                 message_count: 2,
@@ -428,7 +428,7 @@ mod tests {
         );
 
         let rendered = render_info(&parsed);
-        assert!(rendered.contains("library:     mcap-rust/0.24.0"));
+        assert!(rendered.contains(&format!("library:     {}", mcap::LIBRARY_IDENTIFIER)));
         assert!(rendered.contains("profile:     demo"));
         assert!(rendered.contains("messages:    2"));
         assert!(rendered.contains("channels:"));

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -391,7 +391,7 @@ mod tests {
         let mut parsed = ParsedMcap {
             header: Some(Header {
                 profile: "demo".to_string(),
-                library: "mcap-rust".to_string(),
+                library: "mcap-rust/0.24.0".to_string(),
             }),
             statistics: Some(Statistics {
                 message_count: 2,
@@ -428,7 +428,7 @@ mod tests {
         );
 
         let rendered = render_info(&parsed);
-        assert!(rendered.contains("library:     mcap-rust"));
+        assert!(rendered.contains("library:     mcap-rust/0.24.0"));
         assert!(rendered.contains("profile:     demo"));
         assert!(rendered.contains("messages:    2"));
         assert!(rendered.contains("channels:"));

--- a/rust/mcap/src/lib.rs
+++ b/rust/mcap/src/lib.rs
@@ -158,6 +158,8 @@ pub type McapResult<T> = Result<T, McapError>;
 pub const MAGIC: &[u8] = &[0x89, b'M', b'C', b'A', b'P', 0x30, b'\r', b'\n'];
 /// Crate version for the Rust MCAP library.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Default Header.library identifier for the Rust MCAP library.
+pub const LIBRARY_IDENTIFIER: &str = concat!("mcap-rust/", env!("CARGO_PKG_VERSION"));
 
 /// Compression options for chunks of channels, schemas, and messages in an MCAP file
 #[derive(Debug, Copy, Clone)]

--- a/rust/mcap/src/sans_io/linear_reader.rs
+++ b/rust/mcap/src/sans_io/linear_reader.rs
@@ -873,8 +873,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::io::Read;
 
-    const DEFAULT_LIBRARY_LENGTH: u64 =
-        ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+    const DEFAULT_LIBRARY_LENGTH: u64 = crate::LIBRARY_IDENTIFIER.len() as u64;
 
     fn basic_chunked_file(compression: Option<Compression>) -> McapResult<Vec<u8>> {
         let mut buf = std::io::Cursor::new(Vec::new());

--- a/rust/mcap/src/sans_io/linear_reader.rs
+++ b/rust/mcap/src/sans_io/linear_reader.rs
@@ -873,6 +873,9 @@ mod tests {
     use std::collections::BTreeMap;
     use std::io::Read;
 
+    const DEFAULT_LIBRARY_LENGTH: u64 =
+        ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+
     fn basic_chunked_file(compression: Option<Compression>) -> McapResult<Vec<u8>> {
         let mut buf = std::io::Cursor::new(Vec::new());
         {
@@ -1012,13 +1015,13 @@ mod tests {
                     parse_record(opcode, data).expect("parse should not fail");
                 }
                 Err(err) => {
-                    assert!(matches!(
-                        err,
-                        McapError::RecordTooLarge {
-                            opcode: op::HEADER,
-                            len: 22
+                    match err {
+                        McapError::RecordTooLarge { opcode, len } => {
+                            assert_eq!(opcode, op::HEADER);
+                            assert_eq!(len, 8 + DEFAULT_LIBRARY_LENGTH);
                         }
-                    ));
+                        _ => panic!("expected RecordTooLarge, got {err:?}"),
+                    }
                     return;
                 }
             }

--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -1898,6 +1898,9 @@ mod tests {
 
     use super::*;
 
+    const DEFAULT_LIBRARY_LENGTH: u64 =
+        ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+
     #[test]
     fn writes_all_channel_ids() {
         let file = std::io::Cursor::new(Vec::new());
@@ -2102,7 +2105,7 @@ mod tests {
             .into_inner()
             .stream_position()
             .expect("failed to get stream position");
-        assert_eq!(output_len, 487);
+        assert_eq!(output_len, 473 + DEFAULT_LIBRARY_LENGTH);
     }
 
     #[test]

--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -146,7 +146,7 @@ impl Default for WriteOptions {
             #[cfg(not(feature = "zstd"))]
             compression: None,
             profile: String::new(),
-            library: String::from("mcap-rust/") + env!("CARGO_PKG_VERSION"),
+            library: crate::LIBRARY_IDENTIFIER.to_string(),
             chunk_size: Some(Self::DEFAULT_CHUNK_SIZE),
             use_chunks: true,
             disable_seeking: false,
@@ -1898,8 +1898,7 @@ mod tests {
 
     use super::*;
 
-    const DEFAULT_LIBRARY_LENGTH: u64 =
-        ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+    const DEFAULT_LIBRARY_LENGTH: u64 = crate::LIBRARY_IDENTIFIER.len() as u64;
 
     #[test]
     fn writes_all_channel_ids() {

--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -146,7 +146,7 @@ impl Default for WriteOptions {
             #[cfg(not(feature = "zstd"))]
             compression: None,
             profile: String::new(),
-            library: String::from("mcap-rs-") + env!("CARGO_PKG_VERSION"),
+            library: String::from("mcap-rust/") + env!("CARGO_PKG_VERSION"),
             chunk_size: Some(Self::DEFAULT_CHUNK_SIZE),
             use_chunks: true,
             disable_seeking: false,

--- a/rust/mcap/tests/attachment.rs
+++ b/rust/mcap/tests/attachment.rs
@@ -9,6 +9,8 @@ use anyhow::Result;
 use memmap2::Mmap;
 use tempfile::tempfile;
 
+const DEFAULT_LIBRARY_LENGTH: u64 = ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+
 #[test]
 fn smoke() -> Result<()> {
     let mapped = map_mcap("../../tests/conformance/data/OneAttachment/OneAttachment.mcap")?;
@@ -72,7 +74,7 @@ fn test_attach_in_multiple_parts() -> Result<()> {
         }),
         attachment_indexes: vec![mcap::records::AttachmentIndex {
             // offset depends on the length of the embedded library string, which includes the crate version
-            offset: 33 + (env!("CARGO_PKG_VERSION").len() as u64),
+            offset: 25 + DEFAULT_LIBRARY_LENGTH,
             length: 95,
             log_time: 100,
             create_time: 200,
@@ -134,7 +136,7 @@ fn round_trip() -> Result<()> {
         }),
         attachment_indexes: vec![mcap::records::AttachmentIndex {
             // offset depends on the length of the embedded library string, which includes the crate version
-            offset: 33 + (env!("CARGO_PKG_VERSION").len() as u64),
+            offset: 25 + DEFAULT_LIBRARY_LENGTH,
             length: 78,
             log_time: 2,
             create_time: 1,

--- a/rust/mcap/tests/attachment.rs
+++ b/rust/mcap/tests/attachment.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use memmap2::Mmap;
 use tempfile::tempfile;
 
-const DEFAULT_LIBRARY_LENGTH: u64 = ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+const DEFAULT_LIBRARY_LENGTH: u64 = mcap::LIBRARY_IDENTIFIER.len() as u64;
 
 #[test]
 fn smoke() -> Result<()> {

--- a/rust/mcap/tests/metadata.rs
+++ b/rust/mcap/tests/metadata.rs
@@ -8,6 +8,8 @@ use anyhow::Result;
 use memmap2::Mmap;
 use tempfile::tempfile;
 
+const DEFAULT_LIBRARY_LENGTH: u64 = ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+
 #[test]
 fn smoke() -> Result<()> {
     let mapped = map_mcap("../../tests/conformance/data/OneMetadata/OneMetadata.mcap")?;
@@ -57,7 +59,7 @@ fn round_trip() -> Result<()> {
         }),
         metadata_indexes: vec![mcap::records::MetadataIndex {
             // offset depends on the length of the embedded library string, which includes the crate version
-            offset: 33 + (env!("CARGO_PKG_VERSION").len() as u64),
+            offset: 25 + DEFAULT_LIBRARY_LENGTH,
             length: 41,
             name: String::from("myMetadata"),
         }],

--- a/rust/mcap/tests/metadata.rs
+++ b/rust/mcap/tests/metadata.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use memmap2::Mmap;
 use tempfile::tempfile;
 
-const DEFAULT_LIBRARY_LENGTH: u64 = ("mcap-rust/".len() + env!("CARGO_PKG_VERSION").len()) as u64;
+const DEFAULT_LIBRARY_LENGTH: u64 = mcap::LIBRARY_IDENTIFIER.len() as u64;
 
 #[test]
 fn smoke() -> Result<()> {

--- a/swift/mcap/MCAPWriter.swift
+++ b/swift/mcap/MCAPWriter.swift
@@ -106,7 +106,7 @@ public final class MCAPWriter {
     buffer.removeAll(keepingCapacity: true)
   }
 
-  public func start(library: String, profile: String) async {
+  public func start(library: String = mcapLibraryIdentifier, profile: String = "") async {
     buffer.append(mcapMagic)
     Header(profile: profile, library: library).serialize(to: &buffer)
   }

--- a/swift/mcap/Records.swift
+++ b/swift/mcap/Records.swift
@@ -7,6 +7,7 @@ public typealias Timestamp = UInt64
 
 /// Magic bytes that appear at the beginning and end of every valid MCAP file: `"\u{89}MCAP0\r\n"`.
 public let mcapMagic = Data([137, 77, 67, 65, 80, 48, 13, 10])
+public let mcapLibraryIdentifier = "mcap-swift/1.0.0"
 
 public enum MCAPReadError: Error, Equatable {
   case invalidMagic(actual: [UInt8])

--- a/swift/mcap/Records.swift
+++ b/swift/mcap/Records.swift
@@ -7,7 +7,6 @@ public typealias Timestamp = UInt64
 
 /// Magic bytes that appear at the beginning and end of every valid MCAP file: `"\u{89}MCAP0\r\n"`.
 public let mcapMagic = Data([137, 77, 67, 65, 80, 48, 13, 10])
-public let mcapLibraryIdentifier = "mcap-swift/1.0.0"
 
 public enum MCAPReadError: Error, Equatable {
   case invalidMagic(actual: [UInt8])

--- a/swift/mcap/Version.swift
+++ b/swift/mcap/Version.swift
@@ -1,0 +1,2 @@
+public let mcapVersion = "1.0.0"
+public let mcapLibraryIdentifier = "mcap-swift/\(mcapVersion)"

--- a/swift/test/MCAPTests.swift
+++ b/swift/test/MCAPTests.swift
@@ -19,7 +19,6 @@ struct MCAPTests {
 
     #expect(header.profile == "")
     #expect(header.library == mcapLibraryIdentifier)
-    #expect(mcapLibraryIdentifier == "mcap-swift/\(mcapVersion)")
     #expect(header.library.hasPrefix("mcap-swift/"))
   }
 

--- a/swift/test/MCAPTests.swift
+++ b/swift/test/MCAPTests.swift
@@ -19,7 +19,7 @@ struct MCAPTests {
 
     #expect(header.profile == "")
     #expect(header.library == mcapLibraryIdentifier)
-    #expect(header.library == "mcap-swift/1.0.0")
+    #expect(header.library.hasPrefix("mcap-swift/"))
   }
 
   @Test

--- a/swift/test/MCAPTests.swift
+++ b/swift/test/MCAPTests.swift
@@ -7,6 +7,22 @@ import Testing
 
 struct MCAPTests {
   @Test
+  func defaultLibraryIdentifier() async throws {
+    let buffer = Buffer()
+    let writer = MCAPWriter(buffer)
+    await writer.start()
+    await writer.end()
+
+    let reader = MCAPStreamedReader()
+    reader.append(buffer.data)
+    let header = try reader.nextRecord() as! Header
+
+    #expect(header.profile == "")
+    #expect(header.library == mcapLibraryIdentifier)
+    #expect(header.library == "mcap-swift/1.0.0")
+  }
+
+  @Test
   func empty() async throws {
     let buffer = Buffer()
     let writer = MCAPWriter(buffer)

--- a/swift/test/MCAPTests.swift
+++ b/swift/test/MCAPTests.swift
@@ -19,6 +19,7 @@ struct MCAPTests {
 
     #expect(header.profile == "")
     #expect(header.library == mcapLibraryIdentifier)
+    #expect(mcapLibraryIdentifier == "mcap-swift/\(mcapVersion)")
     #expect(header.library.hasPrefix("mcap-swift/"))
   }
 

--- a/tests/cli-conformance/src/cases.ts
+++ b/tests/cli-conformance/src/cases.ts
@@ -1383,9 +1383,9 @@ export const cases: CliTestCase[] = [
     knownDifference: {
       id: "recover-library-header",
       summary:
-        "Rust recover preserves the source Header.library verbatim; Go recover re-stamps it with the go/mcap writer identity (mcap go vX.Y.Z).",
+        "Rust recover preserves the source Header.library verbatim; Go recover re-stamps it with the go/mcap writer identity (mcap-go/X.Y.Z).",
       reason:
-        "Header.library identifies the software that produced the data, which for a single-input transform like recover is still the original recorder. Rust preserves it verbatim, so the value is stable across repeated transforms. Go re-stamps `mcap go vX.Y.Z` and prepends any earlier, differing library (a dedup guard at writer.go skips an identical one), so across version bumps the field accretes distinct tokens (e.g. `mcap go v1.9.0; mcap go v1.8.0`) and stops cleanly identifying the original producer. The TEN_MESSAGES fixture has an empty source library, so Rust writes the empty original while Go writes `mcap go vX.Y.Z`. (Rust's single-input transforms — filter/compress/decompress/recover/sort — all preserve; merge/convert intentionally stamp the mcap-rs identity since there is no single source library to carry forward.)",
+        "Header.library identifies the software that produced the data, which for a single-input transform like recover is still the original recorder. Rust preserves it verbatim, so the value is stable across repeated transforms. Go re-stamps `mcap-go/X.Y.Z` and prepends any earlier, differing library (a dedup guard at writer.go skips an identical one), so across version bumps the field accretes distinct tokens (e.g. `mcap-go/1.9.0; mcap-go/1.8.0`) and stops cleanly identifying the original producer. The TEN_MESSAGES fixture has an empty source library, so Rust writes the empty original while Go writes `mcap-go/X.Y.Z`. (Rust's single-input transforms — filter/compress/decompress/recover/sort — all preserve; merge/convert intentionally stamp the mcap-rust identity since there is no single source library to carry forward.)",
       desiredBehavior:
         "Rust recover should keep preserving the source Header.library verbatim rather than re-stamping it; rewrite provenance, if needed, belongs in a separate record rather than concatenated into the library field.",
       goBehavior: {
@@ -1394,7 +1394,7 @@ export const cases: CliTestCase[] = [
           {
             path: "recovered.mcap",
             exists: true,
-            mcapSummary: { libraryContains: "mcap go" },
+            mcapSummary: { libraryContains: "mcap-go/" },
           },
         ],
       },

--- a/typescript/core/src/McapWriter.test.ts
+++ b/typescript/core/src/McapWriter.test.ts
@@ -35,7 +35,7 @@ describe("McapWriter", () => {
       profile: "",
       library: LIBRARY_IDENTIFIER,
     });
-    expect(LIBRARY_IDENTIFIER).toBe("mcap-typescript/2.2.1");
+    expect(LIBRARY_IDENTIFIER).toMatch(/^mcap-typescript\/.+/);
   });
 
   it("supports messages with logTime 0", async () => {

--- a/typescript/core/src/McapWriter.test.ts
+++ b/typescript/core/src/McapWriter.test.ts
@@ -2,7 +2,7 @@ import { crc32 } from "@foxglove/crc";
 
 import { McapIndexedReader } from "./McapIndexedReader.ts";
 import McapStreamReader from "./McapStreamReader.ts";
-import { McapWriter } from "./McapWriter.ts";
+import { LIBRARY_IDENTIFIER, McapWriter } from "./McapWriter.ts";
 import Reader from "./Reader.ts";
 import { TempBuffer } from "./TempBuffer.ts";
 import { MCAP_MAGIC, Opcode } from "./constants.ts";
@@ -22,6 +22,22 @@ function readAsMcapStream(data: Uint8Array) {
 }
 
 describe("McapWriter", () => {
+  it("uses the TypeScript library identifier by default", async () => {
+    const tempBuffer = new TempBuffer();
+    const writer = new McapWriter({ writable: tempBuffer });
+
+    await writer.start();
+    await writer.end();
+
+    const records = readAsMcapStream(tempBuffer.get());
+    expect(records[0]).toEqual({
+      type: "Header",
+      profile: "",
+      library: LIBRARY_IDENTIFIER,
+    });
+    expect(LIBRARY_IDENTIFIER).toBe("mcap-typescript/2.2.1");
+  });
+
   it("supports messages with logTime 0", async () => {
     const tempBuffer = new TempBuffer();
     const writer = new McapWriter({ writable: tempBuffer });

--- a/typescript/core/src/McapWriter.test.ts
+++ b/typescript/core/src/McapWriter.test.ts
@@ -2,13 +2,14 @@ import { crc32 } from "@foxglove/crc";
 
 import { McapIndexedReader } from "./McapIndexedReader.ts";
 import McapStreamReader from "./McapStreamReader.ts";
-import { LIBRARY_IDENTIFIER, McapWriter } from "./McapWriter.ts";
+import { McapWriter } from "./McapWriter.ts";
 import Reader from "./Reader.ts";
 import { TempBuffer } from "./TempBuffer.ts";
 import { MCAP_MAGIC, Opcode } from "./constants.ts";
 import { parseMagic, parseRecord } from "./parse.ts";
 import { collect, keyValues, record, string, uint16LE, uint32LE, uint64LE } from "./testUtils.ts";
 import type { TypedMcapRecord } from "./types.ts";
+import { LIBRARY_IDENTIFIER, VERSION } from "./version.ts";
 
 function readAsMcapStream(data: Uint8Array) {
   const reader = new McapStreamReader();
@@ -35,6 +36,8 @@ describe("McapWriter", () => {
       profile: "",
       library: LIBRARY_IDENTIFIER,
     });
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+    expect(LIBRARY_IDENTIFIER).toBe(`mcap-typescript/${VERSION}`);
     expect(LIBRARY_IDENTIFIER).toMatch(/^mcap-typescript\/.+/);
   });
 

--- a/typescript/core/src/McapWriter.ts
+++ b/typescript/core/src/McapWriter.ts
@@ -22,6 +22,7 @@ import type {
   Statistics,
   IReadable,
 } from "./types.ts";
+import { LIBRARY_IDENTIFIER } from "./version.ts";
 
 export type McapWriterOptions = {
   writable: IWritable;
@@ -38,8 +39,6 @@ export type McapWriterOptions = {
   chunkSize?: number;
   compressChunk?: (chunkData: Uint8Array) => { compression: string; compressedData: Uint8Array };
 };
-
-export const LIBRARY_IDENTIFIER = "mcap-typescript/2.2.1";
 
 /**
  * McapWriter provides an interface for writing messages to MCAP files.

--- a/typescript/core/src/McapWriter.ts
+++ b/typescript/core/src/McapWriter.ts
@@ -39,6 +39,8 @@ export type McapWriterOptions = {
   compressChunk?: (chunkData: Uint8Array) => { compression: string; compressedData: Uint8Array };
 };
 
+export const LIBRARY_IDENTIFIER = "mcap-typescript/2.2.1";
+
 /**
  * McapWriter provides an interface for writing messages to MCAP files.
  *
@@ -182,7 +184,7 @@ export class McapWriter {
     return writer;
   }
 
-  async start(header: Header): Promise<void> {
+  async start(header: Header = { profile: "", library: LIBRARY_IDENTIFIER }): Promise<void> {
     if (this.#appendMode) {
       throw new Error(`Cannot call start() when writer is in append mode`);
     }

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -1,6 +1,6 @@
 export { McapIndexedReader } from "./McapIndexedReader.ts";
 export { default as McapStreamReader } from "./McapStreamReader.ts";
-export { McapWriter } from "./McapWriter.ts";
+export { LIBRARY_IDENTIFIER, McapWriter } from "./McapWriter.ts";
 export type { McapWriterOptions } from "./McapWriter.ts";
 export { McapRecordBuilder } from "./McapRecordBuilder.ts";
 export { ChunkBuilder as McapChunkBuilder } from "./ChunkBuilder.ts";

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -1,6 +1,6 @@
 export { McapIndexedReader } from "./McapIndexedReader.ts";
 export { default as McapStreamReader } from "./McapStreamReader.ts";
-export { LIBRARY_IDENTIFIER, McapWriter } from "./McapWriter.ts";
+export { McapWriter } from "./McapWriter.ts";
 export type { McapWriterOptions } from "./McapWriter.ts";
 export { McapRecordBuilder } from "./McapRecordBuilder.ts";
 export { ChunkBuilder as McapChunkBuilder } from "./ChunkBuilder.ts";
@@ -11,6 +11,7 @@ export * from "./constants.ts";
 export * from "./hasMcapPrefix.ts";
 export * from "./parse.ts";
 export * from "./TempBuffer.ts";
+export * from "./version.ts";
 export type * from "./types.ts";
 
 // Backwards compatibility

--- a/typescript/core/src/version.ts
+++ b/typescript/core/src/version.ts
@@ -1,0 +1,2 @@
+export const VERSION = "2.2.1";
+export const LIBRARY_IDENTIFIER = `mcap-typescript/${VERSION}`;

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -94,7 +94,7 @@ Report summary statistics on an MCAP file:
 <!-- cspell: disable -->
 
     $ mcap info demo.mcap
-    library: mcap go #(devel)
+    library: mcap-go/#(devel)
     profile: ros1
     messages: 1606
     duration: 7.780758504s
@@ -137,7 +137,7 @@ All commands except `convert` support reading from remote files stored in **GCS*
 <!-- cspell: disable -->
 
     $ mcap info gs://your-remote-bucket/demo.mcap
-    library: mcap go #(devel)
+    library: mcap-go/#(devel)
     profile: ros1
     messages: 1606
     duration: 7.780758504s


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

MCAP writers now use `mcap-<lang>/<ver>` library identifiers consistently across language SDKs.

### Docs

Updated CLI guide samples and release notes for TypeScript/Swift identifier version bumps.

### Description

Standardizes MCAP `Header.library` values to user-agent-like strings such as `mcap-rust/0.24.0` and `mcap-go/1.8.0`. This intentionally changes the prefix format for newly written files, which may affect downstream consumers matching on old prefixes like `mcap go`, `libmcap`, `mcap-rs`, or `python mcap`.