### PR TITLE
cli: Support list/get without summary records

### DIFF
--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -56,17 +56,12 @@ fn local_attachment_indexes(
         .attachment_indexes
         .iter()
         .any(|index| index.name == name);
-    if attachment_indexes_need_scan(&parsed) || missing_requested_name {
+    if parse::attachment_indexes_need_scan(&parsed)
+        || (missing_requested_name && parsed.statistics.is_none())
+    {
         return parse::collect_attachment_indexes_linear(mcap);
     }
     Ok(parsed.attachment_indexes)
-}
-
-fn attachment_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
-    match &parsed.statistics {
-        Some(statistics) => statistics.attachment_count as usize > parsed.attachment_indexes.len(),
-        None => parsed.attachment_indexes.is_empty(),
-    }
 }
 
 fn write_attachment_data(data: &[u8], output: Option<&std::path::Path>) -> Result<()> {
@@ -119,8 +114,9 @@ fn select_attachment_index<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::select_attachment_index;
-    use mcap::records::AttachmentIndex;
+    use super::{local_attachment_indexes, select_attachment_index};
+    use crate::parse;
+    use mcap::records::{AttachmentIndex, Statistics};
 
     fn attachment(name: &str, offset: u64) -> AttachmentIndex {
         AttachmentIndex {
@@ -183,5 +179,22 @@ mod tests {
         let err = select_attachment_index(&indexes, "a", Some(999))
             .expect_err("single record should enforce provided offset");
         assert_eq!(err.to_string(), "failed to find attachment a at offset 999");
+    }
+
+    #[test]
+    fn missing_name_does_not_scan_when_attachment_indexes_are_complete() {
+        let parsed = parse::ParsedMcap {
+            statistics: Some(Statistics {
+                attachment_count: 1,
+                ..Default::default()
+            }),
+            attachment_indexes: vec![attachment("a", 10)],
+            ..Default::default()
+        };
+
+        let indexes =
+            local_attachment_indexes(&[], parsed, "missing").expect("complete index is enough");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "a");
     }
 }

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -59,6 +59,7 @@ fn local_attachment_indexes(
     if parse::attachment_indexes_need_scan(&parsed)
         || (missing_requested_name && parsed.statistics.is_none())
     {
+        parse::warn_index_scan("attachment");
         return parse::collect_attachment_indexes_linear(mcap);
     }
     Ok(parsed.attachment_indexes)
@@ -114,6 +115,8 @@ fn select_attachment_index<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{local_attachment_indexes, select_attachment_index};
     use crate::parse;
     use mcap::records::{AttachmentIndex, Statistics};
@@ -194,6 +197,35 @@ mod tests {
 
         let indexes =
             local_attachment_indexes(&[], parsed, "missing").expect("complete index is enough");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "a");
+    }
+
+    #[test]
+    fn missing_name_scans_when_attachment_index_completeness_is_unknown() {
+        let mut mcap_bytes = Vec::new();
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .emit_summary_records(false)
+                .emit_summary_offsets(false)
+                .emit_attachment_indexes(false)
+                .create(std::io::Cursor::new(&mut mcap_bytes))
+                .expect("writer");
+            writer
+                .attach(&mcap::Attachment {
+                    log_time: 1,
+                    create_time: 1,
+                    name: "a".to_string(),
+                    media_type: "application/octet-stream".to_string(),
+                    data: Cow::Borrowed(b"payload"),
+                })
+                .expect("attachment");
+            writer.finish().expect("finish");
+        }
+        let parsed = parse::parse_mcap(&mcap_bytes).expect("parse");
+
+        let indexes =
+            local_attachment_indexes(&mcap_bytes, parsed, "missing").expect("linear scan");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "a");
     }

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -33,7 +33,8 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     } else {
         let mcap = source::load_path(&args.file, source_options)?;
         let parsed = parse::parse_mcap(&mcap)?;
-        let index = select_attachment_index(&parsed.attachment_indexes, &args.name, args.offset)?;
+        let indexes = local_attachment_indexes(&mcap, parsed, &args.name)?;
+        let index = select_attachment_index(&indexes, &args.name, args.offset)?;
         let attachment = mcap::read::attachment(&mcap, index).with_context(|| {
             format!(
                 "failed to read attachment {} at offset {}",
@@ -44,6 +45,28 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn local_attachment_indexes(
+    mcap: &[u8],
+    parsed: parse::ParsedMcap,
+    name: &str,
+) -> Result<Vec<mcap::records::AttachmentIndex>> {
+    let missing_requested_name = !parsed
+        .attachment_indexes
+        .iter()
+        .any(|index| index.name == name);
+    if attachment_indexes_need_scan(&parsed) || missing_requested_name {
+        return parse::collect_attachment_indexes_linear(mcap);
+    }
+    Ok(parsed.attachment_indexes)
+}
+
+fn attachment_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
+    match &parsed.statistics {
+        Some(statistics) => statistics.attachment_count as usize > parsed.attachment_indexes.len(),
+        None => parsed.attachment_indexes.is_empty(),
+    }
 }
 
 fn write_attachment_data(data: &[u8], output: Option<&std::path::Path>) -> Result<()> {

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -57,7 +57,7 @@ fn local_attachment_indexes(
         .iter()
         .any(|index| index.name == name);
     if parse::attachment_indexes_need_scan(&parsed)
-        || (missing_requested_name && parsed.statistics.is_none())
+        || (missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
     {
         parse::warn_index_scan("attachment");
         return parse::collect_attachment_indexes_linear(mcap);
@@ -187,6 +187,7 @@ mod tests {
     #[test]
     fn missing_name_does_not_scan_when_attachment_indexes_are_complete() {
         let parsed = parse::ParsedMcap {
+            summary_available: true,
             statistics: Some(Statistics {
                 attachment_count: 1,
                 ..Default::default()
@@ -197,6 +198,19 @@ mod tests {
 
         let indexes =
             local_attachment_indexes(&[], parsed, "missing").expect("complete index is enough");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "a");
+    }
+
+    #[test]
+    fn missing_name_does_not_rescan_summaryless_input() {
+        let parsed = parse::ParsedMcap {
+            attachment_indexes: vec![attachment("a", 10)],
+            ..Default::default()
+        };
+
+        let indexes =
+            local_attachment_indexes(&[], parsed, "missing").expect("linear parse is complete");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "a");
     }
@@ -222,7 +236,10 @@ mod tests {
                 .expect("attachment");
             writer.finish().expect("finish");
         }
-        let parsed = parse::parse_mcap(&mcap_bytes).expect("parse");
+        let parsed = parse::ParsedMcap {
+            summary_available: true,
+            ..Default::default()
+        };
 
         let indexes =
             local_attachment_indexes(&mcap_bytes, parsed, "missing").expect("linear scan");

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -13,7 +13,8 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     } else {
         let mcap = source::load_path(&args.file, source_options)?;
         let parsed = parse::parse_mcap(&mcap)?;
-        merged_metadata_for_name(&mcap, &parsed.metadata_indexes, &args.name)?
+        let indexes = local_metadata_indexes(&mcap, parsed, &args.name)?;
+        merged_metadata_for_name(&mcap, &indexes, &args.name)?
     };
     let pretty =
         serde_json::to_string_pretty(&metadata).context("failed to serialize metadata to JSON")?;
@@ -58,6 +59,28 @@ fn merged_remote_metadata_for_name(
         }
     }
     Ok(output)
+}
+
+fn local_metadata_indexes(
+    mcap: &[u8],
+    parsed: parse::ParsedMcap,
+    name: &str,
+) -> Result<Vec<mcap::records::MetadataIndex>> {
+    let missing_requested_name = !parsed
+        .metadata_indexes
+        .iter()
+        .any(|index| index.name == name);
+    if metadata_indexes_need_scan(&parsed) || missing_requested_name {
+        return parse::collect_metadata_indexes_linear(mcap);
+    }
+    Ok(parsed.metadata_indexes)
+}
+
+fn metadata_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
+    match &parsed.statistics {
+        Some(statistics) => statistics.metadata_count as usize > parsed.metadata_indexes.len(),
+        None => parsed.metadata_indexes.is_empty(),
+    }
 }
 
 fn merged_metadata_for_name(

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -73,6 +73,7 @@ fn local_metadata_indexes(
     if parse::metadata_indexes_need_scan(&parsed)
         || (missing_requested_name && parsed.statistics.is_none())
     {
+        parse::warn_index_scan("metadata");
         return parse::collect_metadata_indexes_linear(mcap);
     }
     Ok(parsed.metadata_indexes)
@@ -185,6 +186,31 @@ mod tests {
 
         let indexes =
             local_metadata_indexes(&[], parsed, "missing").expect("complete index is enough");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "demo");
+    }
+
+    #[test]
+    fn missing_name_scans_when_metadata_index_completeness_is_unknown() {
+        let mut mcap_bytes = Vec::new();
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .emit_summary_records(false)
+                .emit_summary_offsets(false)
+                .emit_metadata_indexes(false)
+                .create(std::io::Cursor::new(&mut mcap_bytes))
+                .expect("writer");
+            writer
+                .write_metadata(&mcap::records::Metadata {
+                    name: "demo".to_string(),
+                    metadata: BTreeMap::from([("foo".to_string(), "bar".to_string())]),
+                })
+                .expect("metadata");
+            writer.finish().expect("finish");
+        }
+        let parsed = parse::parse_mcap(&mcap_bytes).expect("parse");
+
+        let indexes = local_metadata_indexes(&mcap_bytes, parsed, "missing").expect("linear scan");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "demo");
     }

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -71,7 +71,7 @@ fn local_metadata_indexes(
         .iter()
         .any(|index| index.name == name);
     if parse::metadata_indexes_need_scan(&parsed)
-        || (missing_requested_name && parsed.statistics.is_none())
+        || (missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
     {
         parse::warn_index_scan("metadata");
         return parse::collect_metadata_indexes_linear(mcap);
@@ -176,6 +176,7 @@ mod tests {
     #[test]
     fn missing_name_does_not_scan_when_metadata_indexes_are_complete() {
         let parsed = parse::ParsedMcap {
+            summary_available: true,
             statistics: Some(Statistics {
                 metadata_count: 1,
                 ..Default::default()
@@ -186,6 +187,19 @@ mod tests {
 
         let indexes =
             local_metadata_indexes(&[], parsed, "missing").expect("complete index is enough");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "demo");
+    }
+
+    #[test]
+    fn missing_name_does_not_rescan_summaryless_input() {
+        let parsed = parse::ParsedMcap {
+            metadata_indexes: vec![metadata_index("demo", 10, 20)],
+            ..Default::default()
+        };
+
+        let indexes =
+            local_metadata_indexes(&[], parsed, "missing").expect("linear parse is complete");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "demo");
     }
@@ -208,7 +222,10 @@ mod tests {
                 .expect("metadata");
             writer.finish().expect("finish");
         }
-        let parsed = parse::parse_mcap(&mcap_bytes).expect("parse");
+        let parsed = parse::ParsedMcap {
+            summary_available: true,
+            ..Default::default()
+        };
 
         let indexes = local_metadata_indexes(&mcap_bytes, parsed, "missing").expect("linear scan");
         assert_eq!(indexes.len(), 1);

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -70,17 +70,12 @@ fn local_metadata_indexes(
         .metadata_indexes
         .iter()
         .any(|index| index.name == name);
-    if metadata_indexes_need_scan(&parsed) || missing_requested_name {
+    if parse::metadata_indexes_need_scan(&parsed)
+        || (missing_requested_name && parsed.statistics.is_none())
+    {
         return parse::collect_metadata_indexes_linear(mcap);
     }
     Ok(parsed.metadata_indexes)
-}
-
-fn metadata_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
-    match &parsed.statistics {
-        Some(statistics) => statistics.metadata_count as usize > parsed.metadata_indexes.len(),
-        None => parsed.metadata_indexes.is_empty(),
-    }
 }
 
 fn merged_metadata_for_name(
@@ -110,9 +105,10 @@ fn merged_metadata_for_name(
 mod tests {
     use std::collections::BTreeMap;
 
-    use mcap::records::MetadataIndex;
+    use mcap::records::{MetadataIndex, Statistics};
 
-    use super::merged_metadata_for_name;
+    use super::{local_metadata_indexes, merged_metadata_for_name};
+    use crate::parse;
 
     fn metadata_index(name: &str, offset: u64, length: u64) -> MetadataIndex {
         MetadataIndex {
@@ -174,5 +170,22 @@ mod tests {
                 ("c".to_string(), "3".to_string()),
             ])
         );
+    }
+
+    #[test]
+    fn missing_name_does_not_scan_when_metadata_indexes_are_complete() {
+        let parsed = parse::ParsedMcap {
+            statistics: Some(Statistics {
+                metadata_count: 1,
+                ..Default::default()
+            }),
+            metadata_indexes: vec![metadata_index("demo", 10, 20)],
+            ..Default::default()
+        };
+
+        let indexes =
+            local_metadata_indexes(&[], parsed, "missing").expect("complete index is enough");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "demo");
     }
 }

--- a/rust/cli/src/commands/list/attachments.rs
+++ b/rust/cli/src/commands/list/attachments.rs
@@ -2,17 +2,31 @@ use anyhow::Result;
 
 use crate::cli::ListAttachmentsCommand;
 use crate::context::CommandContext;
-use crate::{render, source};
+use crate::{parse, render, source};
 
 pub fn run(ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
-    let parsed = source::parse_mcap_from_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
-    let mut indexes = parsed.attachment_indexes;
+    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let mut indexes = if source::is_remote_url(&args.file) {
+        source::parse_mcap_from_path(&args.file, source_options)?.attachment_indexes
+    } else {
+        let mcap = source::load_path(&args.file, source_options)?;
+        let parsed = parse::parse_mcap(&mcap)?;
+        if attachment_indexes_need_scan(&parsed) {
+            parse::collect_attachment_indexes_linear(&mcap)?
+        } else {
+            parsed.attachment_indexes
+        }
+    };
     indexes.sort_by_key(|index| index.offset);
     render::print_table(&render_attachment_rows(&indexes));
     Ok(())
+}
+
+fn attachment_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
+    match &parsed.statistics {
+        Some(statistics) => statistics.attachment_count as usize > parsed.attachment_indexes.len(),
+        None => parsed.attachment_indexes.is_empty(),
+    }
 }
 
 fn render_attachment_rows(indexes: &[mcap::records::AttachmentIndex]) -> Vec<Vec<String>> {

--- a/rust/cli/src/commands/list/attachments.rs
+++ b/rust/cli/src/commands/list/attachments.rs
@@ -13,6 +13,7 @@ pub fn run(ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
             let mcap = source::load_path(&args.file, source_options)?;
             let parsed = parse::parse_mcap(&mcap)?;
             if parse::attachment_indexes_need_scan(&parsed) {
+                parse::warn_index_scan("attachment");
                 parse::collect_attachment_indexes_linear(&mcap)?
             } else {
                 parsed.attachment_indexes

--- a/rust/cli/src/commands/list/attachments.rs
+++ b/rust/cli/src/commands/list/attachments.rs
@@ -6,27 +6,21 @@ use crate::{parse, render, source};
 
 pub fn run(ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
-    let mut indexes = if source::is_remote_url(&args.file) {
-        source::parse_mcap_from_path(&args.file, source_options)?.attachment_indexes
-    } else {
-        let mcap = source::load_path(&args.file, source_options)?;
-        let parsed = parse::parse_mcap(&mcap)?;
-        if attachment_indexes_need_scan(&parsed) {
-            parse::collect_attachment_indexes_linear(&mcap)?
+    let mut indexes =
+        if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
+            remote.summary().attachment_indexes.clone()
         } else {
-            parsed.attachment_indexes
-        }
-    };
+            let mcap = source::load_path(&args.file, source_options)?;
+            let parsed = parse::parse_mcap(&mcap)?;
+            if parse::attachment_indexes_need_scan(&parsed) {
+                parse::collect_attachment_indexes_linear(&mcap)?
+            } else {
+                parsed.attachment_indexes
+            }
+        };
     indexes.sort_by_key(|index| index.offset);
     render::print_table(&render_attachment_rows(&indexes));
     Ok(())
-}
-
-fn attachment_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
-    match &parsed.statistics {
-        Some(statistics) => statistics.attachment_count as usize > parsed.attachment_indexes.len(),
-        None => parsed.attachment_indexes.is_empty(),
-    }
 }
 
 fn render_attachment_rows(indexes: &[mcap::records::AttachmentIndex]) -> Vec<Vec<String>> {

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -48,6 +48,7 @@ fn collect_metadata_records(
     let mut records = Vec::new();
     let parsed = parse::parse_mcap(mcap)?;
     let indexes = if parse::metadata_indexes_need_scan(&parsed) {
+        parse::warn_index_scan("metadata");
         parse::collect_metadata_indexes_linear(mcap)?
     } else {
         parsed.metadata_indexes

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -47,12 +47,24 @@ fn collect_metadata_records(
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
     let mut records = Vec::new();
     let parsed = parse::parse_mcap(mcap)?;
-    for index in parsed.metadata_indexes {
+    let indexes = if metadata_indexes_need_scan(&parsed) {
+        parse::collect_metadata_indexes_linear(mcap)?
+    } else {
+        parsed.metadata_indexes
+    };
+    for index in indexes {
         let metadata = mcap::read::metadata(mcap, &index)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         records.push((index, metadata));
     }
     Ok(records)
+}
+
+fn metadata_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
+    match &parsed.statistics {
+        Some(statistics) => statistics.metadata_count as usize > parsed.metadata_indexes.len(),
+        None => parsed.metadata_indexes.is_empty(),
+    }
 }
 
 fn render_metadata_rows(

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -47,7 +47,7 @@ fn collect_metadata_records(
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
     let mut records = Vec::new();
     let parsed = parse::parse_mcap(mcap)?;
-    let indexes = if metadata_indexes_need_scan(&parsed) {
+    let indexes = if parse::metadata_indexes_need_scan(&parsed) {
         parse::collect_metadata_indexes_linear(mcap)?
     } else {
         parsed.metadata_indexes
@@ -58,13 +58,6 @@ fn collect_metadata_records(
         records.push((index, metadata));
     }
     Ok(records)
-}
-
-fn metadata_indexes_need_scan(parsed: &parse::ParsedMcap) -> bool {
-    match &parsed.statistics {
-        Some(statistics) => statistics.metadata_count as usize > parsed.metadata_indexes.len(),
-        None => parsed.metadata_indexes.is_empty(),
-    }
 }
 
 fn render_metadata_rows(

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -7,6 +7,7 @@ use mcap::records::{self, Record};
 use mcap::sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions};
 
 const FOOTER_RECORD_LEN: usize = 1 + 8 + 8 + 8 + 4;
+const RECORD_PREFIX_LEN: u64 = 1 + 8;
 pub(crate) const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = FOOTER_RECORD_LEN + mcap::MAGIC.len();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -146,6 +147,20 @@ pub(crate) fn collect_metadata_indexes_linear(mcap: &[u8]) -> Result<Vec<records
     Ok(indexes)
 }
 
+pub(crate) fn attachment_indexes_need_scan(parsed: &ParsedMcap) -> bool {
+    match &parsed.statistics {
+        Some(statistics) => statistics.attachment_count as usize > parsed.attachment_indexes.len(),
+        None => parsed.attachment_indexes.is_empty(),
+    }
+}
+
+pub(crate) fn metadata_indexes_need_scan(parsed: &ParsedMcap) -> bool {
+    match &parsed.statistics {
+        Some(statistics) => statistics.metadata_count as usize > parsed.metadata_indexes.len(),
+        None => parsed.metadata_indexes.is_empty(),
+    }
+}
+
 fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
 where
     F: FnMut(Record<'_>, u64, u64) -> Result<()>,
@@ -153,7 +168,6 @@ where
     let mut reader = SansIoReader::new_with_options(
         LinearReaderOptions::default()
             .with_emit_chunks(true)
-            .with_validate_chunk_crcs(true)
             .with_record_length_limit(mcap.len()),
     );
     let mut remaining = mcap;
@@ -170,7 +184,7 @@ where
             }
             LinearReadEvent::Record { opcode, data } => {
                 let record_offset = next_record_offset;
-                let record_length = 9 + data.len() as u64;
+                let record_length = RECORD_PREFIX_LEN + data.len() as u64;
                 next_record_offset += record_length;
                 process(
                     mcap::parse_record(opcode, data)?,

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -462,10 +462,10 @@ mod tests {
         {
             let mut writer = mcap::WriteOptions::new()
                 .use_chunks(false)
-                .emit_attachment_indexes(false)
-                .emit_metadata_indexes(false)
                 .emit_summary_records(emit_summary_records)
                 .emit_summary_offsets(emit_summary_records)
+                .emit_attachment_indexes(false)
+                .emit_metadata_indexes(false)
                 .create(std::io::Cursor::new(&mut buffer))
                 .expect("writer");
             writer

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -19,6 +19,7 @@ pub struct ParsedSchema {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ParsedMcap {
     pub header: Option<records::Header>,
+    pub summary_available: bool,
     pub statistics: Option<records::Statistics>,
     pub channels: std::collections::BTreeMap<u16, records::Channel>,
     pub schemas: std::collections::BTreeMap<u16, ParsedSchema>,
@@ -84,6 +85,7 @@ pub(crate) fn parsed_mcap_from_summary_section(
 ) -> Result<ParsedMcap> {
     let mut out = ParsedMcap {
         header,
+        summary_available: true,
         ..ParsedMcap::default()
     };
     for record in mcap::read::LinearReader::sans_magic(summary) {
@@ -148,6 +150,9 @@ pub(crate) fn collect_metadata_indexes_linear(mcap: &[u8]) -> Result<Vec<records
 }
 
 pub(crate) fn attachment_indexes_need_scan(parsed: &ParsedMcap) -> bool {
+    if !parsed.summary_available {
+        return false;
+    }
     match &parsed.statistics {
         Some(statistics) => statistics.attachment_count as usize > parsed.attachment_indexes.len(),
         None => parsed.attachment_indexes.is_empty(),
@@ -155,6 +160,9 @@ pub(crate) fn attachment_indexes_need_scan(parsed: &ParsedMcap) -> bool {
 }
 
 pub(crate) fn metadata_indexes_need_scan(parsed: &ParsedMcap) -> bool {
+    if !parsed.summary_available {
+        return false;
+    }
     match &parsed.statistics {
         Some(statistics) => statistics.metadata_count as usize > parsed.metadata_indexes.len(),
         None => parsed.metadata_indexes.is_empty(),

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context as _, Result};
 use mcap::records::{self, Record};
+use mcap::sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions};
 
 const FOOTER_RECORD_LEN: usize = 1 + 8 + 8 + 8 + 4;
 pub(crate) const FOOTER_RECORD_AND_END_MAGIC_LEN: usize = FOOTER_RECORD_LEN + mcap::MAGIC.len();
@@ -85,7 +86,7 @@ pub(crate) fn parsed_mcap_from_summary_section(
         ..ParsedMcap::default()
     };
     for record in mcap::read::LinearReader::sans_magic(summary) {
-        collect_record(&mut out, record?)?;
+        collect_record(&mut out, record?, None)?;
     }
     Ok(out)
 }
@@ -95,21 +96,99 @@ fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<Par
         header,
         ..ParsedMcap::default()
     };
-    for record in mcap::read::LinearReader::new(mcap)? {
-        let record = record?;
+    scan_top_level_records(mcap, |record, offset, length| {
         if let Record::Chunk { header, data } = record {
             for nested_record in mcap::read::ChunkReader::new(header, data.as_ref())? {
-                collect_record(&mut out, nested_record?)?;
+                collect_record(&mut out, nested_record?, None)?;
             }
         } else {
-            collect_record(&mut out, record)?;
+            collect_record(&mut out, record, Some((offset, length)))?;
         }
-    }
+        Ok(())
+    })?;
 
     Ok(out)
 }
 
-fn collect_record(out: &mut ParsedMcap, record: Record<'_>) -> Result<()> {
+pub(crate) fn collect_attachment_indexes_linear(
+    mcap: &[u8],
+) -> Result<Vec<records::AttachmentIndex>> {
+    let mut indexes = Vec::new();
+    scan_top_level_records(mcap, |record, offset, length| {
+        if let Record::Attachment { header, data, .. } = record {
+            indexes.push(records::AttachmentIndex {
+                offset,
+                length,
+                log_time: header.log_time,
+                create_time: header.create_time,
+                data_size: data.len() as u64,
+                name: header.name,
+                media_type: header.media_type,
+            });
+        }
+        Ok(())
+    })?;
+    Ok(indexes)
+}
+
+pub(crate) fn collect_metadata_indexes_linear(mcap: &[u8]) -> Result<Vec<records::MetadataIndex>> {
+    let mut indexes = Vec::new();
+    scan_top_level_records(mcap, |record, offset, length| {
+        if let Record::Metadata(metadata) = record {
+            indexes.push(records::MetadataIndex {
+                offset,
+                length,
+                name: metadata.name,
+            });
+        }
+        Ok(())
+    })?;
+    Ok(indexes)
+}
+
+fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
+where
+    F: FnMut(Record<'_>, u64, u64) -> Result<()>,
+{
+    let mut reader = SansIoReader::new_with_options(
+        LinearReaderOptions::default()
+            .with_emit_chunks(true)
+            .with_validate_chunk_crcs(true)
+            .with_record_length_limit(mcap.len()),
+    );
+    let mut remaining = mcap;
+    let mut next_record_offset = mcap::MAGIC.len() as u64;
+
+    while let Some(event) = reader.next_event() {
+        match event? {
+            LinearReadEvent::ReadRequest(need) => {
+                let read = need.min(remaining.len());
+                let dst = reader.insert(read);
+                dst.copy_from_slice(&remaining[..read]);
+                reader.notify_read(read);
+                remaining = &remaining[read..];
+            }
+            LinearReadEvent::Record { opcode, data } => {
+                let record_offset = next_record_offset;
+                let record_length = 9 + data.len() as u64;
+                next_record_offset += record_length;
+                process(
+                    mcap::parse_record(opcode, data)?,
+                    record_offset,
+                    record_length,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_record(
+    out: &mut ParsedMcap,
+    record: Record<'_>,
+    position: Option<(u64, u64)>,
+) -> Result<()> {
     match record {
         Record::Header(header) => {
             if let Some(existing) = &out.header {
@@ -148,6 +227,28 @@ fn collect_record(out: &mut ParsedMcap, record: Record<'_>) -> Result<()> {
         Record::ChunkIndex(index) => out.chunk_indexes.push(index),
         Record::AttachmentIndex(index) => out.attachment_indexes.push(index),
         Record::MetadataIndex(index) => out.metadata_indexes.push(index),
+        Record::Attachment { header, data, .. } => {
+            if let Some((offset, length)) = position {
+                out.attachment_indexes.push(records::AttachmentIndex {
+                    offset,
+                    length,
+                    log_time: header.log_time,
+                    create_time: header.create_time,
+                    data_size: data.len() as u64,
+                    name: header.name,
+                    media_type: header.media_type,
+                });
+            }
+        }
+        Record::Metadata(metadata) => {
+            if let Some((offset, length)) = position {
+                out.metadata_indexes.push(records::MetadataIndex {
+                    offset,
+                    length,
+                    name: metadata.name,
+                });
+            }
+        }
         _ => {}
     }
     Ok(())
@@ -347,10 +448,45 @@ fn collect_definition_record(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::collections::BTreeMap;
 
-    use super::{parse_mcap, parse_mcap_from_summary, parse_summary_section};
+    use super::{
+        collect_attachment_indexes_linear, collect_metadata_indexes_linear, parse_mcap,
+        parse_mcap_from_summary, parse_summary_section,
+    };
     use mcap::records;
+
+    fn write_unindexed_attachment_and_metadata(emit_summary_records: bool) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .use_chunks(false)
+                .emit_attachment_indexes(false)
+                .emit_metadata_indexes(false)
+                .emit_summary_records(emit_summary_records)
+                .emit_summary_offsets(emit_summary_records)
+                .create(std::io::Cursor::new(&mut buffer))
+                .expect("writer");
+            writer
+                .attach(&mcap::Attachment {
+                    log_time: 10,
+                    create_time: 11,
+                    name: "demo.bin".to_string(),
+                    media_type: "application/octet-stream".to_string(),
+                    data: Cow::Borrowed(b"hello"),
+                })
+                .expect("attachment");
+            writer
+                .write_metadata(&records::Metadata {
+                    name: "demo".to_string(),
+                    metadata: BTreeMap::from([("key".to_string(), "value".to_string())]),
+                })
+                .expect("metadata");
+            writer.finish().expect("finish writer");
+        }
+        buffer
+    }
 
     #[test]
     fn parse_mcap_collects_channels_and_schemas() {
@@ -418,6 +554,41 @@ mod tests {
         assert!(parsed.header.is_some());
         assert!(parsed.channels.contains_key(&channel_id));
         assert!(parsed.schemas.contains_key(&schema_id));
+    }
+
+    #[test]
+    fn parse_mcap_linear_collects_unindexed_attachment_and_metadata_offsets() {
+        let buffer = write_unindexed_attachment_and_metadata(false);
+        let parsed = parse_mcap(&buffer).expect("parse mcap");
+
+        assert_eq!(parsed.attachment_indexes.len(), 1);
+        assert_eq!(parsed.metadata_indexes.len(), 1);
+        let attachment = mcap::read::attachment(&buffer, &parsed.attachment_indexes[0])
+            .expect("attachment can be read from synthesized index");
+        assert_eq!(attachment.name, "demo.bin");
+        assert_eq!(attachment.data.as_ref(), b"hello");
+        let metadata = mcap::read::metadata(&buffer, &parsed.metadata_indexes[0])
+            .expect("metadata can be read from synthesized index");
+        assert_eq!(metadata.name, "demo");
+        assert_eq!(metadata.metadata["key"], "value");
+    }
+
+    #[test]
+    fn collect_linear_indexes_finds_records_when_summary_indexes_are_omitted() {
+        let buffer = write_unindexed_attachment_and_metadata(true);
+        let parsed = parse_mcap(&buffer).expect("parse mcap");
+        assert!(parsed.attachment_indexes.is_empty());
+        assert!(parsed.metadata_indexes.is_empty());
+
+        let attachment_indexes =
+            collect_attachment_indexes_linear(&buffer).expect("attachment indexes");
+        let metadata_indexes = collect_metadata_indexes_linear(&buffer).expect("metadata indexes");
+        assert_eq!(attachment_indexes.len(), 1);
+        assert_eq!(metadata_indexes.len(), 1);
+        assert_eq!(attachment_indexes[0].name, "demo.bin");
+        assert_eq!(metadata_indexes[0].name, "demo");
+        assert!(mcap::read::attachment(&buffer, &attachment_indexes[0]).is_ok());
+        assert!(mcap::read::metadata(&buffer, &metadata_indexes[0]).is_ok());
     }
 
     #[test]

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -161,6 +161,10 @@ pub(crate) fn metadata_indexes_need_scan(parsed: &ParsedMcap) -> bool {
     }
 }
 
+pub(crate) fn warn_index_scan(record_kind: &str) {
+    eprintln!("Warning: {record_kind} indexes not available; full scan may be slow.");
+}
+
 fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
 where
     F: FnMut(Record<'_>, u64, u64) -> Result<()>,
@@ -603,6 +607,50 @@ mod tests {
         assert_eq!(metadata_indexes[0].name, "demo");
         assert!(mcap::read::attachment(&buffer, &attachment_indexes[0]).is_ok());
         assert!(mcap::read::metadata(&buffer, &metadata_indexes[0]).is_ok());
+    }
+
+    #[test]
+    fn collect_linear_attachment_indexes_tracks_offsets_after_chunks() {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .emit_summary_records(false)
+                .emit_summary_offsets(false)
+                .emit_attachment_indexes(false)
+                .create(std::io::Cursor::new(&mut buffer))
+                .expect("writer");
+            let schema_id = writer.add_schema("demo", "json", b"{}").expect("schema");
+            let channel_id = writer
+                .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
+                .expect("channel");
+            writer
+                .write_to_known_channel(
+                    &records::MessageHeader {
+                        channel_id,
+                        sequence: 1,
+                        log_time: 1,
+                        publish_time: 1,
+                    },
+                    br#"{"k":"v"}"#,
+                )
+                .expect("message");
+            writer
+                .attach(&mcap::Attachment {
+                    log_time: 10,
+                    create_time: 11,
+                    name: "after-chunk.bin".to_string(),
+                    media_type: "application/octet-stream".to_string(),
+                    data: Cow::Borrowed(b"chunk-safe"),
+                })
+                .expect("attachment");
+            writer.finish().expect("finish writer");
+        }
+
+        let indexes = collect_attachment_indexes_linear(&buffer).expect("attachment indexes");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "after-chunk.bin");
+        let attachment = mcap::read::attachment(&buffer, &indexes[0]).expect("attachment");
+        assert_eq!(attachment.data.as_ref(), b"chunk-safe");
     }
 
     #[test]

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -170,7 +170,7 @@ pub(crate) fn metadata_indexes_need_scan(parsed: &ParsedMcap) -> bool {
 }
 
 pub(crate) fn warn_index_scan(record_kind: &str) {
-    eprintln!("Warning: {record_kind} indexes not available; full scan may be slow.");
+    eprintln!("Warning: {record_kind} indexes incomplete or unavailable; full scan may be slow.");
 }
 
 fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>


### PR DESCRIPTION
### Changelog

`mcap list` and `mcap get` now find local attachment and metadata records in valid MCAP files that omit summary indexes.

### Docs

None

### Description

Fixes #1714

Local attachment and metadata list/get commands synthesize offsets from a top-level linear scan only when summary indexes are missing or incomplete, warn before that fallback, and keep fast indexed not-found lookups when statistics prove the index complete. Remote paths remain index/range based.