### PR TITLE
GHA: Pin Windows runners to windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - run: make run-examples-host
 
   cpp-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         working-directory: cpp
@@ -313,13 +313,13 @@ jobs:
             build: cargo build
             exe: ""
           - os: windows
-            image: windows-latest
+            image: windows-2022
             arch: amd64
             target: x86_64-pc-windows-msvc
             build: cargo build
             exe: ".exe"
           - os: windows
-            image: windows-latest
+            image: windows-2022
             arch: arm64
             target: aarch64-pc-windows-msvc
             build: cargo build
@@ -454,7 +454,7 @@ jobs:
             arch: arm64
             env: {}
           - os: windows
-            image: windows-latest
+            image: windows-2022
             arch: amd64
             env: {}
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

All CI builds are currently failing because `windows-latest` now resolves to Windows Server 2025 (`windows-2025-vs2026`), which ships GCC 15. The C++ Windows CI job uses Conan 1, which auto-detects that compiler but rejects version `15` as an invalid `settings.compiler.version` value.

Pin all Windows runners in CI to `windows-2022` as a short term fix until we upgrade to Conan 2.