### PR TITLE
cli: Remove doctor unnecessary output

### DIFF
--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -12,9 +12,6 @@ pub fn run(ctx: &CommandContext, args: DoctorCommand) -> Result<()> {
         &args.file,
         source::SourceOptions::new(ctx.allow_remote_scan()),
     )?;
-    if ctx.verbose() > 0 {
-        println!("Examining {}", args.file.display());
-    }
 
     let diagnosis = diagnose_mcap(&mcap, args.strict_message_order);
     for warning in &diagnosis.warnings {

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -177,25 +177,6 @@ fn exit_code_doctor_non_strict_allows_out_of_order_top_level_messages() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("Error: Message.log_time"));
 }
 
-#[test]
-fn doctor_verbose_keeps_stdout_clean() {
-    let dir = TempDir::new().unwrap();
-    let path = write_temp(&dir, "valid.mcap", &build_mcap(3));
-
-    let output = mcap(&["-v", "doctor", path_str(&path)]);
-
-    assert!(
-        output.status.success(),
-        "doctor -v should succeed for a valid file; stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        output.stdout.is_empty(),
-        "doctor -v should not write progress text to stdout: {}",
-        stdout(&output)
-    );
-}
-
 // Reading from a non-seekable stdin pipe is only reachable end-to-end; the unit tests use
 // seekable in-memory buffers.
 #[test]

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -177,6 +177,25 @@ fn exit_code_doctor_non_strict_allows_out_of_order_top_level_messages() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("Error: Message.log_time"));
 }
 
+#[test]
+fn doctor_verbose_keeps_stdout_clean() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "valid.mcap", &build_mcap(3));
+
+    let output = mcap(&["-v", "doctor", path_str(&path)]);
+
+    assert!(
+        output.status.success(),
+        "doctor -v should succeed for a valid file; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "doctor -v should not write progress text to stdout: {}",
+        stdout(&output)
+    );
+}
+
 // Reading from a non-seekable stdin pipe is only reachable end-to-end; the unit tests use
 // seekable in-memory buffers.
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the low-value `doctor -v` `Examining ...` progress line so clean diagnostics do not write to stdout.

## Testing
- `cargo test -p mcap-cli --test cli exit_code_doctor_non_strict_allows_out_of_order_top_level_messages`
- `cargo fmt --all -- --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd3bdf38-50f6-4d75-9086-ec2da8a4329e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd3bdf38-50f6-4d75-9086-ec2da8a4329e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

