### PR TITLE
rust: bump mcap to 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "mcap"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/rust/mcap/Cargo.toml
+++ b/rust/mcap/Cargo.toml
@@ -7,7 +7,7 @@ categories = [ "science::robotics", "compression" ]
 repository = "https://github.com/foxglove/mcap"
 documentation = "https://docs.rs/mcap"
 readme = "README.md"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## Added
- `Writer::add_schema_with_id` and `Writer::add_channel_with_id` for writing records with explicit IDs without content de-duplication, so distinct IDs from a source file are preserved even when content is identical (#1632).
- Public `mcap::VERSION` and `mcap::LIBRARY_IDENTIFIER` constants (#1702).
- `WriteOptions::DEFAULT_CHUNK_SIZE` constant.

## Changed
- Default writer `Header.library` string is now `mcap-rust/<version>` (was `mcap-rs-<version>`) (#1702). **Breaking** for anyone asserting on the exact string.
- Default chunk size increased to 1 MiB (was 768 KiB), standardizing with the other MCAP libraries (#1659).
- Established a minimum supported Rust version (`rust-version = "1.81"`) (#1710).
- Dependency bumps: `binrw` 0.12 → 0.15, `thiserror` 1 → 2 (#1705, #1710).

## Removed
- Removed unused `McapError` variants `AttachmentInProgress`, `RecordTooShort`, and `UnexpectedChunkRecord` (#1494). **Breaking** for code matching on these variants.

## Fixed
- Corrected typos in several `McapError` messages (e.g. `expeted` → `expected`, `mulitple` → `multiple`) — note these are user-visible error string changes (#1492).
- Fixed typos and inaccurate references in doc comments, including `ChunkIndex::compressed_data_offset` now correctly documenting `BadChunkStartOffset` (#1607, #1516).