### PR TITLE
cli: Fix fallback for chunk-local channel summaries

### DIFF
--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -297,6 +297,10 @@ pub(crate) fn read_summary_for_indexed_transcode(input: &[u8]) -> Result<Option<
 }
 
 pub(crate) fn summary_supports_indexed_transcode(summary: &mcap::Summary) -> bool {
+    if !summary.chunk_indexes.is_empty() && summary.channels.is_empty() {
+        return false;
+    }
+
     if let Some(stats) = &summary.stats {
         if stats.channel_count as usize > summary.channels.len()
             || stats
@@ -621,7 +625,7 @@ mod tests {
     }
 
     fn write_filter_test_input(chunked: bool, summaryless: bool) -> Vec<u8> {
-        write_filter_test_input_with_summary_repeats(chunked, summaryless, true, true)
+        write_filter_test_input_with_options(chunked, summaryless, true, true, true)
     }
 
     fn write_filter_test_input_with_summary_repeats(
@@ -630,10 +634,27 @@ mod tests {
         repeat_channels: bool,
         repeat_schemas: bool,
     ) -> Vec<u8> {
+        write_filter_test_input_with_options(
+            chunked,
+            summaryless,
+            repeat_channels,
+            repeat_schemas,
+            true,
+        )
+    }
+
+    fn write_filter_test_input_with_options(
+        chunked: bool,
+        summaryless: bool,
+        repeat_channels: bool,
+        repeat_schemas: bool,
+        emit_message_indexes: bool,
+    ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut options = mcap::WriteOptions::new()
                 .use_chunks(chunked)
+                .emit_message_indexes(emit_message_indexes)
                 .library("test-recorder/0.0");
             if chunked {
                 options = options.chunk_size(Some(10));
@@ -973,6 +994,29 @@ mod tests {
     #[test]
     fn chunk_indexed_input_without_repeated_channels_falls_back_to_linear_filtering() {
         let input = write_filter_test_input_with_summary_repeats(true, false, false, false);
+        let opts = FilterOptions {
+            output: None,
+            include_topics: vec![Regex::new("^camera_.*$").expect("regex")],
+            exclude_topics: Vec::new(),
+            last_per_channel_topics: Vec::new(),
+            start: 20,
+            end: 25,
+            include_metadata: false,
+            include_attachments: false,
+            compression: Some(mcap::Compression::Lz4),
+            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            use_chunks: true,
+        };
+        let output = run_filter(&input, &opts);
+        let stats = analyze_output(&output);
+        assert_eq!(stats.topic_counts["camera_a"], 5);
+        assert_eq!(stats.topic_counts["camera_b"], 5);
+        assert!(!stats.topic_counts.contains_key("radar_a"));
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_channels_or_message_indexes_falls_back_to_linear_filtering() {
+        let input = write_filter_test_input_with_options(true, false, false, false, false);
         let opts = FilterOptions {
             output: None,
             include_topics: vec![Regex::new("^camera_.*$").expect("regex")],

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -289,11 +289,13 @@ fn filter_with_writer<W: Write + Seek>(
 
 pub(crate) fn read_summary_for_indexed_transcode(input: &[u8]) -> Result<Option<mcap::Summary>> {
     match mcap::Summary::read(input) {
+        Ok(Some(summary)) if summary.chunk_indexes.is_empty() => Ok(None),
         Ok(Some(summary)) if summary_supports_indexed_transcode(&summary) => Ok(Some(summary)),
-        Ok(Some(summary)) if summary.chunk_indexes.is_empty() => Ok(Some(summary)),
         Ok(Some(_)) => Err(incomplete_indexed_summary_error()),
         Ok(None) => Ok(None),
-        Err(mcap::McapError::UnknownSchema(_, _)) if !summary_section_has_chunk_indexes(input)? => {
+        Err(mcap::McapError::UnknownSchema(_, _))
+            if !parse::summary_section_has_chunk_indexes(input)? =>
+        {
             Ok(None)
         }
         Err(mcap::McapError::UnknownSchema(_, _)) => Err(incomplete_indexed_summary_error()),
@@ -305,27 +307,6 @@ pub(crate) fn incomplete_indexed_summary_error() -> anyhow::Error {
     anyhow::anyhow!(
         "chunk-indexed MCAP summary is missing channel or schema records; run `mcap recover` to rewrite the file"
     )
-}
-
-pub(crate) fn summary_section_has_chunk_indexes(input: &[u8]) -> Result<bool> {
-    let footer = mcap::read::footer(input)?;
-    if footer.summary_start == 0 {
-        return Ok(false);
-    }
-
-    let footer_start = input
-        .len()
-        .checked_sub(parse::FOOTER_RECORD_AND_END_MAGIC_LEN)
-        .context("input is too short to contain a footer")?;
-    let summary_start =
-        usize::try_from(footer.summary_start).context("summary offset is too large")?;
-    if summary_start > footer_start {
-        return Err(mcap::McapError::UnexpectedEof.into());
-    }
-
-    let summary =
-        parse::parsed_mcap_from_summary_section(None, &input[summary_start..footer_start])?;
-    Ok(!summary.chunk_indexes.is_empty())
 }
 
 pub(crate) fn summary_supports_indexed_transcode(summary: &mcap::Summary) -> bool {

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -279,12 +279,40 @@ fn filter_with_writer<W: Write + Seek>(
     writer: &mut mcap::Writer<W>,
     opts: &FilterOptions,
 ) -> Result<()> {
-    if let Some(summary) = mcap::Summary::read(input)? {
+    if let Some(summary) = read_summary_for_indexed_transcode(input)? {
         if !summary.chunk_indexes.is_empty() {
             return filter_indexed(input, &summary, writer, opts);
         }
     }
     filter_linear(input, writer, opts)
+}
+
+pub(crate) fn read_summary_for_indexed_transcode(input: &[u8]) -> Result<Option<mcap::Summary>> {
+    match mcap::Summary::read(input) {
+        Ok(Some(summary)) if summary_supports_indexed_transcode(&summary) => Ok(Some(summary)),
+        Ok(Some(_)) | Ok(None) => Ok(None),
+        Err(mcap::McapError::UnknownSchema(_, _)) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+pub(crate) fn summary_supports_indexed_transcode(summary: &mcap::Summary) -> bool {
+    if let Some(stats) = &summary.stats {
+        if stats.channel_count as usize > summary.channels.len()
+            || stats
+                .channel_message_counts
+                .keys()
+                .any(|channel_id| !summary.channels.contains_key(channel_id))
+        {
+            return false;
+        }
+    }
+
+    summary
+        .chunk_indexes
+        .iter()
+        .flat_map(|index| index.message_index_offsets.keys())
+        .all(|channel_id| summary.channels.contains_key(channel_id))
 }
 
 fn filter_indexed<W: Write + Seek>(
@@ -593,6 +621,15 @@ mod tests {
     }
 
     fn write_filter_test_input(chunked: bool, summaryless: bool) -> Vec<u8> {
+        write_filter_test_input_with_summary_repeats(chunked, summaryless, true, true)
+    }
+
+    fn write_filter_test_input_with_summary_repeats(
+        chunked: bool,
+        summaryless: bool,
+        repeat_channels: bool,
+        repeat_schemas: bool,
+    ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut options = mcap::WriteOptions::new()
@@ -605,6 +642,10 @@ mod tests {
                 options = options
                     .emit_summary_records(false)
                     .emit_summary_offsets(false);
+            } else {
+                options = options
+                    .repeat_channels(repeat_channels)
+                    .repeat_schemas(repeat_schemas);
             }
             let mut writer = options.create(&mut output).expect("writer");
             let schema_id = writer
@@ -927,6 +968,52 @@ mod tests {
         assert_eq!(stats.topic_counts["camera_a"], 5);
         assert_eq!(stats.topic_counts["camera_b"], 5);
         assert!(!stats.topic_counts.contains_key("radar_a"));
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_repeated_channels_falls_back_to_linear_filtering() {
+        let input = write_filter_test_input_with_summary_repeats(true, false, false, false);
+        let opts = FilterOptions {
+            output: None,
+            include_topics: vec![Regex::new("^camera_.*$").expect("regex")],
+            exclude_topics: Vec::new(),
+            last_per_channel_topics: Vec::new(),
+            start: 20,
+            end: 25,
+            include_metadata: false,
+            include_attachments: false,
+            compression: Some(mcap::Compression::Lz4),
+            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            use_chunks: true,
+        };
+        let output = run_filter(&input, &opts);
+        let stats = analyze_output(&output);
+        assert_eq!(stats.topic_counts["camera_a"], 5);
+        assert_eq!(stats.topic_counts["camera_b"], 5);
+        assert!(!stats.topic_counts.contains_key("radar_a"));
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_repeated_schemas_falls_back_to_linear_filtering() {
+        let input = write_filter_test_input_with_summary_repeats(true, false, true, false);
+        let opts = FilterOptions {
+            output: None,
+            include_topics: Vec::new(),
+            exclude_topics: Vec::new(),
+            last_per_channel_topics: Vec::new(),
+            start: 0,
+            end: u64::MAX,
+            include_metadata: false,
+            include_attachments: false,
+            compression: Some(mcap::Compression::Lz4),
+            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            use_chunks: true,
+        };
+        let output = run_filter(&input, &opts);
+        let stats = analyze_output(&output);
+        assert_eq!(stats.topic_counts["camera_a"], 100);
+        assert_eq!(stats.topic_counts["camera_b"], 100);
+        assert_eq!(stats.topic_counts["radar_a"], 100);
     }
 
     #[test]

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 
 use crate::cli::{parse_output_compression, parse_timestamp_or_nanos, FilterCommand};
 use crate::context::CommandContext;
-use crate::source;
+use crate::{parse, source};
 
 #[derive(Debug, Clone)]
 struct FilterOptions {
@@ -290,10 +290,42 @@ fn filter_with_writer<W: Write + Seek>(
 pub(crate) fn read_summary_for_indexed_transcode(input: &[u8]) -> Result<Option<mcap::Summary>> {
     match mcap::Summary::read(input) {
         Ok(Some(summary)) if summary_supports_indexed_transcode(&summary) => Ok(Some(summary)),
-        Ok(Some(_)) | Ok(None) => Ok(None),
-        Err(mcap::McapError::UnknownSchema(_, _)) => Ok(None),
+        Ok(Some(summary)) if summary.chunk_indexes.is_empty() => Ok(Some(summary)),
+        Ok(Some(_)) => Err(incomplete_indexed_summary_error()),
+        Ok(None) => Ok(None),
+        Err(mcap::McapError::UnknownSchema(_, _)) if !summary_section_has_chunk_indexes(input)? => {
+            Ok(None)
+        }
+        Err(mcap::McapError::UnknownSchema(_, _)) => Err(incomplete_indexed_summary_error()),
         Err(err) => Err(err.into()),
     }
+}
+
+pub(crate) fn incomplete_indexed_summary_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "chunk-indexed MCAP summary is missing channel or schema records; run `mcap recover` to rewrite the file"
+    )
+}
+
+pub(crate) fn summary_section_has_chunk_indexes(input: &[u8]) -> Result<bool> {
+    let footer = mcap::read::footer(input)?;
+    if footer.summary_start == 0 {
+        return Ok(false);
+    }
+
+    let footer_start = input
+        .len()
+        .checked_sub(parse::FOOTER_RECORD_AND_END_MAGIC_LEN)
+        .context("input is too short to contain a footer")?;
+    let summary_start =
+        usize::try_from(footer.summary_start).context("summary offset is too large")?;
+    if summary_start > footer_start {
+        return Err(mcap::McapError::UnexpectedEof.into());
+    }
+
+    let summary =
+        parse::parsed_mcap_from_summary_section(None, &input[summary_start..footer_start])?;
+    Ok(!summary.chunk_indexes.is_empty())
 }
 
 pub(crate) fn summary_supports_indexed_transcode(summary: &mcap::Summary) -> bool {
@@ -625,7 +657,7 @@ mod tests {
     }
 
     fn write_filter_test_input(chunked: bool, summaryless: bool) -> Vec<u8> {
-        write_filter_test_input_with_options(chunked, summaryless, true, true, true)
+        write_filter_test_input_with_options(chunked, summaryless, true, true, true, true)
     }
 
     fn write_filter_test_input_with_summary_repeats(
@@ -640,6 +672,7 @@ mod tests {
             repeat_channels,
             repeat_schemas,
             true,
+            true,
         )
     }
 
@@ -649,12 +682,14 @@ mod tests {
         repeat_channels: bool,
         repeat_schemas: bool,
         emit_message_indexes: bool,
+        emit_chunk_indexes: bool,
     ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut options = mcap::WriteOptions::new()
                 .use_chunks(chunked)
                 .emit_message_indexes(emit_message_indexes)
+                .emit_chunk_indexes(emit_chunk_indexes)
                 .library("test-recorder/0.0");
             if chunked {
                 options = options.chunk_size(Some(10));
@@ -992,7 +1027,30 @@ mod tests {
     }
 
     #[test]
-    fn chunk_indexed_input_without_repeated_channels_falls_back_to_linear_filtering() {
+    fn chunked_input_without_chunk_index_falls_back_to_linear_filtering_on_unknown_schema() {
+        let input = write_filter_test_input_with_options(true, false, true, false, true, false);
+        let opts = FilterOptions {
+            output: None,
+            include_topics: vec![Regex::new("^camera_.*$").expect("regex")],
+            exclude_topics: Vec::new(),
+            last_per_channel_topics: Vec::new(),
+            start: 20,
+            end: 25,
+            include_metadata: false,
+            include_attachments: false,
+            compression: Some(mcap::Compression::Lz4),
+            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            use_chunks: true,
+        };
+        let output = run_filter(&input, &opts);
+        let stats = analyze_output(&output);
+        assert_eq!(stats.topic_counts["camera_a"], 5);
+        assert_eq!(stats.topic_counts["camera_b"], 5);
+        assert!(!stats.topic_counts.contains_key("radar_a"));
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_repeated_channels_errors() {
         let input = write_filter_test_input_with_summary_repeats(true, false, false, false);
         let opts = FilterOptions {
             output: None,
@@ -1007,16 +1065,15 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
         };
-        let output = run_filter(&input, &opts);
-        let stats = analyze_output(&output);
-        assert_eq!(stats.topic_counts["camera_a"], 5);
-        assert_eq!(stats.topic_counts["camera_b"], 5);
-        assert!(!stats.topic_counts.contains_key("radar_a"));
+        let mut output = Cursor::new(Vec::new());
+        let err = filter_to_writer(&input, &mut output, &opts, false)
+            .expect_err("invalid indexed summary should fail");
+        assert!(err.to_string().contains("mcap recover"));
     }
 
     #[test]
-    fn chunk_indexed_input_without_channels_or_message_indexes_falls_back_to_linear_filtering() {
-        let input = write_filter_test_input_with_options(true, false, false, false, false);
+    fn chunk_indexed_input_without_channels_or_message_indexes_errors() {
+        let input = write_filter_test_input_with_options(true, false, false, false, false, true);
         let opts = FilterOptions {
             output: None,
             include_topics: vec![Regex::new("^camera_.*$").expect("regex")],
@@ -1030,15 +1087,14 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
         };
-        let output = run_filter(&input, &opts);
-        let stats = analyze_output(&output);
-        assert_eq!(stats.topic_counts["camera_a"], 5);
-        assert_eq!(stats.topic_counts["camera_b"], 5);
-        assert!(!stats.topic_counts.contains_key("radar_a"));
+        let mut output = Cursor::new(Vec::new());
+        let err = filter_to_writer(&input, &mut output, &opts, false)
+            .expect_err("invalid indexed summary should fail");
+        assert!(err.to_string().contains("mcap recover"));
     }
 
     #[test]
-    fn chunk_indexed_input_without_repeated_schemas_falls_back_to_linear_filtering() {
+    fn chunk_indexed_input_without_repeated_schemas_errors() {
         let input = write_filter_test_input_with_summary_repeats(true, false, true, false);
         let opts = FilterOptions {
             output: None,
@@ -1053,11 +1109,10 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
         };
-        let output = run_filter(&input, &opts);
-        let stats = analyze_output(&output);
-        assert_eq!(stats.topic_counts["camera_a"], 100);
-        assert_eq!(stats.topic_counts["camera_b"], 100);
-        assert_eq!(stats.topic_counts["radar_a"], 100);
+        let mut output = Cursor::new(Vec::new());
+        let err = filter_to_writer(&input, &mut output, &opts, false)
+            .expect_err("invalid indexed summary should fail");
+        assert!(err.to_string().contains("mcap recover"));
     }
 
     #[test]

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -136,23 +136,7 @@ fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
             }
             Ok(SortInput::Linear)
         }
-        None => {
-            if file_has_messages(input)? {
-                bail!(
-                    "Error reading file index: summary section not available. You may need to run `mcap recover` if the file is corrupt or not chunk indexed."
-                );
-            }
-            Ok(SortInput::Linear)
-        }
-    }
-}
-
-fn file_has_messages(input: &[u8]) -> Result<bool> {
-    let mut messages = mcap::MessageStream::new(input)?;
-    match messages.next() {
-        Some(Ok(_)) => Ok(true),
-        Some(Err(err)) => Err(err.into()),
-        None => Ok(false),
+        None => Ok(SortInput::Linear),
     }
 }
 
@@ -527,14 +511,14 @@ mod tests {
     }
 
     #[test]
-    fn run_rejects_unindexed_input_without_truncating_existing_output() {
+    fn run_sorts_summaryless_input_with_messages() {
         let input = build_summaryless_message_input();
         let input_path = unique_temp_path("input");
         let output_path = unique_temp_path("output");
         std::fs::write(&input_path, input).expect("write input fixture");
-        std::fs::write(&output_path, b"do-not-truncate").expect("write output sentinel");
+        std::fs::write(&output_path, b"replace-me").expect("write output sentinel");
 
-        let err = super::run(
+        super::run(
             &CommandContext::default(),
             SortCommand {
                 file: input_path.clone(),
@@ -545,14 +529,13 @@ mod tests {
                 no_chunks: false,
             },
         )
-        .expect_err("unindexed input with messages should fail");
-        let text = err.to_string();
-        assert!(text.contains("Error reading file index"));
-        assert!(text.contains("mcap recover"));
-        assert_eq!(
-            std::fs::read(&output_path).expect("read output sentinel"),
-            b"do-not-truncate"
-        );
+        .expect("summaryless input with messages should sort");
+        let output = std::fs::read(&output_path).expect("read output");
+        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+            .expect("message stream")
+            .map(|message| message.expect("message").log_time)
+            .collect();
+        assert_eq!(log_times, vec![5]);
 
         let _ = std::fs::remove_file(input_path);
         let _ = std::fs::remove_file(output_path);
@@ -640,13 +623,10 @@ mod tests {
     }
 
     #[test]
-    fn validate_sort_input_rejects_unindexed_messages() {
+    fn summaryless_input_with_messages_uses_linear_sorting() {
         let input = build_summaryless_message_input();
-        let err =
-            validate_sort_input(&input).expect_err("unindexed input with messages should fail");
-        let text = err.to_string();
-        assert!(text.contains("Error reading file index"));
-        assert!(text.contains("mcap recover"));
+        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
+        assert!(matches!(sort_input, SortInput::Linear));
     }
 
     #[test]

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -116,7 +116,14 @@ fn sort_to_writer<W: Write + Seek>(
 fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
     let summary = match mcap::Summary::read(input) {
         Ok(summary) => summary,
-        Err(mcap::McapError::UnknownSchema(_, _)) => return Ok(SortInput::Linear),
+        Err(mcap::McapError::UnknownSchema(_, _))
+            if !filter::summary_section_has_chunk_indexes(input)? =>
+        {
+            return Ok(SortInput::Linear);
+        }
+        Err(mcap::McapError::UnknownSchema(_, _)) => {
+            return Err(filter::incomplete_indexed_summary_error());
+        }
         Err(err) => return Err(err).context("failed to read file index"),
     };
     match summary {
@@ -125,7 +132,7 @@ fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
                 if filter::summary_supports_indexed_transcode(&summary) {
                     return Ok(SortInput::Indexed(Box::new(summary)));
                 }
-                return Ok(SortInput::Linear);
+                return Err(filter::incomplete_indexed_summary_error());
             }
             if file_has_messages(input)? {
                 bail!(
@@ -301,7 +308,7 @@ mod tests {
     }
 
     fn build_out_of_order_chunked_input(include_records: bool) -> Vec<u8> {
-        build_out_of_order_chunked_input_with_options(include_records, true, true, true)
+        build_out_of_order_chunked_input_with_options(include_records, true, true, true, true)
     }
 
     fn build_out_of_order_chunked_input_with_summary_repeats(
@@ -314,6 +321,7 @@ mod tests {
             repeat_channels,
             repeat_schemas,
             true,
+            true,
         )
     }
 
@@ -322,6 +330,7 @@ mod tests {
         repeat_channels: bool,
         repeat_schemas: bool,
         emit_message_indexes: bool,
+        emit_chunk_indexes: bool,
     ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
@@ -330,6 +339,7 @@ mod tests {
                 .repeat_channels(repeat_channels)
                 .repeat_schemas(repeat_schemas)
                 .emit_message_indexes(emit_message_indexes)
+                .emit_chunk_indexes(emit_chunk_indexes)
                 .library("test-recorder/0.0")
                 .create(&mut output)
                 .expect("writer");
@@ -643,54 +653,41 @@ mod tests {
     }
 
     #[test]
-    fn chunk_indexed_input_without_repeated_channels_falls_back_to_linear_sorting() {
+    fn chunked_input_without_chunk_index_falls_back_to_linear_sorting_on_unknown_schema() {
+        let input = build_out_of_order_chunked_input_with_options(false, true, false, true, false);
+        let mut output = Cursor::new(Vec::new());
+        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
+        assert!(matches!(sort_input, SortInput::Linear));
+
+        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
+            .expect("sort should succeed");
+        let output = output.into_inner();
+        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+            .expect("message stream")
+            .map(|message| message.expect("message").log_time)
+            .collect();
+        assert_eq!(log_times, vec![10, 30]);
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_repeated_channels_errors() {
         let input = build_out_of_order_chunked_input_with_summary_repeats(false, false, false);
-        let mut output = Cursor::new(Vec::new());
-        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
-        assert!(matches!(sort_input, SortInput::Linear));
-
-        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
-            .expect("sort should succeed");
-        let output = output.into_inner();
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![10, 30]);
+        let err = validate_sort_input(&input).expect_err("invalid indexed summary should fail");
+        assert!(err.to_string().contains("mcap recover"));
     }
 
     #[test]
-    fn chunk_indexed_input_without_channels_or_message_indexes_falls_back_to_linear_sorting() {
-        let input = build_out_of_order_chunked_input_with_options(false, false, false, false);
-        let mut output = Cursor::new(Vec::new());
-        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
-        assert!(matches!(sort_input, SortInput::Linear));
-
-        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
-            .expect("sort should succeed");
-        let output = output.into_inner();
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![10, 30]);
+    fn chunk_indexed_input_without_channels_or_message_indexes_errors() {
+        let input = build_out_of_order_chunked_input_with_options(false, false, false, false, true);
+        let err = validate_sort_input(&input).expect_err("invalid indexed summary should fail");
+        assert!(err.to_string().contains("mcap recover"));
     }
 
     #[test]
-    fn chunk_indexed_input_without_repeated_schemas_falls_back_to_linear_sorting() {
+    fn chunk_indexed_input_without_repeated_schemas_errors() {
         let input = build_out_of_order_chunked_input_with_summary_repeats(false, true, false);
-        let mut output = Cursor::new(Vec::new());
-        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
-        assert!(matches!(sort_input, SortInput::Linear));
-
-        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
-            .expect("sort should succeed");
-        let output = output.into_inner();
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![10, 30]);
+        let err = validate_sort_input(&input).expect_err("invalid indexed summary should fail");
+        assert!(err.to_string().contains("mcap recover"));
     }
 
     fn unique_temp_path(stem: &str) -> std::path::PathBuf {

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -134,11 +134,7 @@ fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
                 }
                 return Err(filter::incomplete_indexed_summary_error());
             }
-            if file_has_messages(input)? {
-                bail!(
-                    "Error reading file index: no chunk index records. You may need to run `mcap recover` if the file is corrupt or not chunk indexed."
-                );
-            }
+            Ok(SortInput::Linear)
         }
         None => {
             if file_has_messages(input)? {
@@ -146,9 +142,9 @@ fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
                     "Error reading file index: summary section not available. You may need to run `mcap recover` if the file is corrupt or not chunk indexed."
                 );
             }
+            Ok(SortInput::Linear)
         }
     }
-    Ok(SortInput::Linear)
 }
 
 fn file_has_messages(input: &[u8]) -> Result<bool> {
@@ -232,6 +228,7 @@ fn copy_linear_messages_in_log_time_order<W: Write + Seek>(
     input: &[u8],
     writer: &mut mcap::Writer<W>,
 ) -> Result<()> {
+    // Without chunk indexes, sorting necessarily materializes messages before reordering.
     let mut messages = mcap::MessageStream::new(input)?
         .collect::<mcap::McapResult<Vec<_>>>()
         .context("failed to read messages")?;
@@ -650,6 +647,23 @@ mod tests {
         let text = err.to_string();
         assert!(text.contains("Error reading file index"));
         assert!(text.contains("mcap recover"));
+    }
+
+    #[test]
+    fn chunked_input_without_chunk_index_uses_linear_sorting() {
+        let input = build_out_of_order_chunked_input_with_options(false, true, true, true, false);
+        let mut output = Cursor::new(Vec::new());
+        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
+        assert!(matches!(sort_input, SortInput::Linear));
+
+        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
+            .expect("sort should succeed");
+        let output = output.into_inner();
+        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+            .expect("message stream")
+            .map(|message| message.expect("message").log_time)
+            .collect();
+        assert_eq!(log_times, vec![10, 30]);
     }
 
     #[test]

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -301,7 +301,7 @@ mod tests {
     }
 
     fn build_out_of_order_chunked_input(include_records: bool) -> Vec<u8> {
-        build_out_of_order_chunked_input_with_summary_repeats(include_records, true, true)
+        build_out_of_order_chunked_input_with_options(include_records, true, true, true)
     }
 
     fn build_out_of_order_chunked_input_with_summary_repeats(
@@ -309,12 +309,27 @@ mod tests {
         repeat_channels: bool,
         repeat_schemas: bool,
     ) -> Vec<u8> {
+        build_out_of_order_chunked_input_with_options(
+            include_records,
+            repeat_channels,
+            repeat_schemas,
+            true,
+        )
+    }
+
+    fn build_out_of_order_chunked_input_with_options(
+        include_records: bool,
+        repeat_channels: bool,
+        repeat_schemas: bool,
+        emit_message_indexes: bool,
+    ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut writer = mcap::WriteOptions::new()
                 .chunk_size(Some(1024))
                 .repeat_channels(repeat_channels)
                 .repeat_schemas(repeat_schemas)
+                .emit_message_indexes(emit_message_indexes)
                 .library("test-recorder/0.0")
                 .create(&mut output)
                 .expect("writer");
@@ -630,6 +645,23 @@ mod tests {
     #[test]
     fn chunk_indexed_input_without_repeated_channels_falls_back_to_linear_sorting() {
         let input = build_out_of_order_chunked_input_with_summary_repeats(false, false, false);
+        let mut output = Cursor::new(Vec::new());
+        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
+        assert!(matches!(sort_input, SortInput::Linear));
+
+        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
+            .expect("sort should succeed");
+        let output = output.into_inner();
+        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+            .expect("message stream")
+            .map(|message| message.expect("message").log_time)
+            .collect();
+        assert_eq!(log_times, vec![10, 30]);
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_channels_or_message_indexes_falls_back_to_linear_sorting() {
+        let input = build_out_of_order_chunked_input_with_options(false, false, false, false);
         let mut output = Cursor::new(Vec::new());
         let sort_input = validate_sort_input(&input).expect("sort input should be valid");
         assert!(matches!(sort_input, SortInput::Linear));

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -19,7 +19,7 @@ struct SortOptions {
 
 #[derive(Debug)]
 enum SortInput {
-    Indexed(mcap::Summary),
+    Indexed(Box<mcap::Summary>),
     Linear,
 }
 
@@ -123,7 +123,7 @@ fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
         Some(summary) => {
             if !summary.chunk_indexes.is_empty() {
                 if filter::summary_supports_indexed_transcode(&summary) {
-                    return Ok(SortInput::Indexed(summary));
+                    return Ok(SortInput::Indexed(Box::new(summary)));
                 }
                 return Ok(SortInput::Linear);
             }
@@ -449,7 +449,7 @@ mod tests {
         sort_to_writer(
             &input,
             &mut output,
-            SortInput::Indexed(summary),
+            SortInput::Indexed(Box::new(summary)),
             &default_sort_options(),
         )
         .expect("sort should succeed");
@@ -472,7 +472,7 @@ mod tests {
         sort_to_writer(
             &input,
             &mut output,
-            SortInput::Indexed(summary),
+            SortInput::Indexed(Box::new(summary)),
             &default_sort_options(),
         )
         .expect("sort should succeed");
@@ -496,7 +496,7 @@ mod tests {
         sort_to_writer(
             &input,
             &mut output,
-            SortInput::Indexed(summary),
+            SortInput::Indexed(Box::new(summary)),
             &default_sort_options(),
         )
         .expect("sort should succeed");

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 
 use crate::cli::{CompressionFormat, SortCommand};
+use crate::commands::filter;
 use crate::context::CommandContext;
 use crate::{parse, source};
 
@@ -16,6 +17,12 @@ struct SortOptions {
     chunked: bool,
 }
 
+#[derive(Debug)]
+enum SortInput {
+    Indexed(mcap::Summary),
+    Linear,
+}
+
 pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
     let opts = build_sort_options(&args);
     let input = source::load_path(
@@ -25,10 +32,10 @@ pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
     if !source::is_remote_url(&args.file) {
         ensure_distinct_input_output(&args.file, &args.output_file)?;
     }
-    let summary = validate_sort_input(input.as_slice())?;
+    let sort_input = validate_sort_input(input.as_slice())?;
     let output = std::fs::File::create(&args.output_file)
         .with_context(|| format!("failed to open output '{}'", args.output_file.display()))?;
-    sort_to_writer(input.as_slice(), output, summary, &opts)
+    sort_to_writer(input.as_slice(), output, sort_input, &opts)
 }
 
 fn ensure_distinct_input_output(input: &Path, output: &Path) -> Result<()> {
@@ -69,7 +76,7 @@ fn convert_compression(value: CompressionFormat) -> Option<mcap::Compression> {
 fn sort_to_writer<W: Write + Seek>(
     input: &[u8],
     sink: W,
-    summary: Option<mcap::Summary>,
+    sort_input: SortInput,
     opts: &SortOptions,
 ) -> Result<()> {
     let header = parse::read_header(input)?;
@@ -90,36 +97,51 @@ fn sort_to_writer<W: Write + Seek>(
         .create(sink)
         .context("failed to create mcap writer")?;
 
-    if let Some(summary) = &summary {
-        copy_attachments_from_summary(input, summary, &mut writer)?;
-        copy_metadata_from_summary(input, summary, &mut writer)?;
-        if !summary.chunk_indexes.is_empty() {
+    match &sort_input {
+        SortInput::Indexed(summary) => {
+            copy_attachments_from_summary(input, summary, &mut writer)?;
+            copy_metadata_from_summary(input, summary, &mut writer)?;
             copy_messages_in_log_time_order(input, summary, &mut writer)?;
         }
-    } else {
-        copy_linear_non_message_records(input, &mut writer)?;
+        SortInput::Linear => {
+            copy_linear_non_message_records(input, &mut writer)?;
+            copy_linear_messages_in_log_time_order(input, &mut writer)?;
+        }
     }
 
     writer.finish().context("failed to finish mcap writer")?;
     Ok(())
 }
 
-fn validate_sort_input(input: &[u8]) -> Result<Option<mcap::Summary>> {
-    let summary = mcap::Summary::read(input).context("failed to read file index")?;
-    let has_chunk_indexes = summary
-        .as_ref()
-        .is_some_and(|summary| !summary.chunk_indexes.is_empty());
-    if !has_chunk_indexes && file_has_messages(input)? {
-        let reason = if summary.is_none() {
-            "summary section not available"
-        } else {
-            "no chunk index records"
-        };
-        bail!(
-            "Error reading file index: {reason}. You may need to run `mcap recover` if the file is corrupt or not chunk indexed."
-        );
+fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
+    let summary = match mcap::Summary::read(input) {
+        Ok(summary) => summary,
+        Err(mcap::McapError::UnknownSchema(_, _)) => return Ok(SortInput::Linear),
+        Err(err) => return Err(err).context("failed to read file index"),
+    };
+    match summary {
+        Some(summary) => {
+            if !summary.chunk_indexes.is_empty() {
+                if filter::summary_supports_indexed_transcode(&summary) {
+                    return Ok(SortInput::Indexed(summary));
+                }
+                return Ok(SortInput::Linear);
+            }
+            if file_has_messages(input)? {
+                bail!(
+                    "Error reading file index: no chunk index records. You may need to run `mcap recover` if the file is corrupt or not chunk indexed."
+                );
+            }
+        }
+        None => {
+            if file_has_messages(input)? {
+                bail!(
+                    "Error reading file index: summary section not available. You may need to run `mcap recover` if the file is corrupt or not chunk indexed."
+                );
+            }
+        }
     }
-    Ok(summary)
+    Ok(SortInput::Linear)
 }
 
 fn file_has_messages(input: &[u8]) -> Result<bool> {
@@ -199,6 +221,29 @@ fn copy_messages_in_log_time_order<W: Write + Seek>(
     Ok(())
 }
 
+fn copy_linear_messages_in_log_time_order<W: Write + Seek>(
+    input: &[u8],
+    writer: &mut mcap::Writer<W>,
+) -> Result<()> {
+    let mut messages = mcap::MessageStream::new(input)?
+        .collect::<mcap::McapResult<Vec<_>>>()
+        .context("failed to read messages")?;
+    messages.sort_by_key(|message| {
+        (
+            message.log_time,
+            message.channel.id,
+            message.sequence,
+            message.publish_time,
+        )
+    });
+
+    for message in messages {
+        writer.write(&message)?;
+    }
+
+    Ok(())
+}
+
 fn copy_linear_non_message_records<W: Write + Seek>(
     input: &[u8],
     writer: &mut mcap::Writer<W>,
@@ -241,7 +286,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{sort_to_writer, validate_sort_input, SortOptions};
+    use super::{sort_to_writer, validate_sort_input, SortInput, SortOptions};
     use crate::cli::CompressionFormat;
     use crate::cli::SortCommand;
     use crate::context::CommandContext;
@@ -256,10 +301,20 @@ mod tests {
     }
 
     fn build_out_of_order_chunked_input(include_records: bool) -> Vec<u8> {
+        build_out_of_order_chunked_input_with_summary_repeats(include_records, true, true)
+    }
+
+    fn build_out_of_order_chunked_input_with_summary_repeats(
+        include_records: bool,
+        repeat_channels: bool,
+        repeat_schemas: bool,
+    ) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut writer = mcap::WriteOptions::new()
                 .chunk_size(Some(1024))
+                .repeat_channels(repeat_channels)
+                .repeat_schemas(repeat_schemas)
                 .library("test-recorder/0.0")
                 .create(&mut output)
                 .expect("writer");
@@ -376,8 +431,13 @@ mod tests {
         let summary = mcap::Summary::read(&input)
             .expect("summary read")
             .expect("summary should exist");
-        sort_to_writer(&input, &mut output, Some(summary), &default_sort_options())
-            .expect("sort should succeed");
+        sort_to_writer(
+            &input,
+            &mut output,
+            SortInput::Indexed(summary),
+            &default_sort_options(),
+        )
+        .expect("sort should succeed");
         let output = output.into_inner();
 
         let log_times: Vec<u64> = mcap::MessageStream::new(&output)
@@ -394,8 +454,13 @@ mod tests {
         let summary = mcap::Summary::read(&input)
             .expect("summary read")
             .expect("summary should exist");
-        sort_to_writer(&input, &mut output, Some(summary), &default_sort_options())
-            .expect("sort should succeed");
+        sort_to_writer(
+            &input,
+            &mut output,
+            SortInput::Indexed(summary),
+            &default_sort_options(),
+        )
+        .expect("sort should succeed");
         let output = output.into_inner();
 
         // The fixture's `test-recorder/0.0` library is overwritten with the CLI's own identity.
@@ -413,8 +478,13 @@ mod tests {
         let summary = mcap::Summary::read(&input)
             .expect("summary read")
             .expect("summary should exist");
-        sort_to_writer(&input, &mut output, Some(summary), &default_sort_options())
-            .expect("sort should succeed");
+        sort_to_writer(
+            &input,
+            &mut output,
+            SortInput::Indexed(summary),
+            &default_sort_options(),
+        )
+        .expect("sort should succeed");
         let output = output.into_inner();
 
         let summary = mcap::Summary::read(&output)
@@ -513,8 +583,13 @@ mod tests {
     fn allows_summaryless_inputs_without_messages() {
         let input = build_summaryless_metadata_only_input();
         let mut output = Cursor::new(Vec::new());
-        sort_to_writer(&input, &mut output, None, &default_sort_options())
-            .expect("summaryless metadata-only file should sort");
+        sort_to_writer(
+            &input,
+            &mut output,
+            SortInput::Linear,
+            &default_sort_options(),
+        )
+        .expect("summaryless metadata-only file should sort");
         let output = output.into_inner();
 
         let mut metadata_count = 0usize;
@@ -550,6 +625,40 @@ mod tests {
         let text = err.to_string();
         assert!(text.contains("Error reading file index"));
         assert!(text.contains("mcap recover"));
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_repeated_channels_falls_back_to_linear_sorting() {
+        let input = build_out_of_order_chunked_input_with_summary_repeats(false, false, false);
+        let mut output = Cursor::new(Vec::new());
+        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
+        assert!(matches!(sort_input, SortInput::Linear));
+
+        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
+            .expect("sort should succeed");
+        let output = output.into_inner();
+        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+            .expect("message stream")
+            .map(|message| message.expect("message").log_time)
+            .collect();
+        assert_eq!(log_times, vec![10, 30]);
+    }
+
+    #[test]
+    fn chunk_indexed_input_without_repeated_schemas_falls_back_to_linear_sorting() {
+        let input = build_out_of_order_chunked_input_with_summary_repeats(false, true, false);
+        let mut output = Cursor::new(Vec::new());
+        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
+        assert!(matches!(sort_input, SortInput::Linear));
+
+        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
+            .expect("sort should succeed");
+        let output = output.into_inner();
+        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+            .expect("message stream")
+            .map(|message| message.expect("message").log_time)
+            .collect();
+        assert_eq!(log_times, vec![10, 30]);
     }
 
     fn unique_temp_path(stem: &str) -> std::path::PathBuf {

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -117,7 +117,7 @@ fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
     let summary = match mcap::Summary::read(input) {
         Ok(summary) => summary,
         Err(mcap::McapError::UnknownSchema(_, _))
-            if !filter::summary_section_has_chunk_indexes(input)? =>
+            if !parse::summary_section_has_chunk_indexes(input)? =>
         {
             return Ok(SortInput::Linear);
         }

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -71,6 +71,11 @@ fn parse_mcap_from_summary(
     )?))
 }
 
+pub(crate) fn summary_section_has_chunk_indexes(mcap: &[u8]) -> Result<bool> {
+    Ok(parse_mcap_from_summary(mcap, None)?
+        .is_some_and(|summary| !summary.chunk_indexes.is_empty()))
+}
+
 pub(crate) fn parsed_mcap_from_summary_section(
     header: Option<records::Header>,
     summary: &[u8],


### PR DESCRIPTION
### Changelog
cli: Transcode and sort commands now handle spec-valid non-indexed chunked MCAPs whose schemas are only inside chunks, while invalid chunk-indexed inputs point users to `mcap recover`.

### Docs
None.

### Description
Rust CLI transcode commands treated `Summary::read` failures as fatal, so spec-valid non-indexed chunked files with summary channels but chunk-local schemas failed instead of scanning linearly. This updates shared transcode/sort summary handling to fall back only for non-indexed inputs, keep chunk-indexed incomplete summaries as strict errors, and make sort's non-indexed path consistent for complete, unresolved-schema, and summaryless inputs.