### PR TITLE
go: Bump version to 1.9.0

### DIFF
--- a/go/mcap/version.go
+++ b/go/mcap/version.go
@@ -1,4 +1,4 @@
 package mcap
 
 // Version of the MCAP library.
-var Version = "v1.8.0"
+var Version = "v1.9.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
Go SDK version metadata now reports 1.9.0.

### Docs
None

### Description
Bumps the Go MCAP library version constant to `v1.9.0` per `RELEASING.md`, so the package metadata matches the planned `go/mcap/v1.9.0` release tag.

### Testing
No manual verification required; this is a constant-only release bump. Validated locally with the Go package tests and a temporary release-string assertion that confirmed `Version == "v1.9.0"` and writer metadata reports `mcap-go/1.9.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44cc30cf-5648-45e4-8b72-e130f6ec43dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44cc30cf-5648-45e4-8b72-e130f6ec43dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

