### PR TITLE
cli: Guard outputs from overwriting inputs

### DIFF
--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -152,13 +152,6 @@ mod tests {
         path
     }
 
-    fn temp_path(name: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "mcap-cli-convert-test-{}-{name}",
-            std::process::id()
-        ))
-    }
-
     fn build_sample_mcap(include_crc: bool) -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         let opts = build_write_options(CompressionFormat::None, 1024, include_crc, true, "ros1");
@@ -280,30 +273,6 @@ size 123\n",
         std::fs::remove_file(path).expect("remove temp input");
         assert!(err.to_string().contains("Git LFS pointer"));
         assert!(err.to_string().contains("git lfs pull"));
-    }
-
-    #[test]
-    fn distinct_path_check_allows_single_component_missing_output() {
-        let input_path = temp_input("distinct-input.db3", b"placeholder");
-        let output_path = temp_path("single-component-output.mcap");
-        let file_name = output_path.file_name().expect("file name");
-        let current_dir_output = std::env::current_dir()
-            .expect("current dir")
-            .join(file_name);
-        let _ = std::fs::remove_file(&current_dir_output);
-
-        crate::source::ensure_distinct_local_input_output(&input_path, Path::new(file_name))
-            .expect("single-component output should resolve through current directory");
-        std::fs::remove_file(input_path).expect("remove temp input");
-    }
-
-    #[test]
-    fn distinct_path_check_rejects_same_file_paths() {
-        let path = temp_input("same-path.db3", b"placeholder");
-        let err = crate::source::ensure_distinct_local_input_output(&path, &path)
-            .expect_err("same input/output should fail");
-        assert!(err.to_string().contains("input and output paths"));
-        std::fs::remove_file(path).expect("remove temp input");
     }
 
     #[test]

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{bail, Context, Result};
 use mcap::{Compression, WriteOptions};
 
 use crate::cli::{CompressionFormat, ConvertCommand};
@@ -24,7 +24,7 @@ pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),
     )?;
     if !is_remote {
-        ensure_distinct_paths(materialized_input.path(), &args.output)?;
+        crate::source::ensure_distinct_local_input_output(materialized_input.path(), &args.output)?;
     }
     let opts = build_write_options(
         args.compression,
@@ -130,46 +130,6 @@ fn read_prefix(input: &mut File, buffer: &mut [u8]) -> std::io::Result<usize> {
     Ok(bytes_read)
 }
 
-fn ensure_distinct_paths(input: &Path, output: &Path) -> Result<()> {
-    let input_path = input
-        .canonicalize()
-        .with_context(|| format!("failed to resolve input path '{}'", input.display()))?;
-    let output_path = match output.canonicalize() {
-        Ok(path) => path,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            let parent = output
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty())
-                .unwrap_or_else(|| Path::new("."));
-            let file_name = output
-                .file_name()
-                .with_context(|| format!("invalid output path '{}'", output.display()))?;
-            let parent_path = match parent.canonicalize() {
-                Ok(path) => path,
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    return Ok(());
-                }
-                Err(err) => {
-                    return Err(err).with_context(|| {
-                        format!("failed to resolve output parent '{}'", parent.display())
-                    });
-                }
-            };
-            parent_path.join(file_name)
-        }
-        Err(err) => {
-            return Err(err)
-                .with_context(|| format!("failed to resolve output path '{}'", output.display()));
-        }
-    };
-
-    ensure!(
-        input_path != output_path,
-        "input and output paths must be different"
-    );
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -179,7 +139,7 @@ mod tests {
 
     use anyhow::Result;
 
-    use super::{build_write_options, ensure_distinct_paths, reject_lfs_pointer, ConvertInput};
+    use super::{build_write_options, reject_lfs_pointer, ConvertInput};
     use crate::cli::{CompressionFormat, ConvertCommand};
     use crate::context::CommandContext;
 
@@ -332,7 +292,7 @@ size 123\n",
             .join(file_name);
         let _ = std::fs::remove_file(&current_dir_output);
 
-        ensure_distinct_paths(&input_path, Path::new(file_name))
+        crate::source::ensure_distinct_local_input_output(&input_path, Path::new(file_name))
             .expect("single-component output should resolve through current directory");
         std::fs::remove_file(input_path).expect("remove temp input");
     }
@@ -340,7 +300,8 @@ size 123\n",
     #[test]
     fn distinct_path_check_rejects_same_file_paths() {
         let path = temp_input("same-path.db3", b"placeholder");
-        let err = ensure_distinct_paths(&path, &path).expect_err("same input/output should fail");
+        let err = crate::source::ensure_distinct_local_input_output(&path, &path)
+            .expect_err("same input/output should fail");
         assert!(err.to_string().contains("input and output paths"));
         std::fs::remove_file(path).expect("remove temp input");
     }
@@ -361,6 +322,31 @@ size 123\n",
         .expect_err("missing input should fail");
 
         assert!(err.to_string().contains("failed to open input"));
+    }
+
+    #[test]
+    fn run_rejects_same_input_and_output_without_truncating() {
+        let input_path = temp_input("same-path.db3", b"not a sqlite db");
+
+        let err = super::run(
+            &CommandContext::default(),
+            ConvertCommand {
+                input: input_path.clone(),
+                output: input_path.clone(),
+                compression: CompressionFormat::None,
+                chunk_size: 8 * 1024 * 1024,
+                no_crc: true,
+                no_chunks: false,
+            },
+        )
+        .expect_err("same input/output should fail");
+
+        assert!(err.to_string().contains("input and output paths"));
+        assert_eq!(
+            std::fs::read(&input_path).expect("read input"),
+            b"not a sqlite db"
+        );
+        std::fs::remove_file(input_path).expect("remove temp input");
     }
 
     #[test]

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -133,6 +133,9 @@ pub(crate) fn run_transcode(
     source_options: source::SourceOptions,
 ) -> Result<()> {
     let opts = build_filter_options_from_transcode_options(&args)?;
+    if let (Some(input), Some(output)) = (args.file.as_deref(), opts.output.as_deref()) {
+        source::ensure_distinct_local_input_output(input, output)?;
+    }
     let input = source::load_input(args.file.as_deref(), source_options)?;
 
     if let Some(output) = &opts.output {
@@ -615,6 +618,7 @@ mod tests {
 
     use super::{build_filter_options, filter_to_writer, include_topic, FilterOptions};
     use crate::cli::FilterCommand;
+    use crate::context::CommandContext;
 
     fn default_filter_command() -> FilterCommand {
         FilterCommand {
@@ -755,6 +759,19 @@ mod tests {
         let mut output = Cursor::new(Vec::new());
         filter_to_writer(input, &mut output, opts, false).expect("filter should succeed");
         output.into_inner()
+    }
+
+    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "mcap-cli-filter-{stem}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        path
     }
 
     #[derive(Default)]
@@ -1173,5 +1190,38 @@ mod tests {
 
         let _ = std::fs::remove_file(input_path);
         let _ = std::fs::remove_file(output_path);
+    }
+
+    #[test]
+    fn run_rejects_same_input_and_output_without_truncating() {
+        let input = write_filter_test_input(true, false);
+        let path = unique_temp_path("same-path.mcap");
+        std::fs::write(&path, &input).expect("write input");
+
+        let err = super::run(
+            &CommandContext::default(),
+            FilterCommand {
+                file: Some(path.clone()),
+                output: Some(path.clone()),
+                include_topic_regex: Vec::new(),
+                exclude_topic_regex: Vec::new(),
+                last_per_channel_topic_regex: Vec::new(),
+                start: None,
+                start_secs: 0,
+                start_nsecs: 0,
+                end: None,
+                end_secs: 0,
+                end_nsecs: 0,
+                include_metadata: false,
+                include_attachments: false,
+                output_compression: "zstd".to_string(),
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            },
+        )
+        .expect_err("same input/output should fail");
+
+        assert!(err.to_string().contains("input and output paths"));
+        assert_eq!(std::fs::read(&path).expect("read input"), input);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -761,19 +761,6 @@ mod tests {
         output.into_inner()
     }
 
-    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "mcap-cli-filter-{stem}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time should be after epoch")
-                .as_nanos()
-        ));
-        path
-    }
-
     #[derive(Default)]
     struct OutputStats {
         topic_counts: BTreeMap<String, usize>,
@@ -1195,7 +1182,8 @@ mod tests {
     #[test]
     fn run_rejects_same_input_and_output_without_truncating() {
         let input = write_filter_test_input(true, false);
-        let path = unique_temp_path("same-path.mcap");
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("same-path.mcap");
         std::fs::write(&path, &input).expect("write input");
 
         let err = super::run(
@@ -1222,6 +1210,5 @@ mod tests {
 
         assert!(err.to_string().contains("input and output paths"));
         assert_eq!(std::fs::read(&path).expect("read input"), input);
-        let _ = std::fs::remove_file(path);
     }
 }

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -12,6 +12,9 @@ const PLEASE_REDIRECT: &str =
 
 pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    if let Some(output) = args.output.as_deref() {
+        source::ensure_distinct_local_input_output(&args.file, output)?;
+    }
     if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
         let index = select_attachment_index(
             &remote.summary().attachment_indexes,
@@ -118,6 +121,8 @@ mod tests {
     use std::borrow::Cow;
 
     use super::{local_attachment_indexes, select_attachment_index};
+    use crate::cli::GetAttachmentCommand;
+    use crate::context::CommandContext;
     use crate::parse;
     use mcap::records::{AttachmentIndex, Statistics};
 
@@ -133,12 +138,66 @@ mod tests {
         }
     }
 
+    fn mcap_with_attachment() -> Vec<u8> {
+        let mut mcap_bytes = Vec::new();
+        {
+            let mut writer =
+                mcap::Writer::new(std::io::Cursor::new(&mut mcap_bytes)).expect("writer");
+            writer
+                .attach(&mcap::Attachment {
+                    log_time: 1,
+                    create_time: 1,
+                    name: "a".to_string(),
+                    media_type: "application/octet-stream".to_string(),
+                    data: Cow::Borrowed(b"payload"),
+                })
+                .expect("attachment");
+            writer.finish().expect("finish");
+        }
+        mcap_bytes
+    }
+
+    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "mcap-cli-get-attachment-{stem}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        path
+    }
+
     #[test]
     fn selects_single_match_without_offset() {
         let indexes = vec![attachment("a", 10)];
         let selected =
             select_attachment_index(&indexes, "a", None).expect("attachment should resolve");
         assert_eq!(selected.offset, 10);
+    }
+
+    #[test]
+    fn run_rejects_same_input_and_output_without_truncating() {
+        let input = mcap_with_attachment();
+        let path = unique_temp_path("same-path.mcap");
+        std::fs::write(&path, &input).expect("write input");
+
+        let err = super::run(
+            &CommandContext::default(),
+            GetAttachmentCommand {
+                file: path.clone(),
+                name: "a".to_string(),
+                offset: None,
+                output: Some(path.clone()),
+            },
+        )
+        .expect_err("same input/output should fail");
+
+        assert!(err.to_string().contains("input and output paths"));
+        assert_eq!(std::fs::read(&path).expect("read input"), input);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -157,19 +157,6 @@ mod tests {
         mcap_bytes
     }
 
-    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "mcap-cli-get-attachment-{stem}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time should be after epoch")
-                .as_nanos()
-        ));
-        path
-    }
-
     #[test]
     fn selects_single_match_without_offset() {
         let indexes = vec![attachment("a", 10)];
@@ -181,7 +168,8 @@ mod tests {
     #[test]
     fn run_rejects_same_input_and_output_without_truncating() {
         let input = mcap_with_attachment();
-        let path = unique_temp_path("same-path.mcap");
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("same-path.mcap");
         std::fs::write(&path, &input).expect("write input");
 
         let err = super::run(
@@ -197,7 +185,6 @@ mod tests {
 
         assert!(err.to_string().contains("input and output paths"));
         assert_eq!(std::fs::read(&path).expect("read input"), input);
-        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -772,19 +772,6 @@ mod tests {
         Ok(output.into_inner())
     }
 
-    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "mcap-cli-merge-{stem}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time should be after epoch")
-                .as_nanos()
-        ));
-        path
-    }
-
     #[test]
     fn build_merge_options_maps_cli_fields() {
         let options = build_merge_options(MergeCommand {
@@ -834,7 +821,8 @@ mod tests {
     #[test]
     fn run_rejects_same_input_and_output_without_truncating() {
         let input = build_mcap("profile", &[], &[], &[], true, true);
-        let path = unique_temp_path("same-path.mcap");
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("same-path.mcap");
         std::fs::write(&path, &input).expect("write input");
 
         let err = run(
@@ -854,7 +842,6 @@ mod tests {
 
         assert!(err.to_string().contains("input and output paths"));
         assert_eq!(std::fs::read(&path).expect("read input"), input);
-        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -114,6 +114,12 @@ pub fn run(ctx: &CommandContext, args: MergeCommand) -> Result<()> {
     let opts = build_merge_options(args);
     let source_options = crate::source::SourceOptions::new(ctx.allow_remote_scan());
 
+    if let Some(output_path) = &opts.output_file {
+        for input_path in &opts.files {
+            crate::source::ensure_distinct_local_input_output(input_path, output_path)?;
+        }
+    }
+
     let mut mapped_inputs = Vec::with_capacity(opts.files.len());
     let mut input_names = Vec::with_capacity(opts.files.len());
     for path in &opts.files {
@@ -766,6 +772,19 @@ mod tests {
         Ok(output.into_inner())
     }
 
+    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "mcap-cli-merge-{stem}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        path
+    }
+
     #[test]
     fn build_merge_options_maps_cli_fields() {
         let options = build_merge_options(MergeCommand {
@@ -810,6 +829,32 @@ mod tests {
         .expect_err("remote merge input should require opt-in");
 
         assert!(err.to_string().contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn run_rejects_same_input_and_output_without_truncating() {
+        let input = build_mcap("profile", &[], &[], &[], true, true);
+        let path = unique_temp_path("same-path.mcap");
+        std::fs::write(&path, &input).expect("write input");
+
+        let err = run(
+            &CommandContext::default(),
+            MergeCommand {
+                files: vec![path.clone()],
+                output_file: Some(path.clone()),
+                compression: CompressionFormat::Zstd,
+                chunk_size: 1024,
+                no_crc: false,
+                no_chunks: false,
+                allow_duplicate_metadata: false,
+                coalesce_channels: CoalesceChannels::Auto,
+            },
+        )
+        .expect_err("same input/output should fail");
+
+        assert!(err.to_string().contains("input and output paths"));
+        assert_eq!(std::fs::read(&path).expect("read input"), input);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -825,19 +825,6 @@ mod tests {
         recover_to_vec_with_selection(input, target)
     }
 
-    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "mcap-cli-recover-{stem}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time should be after epoch")
-                .as_nanos()
-        ));
-        path
-    }
-
     fn recover_to_vec_with_selection(
         input: &[u8],
         compression: super::CompressionSelection,
@@ -922,7 +909,8 @@ mod tests {
     #[test]
     fn run_rejects_same_input_and_output_without_truncating() {
         let input = write_test_input(Some(mcap::Compression::Zstd));
-        let path = unique_temp_path("same-path.mcap");
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("same-path.mcap");
         std::fs::write(&path, &input).expect("write input");
 
         let err = super::run(
@@ -938,7 +926,6 @@ mod tests {
 
         assert!(err.to_string().contains("input and output paths"));
         assert_eq!(std::fs::read(&path).expect("read input"), input);
-        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -120,6 +120,9 @@ impl RecoverStats {
 /// - 3: successful recovery with warning-level data loss (`CommandOutcome::Warnings`)
 pub fn run(ctx: &CommandContext, args: RecoverCommand) -> Result<CommandOutcome> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    if let (Some(input), Some(output)) = (args.file.as_deref(), args.output.as_deref()) {
+        source::ensure_distinct_local_input_output(input, output)?;
+    }
     let input = source::open_streaming_input(args.file.as_deref(), source_options)?;
     let compression = resolve_compression(&args.compression)?;
 
@@ -637,6 +640,8 @@ mod tests {
     use mcap::records::{op, MessageHeader, Record};
 
     use super::{recover_to_sink, RecoverStats};
+    use crate::cli::RecoverCommand;
+    use crate::context::CommandContext;
 
     const OPCODE_LEN_SIZE: usize = 1 + 8;
 
@@ -820,6 +825,19 @@ mod tests {
         recover_to_vec_with_selection(input, target)
     }
 
+    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "mcap-cli-recover-{stem}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        path
+    }
+
     fn recover_to_vec_with_selection(
         input: &[u8],
         compression: super::CompressionSelection,
@@ -899,6 +917,28 @@ mod tests {
         assert_eq!(stats.attachments.recovered, 1);
         assert_eq!(stats.metadata.recovered, 1);
         assert!(!stats.is_lossy());
+    }
+
+    #[test]
+    fn run_rejects_same_input_and_output_without_truncating() {
+        let input = write_test_input(Some(mcap::Compression::Zstd));
+        let path = unique_temp_path("same-path.mcap");
+        std::fs::write(&path, &input).expect("write input");
+
+        let err = super::run(
+            &CommandContext::default(),
+            RecoverCommand {
+                file: Some(path.clone()),
+                output: Some(path.clone()),
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                compression: "preserve".to_string(),
+            },
+        )
+        .expect_err("same input/output should fail");
+
+        assert!(err.to_string().contains("input and output paths"));
+        assert_eq!(std::fs::read(&path).expect("read input"), input);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -1,8 +1,7 @@
 use std::borrow::Cow;
 use std::io::{Seek, Write};
-use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use crate::cli::{CompressionFormat, SortCommand};
 use crate::commands::filter;
@@ -25,35 +24,15 @@ enum SortInput {
 
 pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
     let opts = build_sort_options(&args);
+    source::ensure_distinct_local_input_output(&args.file, &args.output_file)?;
     let input = source::load_path(
         &args.file,
         source::SourceOptions::new(ctx.allow_remote_scan()),
     )?;
-    if !source::is_remote_url(&args.file) {
-        ensure_distinct_input_output(&args.file, &args.output_file)?;
-    }
     let sort_input = validate_sort_input(input.as_slice())?;
     let output = std::fs::File::create(&args.output_file)
         .with_context(|| format!("failed to open output '{}'", args.output_file.display()))?;
     sort_to_writer(input.as_slice(), output, sort_input, &opts)
-}
-
-fn ensure_distinct_input_output(input: &Path, output: &Path) -> Result<()> {
-    let input_path = std::fs::canonicalize(input)
-        .with_context(|| format!("failed to canonicalize input '{}'", input.display()))?;
-
-    if !output.exists() {
-        return Ok(());
-    }
-
-    let output_path = std::fs::canonicalize(output)
-        .with_context(|| format!("failed to canonicalize output '{}'", output.display()))?;
-
-    if input_path == output_path {
-        bail!("input and output paths resolve to the same file");
-    }
-
-    Ok(())
 }
 
 fn build_sort_options(args: &SortCommand) -> SortOptions {
@@ -545,7 +524,7 @@ mod tests {
     fn run_rejects_same_input_and_output_file() {
         let input = build_out_of_order_chunked_input(false);
         let file_path = unique_temp_path("same-file");
-        std::fs::write(&file_path, input).expect("write input fixture");
+        std::fs::write(&file_path, &input).expect("write input fixture");
 
         let err = super::run(
             &CommandContext::default(),
@@ -559,9 +538,8 @@ mod tests {
             },
         )
         .expect_err("same input/output path should fail");
-        assert!(err
-            .to_string()
-            .contains("input and output paths resolve to the same file"));
+        assert!(err.to_string().contains("input and output paths"));
+        assert_eq!(std::fs::read(&file_path).expect("read input"), input);
 
         let _ = std::fs::remove_file(file_path);
     }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -165,8 +165,8 @@ pub fn ensure_distinct_local_input_output(input: &Path, output: &Path) -> Result
                 .with_context(|| format!("failed to resolve input path '{}'", input.display()));
         }
     };
-    let output_path = match output.canonicalize() {
-        Ok(path) => path,
+    let (output_path, output_exists) = match output.canonicalize() {
+        Ok(path) => (path, true),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             let parent = output
                 .parent()
@@ -176,7 +176,7 @@ pub fn ensure_distinct_local_input_output(input: &Path, output: &Path) -> Result
                 .file_name()
                 .with_context(|| format!("invalid output path '{}'", output.display()))?;
             match parent.canonicalize() {
-                Ok(parent_path) => parent_path.join(file_name),
+                Ok(parent_path) => (parent_path.join(file_name), false),
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
                 Err(err) => {
                     return Err(err).with_context(|| {
@@ -192,10 +192,46 @@ pub fn ensure_distinct_local_input_output(input: &Path, output: &Path) -> Result
     };
 
     anyhow::ensure!(
-        input_path != output_path,
+        !local_paths_refer_to_same_file(input, output, &input_path, &output_path, output_exists)?,
         "input and output paths must be different"
     );
     Ok(())
+}
+
+fn local_paths_refer_to_same_file(
+    input: &Path,
+    output: &Path,
+    input_path: &Path,
+    output_path: &Path,
+    output_exists: bool,
+) -> Result<bool> {
+    if input_path == output_path {
+        return Ok(true);
+    }
+    if !output_exists {
+        return Ok(false);
+    }
+
+    local_paths_have_same_file_id(input, output)
+}
+
+#[cfg(unix)]
+fn local_paths_have_same_file_id(input: &Path, output: &Path) -> Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let input_metadata = input
+        .metadata()
+        .with_context(|| format!("failed to stat input path '{}'", input.display()))?;
+    let output_metadata = output
+        .metadata()
+        .with_context(|| format!("failed to stat output path '{}'", output.display()))?;
+    Ok(input_metadata.dev() == output_metadata.dev()
+        && input_metadata.ino() == output_metadata.ino())
+}
+
+#[cfg(not(unix))]
+fn local_paths_have_same_file_id(_input: &Path, _output: &Path) -> Result<bool> {
+    Ok(false)
 }
 
 pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
@@ -1222,6 +1258,20 @@ mod tests {
 
         let err = super::ensure_distinct_local_input_output(&input, &output)
             .expect_err("aliased output should fail");
+        assert!(err.to_string().contains("input and output paths"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn distinct_local_input_output_rejects_existing_output_hard_link() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input = dir.path().join("input.mcap");
+        let output = dir.path().join("output-hard-link.mcap");
+        std::fs::write(&input, b"placeholder").expect("write input");
+        std::fs::hard_link(&input, &output).expect("hard link");
+
+        let err = super::ensure_distinct_local_input_output(&input, &output)
+            .expect_err("hard-linked output should fail");
         assert!(err.to_string().contains("input and output paths"));
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -231,6 +231,8 @@ fn local_paths_have_same_file_id(input: &Path, output: &Path) -> Result<bool> {
 
 #[cfg(not(unix))]
 fn local_paths_have_same_file_id(_input: &Path, _output: &Path) -> Result<bool> {
+    // Same-path and symlink aliases are still caught by canonical path equality above. Detecting
+    // NTFS hard links would require platform-specific file IDs beyond the standard library.
     Ok(false)
 }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1289,6 +1289,25 @@ mod tests {
     }
 
     #[test]
+    fn distinct_local_input_output_allows_single_component_missing_output() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input = dir.path().join("input.mcap");
+        let output_name = format!(
+            "mcap-cli-missing-output-{}-{}.mcap",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        );
+        std::fs::write(&input, b"placeholder").expect("write input");
+        let _ = std::fs::remove_file(&output_name);
+
+        super::ensure_distinct_local_input_output(&input, Path::new(&output_name))
+            .expect("single-component missing output should resolve through current directory");
+    }
+
+    #[test]
     fn distinct_local_input_output_allows_missing_input() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let input = dir.path().join("missing.mcap");

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -152,6 +152,52 @@ pub fn map_file(path: &Path) -> anyhow::Result<Mmap> {
     unsafe { Mmap::map(&file) }.with_context(|| format!("couldn't map '{}'", path.display()))
 }
 
+pub fn ensure_distinct_local_input_output(input: &Path, output: &Path) -> Result<()> {
+    if is_remote_url(input) {
+        return Ok(());
+    }
+
+    let input_path = match input.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to resolve input path '{}'", input.display()));
+        }
+    };
+    let output_path = match output.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let parent = output
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            let file_name = output
+                .file_name()
+                .with_context(|| format!("invalid output path '{}'", output.display()))?;
+            match parent.canonicalize() {
+                Ok(parent_path) => parent_path.join(file_name),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(err) => {
+                    return Err(err).with_context(|| {
+                        format!("failed to resolve output parent '{}'", parent.display())
+                    });
+                }
+            }
+        }
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to resolve output path '{}'", output.display()));
+        }
+    };
+
+    anyhow::ensure!(
+        input_path != output_path,
+        "input and output paths must be different"
+    );
+    Ok(())
+}
+
 pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
     std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))
 }
@@ -1151,6 +1197,54 @@ mod tests {
     use crate::render::human_bytes;
     use mcap::records;
     use object_store::ObjectStoreExt;
+
+    #[test]
+    fn distinct_local_input_output_rejects_same_file() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input = dir.path().join("input.mcap");
+        std::fs::write(&input, b"placeholder").expect("write input");
+
+        let err = super::ensure_distinct_local_input_output(&input, &input)
+            .expect_err("same input/output should fail");
+        assert!(err.to_string().contains("input and output paths"));
+    }
+
+    #[test]
+    fn distinct_local_input_output_rejects_existing_output_alias() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input = dir.path().join("input.mcap");
+        let output = dir.path().join("output-link.mcap");
+        std::fs::write(&input, b"placeholder").expect("write input");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&input, &output).expect("symlink");
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&input, &output).expect("symlink");
+
+        let err = super::ensure_distinct_local_input_output(&input, &output)
+            .expect_err("aliased output should fail");
+        assert!(err.to_string().contains("input and output paths"));
+    }
+
+    #[test]
+    fn distinct_local_input_output_allows_missing_output() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input = dir.path().join("input.mcap");
+        let output = dir.path().join("new-output.mcap");
+        std::fs::write(&input, b"placeholder").expect("write input");
+
+        super::ensure_distinct_local_input_output(&input, &output)
+            .expect("missing output should be allowed");
+    }
+
+    #[test]
+    fn distinct_local_input_output_allows_missing_input() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input = dir.path().join("missing.mcap");
+        let output = dir.path().join("output.mcap");
+
+        super::ensure_distinct_local_input_output(&input, &output)
+            .expect("missing input should be left to command open errors");
+    }
 
     fn serve_http(body: &'static [u8], supports_ranges: bool) -> String {
         serve_http_with_headers(body, supports_ranges, &[])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reject local Rust CLI output paths that point at the input before creating/truncating output files.
- Cover same paths, symlink aliases, and Unix hard links through the shared source helper.
- Apply the guard to `convert`, `filter`/`compress`/`decompress`, `get attachment`, `merge`, `recover`, and `sort`.

## Testing
- `cargo test -p mcap-cli distinct_local_input_output`
- `cargo test -p mcap-cli run_rejects_same_input_and_output`
- `target/debug/mcap ...` same-path reproductions for guarded commands
- `cargo fmt --all -- --check && cargo test -p mcap-cli && cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`

## Issues
- No matching open GitHub issue found.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2948bb0-34f8-4a57-aaff-7ffe2b541a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2948bb0-34f8-4a57-aaff-7ffe2b541a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

