### PR TITLE
cli: Handle broken pipes in completion command

### DIFF
--- a/rust/cli/src/commands/completion.rs
+++ b/rust/cli/src/commands/completion.rs
@@ -1,6 +1,6 @@
-use std::io;
+use std::io::{self, ErrorKind, Write};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::CommandFactory;
 use clap_complete::generate;
 
@@ -8,8 +8,61 @@ use crate::cli::{Args, CompletionCommand};
 
 /// Generate a shell completion script for the requested shell and write it to stdout.
 pub fn run(args: CompletionCommand) -> Result<()> {
+    let mut buffer = Vec::new();
     let mut cmd = Args::command();
     let bin_name = cmd.get_name().to_string();
-    generate(args.shell, &mut cmd, bin_name, &mut io::stdout());
-    Ok(())
+    generate(args.shell, &mut cmd, bin_name, &mut buffer);
+
+    write_completion(&mut io::stdout(), &buffer)
+}
+
+fn write_completion(writer: &mut impl Write, buffer: &[u8]) -> Result<()> {
+    match writer.write_all(buffer) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(err).context("failed to write completion script"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, ErrorKind, Write};
+
+    use super::write_completion;
+
+    struct FailingWriter {
+        kind: ErrorKind,
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.kind, "failed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_completion_ignores_broken_pipe() {
+        let mut writer = FailingWriter {
+            kind: ErrorKind::BrokenPipe,
+        };
+
+        write_completion(&mut writer, b"completion").expect("broken pipe should be ignored");
+    }
+
+    #[test]
+    fn write_completion_reports_other_errors() {
+        let mut writer = FailingWriter {
+            kind: ErrorKind::PermissionDenied,
+        };
+
+        let err =
+            write_completion(&mut writer, b"completion").expect_err("other errors should fail");
+        assert!(err
+            .to_string()
+            .contains("failed to write completion script"));
+    }
 }

--- a/rust/cli/src/commands/completion.rs
+++ b/rust/cli/src/commands/completion.rs
@@ -24,3 +24,38 @@ fn write_completion(mut writer: impl Write, buffer: &[u8]) -> Result<()> {
         Err(err) => Err(err).context("failed to write completion script"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, ErrorKind, Write};
+
+    use super::write_completion;
+
+    struct FailingWriter(ErrorKind);
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.0, "failed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_completion_ignores_broken_pipe() {
+        write_completion(FailingWriter(ErrorKind::BrokenPipe), b"completion")
+            .expect("broken pipe should be ignored");
+    }
+
+    #[test]
+    fn write_completion_reports_other_errors() {
+        let err = write_completion(FailingWriter(ErrorKind::PermissionDenied), b"completion")
+            .expect_err("other errors should fail");
+
+        assert!(err
+            .to_string()
+            .contains("failed to write completion script"));
+    }
+}

--- a/rust/cli/src/commands/completion.rs
+++ b/rust/cli/src/commands/completion.rs
@@ -13,56 +13,14 @@ pub fn run(args: CompletionCommand) -> Result<()> {
     let bin_name = cmd.get_name().to_string();
     generate(args.shell, &mut cmd, bin_name, &mut buffer);
 
-    write_completion(&mut io::stdout(), &buffer)
+    let stdout = io::stdout();
+    write_completion(stdout.lock(), &buffer)
 }
 
-fn write_completion(writer: &mut impl Write, buffer: &[u8]) -> Result<()> {
+fn write_completion(mut writer: impl Write, buffer: &[u8]) -> Result<()> {
     match writer.write_all(buffer) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(err).context("failed to write completion script"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::{self, ErrorKind, Write};
-
-    use super::write_completion;
-
-    struct FailingWriter {
-        kind: ErrorKind,
-    }
-
-    impl Write for FailingWriter {
-        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-            Err(io::Error::new(self.kind, "failed"))
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn write_completion_ignores_broken_pipe() {
-        let mut writer = FailingWriter {
-            kind: ErrorKind::BrokenPipe,
-        };
-
-        write_completion(&mut writer, b"completion").expect("broken pipe should be ignored");
-    }
-
-    #[test]
-    fn write_completion_reports_other_errors() {
-        let mut writer = FailingWriter {
-            kind: ErrorKind::PermissionDenied,
-        };
-
-        let err =
-            write_completion(&mut writer, b"completion").expect_err("other errors should fail");
-        assert!(err
-            .to_string()
-            .contains("failed to write completion script"));
     }
 }

--- a/rust/cli/tests/completion.rs
+++ b/rust/cli/tests/completion.rs
@@ -1,19 +1,21 @@
-use std::process::{Command, Stdio};
+#[cfg(unix)]
+use std::{
+    os::{fd::OwnedFd, unix::net::UnixStream},
+    process::{Command, Stdio},
+};
 
+#[cfg(unix)]
 #[test]
 fn fish_completion_allows_downstream_pipe_to_close() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_mcap"))
+    let (read_end, write_end) = UnixStream::pair().expect("failed to create pipe");
+    drop(read_end);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mcap"))
         .args(["completion", "fish"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+        .stdout(Stdio::from(OwnedFd::from(write_end)))
+        .output()
         .expect("failed to run mcap completion fish");
 
-    drop(child.stdout.take());
-
-    let output = child
-        .wait_with_output()
-        .expect("failed to wait for mcap completion fish");
     assert!(
         output.status.success(),
         "completion should exit successfully after a downstream pipe closes; status: {:?}; stderr: {}",

--- a/rust/cli/tests/completion.rs
+++ b/rust/cli/tests/completion.rs
@@ -1,0 +1,35 @@
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+#[test]
+fn fish_completion_allows_downstream_pipe_to_close() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mcap"))
+        .args(["completion", "fish"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run mcap completion fish");
+
+    let stdout = child.stdout.take().expect("stdout should be piped");
+    let mut reader = BufReader::new(stdout);
+
+    for _ in 0..10 {
+        let mut line = String::new();
+        let bytes = reader
+            .read_line(&mut line)
+            .expect("failed to read completion output");
+        assert!(bytes > 0, "completion output ended too early");
+    }
+
+    drop(reader);
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait for mcap completion fish");
+    assert!(
+        output.status.success(),
+        "completion should exit successfully after a downstream pipe closes; status: {:?}; stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/rust/cli/tests/completion.rs
+++ b/rust/cli/tests/completion.rs
@@ -1,4 +1,3 @@
-use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 
 #[test]
@@ -10,18 +9,7 @@ fn fish_completion_allows_downstream_pipe_to_close() {
         .spawn()
         .expect("failed to run mcap completion fish");
 
-    let stdout = child.stdout.take().expect("stdout should be piped");
-    let mut reader = BufReader::new(stdout);
-
-    for _ in 0..10 {
-        let mut line = String::new();
-        let bytes = reader
-            .read_line(&mut line)
-            .expect("failed to read completion output");
-        assert!(bytes > 0, "completion output ended too early");
-    }
-
-    drop(reader);
+    drop(child.stdout.take());
 
     let output = child
         .wait_with_output()


### PR DESCRIPTION
### Changelog

None (fixes bug in not-yet-released rust CLI)

### Docs

None

### Description

`clap_complete::generate` panics on `BrokenPipe` when Fish completion output is written directly to stdout and the consumer exits early. Buffer completion generation first, then lock stdout once and write the finished script with local handling that treats `BrokenPipe` as normal CLI termination while still surfacing other write errors. The tests combine deterministic unit coverage for both writer error branches with a Unix subprocess regression that runs the real binary against an already-closed stdout peer.