### PR TITLE
rust: Relax binrw, add MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,14 @@ jobs:
       - run: cargo test --workspace --all-features
       - run: cargo build -p mcap --all-features --target wasm32-unknown-unknown
       - run: cargo check -p mcap --all-features --target wasm32-unknown-unknown
+
+      # Verify the crate builds with the rust-version declared in rust/mcap/Cargo.toml,
+      # using the committed Cargo.lock so we test our own MSRV rather than dependencies.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - run: cargo msrv verify --manifest-path rust/mcap/Cargo.toml -- cargo check -p mcap --all-features --locked
+
       - run: cargo publish -p mcap --dry-run
       - name: "publish to crates.io"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/rust/v')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binrw"
-version = "0.15.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
+checksum = "81419ff39e6ed10a92a7f125290859776ced35d9a08a665ae40b23e7ca702f30"
 dependencies = [
  "array-init",
  "binrw_derive",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "binrw_derive"
-version = "0.15.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
+checksum = "376404e55ec40d0d6f8b4b7df3f87b87954bd987f0cf9a7207ea3b6ea5c9add4"
 dependencies = [
  "either",
  "owo-colors",

--- a/rust/mcap/Cargo.toml
+++ b/rust/mcap/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/mcap"
 readme = "README.md"
 version = "0.24.0"
 edition = "2021"
+rust-version = "1.81"
 license = "MIT"
 
 [dependencies]

--- a/rust/mcap/Cargo.toml
+++ b/rust/mcap/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-binrw = "0.15.1"
+binrw = "0.15"
 byteorder = "1.4"
 crc32fast = "1.3"
 enumset = "1.0.11"


### PR DESCRIPTION
### Changelog

- rust: Add minimum supported rust-version

(binrw change has not been released, so no changelog entry)

### Docs

None

### Description

- Relax `binrw` (bumped in https://github.com/foxglove/mcap/pull/1705) from `0.15.1` to `0.15`. Because mcap is a library, we shouldn't be unnecessarily strict with dependencies.
- Add missing `rust-version` from mcap crate, and verify support in CI