### PR TITLE
cli: Consistent doctor message order warnings

### DIFF
--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -58,6 +58,7 @@ struct Doctor {
     saw_footer: bool,
     saw_top_level_message: bool,
     message_index_warning_emitted: bool,
+    last_top_level_message_time: Option<u64>,
     global_max_log_time: Option<u64>,
     min_log_time: Option<u64>,
     max_log_time: Option<u64>,
@@ -92,6 +93,7 @@ impl Doctor {
             saw_footer: false,
             saw_top_level_message: false,
             message_index_warning_emitted: false,
+            last_top_level_message_time: None,
             global_max_log_time: None,
             min_log_time: None,
             max_log_time: None,
@@ -393,7 +395,15 @@ impl Doctor {
             ));
         }
 
-        self.check_message_order(header.log_time, channel_topic.as_deref());
+        if let Some(previous) = self.last_top_level_message_time {
+            self.check_message_order(
+                header.log_time,
+                channel_topic.as_deref(),
+                previous,
+                "previous message record time",
+            );
+        }
+        self.last_top_level_message_time = Some(header.log_time);
         self.observe_message_time(header.log_time);
     }
 
@@ -448,7 +458,14 @@ impl Doctor {
                         ));
                     }
 
-                    self.check_message_order(header.log_time, channel_topic.as_deref());
+                    if let Some(latest_log_time) = self.global_max_log_time {
+                        self.check_message_order(
+                            header.log_time,
+                            channel_topic.as_deref(),
+                            latest_log_time,
+                            "latest log time",
+                        );
+                    }
                     min_log_time =
                         Some(min_log_time.map_or(header.log_time, |min| min.min(header.log_time)));
                     max_log_time =
@@ -496,19 +513,22 @@ impl Doctor {
         self.max_log_time = Some(self.max_log_time.map_or(log_time, |max| max.max(log_time)));
     }
 
-    fn check_message_order(&mut self, log_time: u64, topic: Option<&str>) {
-        if let Some(latest_log_time) = self.global_max_log_time {
-            if log_time < latest_log_time {
-                let topic = topic.unwrap_or("<unknown>");
-                let message = format!(
-                    "Message.log_time {} on {:?} is less than the latest log time {}",
-                    log_time, topic, latest_log_time
-                );
-                if self.strict_message_order {
-                    self.error(message);
-                } else {
-                    self.warn(message);
-                }
+    fn check_message_order(
+        &mut self,
+        log_time: u64,
+        topic: Option<&str>,
+        reference_time: u64,
+        reference_name: &str,
+    ) {
+        if log_time < reference_time {
+            let topic = topic.unwrap_or("<unknown>");
+            let message = format!(
+                "Message.log_time {log_time} on {topic:?} is less than the {reference_name} {reference_time}",
+            );
+            if self.strict_message_order {
+                self.error(message);
+            } else {
+                self.warn(message);
             }
         }
     }
@@ -832,7 +852,7 @@ mod tests {
             non_strict
                 .warnings
                 .iter()
-                .any(|msg| msg.contains("less than the latest log time")),
+                .any(|msg| msg.contains("less than the previous message record time")),
             "{:?}",
             non_strict.warnings
         );
@@ -843,10 +863,24 @@ mod tests {
             strict
                 .errors
                 .iter()
-                .any(|msg| msg.contains("less than the latest log time")),
+                .any(|msg| msg.contains("less than the previous message record time")),
             "{:?}",
             strict.errors
         );
+    }
+
+    #[test]
+    fn top_level_messages_keep_previous_message_order_baseline() {
+        let mcap = write_mcap(|opts| opts.use_chunks(false), None, &[100, 1, 2, 99]);
+
+        let diagnosis = diagnose_mcap(&mcap, false);
+        assert_eq!(diagnosis.warnings.len(), 1, "{:?}", diagnosis.warnings);
+        assert!(
+            diagnosis.warnings[0].contains("less than the previous message record time"),
+            "{:?}",
+            diagnosis.warnings
+        );
+        assert!(diagnosis.errors.is_empty(), "{:?}", diagnosis.errors);
     }
 
     #[test]

--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -58,7 +58,6 @@ struct Doctor {
     saw_footer: bool,
     saw_top_level_message: bool,
     message_index_warning_emitted: bool,
-    last_top_level_message_time: Option<u64>,
     global_max_log_time: Option<u64>,
     min_log_time: Option<u64>,
     max_log_time: Option<u64>,
@@ -93,7 +92,6 @@ impl Doctor {
             saw_footer: false,
             saw_top_level_message: false,
             message_index_warning_emitted: false,
-            last_top_level_message_time: None,
             global_max_log_time: None,
             min_log_time: None,
             max_log_time: None,
@@ -395,18 +393,7 @@ impl Doctor {
             ));
         }
 
-        if let Some(previous) = self.last_top_level_message_time {
-            // Top-level messages are required to be ordered by log time.
-            // `--strict-message-order` only governs ordering checks across chunked messages.
-            if header.log_time < previous {
-                let topic = channel_topic.as_deref().unwrap_or("<unknown>");
-                self.error(format!(
-                    "Message.log_time {} on {:?} is less than the previous message record time {}",
-                    header.log_time, topic, previous
-                ));
-            }
-        }
-        self.last_top_level_message_time = Some(header.log_time);
+        self.check_message_order(header.log_time, channel_topic.as_deref());
         self.observe_message_time(header.log_time);
     }
 
@@ -461,21 +448,7 @@ impl Doctor {
                         ));
                     }
 
-                    if let Some(latest_log_time) = self.global_max_log_time {
-                        if header.log_time < latest_log_time {
-                            let topic = channel_topic.as_deref().unwrap_or("<unknown>");
-                            let message = format!(
-                                "Message.log_time {} on {:?} is less than the latest log time {}",
-                                header.log_time, topic, latest_log_time
-                            );
-                            if self.strict_message_order {
-                                self.error(message);
-                            } else {
-                                self.warn(message);
-                            }
-                        }
-                    }
-
+                    self.check_message_order(header.log_time, channel_topic.as_deref());
                     min_log_time =
                         Some(min_log_time.map_or(header.log_time, |min| min.min(header.log_time)));
                     max_log_time =
@@ -521,6 +494,23 @@ impl Doctor {
         );
         self.min_log_time = Some(self.min_log_time.map_or(log_time, |min| min.min(log_time)));
         self.max_log_time = Some(self.max_log_time.map_or(log_time, |max| max.max(log_time)));
+    }
+
+    fn check_message_order(&mut self, log_time: u64, topic: Option<&str>) {
+        if let Some(latest_log_time) = self.global_max_log_time {
+            if log_time < latest_log_time {
+                let topic = topic.unwrap_or("<unknown>");
+                let message = format!(
+                    "Message.log_time {} on {:?} is less than the latest log time {}",
+                    log_time, topic, latest_log_time
+                );
+                if self.strict_message_order {
+                    self.error(message);
+                } else {
+                    self.warn(message);
+                }
+            }
+        }
     }
 
     fn validate_chunk_indexes(&mut self, mcap: &[u8]) {
@@ -720,7 +710,7 @@ mod tests {
     use super::diagnose_mcap;
     use mcap::records::op;
 
-    fn write_chunked_mcap(
+    fn write_mcap(
         configure: impl FnOnce(mcap::WriteOptions) -> mcap::WriteOptions,
         schema_id: Option<u16>,
         message_times: &[u64],
@@ -762,21 +752,21 @@ mod tests {
 
     #[test]
     fn no_error_on_messageless_chunks() {
-        let mcap = write_chunked_mcap(|opts| opts, Some(0), &[]);
+        let mcap = write_mcap(|opts| opts, Some(0), &[]);
         let diagnosis = diagnose_mcap(&mcap, false);
         assert!(diagnosis.errors.is_empty(), "{:?}", diagnosis.errors);
     }
 
     #[test]
     fn no_error_on_schemaless_messages() {
-        let mcap = write_chunked_mcap(|opts| opts, Some(0), &[10]);
+        let mcap = write_mcap(|opts| opts, Some(0), &[10]);
         let diagnosis = diagnose_mcap(&mcap, false);
         assert!(diagnosis.errors.is_empty(), "{:?}", diagnosis.errors);
     }
 
     #[test]
     fn requires_duplicated_schemas_for_indexed_messages() {
-        let mcap = write_chunked_mcap(
+        let mcap = write_mcap(
             |opts| opts.repeat_channels(false).repeat_schemas(false),
             None,
             &[10],
@@ -802,14 +792,40 @@ mod tests {
 
     #[test]
     fn passes_indexed_messages_with_repeated_schemas() {
-        let mcap = write_chunked_mcap(|opts| opts, None, &[10]);
+        let mcap = write_mcap(|opts| opts, None, &[10]);
         let diagnosis = diagnose_mcap(&mcap, false);
         assert!(diagnosis.errors.is_empty(), "{:?}", diagnosis.errors);
     }
 
     #[test]
-    fn strict_message_order_toggles_warning_vs_error() {
-        let mcap = write_chunked_mcap(|opts| opts, None, &[20, 10]);
+    fn strict_message_order_toggles_warning_vs_error_for_chunked_messages() {
+        let mcap = write_mcap(|opts| opts, None, &[20, 10]);
+
+        let non_strict = diagnose_mcap(&mcap, false);
+        assert!(
+            non_strict
+                .warnings
+                .iter()
+                .any(|msg| msg.contains("less than the latest log time")),
+            "{:?}",
+            non_strict.warnings
+        );
+        assert!(non_strict.errors.is_empty(), "{:?}", non_strict.errors);
+
+        let strict = diagnose_mcap(&mcap, true);
+        assert!(
+            strict
+                .errors
+                .iter()
+                .any(|msg| msg.contains("less than the latest log time")),
+            "{:?}",
+            strict.errors
+        );
+    }
+
+    #[test]
+    fn strict_message_order_toggles_warning_vs_error_for_top_level_messages() {
+        let mcap = write_mcap(|opts| opts.use_chunks(false), None, &[20, 10]);
 
         let non_strict = diagnose_mcap(&mcap, false);
         assert!(
@@ -835,7 +851,7 @@ mod tests {
 
     #[test]
     fn continues_scanning_after_corrupt_top_level_record() {
-        let mut mcap = write_chunked_mcap(
+        let mut mcap = write_mcap(
             |opts| {
                 opts.use_chunks(false)
                     .repeat_channels(false)

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -20,10 +20,14 @@ use tempfile::TempDir;
 
 /// Build a small chunked, indexed MCAP in memory with `num_messages` messages on `/example`.
 fn build_mcap(num_messages: u64) -> Vec<u8> {
+    build_mcap_with_options(true, &(0..num_messages).map(|i| i + 1).collect::<Vec<_>>())
+}
+
+fn build_mcap_with_options(use_chunks: bool, message_log_times: &[u64]) -> Vec<u8> {
     let mut buffer = Vec::new();
     {
         let mut writer = mcap::WriteOptions::new()
-            .use_chunks(true)
+            .use_chunks(use_chunks)
             // Small chunks so even a modest message count spans multiple chunks; this makes a
             // mid-file truncation land inside chunk data (needed for the lossy-recover test).
             .chunk_size(Some(256))
@@ -35,14 +39,14 @@ fn build_mcap(num_messages: u64) -> Vec<u8> {
         let channel_id = writer
             .add_channel(schema_id, "/example", "json", &BTreeMap::new())
             .expect("add channel");
-        for i in 0..num_messages {
+        for (i, log_time) in message_log_times.iter().copied().enumerate() {
             writer
                 .write_to_known_channel(
                     &MessageHeader {
                         channel_id,
                         sequence: i as u32,
-                        log_time: i + 1,
-                        publish_time: i + 1,
+                        log_time,
+                        publish_time: log_time,
                     },
                     format!("{{\"n\":{i}}}").as_bytes(),
                 )
@@ -149,6 +153,28 @@ fn exit_code_3_on_lossy_recover() {
         looks_like_mcap(&recovered),
         "recovered file should be valid MCAP"
     );
+}
+
+#[test]
+fn exit_code_doctor_non_strict_allows_out_of_order_top_level_messages() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(
+        &dir,
+        "out_of_order.mcap",
+        &build_mcap_with_options(false, &[2, 1]),
+    );
+
+    let output = mcap(&["doctor", path_str(&path)]);
+    assert!(
+        output.status.success(),
+        "non-strict doctor should warn but exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Warning: Message.log_time"));
+
+    let output = mcap(&["doctor", "--strict-message-order", path_str(&path)]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Error: Message.log_time"));
 }
 
 // Reading from a non-seekable stdin pipe is only reachable end-to-end; the unit tests use


### PR DESCRIPTION
## Summary

Make Rust `mcap doctor` consistently warn for out-of-order top-level messages, and consistently error only with `--strict-message-order`.

- Preserve existing comparison behavior: top-level messages compare with the previous top-level message; chunked messages compare with the prior max log time.
- Add unit and CLI exit-code regressions for default and strict mode.

## Rationale

Out-of-order message `log_time` values are spec-legal, so default `doctor` should not fail valid files. They are still useful quality/interoperability diagnostics, so they remain warnings rather than being hidden or downgraded to info.

`doctor` warnings continue to exit 0; exit 3 remains reserved for warning-level data loss such as `recover` producing incomplete output.

## Behavior matrix

| CLI | Storage | Before: default | Before: `--strict-message-order` | After this PR: default | After this PR: `--strict-message-order` |
| --- | --- | --- | --- | --- | --- |
| Rust | Unchunked | Error, exit 1 | Error, exit 1 | Warning, exit 0 | Error, exit 1 |
| Rust | Chunked | Warning, exit 0 | Error, exit 1 | Warning, exit 0 | Error, exit 1 |
| Go (Legacy) | Unchunked | Error, exit 1 | Error, exit 1 | N/A | N/A |
| Go (Legacy) | Chunked | Warning, exit 0 | Error, exit 1 | N/A | N/A |

Fixes #1717