### PR TITLE
cli: Fix info counts without statistics record

### DIFF
--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -10,7 +10,7 @@ use crate::{parse, render, source};
 pub fn run(ctx: &CommandContext, args: InfoCommand) -> Result<()> {
     let parsed = source::parse_mcap_from_path(
         &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
+        source::SourceOptions::new(ctx.allow_remote_scan()).scan_data_without_statistics(true),
     )?;
     print!("{}", render_info(&parsed));
     Ok(())
@@ -27,22 +27,25 @@ fn render_info(parsed: &parse::ParsedMcap) -> String {
         let _ = writeln!(&mut out, "profile:     unknown");
     }
 
+    let message_count = message_count(parsed);
+    let message_time_range = message_time_range(parsed);
     let mut duration_seconds = 0.0f64;
-    if let Some(stats) = &parsed.statistics {
-        let _ = writeln!(&mut out, "messages:    {}", stats.message_count);
-        let (duration_ns, signed_duration) =
-            format_duration(stats.message_start_time, stats.message_end_time);
+    if let Some(count) = message_count {
+        let _ = writeln!(&mut out, "messages:    {count}");
+    }
+    if let Some((message_start_time, message_end_time)) = message_time_range {
+        let (duration_ns, signed_duration) = format_duration(message_start_time, message_end_time);
         duration_seconds = duration_ns / 1e9;
         let _ = writeln!(&mut out, "duration:    {signed_duration}");
         let _ = writeln!(
             &mut out,
             "start:       {}",
-            render::formatted_time(stats.message_start_time)
+            render::formatted_time(message_start_time)
         );
         let _ = writeln!(
             &mut out,
             "end:         {}",
-            render::formatted_time(stats.message_end_time)
+            render::formatted_time(message_end_time)
         );
     }
 
@@ -119,17 +122,52 @@ fn render_info(parsed: &parse::ParsedMcap) -> String {
     let rows = render_channel_summary_rows(parsed, duration_seconds);
     out.push_str(&render::format_table(&rows));
 
-    if let Some(stats) = &parsed.statistics {
-        let _ = writeln!(&mut out, "channels:    {}", stats.channel_count);
-        let _ = writeln!(&mut out, "attachments: {}", stats.attachment_count);
-        let _ = writeln!(&mut out, "metadata:    {}", stats.metadata_count);
-    } else {
-        let _ = writeln!(&mut out, "channels:    unknown");
-        let _ = writeln!(&mut out, "attachments: unknown");
-        let _ = writeln!(&mut out, "metadata:    unknown");
-    }
+    let _ = writeln!(&mut out, "channels:    {}", channel_count(parsed));
+    let _ = writeln!(&mut out, "attachments: {}", attachment_count(parsed));
+    let _ = writeln!(&mut out, "metadata:    {}", metadata_count(parsed));
 
     out
+}
+
+fn message_count(parsed: &parse::ParsedMcap) -> Option<u64> {
+    parsed
+        .statistics
+        .as_ref()
+        .map(|stats| stats.message_count)
+        .or(parsed.message_count)
+}
+
+fn message_time_range(parsed: &parse::ParsedMcap) -> Option<(u64, u64)> {
+    if let Some(stats) = &parsed.statistics {
+        return Some((stats.message_start_time, stats.message_end_time));
+    }
+    Some((parsed.message_start_time?, parsed.message_end_time?))
+}
+
+fn channel_count(parsed: &parse::ParsedMcap) -> u32 {
+    parsed
+        .statistics
+        .as_ref()
+        .map(|stats| stats.channel_count)
+        .unwrap_or(parsed.channels.len() as u32)
+}
+
+fn attachment_count(parsed: &parse::ParsedMcap) -> u32 {
+    parsed
+        .statistics
+        .as_ref()
+        .map(|stats| stats.attachment_count)
+        .or(parsed.attachment_count)
+        .unwrap_or(parsed.attachment_indexes.len() as u32)
+}
+
+fn metadata_count(parsed: &parse::ParsedMcap) -> u32 {
+    parsed
+        .statistics
+        .as_ref()
+        .map(|stats| stats.metadata_count)
+        .or(parsed.metadata_count)
+        .unwrap_or(parsed.metadata_indexes.len() as u32)
 }
 
 fn render_channel_summary_rows(
@@ -144,20 +182,13 @@ fn render_channel_summary_rows(
         .copied()
         .map(digits_u16)
         .unwrap_or(1);
-    let max_count_width = parsed
-        .statistics
-        .as_ref()
-        .map(|stats| {
+    let channel_message_counts = channel_message_counts(parsed);
+    let max_count_width = channel_message_counts
+        .map(|counts| {
             parsed
                 .channels
                 .keys()
-                .map(|channel_id| {
-                    stats
-                        .channel_message_counts
-                        .get(channel_id)
-                        .copied()
-                        .unwrap_or_default()
-                })
+                .map(|channel_id| counts.get(channel_id).copied().unwrap_or_default())
                 .max()
                 .unwrap_or_default()
                 .to_string()
@@ -166,12 +197,8 @@ fn render_channel_summary_rows(
         .unwrap_or(0);
 
     for channel in parsed.channels.values() {
-        let msg_col = if let Some(stats) = &parsed.statistics {
-            let count = stats
-                .channel_message_counts
-                .get(&channel.id)
-                .copied()
-                .unwrap_or_default();
+        let msg_col = if let Some(counts) = channel_message_counts {
+            let count = counts.get(&channel.id).copied().unwrap_or_default();
             if count > 1 && duration_seconds > 0.0 {
                 let max_hz = count as f64 / duration_seconds;
                 let min_hz = (count - 1) as f64 / duration_seconds;
@@ -210,6 +237,16 @@ fn render_channel_summary_rows(
         ]);
     }
     rows
+}
+
+fn channel_message_counts(parsed: &parse::ParsedMcap) -> Option<&BTreeMap<u16, u64>> {
+    if let Some(stats) = &parsed.statistics {
+        return Some(&stats.channel_message_counts);
+    }
+    parsed
+        .message_count
+        .is_some()
+        .then_some(&parsed.channel_message_counts)
 }
 
 fn format_duration(start: u64, end: u64) -> (f64, String) {
@@ -352,7 +389,7 @@ mod tests {
 
     use super::{count_chunk_overlaps, format_duration, render_channel_summary_rows, render_info};
     use crate::parse::{ParsedMcap, ParsedSchema};
-    use mcap::records::{self, ChunkIndex, Header, Statistics};
+    use mcap::records::{self, AttachmentIndex, ChunkIndex, Header, MetadataIndex, Statistics};
 
     #[test]
     fn overlaps_counts_concurrent_chunks() {
@@ -433,6 +470,73 @@ mod tests {
         assert!(rendered.contains("messages:    2"));
         assert!(rendered.contains("channels:"));
         assert!(rendered.contains("/demo"));
+    }
+
+    #[test]
+    fn info_render_uses_scanned_counts_without_statistics() {
+        let mut parsed = ParsedMcap {
+            message_count: Some(1),
+            message_start_time: Some(10),
+            message_end_time: Some(10),
+            attachment_count: Some(0),
+            metadata_count: Some(0),
+            ..ParsedMcap::default()
+        };
+        parsed.channels.insert(
+            7,
+            records::Channel {
+                id: 7,
+                schema_id: 0,
+                topic: "/demo".to_string(),
+                message_encoding: "json".to_string(),
+                metadata: BTreeMap::new(),
+            },
+        );
+        parsed.channel_message_counts.insert(7, 1);
+
+        let rendered = render_info(&parsed);
+        assert!(rendered.contains("messages:    1"));
+        assert!(rendered.contains("duration:    0ns"));
+        assert!(rendered.contains("1 msgs"));
+        assert!(rendered.contains("channels:    1"));
+        assert!(rendered.contains("attachments: 0"));
+        assert!(rendered.contains("metadata:    0"));
+        assert!(!rendered.contains("unknown"));
+    }
+
+    #[test]
+    fn info_render_uses_summary_record_counts_without_statistics() {
+        let mut parsed = ParsedMcap::default();
+        parsed.channels.insert(
+            7,
+            records::Channel {
+                id: 7,
+                schema_id: 0,
+                topic: "/demo".to_string(),
+                message_encoding: "json".to_string(),
+                metadata: BTreeMap::new(),
+            },
+        );
+        parsed.attachment_indexes.push(AttachmentIndex {
+            offset: 22,
+            length: 10,
+            log_time: 2,
+            create_time: 3,
+            data_size: 44,
+            name: "demo.bin".to_string(),
+            media_type: "application/octet-stream".to_string(),
+        });
+        parsed.metadata_indexes.push(MetadataIndex {
+            offset: 7,
+            length: 42,
+            name: "demo".to_string(),
+        });
+
+        let rendered = render_info(&parsed);
+        assert!(rendered.contains("channels:    1"));
+        assert!(rendered.contains("attachments: 1"));
+        assert!(rendered.contains("metadata:    1"));
+        assert!(!rendered.contains("unknown"));
     }
 
     #[test]

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -501,7 +501,9 @@ mod tests {
         assert!(rendered.contains("channels:    1"));
         assert!(rendered.contains("attachments: 0"));
         assert!(rendered.contains("metadata:    0"));
-        assert!(!rendered.contains("unknown"));
+        assert!(!rendered.contains("channels:    unknown"));
+        assert!(!rendered.contains("attachments: unknown"));
+        assert!(!rendered.contains("metadata:    unknown"));
     }
 
     #[test]
@@ -536,7 +538,9 @@ mod tests {
         assert!(rendered.contains("channels:    1"));
         assert!(rendered.contains("attachments: 1"));
         assert!(rendered.contains("metadata:    1"));
-        assert!(!rendered.contains("unknown"));
+        assert!(!rendered.contains("channels:    unknown"));
+        assert!(!rendered.contains("attachments: unknown"));
+        assert!(!rendered.contains("metadata:    unknown"));
     }
 
     #[test]

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -507,6 +507,22 @@ mod tests {
     }
 
     #[test]
+    fn info_render_includes_zero_scanned_message_count() {
+        let parsed = ParsedMcap {
+            message_count: Some(0),
+            attachment_count: Some(0),
+            metadata_count: Some(0),
+            ..ParsedMcap::default()
+        };
+
+        let rendered = render_info(&parsed);
+        assert!(rendered.contains("messages:    0"));
+        assert!(rendered.contains("channels:    0"));
+        assert!(rendered.contains("attachments: 0"));
+        assert!(rendered.contains("metadata:    0"));
+    }
+
+    #[test]
     fn info_render_uses_summary_record_counts_without_statistics() {
         let mut parsed = ParsedMcap::default();
         parsed.channels.insert(

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -112,6 +112,9 @@ pub(crate) fn parsed_mcap_from_summary_section(
 fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<ParsedMcap> {
     let mut out = ParsedMcap {
         header,
+        message_count: Some(0),
+        attachment_count: Some(0),
+        metadata_count: Some(0),
         ..ParsedMcap::default()
     };
     for record in mcap::read::LinearReader::new(mcap)? {
@@ -494,6 +497,25 @@ mod tests {
             parsed.channel_message_counts.get(&channel_id).copied(),
             Some(2)
         );
+    }
+
+    #[test]
+    fn parse_mcap_scan_fallback_reports_zero_counts() {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .emit_statistics(false)
+                .create(std::io::Cursor::new(&mut buffer))
+                .expect("writer");
+            writer.finish().expect("finish writer");
+        }
+
+        let parsed =
+            parse_mcap_with_scan_fallback(&buffer, true).expect("parse mcap with scan fallback");
+        assert!(parsed.statistics.is_none());
+        assert_eq!(parsed.message_count, Some(0));
+        assert_eq!(parsed.attachment_count, Some(0));
+        assert_eq!(parsed.metadata_count, Some(0));
     }
 
     #[test]

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -447,13 +447,6 @@ mod tests {
         assert!(parsed.header.is_some());
         assert!(parsed.channels.contains_key(&channel_id));
         assert!(parsed.schemas.contains_key(&schema_id));
-        assert_eq!(parsed.message_count, Some(1));
-        assert_eq!(parsed.message_start_time, Some(10));
-        assert_eq!(parsed.message_end_time, Some(10));
-        assert_eq!(
-            parsed.channel_message_counts.get(&channel_id).copied(),
-            Some(1)
-        );
     }
 
     #[test]

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use anyhow::{bail, Context as _, Result};
@@ -18,6 +18,12 @@ pub struct ParsedSchema {
 pub struct ParsedMcap {
     pub header: Option<records::Header>,
     pub statistics: Option<records::Statistics>,
+    pub message_count: Option<u64>,
+    pub message_start_time: Option<u64>,
+    pub message_end_time: Option<u64>,
+    pub channel_message_counts: BTreeMap<u16, u64>,
+    pub attachment_count: Option<u32>,
+    pub metadata_count: Option<u32>,
     pub channels: std::collections::BTreeMap<u16, records::Channel>,
     pub schemas: std::collections::BTreeMap<u16, ParsedSchema>,
     pub chunk_indexes: Vec<records::ChunkIndex>,
@@ -26,8 +32,21 @@ pub struct ParsedMcap {
 }
 
 pub fn parse_mcap(mcap: &[u8]) -> Result<ParsedMcap> {
+    parse_mcap_with_scan_fallback(mcap, false)
+}
+
+pub fn parse_mcap_with_scan_fallback(
+    mcap: &[u8],
+    scan_without_statistics: bool,
+) -> Result<ParsedMcap> {
     let header = read_header(mcap)?;
     if let Some(parsed_from_summary) = parse_mcap_from_summary(mcap, header.clone())? {
+        if scan_without_statistics && parsed_from_summary.statistics.is_none() {
+            eprintln!(
+                "Warning: Statistics record not available; full scan may be slow. Run `mcap doctor` for details."
+            );
+            return parse_mcap_linear(mcap, header);
+        }
         return Ok(parsed_from_summary);
     }
 
@@ -123,6 +142,18 @@ fn collect_record(out: &mut ParsedMcap, record: Record<'_>) -> Result<()> {
         Record::Statistics(statistics) => {
             out.statistics = Some(statistics);
         }
+        Record::Message { header, .. } => {
+            increment_optional_u64(&mut out.message_count, "message")?;
+            increment_map_count(&mut out.channel_message_counts, header.channel_id)?;
+            out.message_start_time = Some(
+                out.message_start_time
+                    .map_or(header.log_time, |start| start.min(header.log_time)),
+            );
+            out.message_end_time = Some(
+                out.message_end_time
+                    .map_or(header.log_time, |end| end.max(header.log_time)),
+            );
+        }
         Record::Channel(channel) => {
             if let Some(existing) = out.channels.get(&channel.id) {
                 if existing != &channel {
@@ -145,11 +176,43 @@ fn collect_record(out: &mut ParsedMcap, record: Record<'_>) -> Result<()> {
                 out.schemas.insert(schema.header.id, schema);
             }
         }
+        Record::Attachment { .. } => {
+            increment_optional_u32(&mut out.attachment_count, "attachment")?
+        }
+        Record::Metadata(_) => increment_optional_u32(&mut out.metadata_count, "metadata")?,
         Record::ChunkIndex(index) => out.chunk_indexes.push(index),
         Record::AttachmentIndex(index) => out.attachment_indexes.push(index),
         Record::MetadataIndex(index) => out.metadata_indexes.push(index),
         _ => {}
     }
+    Ok(())
+}
+
+fn increment_optional_u64(count: &mut Option<u64>, label: &str) -> Result<()> {
+    *count = Some(
+        count
+            .unwrap_or_default()
+            .checked_add(1)
+            .with_context(|| format!("{label} count exceeds u64::MAX"))?,
+    );
+    Ok(())
+}
+
+fn increment_optional_u32(count: &mut Option<u32>, label: &str) -> Result<()> {
+    *count = Some(
+        count
+            .unwrap_or_default()
+            .checked_add(1)
+            .with_context(|| format!("{label} count exceeds u32::MAX"))?,
+    );
+    Ok(())
+}
+
+fn increment_map_count(counts: &mut BTreeMap<u16, u64>, channel_id: u16) -> Result<()> {
+    let count = counts.entry(channel_id).or_default();
+    *count = count
+        .checked_add(1)
+        .with_context(|| format!("message count for channel {channel_id} exceeds u64::MAX"))?;
     Ok(())
 }
 
@@ -349,7 +412,9 @@ fn collect_definition_record(
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::{parse_mcap, parse_mcap_from_summary, parse_summary_section};
+    use super::{
+        parse_mcap, parse_mcap_from_summary, parse_mcap_with_scan_fallback, parse_summary_section,
+    };
     use mcap::records;
 
     #[test]
@@ -382,6 +447,60 @@ mod tests {
         assert!(parsed.header.is_some());
         assert!(parsed.channels.contains_key(&channel_id));
         assert!(parsed.schemas.contains_key(&schema_id));
+        assert_eq!(parsed.message_count, Some(1));
+        assert_eq!(parsed.message_start_time, Some(10));
+        assert_eq!(parsed.message_end_time, Some(10));
+        assert_eq!(
+            parsed.channel_message_counts.get(&channel_id).copied(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn parse_mcap_scan_fallback_counts_records_when_summary_lacks_statistics() {
+        let mut buffer = Vec::new();
+        let channel_id = {
+            let mut writer = mcap::WriteOptions::new()
+                .emit_statistics(false)
+                .create(std::io::Cursor::new(&mut buffer))
+                .expect("writer");
+            let schema_id = writer
+                .add_schema("demo_schema", "jsonschema", br#"{"type":"object"}"#)
+                .expect("schema");
+            let channel_id = writer
+                .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
+                .expect("channel");
+            for (sequence, log_time) in [(1, 10), (2, 40)] {
+                writer
+                    .write_to_known_channel(
+                        &records::MessageHeader {
+                            channel_id,
+                            sequence,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        br#"{"k":"v"}"#,
+                    )
+                    .expect("write message");
+            }
+            writer.finish().expect("finish writer");
+            channel_id
+        };
+
+        let summary_only = parse_mcap(&buffer).expect("parse mcap from summary");
+        assert!(summary_only.statistics.is_none());
+        assert_eq!(summary_only.message_count, None);
+
+        let parsed =
+            parse_mcap_with_scan_fallback(&buffer, true).expect("parse mcap with scan fallback");
+        assert!(parsed.statistics.is_none());
+        assert_eq!(parsed.message_count, Some(2));
+        assert_eq!(parsed.message_start_time, Some(10));
+        assert_eq!(parsed.message_end_time, Some(40));
+        assert_eq!(
+            parsed.channel_message_counts.get(&channel_id).copied(),
+            Some(2)
+        );
     }
 
     #[test]

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -77,11 +77,20 @@ impl InputData {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SourceOptions {
     pub allow_remote_scan: bool,
+    pub scan_data_without_statistics: bool,
 }
 
 impl SourceOptions {
     pub fn new(allow_remote_scan: bool) -> Self {
-        Self { allow_remote_scan }
+        Self {
+            allow_remote_scan,
+            ..Self::default()
+        }
+    }
+
+    pub fn scan_data_without_statistics(mut self, scan_data_without_statistics: bool) -> Self {
+        self.scan_data_without_statistics = scan_data_without_statistics;
+        self
     }
 }
 
@@ -155,10 +164,16 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
                     .map_err(|err| remote_read_error(path, err))?
                 {
                     let header = read_header_from_seekable(&mut reader)?;
-                    return parse::parsed_mcap_from_summary_section(header, &summary_bytes)
+                    let parsed = parse::parsed_mcap_from_summary_section(header, &summary_bytes)
                         .map_err(|err| {
                             remote_read_error(path, classify_remote_summary_error(&reader, err))
-                        });
+                        })?;
+                    if parsed.statistics.is_some()
+                        || !options.scan_data_without_statistics
+                        || !options.allow_remote_scan
+                    {
+                        return Ok(parsed);
+                    }
                 }
                 if !options.allow_remote_scan {
                     bail!(
@@ -180,7 +195,7 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
     }
 
     let mcap = load_path(path, options)?;
-    let parsed = parse::parse_mcap(&mcap);
+    let parsed = parse::parse_mcap_with_scan_fallback(&mcap, options.scan_data_without_statistics);
     if is_remote_url(path) {
         parsed.map_err(|err| remote_read_error(path, err))
     } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

`mcap info` now reports numeric counts for readable files without a Statistics record.

### Docs

None

### Description

Fixes #1718

`mcap info` keeps Statistics authoritative, but when they are absent it derives counts from a data scan or available summary indexes instead of printing `unknown`.