### PR TITLE
cli: Stamp commit sha into --version for tarball builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
+# Embed the commit hash in `git archive` tarballs
+/rust/cli/build.rs export-subst
 cpp/examples/protobuf/proto/** linguist-vendored=true linguist-generated=true
 python/mcap-ros1-support/mcap_ros1/vendor/** linguist-vendored=true
 tests/conformance/data/** linguist-generated=true

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -19,7 +19,7 @@ A few modules carry more than their name implies:
 | `source.rs`  | Input abstraction over local files (memory-mapped) and remote object stores. Owns summary/index range reads, remote materialization, and `--allow-remote-scan` gating. |
 | `parse.rs`   | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                         |
 | `context.rs` | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`) threaded into every handler.                                                              |
-| `build.rs`   | Embeds the git SHA into the binary via the `GIT_SHA` env var.                                                                                                          |
+| `build.rs`   | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                      |
 
 ## Conventions
 

--- a/rust/cli/build.rs
+++ b/rust/cli/build.rs
@@ -1,15 +1,39 @@
 use std::process::Command;
 
+/// Leading hex characters of the commit hash to embed.
+/// Use a fixed length to ensure GitHub tarballs are deterministic.
+const SHORT_SHA_LEN: usize = 9;
+
 fn main() {
-    let git_sha = Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
+
+    let revision = git_short_sha().unwrap_or_else(|| "unknown".to_owned());
+    println!("cargo:rustc-env=GIT_SHORT_SHA={revision}");
+}
+
+/// This build's short sha, extracted from the current tarball or local git checkout.
+fn git_short_sha() -> Option<String> {
+    archive_sha()
+        .or_else(git_rev_parse)
+        .map(|sha| sha.chars().take(SHORT_SHA_LEN).collect())
+}
+
+fn archive_sha() -> Option<String> {
+    // In a `git archive` or GitHub tarball, this string is automatically
+    // replaced by the commit hash using `.gitattributes` export-subst.
+    let sha = "$Format:%H$";
+    // If string was not replaced, return None.
+    (!sha.starts_with('$')).then_some(sha.to_owned())
+}
+
+fn git_rev_parse() -> Option<String> {
+    // Fetch the commit hash from local git checkout.
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
         .output()
         .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        .filter(|sha| !sha.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    println!("cargo:rustc-env=GIT_SHA={git_sha}");
-    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
+        .filter(|output| output.status.success())?;
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (!sha.is_empty()).then_some(sha)
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -8,10 +8,12 @@ use clap_complete::Shell;
 use crate::logsetup;
 
 pub(crate) static VERSION: LazyLock<String> = LazyLock::new(|| {
+    // `GIT_SHORT_SHA` is the abbreviated commit (set by `build.rs`), or `unknown` when
+    // the build had no provenance (no git checkout and not a `git archive` tarball).
     format!(
         "{} ({}) mcap-rust/{}",
         env!("CARGO_PKG_VERSION"),
-        env!("GIT_SHA"),
+        env!("GIT_SHORT_SHA"),
         mcap::VERSION
     )
 });


### PR DESCRIPTION
## Summary

mcap homebrew release is stamping `(unknown)` as the commit has into --version, due to building from a tar.gz instead of git:

```sh
$ mcap --version
mcap 0.1.0 (unknown) mcap-rust/0.25.0
```

Use `export-subst` via `.gitattributes` to inject the git sha into `build.rs`, making the git sha available to source builds from tarball. This is set by `git archive` which GitHub (and GitLab) use to generate tar.gz downloads.

Also renames the embedded env var `GIT_SHA` → `GIT_SHORT_SHA` and widens the abbreviation from 7 to 9 hex chars (git's current auto-abbreviation for this repo), applied uniformly so checkout and tarball builds report the same revision.