### PR TITLE
cli: Add command benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "crc32fast",
+ "criterion",
  "futures-util",
  "log",
  "lz4",

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -50,6 +50,6 @@ End-to-end tests that run the built binary live in `tests/cli.rs` (spawned via `
 
 CLI benchmarks live in `benches/commands.rs` and run with `cargo bench -p mcap-cli --bench commands`. They are for performance work only: run them when explicitly improving performance or when a change could significantly affect CLI throughput. Do not run them for routine CLI edits.
 
-The full default matrix uses a 256 MiB generated workload per case and took about 20 minutes on a Cursor Cloud VM. In most cases, run the narrowest relevant Criterion filter instead of the full suite, for example `cargo bench -p mcap-cli --bench commands -- merge/indexed/100KiB` or `cargo bench -p mcap-cli --bench commands -- filter/linear`.
+The full default matrix uses a 256 MB generated workload per case and took about 20 minutes on a Cursor Cloud VM. In most cases, run the narrowest relevant Criterion filter instead of the full suite, for example `cargo bench -p mcap-cli --bench commands -- merge/indexed/100KB` or `cargo bench -p mcap-cli --bench commands -- filter/linear`.
 
-Benchmarks are named `cli/<command>/<mode>/<payload>`. The modes are `indexed` (summary, chunk indexes, and message indexes present) and `linear` (summary omitted to force scan fallback). Payload sizes are `100B`, `1KiB`, `10KiB`, `100KiB`, and `1MiB`.
+Benchmarks are named `cli/<command>/<mode>/<payload>`. The modes are `indexed` (summary, chunk indexes, and message indexes present) and `linear` (summary omitted to force scan fallback). Payload sizes are `100B`, `1KB`, `10KB`, `100KB`, and `1MB`.

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -45,3 +45,11 @@ Results go to stdout; diagnostics and warnings go to stderr. Use the `render` he
 Most tests live inline in each module under `#[cfg(test)]`. Argument-parsing behavior is covered in `cli.rs`/`main.rs`, and dispatch/handler behavior in the relevant command module. For MCAP inputs, build fixtures in-memory with `mcap::Writer` rather than committing files. Committed binary fixtures are used where the input can't be synthesized that way — notably the `convert` tests, which load real ROS bag/db3 files from `testdata/` (resolved via `CARGO_MANIFEST_DIR`).
 
 End-to-end tests that run the built binary live in `tests/cli.rs` (spawned via `CARGO_BIN_EXE_mcap`). Keep them at the process boundary — only behavior the unit tests can't reach, such as real exit codes and reading a non-seekable stdin pipe — and cover command logic with unit tests instead. Tests group by name prefix (`exit_code_*`, `stdin_pipe_*`, `completion_*`).
+
+### Performance benchmarks
+
+CLI benchmarks live in `benches/commands.rs` and run with `cargo bench -p mcap-cli --bench commands`. They are for performance work only: run them when explicitly improving performance or when a change could significantly affect CLI throughput. Do not run them for routine CLI edits.
+
+The full default matrix uses a 256 MiB generated workload per case and took about 20 minutes on a Cursor Cloud VM. In most cases, run the narrowest relevant Criterion filter instead of the full suite, for example `cargo bench -p mcap-cli --bench commands -- merge/indexed/100KiB` or `cargo bench -p mcap-cli --bench commands -- filter/linear`.
+
+Benchmarks are named `cli/<command>/<mode>/<payload>`. The modes are `indexed` (summary, chunk indexes, and message indexes present) and `linear` (summary omitted to force scan fallback). Payload sizes are `100B`, `1KiB`, `10KiB`, `100KiB`, and `1MiB`.

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -50,6 +50,6 @@ End-to-end tests that run the built binary live in `tests/cli.rs` (spawned via `
 
 CLI benchmarks live in `benches/commands.rs` and run with `cargo bench -p mcap-cli --bench commands`. They are for performance work only: run them when explicitly improving performance or when a change could significantly affect CLI throughput. Do not run them for routine CLI edits.
 
-The full default matrix uses a 256 MB generated workload per case and took about 20 minutes on a Cursor Cloud VM. In most cases, run the narrowest relevant Criterion filter instead of the full suite, for example `cargo bench -p mcap-cli --bench commands -- merge/indexed/100KB` or `cargo bench -p mcap-cli --bench commands -- filter/linear`.
+The full default matrix uses a 250 MB generated workload per case and took about 20 minutes on a Cursor Cloud VM. In most cases, run the narrowest relevant Criterion filter instead of the full suite, for example `cargo bench -p mcap-cli --bench commands -- merge/indexed/100KB` or `cargo bench -p mcap-cli --bench commands -- filter/linear`.
 
 Benchmarks are named `cli/<command>/<mode>/<payload>`. The modes are `indexed` (summary, chunk indexes, and message indexes present) and `linear` (summary omitted to force scan fallback). Payload sizes are `100B`, `1KB`, `10KB`, `100KB`, and `1MB`.

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -37,5 +37,5 @@ futures-util = "0.3.32"
 criterion = "0.8.2"
 
 [[bench]]
-name = "cli_commands"
+name = "commands"
 harness = false

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -32,3 +32,10 @@ object_store = { version = "0.13.2", features = ["aws", "gcp", "azure", "http"] 
 tokio = { version = "1.52.3", features = ["net", "rt", "time"] }
 url = "2.5.8"
 futures-util = "0.3.32"
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "cli_commands"
+harness = false

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -28,7 +28,7 @@ variables when collecting comparison data:
 
 | Variable                          |                 Default | Description                                              |
 | --------------------------------- | ----------------------: | -------------------------------------------------------- |
-| `MCAP_CLI_BENCH_TOTAL_MIB`        |                    `16` | Total generated payload bytes per payload-size case.     |
+| `MCAP_CLI_BENCH_TOTAL_MIB`        |                   `256` | Total generated payload bytes per payload-size case.     |
 | `MCAP_CLI_BENCH_INPUTS`           |                     `4` | Number of inputs for `merge` benchmarks.                 |
 | `MCAP_CLI_BENCH_CHUNK_SIZE`       |               `4194304` | Generated output chunk size in bytes.                    |
 | `MCAP_CLI_BENCH_DIR`              | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs.      |

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -1,6 +1,6 @@
-# MCAP CLI command benchmarks
+# MCAP CLI benchmarks
 
-This directory contains Criterion benchmarks for the `mcap` CLI. The benchmarks generate synthetic
+This directory contains benchmarks for the `mcap` CLI. The benchmarks generate synthetic
 MCAP inputs at runtime and run the real `mcap` binary, so large benchmark fixtures do not need to be
 checked into the repository.
 

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -32,7 +32,7 @@ variables when collecting comparison data:
 | `MCAP_CLI_BENCH_INPUTS`           |                     `4` | Number of inputs for `merge` benchmarks.                 |
 | `MCAP_CLI_BENCH_CHUNK_SIZE`       |               `4194304` | Generated output chunk size in bytes.                    |
 | `MCAP_CLI_BENCH_DIR`              | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs.      |
-| `MCAP_CLI_BENCH_BIN`              |   `target/release/mcap` | CLI binary to execute.                                   |
+| `MCAP_CLI_BENCH_BIN`              |      Cargo bench binary | CLI binary to execute.                                   |
 | `MCAP_CLI_BENCH_SAMPLE_SIZE`      |                    `10` | Criterion sample size; values below 10 are raised to 10. |
 | `MCAP_CLI_BENCH_WARMUP_MS`        |                   `250` | Criterion warmup duration.                               |
 | `MCAP_CLI_BENCH_MEASUREMENT_SECS` |                     `2` | Criterion measurement duration.                          |

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -32,7 +32,7 @@ variables for faster local iteration or larger comparison runs:
 | --------------------------------- | ----------------------: | -------------------------------------------------------- |
 | `MCAP_CLI_BENCH_TOTAL_MB`         |                   `256` | Total generated payload bytes per payload-size case.     |
 | `MCAP_CLI_BENCH_INPUTS`           |                     `4` | Number of inputs for `merge` benchmarks.                 |
-| `MCAP_CLI_BENCH_CHUNK_BYTES`      |               `4000000` | Generated output chunk size in bytes.                    |
+| `MCAP_CLI_BENCH_CHUNK_BYTES`      |     Rust writer default | Generated output chunk size in bytes.                    |
 | `MCAP_CLI_BENCH_DIR`              | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs.      |
 | `MCAP_CLI_BENCH_BIN`              |      Cargo bench binary | CLI binary to execute.                                   |
 | `MCAP_CLI_BENCH_SAMPLE_SIZE`      |                    `10` | Criterion sample size; values below 10 are raised to 10. |

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -47,8 +47,8 @@ cargo bench -p mcap-cli --bench cli_commands -- merge
 
 ## Generated inputs and cleanup
 
-Each suite uses deterministic pseudo-random message payloads at `1 KiB`, `10 KiB`, `100 KiB`, and
-`1 MiB` sizes. The benchmark validates each command output for basic MCAP correctness, expected
+Each suite uses deterministic pseudo-random message payloads at `100B`, `1KiB`, `10KiB`, `100KiB`,
+and `1MiB` sizes. The benchmark validates each command output for basic MCAP correctness, expected
 message count, summary presence, and log-time ordering where applicable.
 
 Generated inputs are cached under `MCAP_CLI_BENCH_DIR` and reused when the benchmark parameters

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -4,9 +4,9 @@ This directory contains benchmarks for the `mcap` CLI. The benchmarks generate s
 MCAP inputs at runtime and run the real `mcap` binary, so large benchmark fixtures do not need to be
 checked into the repository.
 
-## Quick run
+## Running benchmarks
 
-Run the benchmark target:
+Run the full benchmark target:
 
 ```sh
 cargo bench -p mcap-cli --bench commands
@@ -14,17 +14,19 @@ cargo bench -p mcap-cli --bench commands
 
 Cargo provides the bench-built `mcap` binary by default. Set `MCAP_CLI_BENCH_BIN` to compare a
 different binary. Criterion writes reports under `target/criterion/`. Use Criterion's benchmark
-filter to run a single suite:
+filter to run a single command, input mode, or specific case:
 
 ```sh
 cargo bench -p mcap-cli --bench commands -- merge
-cargo bench -p mcap-cli --bench commands -- filter
+cargo bench -p mcap-cli --bench commands -- indexed
+cargo bench -p mcap-cli --bench commands -- filter/linear
+cargo bench -p mcap-cli --bench commands -- merge/indexed/100KiB
 ```
 
 ## Workload controls
 
-The default workload is intentionally small enough for local iteration. Increase it with environment
-variables when collecting comparison data:
+The default workload is large enough to reduce fixed overhead noise. Override it with environment
+variables for faster local iteration or larger comparison runs:
 
 | Variable                          |                 Default | Description                                              |
 | --------------------------------- | ----------------------: | -------------------------------------------------------- |
@@ -47,9 +49,11 @@ cargo bench -p mcap-cli --bench commands -- merge
 
 ## Generated inputs and cleanup
 
-Each suite uses deterministic pseudo-random message payloads at `100B`, `1KiB`, `10KiB`, `100KiB`,
-and `1MiB` sizes. The benchmark validates each command output for basic MCAP correctness, expected
-message count, summary presence, and log-time ordering where applicable.
+Each suite runs both `indexed` inputs (summary, chunk indexes, and message indexes present) and
+`linear` inputs (summary omitted, forcing a scan fallback). It uses deterministic pseudo-random
+message payloads at `100B`, `1KiB`, `10KiB`, `100KiB`, and `1MiB` sizes. The benchmark validates
+each command output for basic MCAP correctness, expected message count, summary presence, and
+log-time ordering where applicable.
 
 Generated inputs are cached under `MCAP_CLI_BENCH_DIR` and reused when the benchmark parameters
 match the filename. Delete that directory if a previous run was interrupted or after large runs to

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -6,15 +6,15 @@ checked into the repository.
 
 ## Quick run
 
-Build the release CLI once, then run the benchmark target:
+Run the benchmark target:
 
 ```sh
-cargo build --release -p mcap-cli
 cargo bench -p mcap-cli --bench cli_commands
 ```
 
-Criterion writes reports under `target/criterion/`. Use Criterion's benchmark filter to run a single
-suite:
+Cargo provides the bench-built `mcap` binary by default. Set `MCAP_CLI_BENCH_BIN` to compare a
+different binary. Criterion writes reports under `target/criterion/`. Use Criterion's benchmark
+filter to run a single suite:
 
 ```sh
 cargo bench -p mcap-cli --bench cli_commands -- merge

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -9,7 +9,7 @@ checked into the repository.
 Run the benchmark target:
 
 ```sh
-cargo bench -p mcap-cli --bench cli_commands
+cargo bench -p mcap-cli --bench commands
 ```
 
 Cargo provides the bench-built `mcap` binary by default. Set `MCAP_CLI_BENCH_BIN` to compare a
@@ -17,8 +17,8 @@ different binary. Criterion writes reports under `target/criterion/`. Use Criter
 filter to run a single suite:
 
 ```sh
-cargo bench -p mcap-cli --bench cli_commands -- merge
-cargo bench -p mcap-cli --bench cli_commands -- filter
+cargo bench -p mcap-cli --bench commands -- merge
+cargo bench -p mcap-cli --bench commands -- filter
 ```
 
 ## Workload controls
@@ -42,7 +42,7 @@ Example larger run:
 ```sh
 MCAP_CLI_BENCH_TOTAL_MIB=1024 \
 MCAP_CLI_BENCH_INPUTS=8 \
-cargo bench -p mcap-cli --bench cli_commands -- merge
+cargo bench -p mcap-cli --bench commands -- merge
 ```
 
 ## Generated inputs and cleanup

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -26,16 +26,16 @@ cargo bench -p mcap-cli --bench cli_commands -- filter
 The default workload is intentionally small enough for local iteration. Increase it with environment
 variables when collecting comparison data:
 
-| Variable | Default | Description |
-| --- | ---: | --- |
-| `MCAP_CLI_BENCH_TOTAL_MIB` | `16` | Total generated payload bytes per payload-size case. |
-| `MCAP_CLI_BENCH_INPUTS` | `4` | Number of inputs for `merge` benchmarks. |
-| `MCAP_CLI_BENCH_CHUNK_SIZE` | `4194304` | Generated output chunk size in bytes. |
-| `MCAP_CLI_BENCH_DIR` | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs. |
-| `MCAP_CLI_BENCH_BIN` | `target/release/mcap` | CLI binary to execute. |
-| `MCAP_CLI_BENCH_SAMPLE_SIZE` | `10` | Criterion sample size; values below 10 are raised to 10. |
-| `MCAP_CLI_BENCH_WARMUP_MS` | `250` | Criterion warmup duration. |
-| `MCAP_CLI_BENCH_MEASUREMENT_SECS` | `2` | Criterion measurement duration. |
+| Variable                          |                 Default | Description                                              |
+| --------------------------------- | ----------------------: | -------------------------------------------------------- |
+| `MCAP_CLI_BENCH_TOTAL_MIB`        |                    `16` | Total generated payload bytes per payload-size case.     |
+| `MCAP_CLI_BENCH_INPUTS`           |                     `4` | Number of inputs for `merge` benchmarks.                 |
+| `MCAP_CLI_BENCH_CHUNK_SIZE`       |               `4194304` | Generated output chunk size in bytes.                    |
+| `MCAP_CLI_BENCH_DIR`              | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs.      |
+| `MCAP_CLI_BENCH_BIN`              |   `target/release/mcap` | CLI binary to execute.                                   |
+| `MCAP_CLI_BENCH_SAMPLE_SIZE`      |                    `10` | Criterion sample size; values below 10 are raised to 10. |
+| `MCAP_CLI_BENCH_WARMUP_MS`        |                   `250` | Criterion warmup duration.                               |
+| `MCAP_CLI_BENCH_MEASUREMENT_SECS` |                     `2` | Criterion measurement duration.                          |
 
 Example larger run:
 
@@ -45,8 +45,12 @@ MCAP_CLI_BENCH_INPUTS=8 \
 cargo bench -p mcap-cli --bench cli_commands -- merge
 ```
 
-## Generated inputs
+## Generated inputs and cleanup
 
 Each suite uses deterministic pseudo-random message payloads at `1 KiB`, `10 KiB`, `100 KiB`, and
 `1 MiB` sizes. The benchmark validates each command output for basic MCAP correctness, expected
 message count, summary presence, and log-time ordering where applicable.
+
+Generated inputs are cached under `MCAP_CLI_BENCH_DIR` and reused when the benchmark parameters
+match the filename. Delete that directory if a previous run was interrupted or after large runs to
+free disk space.

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -1,0 +1,52 @@
+# MCAP CLI command benchmarks
+
+This directory contains Criterion benchmarks for the `mcap` CLI. The benchmarks generate synthetic
+MCAP inputs at runtime and run the real `mcap` binary, so large benchmark fixtures do not need to be
+checked into the repository.
+
+## Quick run
+
+Build the release CLI once, then run the benchmark target:
+
+```sh
+cargo build --release -p mcap-cli
+cargo bench -p mcap-cli --bench cli_commands
+```
+
+Criterion writes reports under `target/criterion/`. Use Criterion's benchmark filter to run a single
+suite:
+
+```sh
+cargo bench -p mcap-cli --bench cli_commands -- merge
+cargo bench -p mcap-cli --bench cli_commands -- filter
+```
+
+## Workload controls
+
+The default workload is intentionally small enough for local iteration. Increase it with environment
+variables when collecting comparison data:
+
+| Variable | Default | Description |
+| --- | ---: | --- |
+| `MCAP_CLI_BENCH_TOTAL_MIB` | `16` | Total generated payload bytes per payload-size case. |
+| `MCAP_CLI_BENCH_INPUTS` | `4` | Number of inputs for `merge` benchmarks. |
+| `MCAP_CLI_BENCH_CHUNK_SIZE` | `4194304` | Generated output chunk size in bytes. |
+| `MCAP_CLI_BENCH_DIR` | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs. |
+| `MCAP_CLI_BENCH_BIN` | `target/release/mcap` | CLI binary to execute. |
+| `MCAP_CLI_BENCH_SAMPLE_SIZE` | `10` | Criterion sample size; values below 10 are raised to 10. |
+| `MCAP_CLI_BENCH_WARMUP_MS` | `250` | Criterion warmup duration. |
+| `MCAP_CLI_BENCH_MEASUREMENT_SECS` | `2` | Criterion measurement duration. |
+
+Example larger run:
+
+```sh
+MCAP_CLI_BENCH_TOTAL_MIB=1024 \
+MCAP_CLI_BENCH_INPUTS=8 \
+cargo bench -p mcap-cli --bench cli_commands -- merge
+```
+
+## Generated inputs
+
+Each suite uses deterministic pseudo-random message payloads at `1 KiB`, `10 KiB`, `100 KiB`, and
+`1 MiB` sizes. The benchmark validates each command output for basic MCAP correctness, expected
+message count, summary presence, and log-time ordering where applicable.

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -30,7 +30,7 @@ variables for faster local iteration or larger comparison runs:
 
 | Variable                          |                 Default | Description                                              |
 | --------------------------------- | ----------------------: | -------------------------------------------------------- |
-| `MCAP_CLI_BENCH_TOTAL_MB`         |                   `256` | Total generated payload bytes per payload-size case.     |
+| `MCAP_CLI_BENCH_TOTAL_MB`         |                   `250` | Total generated payload bytes per payload-size case.     |
 | `MCAP_CLI_BENCH_INPUTS`           |                     `4` | Number of inputs for `merge` benchmarks.                 |
 | `MCAP_CLI_BENCH_CHUNK_BYTES`      |     Rust writer default | Generated output chunk size in bytes.                    |
 | `MCAP_CLI_BENCH_DIR`              | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs.      |

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -20,7 +20,7 @@ filter to run a single command, input mode, or specific case:
 cargo bench -p mcap-cli --bench commands -- merge
 cargo bench -p mcap-cli --bench commands -- indexed
 cargo bench -p mcap-cli --bench commands -- filter/linear
-cargo bench -p mcap-cli --bench commands -- merge/indexed/100KiB
+cargo bench -p mcap-cli --bench commands -- merge/indexed/100KB
 ```
 
 ## Workload controls
@@ -30,9 +30,9 @@ variables for faster local iteration or larger comparison runs:
 
 | Variable                          |                 Default | Description                                              |
 | --------------------------------- | ----------------------: | -------------------------------------------------------- |
-| `MCAP_CLI_BENCH_TOTAL_MIB`        |                   `256` | Total generated payload bytes per payload-size case.     |
+| `MCAP_CLI_BENCH_TOTAL_MB`         |                   `256` | Total generated payload bytes per payload-size case.     |
 | `MCAP_CLI_BENCH_INPUTS`           |                     `4` | Number of inputs for `merge` benchmarks.                 |
-| `MCAP_CLI_BENCH_CHUNK_SIZE`       |               `4194304` | Generated output chunk size in bytes.                    |
+| `MCAP_CLI_BENCH_CHUNK_BYTES`      |               `4000000` | Generated output chunk size in bytes.                    |
 | `MCAP_CLI_BENCH_DIR`              | `target/mcap-cli-bench` | Directory for generated inputs and per-run outputs.      |
 | `MCAP_CLI_BENCH_BIN`              |      Cargo bench binary | CLI binary to execute.                                   |
 | `MCAP_CLI_BENCH_SAMPLE_SIZE`      |                    `10` | Criterion sample size; values below 10 are raised to 10. |
@@ -42,7 +42,7 @@ variables for faster local iteration or larger comparison runs:
 Example larger run:
 
 ```sh
-MCAP_CLI_BENCH_TOTAL_MIB=1024 \
+MCAP_CLI_BENCH_TOTAL_MB=1000 \
 MCAP_CLI_BENCH_INPUTS=8 \
 cargo bench -p mcap-cli --bench commands -- merge
 ```
@@ -51,9 +51,12 @@ cargo bench -p mcap-cli --bench commands -- merge
 
 Each suite runs both `indexed` inputs (summary, chunk indexes, and message indexes present) and
 `linear` inputs (summary omitted, forcing a scan fallback). It uses deterministic pseudo-random
-message payloads at `100B`, `1KiB`, `10KiB`, `100KiB`, and `1MiB` sizes. The benchmark validates
+message payloads at `100B`, `1KB`, `10KB`, `100KB`, and `1MB` sizes. The benchmark validates
 each command output for basic MCAP correctness, expected message count, summary presence, and
 log-time ordering where applicable.
+
+Workload and payload sizes use SI units (`1KB = 1,000 bytes`, `1MB = 1,000,000 bytes`). Criterion
+reports byte throughput using its native IEC units such as `MiB/s` and `GiB/s`.
 
 Generated inputs are cached under `MCAP_CLI_BENCH_DIR` and reused when the benchmark parameters
 match the filename. Delete that directory if a previous run was interrupted or after large runs to

--- a/rust/cli/benches/cli_commands.rs
+++ b/rust/cli/benches/cli_commands.rs
@@ -1,0 +1,669 @@
+use std::borrow::Cow;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+const DEFAULT_TOTAL_MIB: u64 = 16;
+const DEFAULT_MERGE_INPUTS: usize = 4;
+const DEFAULT_CHUNK_SIZE: u64 = 4 * 1024 * 1024;
+const DEFAULT_SAMPLE_SIZE: usize = 10;
+const DEFAULT_WARMUP_MS: u64 = 250;
+const DEFAULT_MEASUREMENT_SECS: u64 = 2;
+const PAYLOAD_SIZES: &[usize] = &[1024, 10 * 1024, 100 * 1024, 1024 * 1024];
+
+#[derive(Debug, Clone)]
+struct BenchConfig {
+    root: PathBuf,
+    mcap_bin: PathBuf,
+    total_mib: u64,
+    merge_inputs: usize,
+    chunk_size: u64,
+}
+
+#[derive(Debug, Clone)]
+struct InputCase {
+    path: PathBuf,
+    payload_size: usize,
+    message_count: usize,
+    selected_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct MergeCase {
+    paths: Vec<PathBuf>,
+    payload_size: usize,
+    expected_count: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InputOrder {
+    Ordered,
+    Reversed,
+    Interleaved {
+        input_idx: usize,
+        input_count: usize,
+    },
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        .sample_size(env_usize("MCAP_CLI_BENCH_SAMPLE_SIZE", DEFAULT_SAMPLE_SIZE).max(10))
+        .warm_up_time(Duration::from_millis(env_u64(
+            "MCAP_CLI_BENCH_WARMUP_MS",
+            DEFAULT_WARMUP_MS,
+        )))
+        .measurement_time(Duration::from_secs(env_u64(
+            "MCAP_CLI_BENCH_MEASUREMENT_SECS",
+            DEFAULT_MEASUREMENT_SECS,
+        )))
+}
+
+fn bench_cli_commands(c: &mut Criterion) {
+    let config = BenchConfig::from_env();
+    let suites = SuiteSelection::from_args();
+    std::fs::create_dir_all(config.inputs_dir()).expect("create benchmark input dir");
+    std::fs::create_dir_all(config.outputs_dir()).expect("create benchmark output dir");
+    assert!(
+        config.mcap_bin.exists(),
+        "mcap binary '{}' does not exist; run `cargo build --release -p mcap-cli` or set MCAP_CLI_BENCH_BIN",
+        config.mcap_bin.display()
+    );
+
+    if suites.merge {
+        let merge_cases = PAYLOAD_SIZES
+            .iter()
+            .copied()
+            .map(|payload_size| config.merge_case(payload_size))
+            .collect::<Vec<_>>();
+        bench_merge(c, &config, &merge_cases);
+    }
+
+    if suites.filter || suites.decompress {
+        let input_cases = PAYLOAD_SIZES
+            .iter()
+            .copied()
+            .map(|payload_size| config.input_case(payload_size, InputOrder::Ordered, Some("zstd")))
+            .collect::<Vec<_>>();
+        if suites.filter {
+            bench_filter(c, &config, &input_cases);
+        }
+        if suites.decompress {
+            bench_decompress(c, &config, &input_cases);
+        }
+    }
+
+    if suites.sort {
+        let sort_cases = PAYLOAD_SIZES
+            .iter()
+            .copied()
+            .map(|payload_size| config.input_case(payload_size, InputOrder::Reversed, Some("zstd")))
+            .collect::<Vec<_>>();
+        bench_sort(c, &config, &sort_cases);
+    }
+
+    if suites.compress {
+        let uncompressed_cases = PAYLOAD_SIZES
+            .iter()
+            .copied()
+            .map(|payload_size| config.input_case(payload_size, InputOrder::Ordered, None))
+            .collect::<Vec<_>>();
+        bench_compress(c, &config, &uncompressed_cases);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SuiteSelection {
+    merge: bool,
+    filter: bool,
+    sort: bool,
+    compress: bool,
+    decompress: bool,
+}
+
+impl SuiteSelection {
+    fn from_args() -> Self {
+        let filters = std::env::args()
+            .skip(1)
+            .filter(|arg| !arg.starts_with('-'))
+            .collect::<Vec<_>>();
+        let selected = |name: &str| {
+            filters
+                .iter()
+                .any(|filter| filter.split(['/', ':']).any(|component| component == name))
+        };
+        let any_suite = ["merge", "filter", "sort", "compress", "decompress"]
+            .iter()
+            .any(|name| selected(name));
+
+        if !any_suite {
+            return Self {
+                merge: true,
+                filter: true,
+                sort: true,
+                compress: true,
+                decompress: true,
+            };
+        }
+
+        Self {
+            merge: selected("merge"),
+            filter: selected("filter"),
+            sort: selected("sort"),
+            compress: selected("compress"),
+            decompress: selected("decompress"),
+        }
+    }
+}
+
+fn bench_merge(c: &mut Criterion, config: &BenchConfig, cases: &[MergeCase]) {
+    let mut group = c.benchmark_group("cli/merge");
+    for case in cases {
+        group.throughput(Throughput::Bytes(config.total_bytes()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size_label(case.payload_size)),
+            case,
+            |bench, case| {
+                bench.iter_custom(|iters| {
+                    run_measured(iters, |iteration| {
+                        let output = config.output_path("merge", case.payload_size, iteration);
+                        let mut args = vec![OsString::from("merge")];
+                        args.extend(case.paths.iter().map(|path| path.as_os_str().to_owned()));
+                        args.extend([
+                            OsString::from("--compression"),
+                            OsString::from("zstd"),
+                            OsString::from("--chunk-size"),
+                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from("--output-file"),
+                            output.as_os_str().to_owned(),
+                        ]);
+                        let duration = run_mcap(&config.mcap_bin, args);
+                        validate_output(&output, case.expected_count, true);
+                        remove_file(&output);
+                        duration
+                    })
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_filter(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
+    let mut group = c.benchmark_group("cli/filter");
+    for case in cases {
+        group.throughput(Throughput::Bytes(config.total_bytes()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size_label(case.payload_size)),
+            case,
+            |bench, case| {
+                bench.iter_custom(|iters| {
+                    run_measured(iters, |iteration| {
+                        let output = config.output_path("filter", case.payload_size, iteration);
+                        let args = vec![
+                            OsString::from("filter"),
+                            case.path.as_os_str().to_owned(),
+                            OsString::from("--include-topic-regex"),
+                            OsString::from("/bench/selected"),
+                            OsString::from("--output"),
+                            output.as_os_str().to_owned(),
+                            OsString::from("--output-compression"),
+                            OsString::from("zstd"),
+                            OsString::from("--chunk-size"),
+                            OsString::from(config.chunk_size.to_string()),
+                        ];
+                        let duration = run_mcap(&config.mcap_bin, args);
+                        validate_output(&output, case.selected_count, true);
+                        remove_file(&output);
+                        duration
+                    })
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_sort(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
+    let mut group = c.benchmark_group("cli/sort");
+    for case in cases {
+        group.throughput(Throughput::Bytes(config.total_bytes()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size_label(case.payload_size)),
+            case,
+            |bench, case| {
+                bench.iter_custom(|iters| {
+                    run_measured(iters, |iteration| {
+                        let output = config.output_path("sort", case.payload_size, iteration);
+                        let args = vec![
+                            OsString::from("sort"),
+                            case.path.as_os_str().to_owned(),
+                            OsString::from("--compression"),
+                            OsString::from("zstd"),
+                            OsString::from("--chunk-size"),
+                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from("--output-file"),
+                            output.as_os_str().to_owned(),
+                        ];
+                        let duration = run_mcap(&config.mcap_bin, args);
+                        validate_output(&output, case.message_count, true);
+                        remove_file(&output);
+                        duration
+                    })
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_compress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
+    let mut group = c.benchmark_group("cli/compress");
+    for case in cases {
+        group.throughput(Throughput::Bytes(config.total_bytes()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size_label(case.payload_size)),
+            case,
+            |bench, case| {
+                bench.iter_custom(|iters| {
+                    run_measured(iters, |iteration| {
+                        let output = config.output_path("compress", case.payload_size, iteration);
+                        let args = vec![
+                            OsString::from("compress"),
+                            case.path.as_os_str().to_owned(),
+                            OsString::from("--output"),
+                            output.as_os_str().to_owned(),
+                            OsString::from("--compression"),
+                            OsString::from("zstd"),
+                            OsString::from("--chunk-size"),
+                            OsString::from(config.chunk_size.to_string()),
+                        ];
+                        let duration = run_mcap(&config.mcap_bin, args);
+                        validate_output(&output, case.message_count, true);
+                        remove_file(&output);
+                        duration
+                    })
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_decompress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
+    let mut group = c.benchmark_group("cli/decompress");
+    for case in cases {
+        group.throughput(Throughput::Bytes(config.total_bytes()));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size_label(case.payload_size)),
+            case,
+            |bench, case| {
+                bench.iter_custom(|iters| {
+                    run_measured(iters, |iteration| {
+                        let output = config.output_path("decompress", case.payload_size, iteration);
+                        let args = vec![
+                            OsString::from("decompress"),
+                            case.path.as_os_str().to_owned(),
+                            OsString::from("--output"),
+                            output.as_os_str().to_owned(),
+                            OsString::from("--chunk-size"),
+                            OsString::from(config.chunk_size.to_string()),
+                        ];
+                        let duration = run_mcap(&config.mcap_bin, args);
+                        validate_output(&output, case.message_count, true);
+                        remove_file(&output);
+                        duration
+                    })
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+impl BenchConfig {
+    fn from_env() -> Self {
+        Self {
+            root: env_path("MCAP_CLI_BENCH_DIR").unwrap_or_else(default_bench_dir),
+            mcap_bin: env_path("MCAP_CLI_BENCH_BIN").unwrap_or_else(default_mcap_bin),
+            total_mib: env_u64("MCAP_CLI_BENCH_TOTAL_MIB", DEFAULT_TOTAL_MIB),
+            merge_inputs: env_usize("MCAP_CLI_BENCH_INPUTS", DEFAULT_MERGE_INPUTS).max(1),
+            chunk_size: env_u64("MCAP_CLI_BENCH_CHUNK_SIZE", DEFAULT_CHUNK_SIZE),
+        }
+    }
+
+    fn total_bytes(&self) -> u64 {
+        self.total_mib * 1024 * 1024
+    }
+
+    fn inputs_dir(&self) -> PathBuf {
+        self.root.join("inputs")
+    }
+
+    fn outputs_dir(&self) -> PathBuf {
+        self.root.join("outputs")
+    }
+
+    fn input_case(
+        &self,
+        payload_size: usize,
+        order: InputOrder,
+        compression: Option<&'static str>,
+    ) -> InputCase {
+        let message_count = message_count(self.total_bytes(), payload_size, 1);
+        let selected_count = message_count.div_ceil(2);
+        let path = self.input_path(payload_size, message_count, order, compression, 0);
+        if !path.exists() {
+            write_input(
+                &path,
+                payload_size,
+                message_count,
+                order,
+                compression,
+                self.chunk_size,
+            );
+        }
+        InputCase {
+            path,
+            payload_size,
+            message_count,
+            selected_count,
+        }
+    }
+
+    fn merge_case(&self, payload_size: usize) -> MergeCase {
+        let messages_per_input = message_count(self.total_bytes(), payload_size, self.merge_inputs);
+        let paths = (0..self.merge_inputs)
+            .map(|input_idx| {
+                let order = InputOrder::Interleaved {
+                    input_idx,
+                    input_count: self.merge_inputs,
+                };
+                let path = self.input_path(
+                    payload_size,
+                    messages_per_input,
+                    order,
+                    Some("zstd"),
+                    input_idx,
+                );
+                if !path.exists() {
+                    write_input(
+                        &path,
+                        payload_size,
+                        messages_per_input,
+                        order,
+                        Some("zstd"),
+                        self.chunk_size,
+                    );
+                }
+                path
+            })
+            .collect::<Vec<_>>();
+        MergeCase {
+            paths,
+            payload_size,
+            expected_count: messages_per_input * self.merge_inputs,
+        }
+    }
+
+    fn input_path(
+        &self,
+        payload_size: usize,
+        message_count: usize,
+        order: InputOrder,
+        compression: Option<&str>,
+        input_idx: usize,
+    ) -> PathBuf {
+        let order_label = match order {
+            InputOrder::Ordered => "ordered".to_string(),
+            InputOrder::Reversed => "reversed".to_string(),
+            InputOrder::Interleaved { input_count, .. } => format!("interleaved{input_count}"),
+        };
+        let compression_label = compression.unwrap_or("none");
+        self.inputs_dir().join(format!(
+            "payload{}_messages{}_chunk{}_{}_{}_part{}.mcap",
+            payload_size, message_count, self.chunk_size, order_label, compression_label, input_idx
+        ))
+    }
+
+    fn output_path(&self, command: &str, payload_size: usize, iteration: u64) -> PathBuf {
+        self.outputs_dir().join(format!(
+            "{}_payload{}_pid{}_iter{}.mcap",
+            command,
+            payload_size,
+            std::process::id(),
+            iteration
+        ))
+    }
+}
+
+fn write_input(
+    path: &Path,
+    payload_size: usize,
+    message_count: usize,
+    order: InputOrder,
+    compression: Option<&str>,
+    chunk_size: u64,
+) {
+    let compression = match compression {
+        Some("zstd") => Some(mcap::Compression::Zstd),
+        Some("lz4") => Some(mcap::Compression::Lz4),
+        Some(value) => panic!("unsupported compression {value}"),
+        None => None,
+    };
+
+    let file = std::fs::File::create(path).expect("create generated MCAP");
+    let mut writer = mcap::WriteOptions::new()
+        .profile("bench")
+        .library("mcap-cli-bench")
+        .compression(compression)
+        .chunk_size(Some(chunk_size))
+        .create(std::io::BufWriter::new(file))
+        .expect("create MCAP writer");
+
+    let schema = Arc::new(mcap::Schema {
+        id: 1,
+        name: "Bench".to_string(),
+        encoding: "raw".to_string(),
+        data: Cow::Borrowed(b"{}"),
+    });
+    let selected = Arc::new(mcap::Channel {
+        id: 1,
+        topic: "/bench/selected".to_string(),
+        schema: Some(schema.clone()),
+        message_encoding: "raw".to_string(),
+        metadata: Default::default(),
+    });
+    let other = Arc::new(mcap::Channel {
+        id: 2,
+        topic: "/bench/other".to_string(),
+        schema: Some(schema),
+        message_encoding: "raw".to_string(),
+        metadata: Default::default(),
+    });
+
+    let mut payload = vec![0u8; payload_size];
+    for input_order in 0..message_count {
+        fill_payload(&mut payload, input_order as u64);
+        let log_time = match order {
+            InputOrder::Ordered => input_order as u64,
+            InputOrder::Reversed => (message_count - input_order) as u64,
+            InputOrder::Interleaved {
+                input_idx,
+                input_count,
+            } => (input_order * input_count + input_idx) as u64,
+        };
+        let channel = if input_order % 2 == 0 {
+            selected.clone()
+        } else {
+            other.clone()
+        };
+        writer
+            .write(&mcap::Message {
+                channel,
+                sequence: input_order as u32,
+                log_time,
+                publish_time: log_time,
+                data: Cow::Borrowed(payload.as_slice()),
+            })
+            .expect("write generated message");
+    }
+    writer.finish().expect("finish generated MCAP");
+}
+
+fn run_measured<F>(iters: u64, mut run_once: F) -> Duration
+where
+    F: FnMut(u64) -> Duration,
+{
+    let mut total = Duration::ZERO;
+    for iteration in 0..iters {
+        total += run_once(iteration);
+    }
+    total
+}
+
+fn run_mcap(bin: &Path, args: Vec<OsString>) -> Duration {
+    let start = Instant::now();
+    let output = Command::new(bin)
+        .args(args)
+        .output()
+        .expect("run mcap command");
+    let duration = start.elapsed();
+    if !output.status.success() {
+        panic!(
+            "mcap command failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    duration
+}
+
+fn validate_output(path: &Path, expected_count: usize, require_ordered: bool) {
+    let bytes = std::fs::read(path).expect("read benchmark output");
+    assert!(
+        bytes.starts_with(mcap::MAGIC) && bytes.ends_with(mcap::MAGIC),
+        "output is not an MCAP file: {}",
+        path.display()
+    );
+    assert!(
+        mcap::Summary::read(&bytes)
+            .expect("read output summary")
+            .is_some(),
+        "output should include a summary: {}",
+        path.display()
+    );
+
+    let mut count = 0usize;
+    let mut previous_log_time = None;
+    for message in mcap::MessageStream::new(&bytes).expect("open output message stream") {
+        let message = message.expect("read output message");
+        if require_ordered {
+            if let Some(previous) = previous_log_time {
+                assert!(
+                    previous <= message.log_time,
+                    "messages are not log-time ordered in {}",
+                    path.display()
+                );
+            }
+            previous_log_time = Some(message.log_time);
+        }
+        count += 1;
+    }
+    assert_eq!(
+        count,
+        expected_count,
+        "unexpected output message count for {}",
+        path.display()
+    );
+}
+
+fn remove_file(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => panic!("failed to remove {}: {err}", path.display()),
+    }
+}
+
+fn message_count(total_bytes: u64, payload_size: usize, inputs: usize) -> usize {
+    ((total_bytes / payload_size as u64) / inputs as u64).max(1) as usize
+}
+
+fn fill_payload(payload: &mut [u8], message_idx: u64) {
+    let mut state = splitmix64(message_idx ^ payload.len() as u64);
+    for chunk in payload.chunks_mut(8) {
+        state = splitmix64(state);
+        let bytes = state.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+fn default_bench_dir() -> PathBuf {
+    workspace_root().join("target/mcap-cli-bench")
+}
+
+fn default_mcap_bin() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_mcap") {
+        return PathBuf::from(path);
+    }
+    if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target_dir).join("release/mcap");
+    }
+    workspace_root().join("target/release/mcap")
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rust/cli has parent rust")
+        .parent()
+        .expect("rust has parent workspace")
+        .to_path_buf()
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name).map(PathBuf::from)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn size_label(bytes: usize) -> String {
+    match bytes {
+        1024 => "1KiB".to_string(),
+        10240 => "10KiB".to_string(),
+        102400 => "100KiB".to_string(),
+        1048576 => "1MiB".to_string(),
+        _ => format!("{bytes}B"),
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = bench_cli_commands
+}
+criterion_main!(benches);

--- a/rust/cli/benches/cli_commands.rs
+++ b/rust/cli/benches/cli_commands.rs
@@ -13,7 +13,7 @@ const DEFAULT_CHUNK_SIZE: u64 = 4 * 1024 * 1024;
 const DEFAULT_SAMPLE_SIZE: usize = 10;
 const DEFAULT_WARMUP_MS: u64 = 250;
 const DEFAULT_MEASUREMENT_SECS: u64 = 2;
-const PAYLOAD_SIZES: &[usize] = &[1024, 10 * 1024, 100 * 1024, 1024 * 1024];
+const PAYLOAD_SIZES: &[usize] = &[100, 1024, 10 * 1024, 100 * 1024, 1024 * 1024];
 
 #[derive(Debug, Clone)]
 struct BenchConfig {
@@ -665,6 +665,7 @@ fn env_usize(name: &str, default: usize) -> usize {
 
 fn size_label(bytes: usize) -> String {
     match bytes {
+        100 => "100B".to_string(),
         1024 => "1KiB".to_string(),
         10240 => "10KiB".to_string(),
         102400 => "100KiB".to_string(),

--- a/rust/cli/benches/cli_commands.rs
+++ b/rust/cli/benches/cli_commands.rs
@@ -183,7 +183,9 @@ fn bench_merge(c: &mut Criterion, config: &BenchConfig, cases: &[MergeCase]) {
                             output.as_os_str().to_owned(),
                         ]);
                         let duration = run_mcap(&config.mcap_bin, args);
-                        validate_output(&output, case.expected_count, true);
+                        if iteration == 0 {
+                            validate_output(&output, case.expected_count, true);
+                        }
                         remove_file(&output);
                         duration
                     })
@@ -218,7 +220,9 @@ fn bench_filter(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
                             OsString::from(config.chunk_size.to_string()),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
-                        validate_output(&output, case.selected_count, true);
+                        if iteration == 0 {
+                            validate_output(&output, case.selected_count, true);
+                        }
                         remove_file(&output);
                         duration
                     })
@@ -251,7 +255,9 @@ fn bench_sort(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
                             output.as_os_str().to_owned(),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
-                        validate_output(&output, case.message_count, true);
+                        if iteration == 0 {
+                            validate_output(&output, case.message_count, true);
+                        }
                         remove_file(&output);
                         duration
                     })
@@ -284,7 +290,9 @@ fn bench_compress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) 
                             OsString::from(config.chunk_size.to_string()),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
-                        validate_output(&output, case.message_count, true);
+                        if iteration == 0 {
+                            validate_output(&output, case.message_count, true);
+                        }
                         remove_file(&output);
                         duration
                     })
@@ -315,7 +323,9 @@ fn bench_decompress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]
                             OsString::from(config.chunk_size.to_string()),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
-                        validate_output(&output, case.message_count, true);
+                        if iteration == 0 {
+                            validate_output(&output, case.message_count, true);
+                        }
                         remove_file(&output);
                         duration
                     })

--- a/rust/cli/benches/cli_commands.rs
+++ b/rust/cli/benches/cli_commands.rs
@@ -69,7 +69,7 @@ fn bench_cli_commands(c: &mut Criterion) {
     std::fs::create_dir_all(config.outputs_dir()).expect("create benchmark output dir");
     assert!(
         config.mcap_bin.exists(),
-        "mcap binary '{}' does not exist; run `cargo build --release -p mcap-cli` or set MCAP_CLI_BENCH_BIN",
+        "mcap binary '{}' does not exist; set MCAP_CLI_BENCH_BIN to a built mcap binary",
         config.mcap_bin.display()
     );
 

--- a/rust/cli/benches/cli_commands.rs
+++ b/rust/cli/benches/cli_commands.rs
@@ -126,6 +126,8 @@ struct SuiteSelection {
 
 impl SuiteSelection {
     fn from_args() -> Self {
+        // Mirror the documented Criterion filters (`-- merge`, `-- filter`) so filtered runs only
+        // generate inputs for selected suites.
         let filters = std::env::args()
             .skip(1)
             .filter(|arg| !arg.starts_with('-'))

--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -62,7 +62,7 @@ fn criterion_config() -> Criterion {
         )))
 }
 
-fn bench_cli_commands(c: &mut Criterion) {
+fn bench_commands(c: &mut Criterion) {
     let config = BenchConfig::from_env();
     let suites = SuiteSelection::from_args();
     std::fs::create_dir_all(config.inputs_dir()).expect("create benchmark input dir");
@@ -677,6 +677,6 @@ fn size_label(bytes: usize) -> String {
 criterion_group! {
     name = benches;
     config = criterion_config();
-    targets = bench_cli_commands
+    targets = bench_commands
 }
 criterion_main!(benches);

--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -9,7 +9,6 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 
 const DEFAULT_TOTAL_MB: u64 = 256;
 const DEFAULT_MERGE_INPUTS: usize = 4;
-const DEFAULT_CHUNK_BYTES: u64 = 4_000_000;
 const DEFAULT_SAMPLE_SIZE: usize = 10;
 const DEFAULT_WARMUP_MS: u64 = 250;
 const DEFAULT_MEASUREMENT_SECS: u64 = 2;
@@ -375,7 +374,10 @@ impl BenchConfig {
             mcap_bin: env_path("MCAP_CLI_BENCH_BIN").unwrap_or_else(default_mcap_bin),
             total_mb: env_u64("MCAP_CLI_BENCH_TOTAL_MB", DEFAULT_TOTAL_MB),
             merge_inputs: env_usize("MCAP_CLI_BENCH_INPUTS", DEFAULT_MERGE_INPUTS).max(1),
-            chunk_bytes: env_u64("MCAP_CLI_BENCH_CHUNK_BYTES", DEFAULT_CHUNK_BYTES),
+            chunk_bytes: env_u64(
+                "MCAP_CLI_BENCH_CHUNK_BYTES",
+                mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            ),
         }
     }
 

--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
-const DEFAULT_TOTAL_MIB: u64 = 16;
+const DEFAULT_TOTAL_MIB: u64 = 256;
 const DEFAULT_MERGE_INPUTS: usize = 4;
 const DEFAULT_CHUNK_SIZE: u64 = 4 * 1024 * 1024;
 const DEFAULT_SAMPLE_SIZE: usize = 10;

--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -7,21 +7,21 @@ use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
-const DEFAULT_TOTAL_MIB: u64 = 256;
+const DEFAULT_TOTAL_MB: u64 = 256;
 const DEFAULT_MERGE_INPUTS: usize = 4;
-const DEFAULT_CHUNK_SIZE: u64 = 4 * 1024 * 1024;
+const DEFAULT_CHUNK_BYTES: u64 = 4_000_000;
 const DEFAULT_SAMPLE_SIZE: usize = 10;
 const DEFAULT_WARMUP_MS: u64 = 250;
 const DEFAULT_MEASUREMENT_SECS: u64 = 2;
-const PAYLOAD_SIZES: &[usize] = &[100, 1024, 10 * 1024, 100 * 1024, 1024 * 1024];
+const PAYLOAD_SIZES: &[usize] = &[100, 1_000, 10_000, 100_000, 1_000_000];
 
 #[derive(Debug, Clone)]
 struct BenchConfig {
     root: PathBuf,
     mcap_bin: PathBuf,
-    total_mib: u64,
+    total_mb: u64,
     merge_inputs: usize,
-    chunk_size: u64,
+    chunk_bytes: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -207,7 +207,7 @@ fn bench_merge(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: 
                             OsString::from("--compression"),
                             OsString::from("zstd"),
                             OsString::from("--chunk-size"),
-                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from(config.chunk_bytes.to_string()),
                             OsString::from("--output-file"),
                             output.as_os_str().to_owned(),
                         ]);
@@ -247,7 +247,7 @@ fn bench_filter(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases:
                             OsString::from("--output-compression"),
                             OsString::from("zstd"),
                             OsString::from("--chunk-size"),
-                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from(config.chunk_bytes.to_string()),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
                         if iteration == 0 {
@@ -280,7 +280,7 @@ fn bench_sort(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &
                             OsString::from("--compression"),
                             OsString::from("zstd"),
                             OsString::from("--chunk-size"),
-                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from(config.chunk_bytes.to_string()),
                             OsString::from("--output-file"),
                             output.as_os_str().to_owned(),
                         ];
@@ -318,7 +318,7 @@ fn bench_compress(c: &mut Criterion, config: &BenchConfig, mode: InputMode, case
                             OsString::from("--compression"),
                             OsString::from("zstd"),
                             OsString::from("--chunk-size"),
-                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from(config.chunk_bytes.to_string()),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
                         if iteration == 0 {
@@ -352,7 +352,7 @@ fn bench_decompress(c: &mut Criterion, config: &BenchConfig, mode: InputMode, ca
                             OsString::from("--output"),
                             output.as_os_str().to_owned(),
                             OsString::from("--chunk-size"),
-                            OsString::from(config.chunk_size.to_string()),
+                            OsString::from(config.chunk_bytes.to_string()),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);
                         if iteration == 0 {
@@ -373,14 +373,14 @@ impl BenchConfig {
         Self {
             root: env_path("MCAP_CLI_BENCH_DIR").unwrap_or_else(default_bench_dir),
             mcap_bin: env_path("MCAP_CLI_BENCH_BIN").unwrap_or_else(default_mcap_bin),
-            total_mib: env_u64("MCAP_CLI_BENCH_TOTAL_MIB", DEFAULT_TOTAL_MIB),
+            total_mb: env_u64("MCAP_CLI_BENCH_TOTAL_MB", DEFAULT_TOTAL_MB),
             merge_inputs: env_usize("MCAP_CLI_BENCH_INPUTS", DEFAULT_MERGE_INPUTS).max(1),
-            chunk_size: env_u64("MCAP_CLI_BENCH_CHUNK_SIZE", DEFAULT_CHUNK_SIZE),
+            chunk_bytes: env_u64("MCAP_CLI_BENCH_CHUNK_BYTES", DEFAULT_CHUNK_BYTES),
         }
     }
 
     fn total_bytes(&self) -> u64 {
-        self.total_mib * 1024 * 1024
+        self.total_mb * 1_000_000
     }
 
     fn inputs_dir(&self) -> PathBuf {
@@ -409,7 +409,7 @@ impl BenchConfig {
                 message_count,
                 order,
                 compression,
-                self.chunk_size,
+                self.chunk_bytes,
             );
         }
         InputCase {
@@ -444,7 +444,7 @@ impl BenchConfig {
                         messages_per_input,
                         order,
                         Some("zstd"),
-                        self.chunk_size,
+                        self.chunk_bytes,
                     );
                 }
                 path
@@ -476,7 +476,7 @@ impl BenchConfig {
             "payload{}_messages{}_chunk{}_{}_{}_{}_part{}.mcap",
             payload_size,
             message_count,
-            self.chunk_size,
+            self.chunk_bytes,
             mode.label(),
             order_label,
             compression_label,
@@ -509,7 +509,7 @@ fn write_input(
     message_count: usize,
     order: InputOrder,
     compression: Option<&str>,
-    chunk_size: u64,
+    chunk_bytes: u64,
 ) {
     let compression = match compression {
         Some("zstd") => Some(mcap::Compression::Zstd),
@@ -523,7 +523,7 @@ fn write_input(
         .profile("bench")
         .library("mcap-cli-bench")
         .compression(compression)
-        .chunk_size(Some(chunk_size));
+        .chunk_size(Some(chunk_bytes));
     if mode == InputMode::Linear {
         write_options = write_options
             .emit_summary_records(false)
@@ -723,10 +723,10 @@ fn env_usize(name: &str, default: usize) -> usize {
 fn size_label(bytes: usize) -> String {
     match bytes {
         100 => "100B".to_string(),
-        1024 => "1KiB".to_string(),
-        10240 => "10KiB".to_string(),
-        102400 => "100KiB".to_string(),
-        1048576 => "1MiB".to_string(),
+        1_000 => "1KB".to_string(),
+        10_000 => "10KB".to_string(),
+        100_000 => "100KB".to_string(),
+        1_000_000 => "1MB".to_string(),
         _ => format!("{bytes}B"),
     }
 }

--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -49,6 +49,21 @@ enum InputOrder {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputMode {
+    Indexed,
+    Linear,
+}
+
+impl InputMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Indexed => "indexed",
+            Self::Linear => "linear",
+        }
+    }
+}
+
 fn criterion_config() -> Criterion {
     Criterion::default()
         .sample_size(env_usize("MCAP_CLI_BENCH_SAMPLE_SIZE", DEFAULT_SAMPLE_SIZE).max(10))
@@ -73,45 +88,53 @@ fn bench_commands(c: &mut Criterion) {
         config.mcap_bin.display()
     );
 
-    if suites.merge {
-        let merge_cases = PAYLOAD_SIZES
-            .iter()
-            .copied()
-            .map(|payload_size| config.merge_case(payload_size))
-            .collect::<Vec<_>>();
-        bench_merge(c, &config, &merge_cases);
-    }
-
-    if suites.filter || suites.decompress {
-        let input_cases = PAYLOAD_SIZES
-            .iter()
-            .copied()
-            .map(|payload_size| config.input_case(payload_size, InputOrder::Ordered, Some("zstd")))
-            .collect::<Vec<_>>();
-        if suites.filter {
-            bench_filter(c, &config, &input_cases);
+    for mode in suites.modes() {
+        if suites.merge {
+            let merge_cases = PAYLOAD_SIZES
+                .iter()
+                .copied()
+                .map(|payload_size| config.merge_case(mode, payload_size))
+                .collect::<Vec<_>>();
+            bench_merge(c, &config, mode, &merge_cases);
         }
-        if suites.decompress {
-            bench_decompress(c, &config, &input_cases);
+
+        if suites.filter || suites.decompress {
+            let input_cases = PAYLOAD_SIZES
+                .iter()
+                .copied()
+                .map(|payload_size| {
+                    config.input_case(mode, payload_size, InputOrder::Ordered, Some("zstd"))
+                })
+                .collect::<Vec<_>>();
+            if suites.filter {
+                bench_filter(c, &config, mode, &input_cases);
+            }
+            if suites.decompress {
+                bench_decompress(c, &config, mode, &input_cases);
+            }
         }
-    }
 
-    if suites.sort {
-        let sort_cases = PAYLOAD_SIZES
-            .iter()
-            .copied()
-            .map(|payload_size| config.input_case(payload_size, InputOrder::Reversed, Some("zstd")))
-            .collect::<Vec<_>>();
-        bench_sort(c, &config, &sort_cases);
-    }
+        if suites.sort {
+            let sort_cases = PAYLOAD_SIZES
+                .iter()
+                .copied()
+                .map(|payload_size| {
+                    config.input_case(mode, payload_size, InputOrder::Reversed, Some("zstd"))
+                })
+                .collect::<Vec<_>>();
+            bench_sort(c, &config, mode, &sort_cases);
+        }
 
-    if suites.compress {
-        let uncompressed_cases = PAYLOAD_SIZES
-            .iter()
-            .copied()
-            .map(|payload_size| config.input_case(payload_size, InputOrder::Ordered, None))
-            .collect::<Vec<_>>();
-        bench_compress(c, &config, &uncompressed_cases);
+        if suites.compress {
+            let uncompressed_cases = PAYLOAD_SIZES
+                .iter()
+                .copied()
+                .map(|payload_size| {
+                    config.input_case(mode, payload_size, InputOrder::Ordered, None)
+                })
+                .collect::<Vec<_>>();
+            bench_compress(c, &config, mode, &uncompressed_cases);
+        }
     }
 }
 
@@ -122,12 +145,15 @@ struct SuiteSelection {
     sort: bool,
     compress: bool,
     decompress: bool,
+    indexed: bool,
+    linear: bool,
 }
 
 impl SuiteSelection {
     fn from_args() -> Self {
-        // Mirror the documented Criterion filters (`-- merge`, `-- filter`) so filtered runs only
-        // generate inputs for selected suites.
+        // Mirror documented Criterion filters (`-- merge`, `-- indexed`) so filtered runs only
+        // generate inputs for selected suites. This intentionally handles positional filters, not
+        // arbitrary Criterion flag values.
         let filters = std::env::args()
             .skip(1)
             .filter(|arg| !arg.starts_with('-'))
@@ -140,29 +166,31 @@ impl SuiteSelection {
         let any_suite = ["merge", "filter", "sort", "compress", "decompress"]
             .iter()
             .any(|name| selected(name));
-
-        if !any_suite {
-            return Self {
-                merge: true,
-                filter: true,
-                sort: true,
-                compress: true,
-                decompress: true,
-            };
-        }
+        let any_mode = ["indexed", "linear"].iter().any(|name| selected(name));
 
         Self {
-            merge: selected("merge"),
-            filter: selected("filter"),
-            sort: selected("sort"),
-            compress: selected("compress"),
-            decompress: selected("decompress"),
+            merge: !any_suite || selected("merge"),
+            filter: !any_suite || selected("filter"),
+            sort: !any_suite || selected("sort"),
+            compress: !any_suite || selected("compress"),
+            decompress: !any_suite || selected("decompress"),
+            indexed: !any_mode || selected("indexed"),
+            linear: !any_mode || selected("linear"),
         }
+    }
+
+    fn modes(self) -> impl Iterator<Item = InputMode> {
+        [
+            (self.indexed, InputMode::Indexed),
+            (self.linear, InputMode::Linear),
+        ]
+        .into_iter()
+        .filter_map(|(enabled, mode)| enabled.then_some(mode))
     }
 }
 
-fn bench_merge(c: &mut Criterion, config: &BenchConfig, cases: &[MergeCase]) {
-    let mut group = c.benchmark_group("cli/merge");
+fn bench_merge(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &[MergeCase]) {
+    let mut group = c.benchmark_group(format!("cli/merge/{}", mode.label()));
     for case in cases {
         group.throughput(Throughput::Bytes(config.total_bytes()));
         group.bench_with_input(
@@ -171,7 +199,8 @@ fn bench_merge(c: &mut Criterion, config: &BenchConfig, cases: &[MergeCase]) {
             |bench, case| {
                 bench.iter_custom(|iters| {
                     run_measured(iters, |iteration| {
-                        let output = config.output_path("merge", case.payload_size, iteration);
+                        let output =
+                            config.output_path("merge", mode, case.payload_size, iteration);
                         let mut args = vec![OsString::from("merge")];
                         args.extend(case.paths.iter().map(|path| path.as_os_str().to_owned()));
                         args.extend([
@@ -196,8 +225,8 @@ fn bench_merge(c: &mut Criterion, config: &BenchConfig, cases: &[MergeCase]) {
     group.finish();
 }
 
-fn bench_filter(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
-    let mut group = c.benchmark_group("cli/filter");
+fn bench_filter(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &[InputCase]) {
+    let mut group = c.benchmark_group(format!("cli/filter/{}", mode.label()));
     for case in cases {
         group.throughput(Throughput::Bytes(config.total_bytes()));
         group.bench_with_input(
@@ -206,7 +235,8 @@ fn bench_filter(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
             |bench, case| {
                 bench.iter_custom(|iters| {
                     run_measured(iters, |iteration| {
-                        let output = config.output_path("filter", case.payload_size, iteration);
+                        let output =
+                            config.output_path("filter", mode, case.payload_size, iteration);
                         let args = vec![
                             OsString::from("filter"),
                             case.path.as_os_str().to_owned(),
@@ -233,8 +263,8 @@ fn bench_filter(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
     group.finish();
 }
 
-fn bench_sort(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
-    let mut group = c.benchmark_group("cli/sort");
+fn bench_sort(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &[InputCase]) {
+    let mut group = c.benchmark_group(format!("cli/sort/{}", mode.label()));
     for case in cases {
         group.throughput(Throughput::Bytes(config.total_bytes()));
         group.bench_with_input(
@@ -243,7 +273,7 @@ fn bench_sort(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
             |bench, case| {
                 bench.iter_custom(|iters| {
                     run_measured(iters, |iteration| {
-                        let output = config.output_path("sort", case.payload_size, iteration);
+                        let output = config.output_path("sort", mode, case.payload_size, iteration);
                         let args = vec![
                             OsString::from("sort"),
                             case.path.as_os_str().to_owned(),
@@ -268,8 +298,8 @@ fn bench_sort(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
     group.finish();
 }
 
-fn bench_compress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
-    let mut group = c.benchmark_group("cli/compress");
+fn bench_compress(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &[InputCase]) {
+    let mut group = c.benchmark_group(format!("cli/compress/{}", mode.label()));
     for case in cases {
         group.throughput(Throughput::Bytes(config.total_bytes()));
         group.bench_with_input(
@@ -278,7 +308,8 @@ fn bench_compress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) 
             |bench, case| {
                 bench.iter_custom(|iters| {
                     run_measured(iters, |iteration| {
-                        let output = config.output_path("compress", case.payload_size, iteration);
+                        let output =
+                            config.output_path("compress", mode, case.payload_size, iteration);
                         let args = vec![
                             OsString::from("compress"),
                             case.path.as_os_str().to_owned(),
@@ -303,8 +334,8 @@ fn bench_compress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) 
     group.finish();
 }
 
-fn bench_decompress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]) {
-    let mut group = c.benchmark_group("cli/decompress");
+fn bench_decompress(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &[InputCase]) {
+    let mut group = c.benchmark_group(format!("cli/decompress/{}", mode.label()));
     for case in cases {
         group.throughput(Throughput::Bytes(config.total_bytes()));
         group.bench_with_input(
@@ -313,7 +344,8 @@ fn bench_decompress(c: &mut Criterion, config: &BenchConfig, cases: &[InputCase]
             |bench, case| {
                 bench.iter_custom(|iters| {
                     run_measured(iters, |iteration| {
-                        let output = config.output_path("decompress", case.payload_size, iteration);
+                        let output =
+                            config.output_path("decompress", mode, case.payload_size, iteration);
                         let args = vec![
                             OsString::from("decompress"),
                             case.path.as_os_str().to_owned(),
@@ -361,16 +393,18 @@ impl BenchConfig {
 
     fn input_case(
         &self,
+        mode: InputMode,
         payload_size: usize,
         order: InputOrder,
         compression: Option<&'static str>,
     ) -> InputCase {
         let message_count = message_count(self.total_bytes(), payload_size, 1);
         let selected_count = message_count.div_ceil(2);
-        let path = self.input_path(payload_size, message_count, order, compression, 0);
+        let path = self.input_path(mode, payload_size, message_count, order, compression, 0);
         if !path.exists() {
             write_input(
                 &path,
+                mode,
                 payload_size,
                 message_count,
                 order,
@@ -386,7 +420,7 @@ impl BenchConfig {
         }
     }
 
-    fn merge_case(&self, payload_size: usize) -> MergeCase {
+    fn merge_case(&self, mode: InputMode, payload_size: usize) -> MergeCase {
         let messages_per_input = message_count(self.total_bytes(), payload_size, self.merge_inputs);
         let paths = (0..self.merge_inputs)
             .map(|input_idx| {
@@ -395,6 +429,7 @@ impl BenchConfig {
                     input_count: self.merge_inputs,
                 };
                 let path = self.input_path(
+                    mode,
                     payload_size,
                     messages_per_input,
                     order,
@@ -404,6 +439,7 @@ impl BenchConfig {
                 if !path.exists() {
                     write_input(
                         &path,
+                        mode,
                         payload_size,
                         messages_per_input,
                         order,
@@ -423,6 +459,7 @@ impl BenchConfig {
 
     fn input_path(
         &self,
+        mode: InputMode,
         payload_size: usize,
         message_count: usize,
         order: InputOrder,
@@ -436,15 +473,28 @@ impl BenchConfig {
         };
         let compression_label = compression.unwrap_or("none");
         self.inputs_dir().join(format!(
-            "payload{}_messages{}_chunk{}_{}_{}_part{}.mcap",
-            payload_size, message_count, self.chunk_size, order_label, compression_label, input_idx
+            "payload{}_messages{}_chunk{}_{}_{}_{}_part{}.mcap",
+            payload_size,
+            message_count,
+            self.chunk_size,
+            mode.label(),
+            order_label,
+            compression_label,
+            input_idx
         ))
     }
 
-    fn output_path(&self, command: &str, payload_size: usize, iteration: u64) -> PathBuf {
+    fn output_path(
+        &self,
+        command: &str,
+        mode: InputMode,
+        payload_size: usize,
+        iteration: u64,
+    ) -> PathBuf {
         self.outputs_dir().join(format!(
-            "{}_payload{}_pid{}_iter{}.mcap",
+            "{}_{}_payload{}_pid{}_iter{}.mcap",
             command,
+            mode.label(),
             payload_size,
             std::process::id(),
             iteration
@@ -454,6 +504,7 @@ impl BenchConfig {
 
 fn write_input(
     path: &Path,
+    mode: InputMode,
     payload_size: usize,
     message_count: usize,
     order: InputOrder,
@@ -468,11 +519,17 @@ fn write_input(
     };
 
     let file = std::fs::File::create(path).expect("create generated MCAP");
-    let mut writer = mcap::WriteOptions::new()
+    let mut write_options = mcap::WriteOptions::new()
         .profile("bench")
         .library("mcap-cli-bench")
         .compression(compression)
-        .chunk_size(Some(chunk_size))
+        .chunk_size(Some(chunk_size));
+    if mode == InputMode::Linear {
+        write_options = write_options
+            .emit_summary_records(false)
+            .emit_summary_offsets(false);
+    }
+    let mut writer = write_options
         .create(std::io::BufWriter::new(file))
         .expect("create MCAP writer");
 

--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
-const DEFAULT_TOTAL_MB: u64 = 256;
+const DEFAULT_TOTAL_MB: u64 = 250;
 const DEFAULT_MERGE_INPUTS: usize = 4;
 const DEFAULT_SAMPLE_SIZE: usize = 10;
 const DEFAULT_WARMUP_MS: u64 = 250;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
None

### Docs
Added contributor-facing benchmark usage docs in `rust/cli/benches/README.md` and agent guidance in `rust/cli/AGENTS.md`.

### Description
Adds a Criterion benchmark target for the Rust `mcap` CLI that generates synthetic MCAP inputs at runtime and benchmarks real `mcap` subprocesses. The framework covers `merge`, `filter`, `sort`, `compress`, and `decompress` across indexed and linear-scan input modes and 100B, 1KB, 10KB, 100KB, and 1MB payload sizes. Workload and payload sizes use SI units, the default chunk size inherits `mcap::WriteOptions::DEFAULT_CHUNK_SIZE`, and Criterion reports throughput in its native IEC units. Each measured command validates the output MCAP for magic bytes, summary presence, expected message count, and log-time ordering where applicable.

Default 250 MB benchmark run on a Cursor Cloud VM took 20m54s total, including 2m17s compile time. Median throughput:

| command / mode | 100B | 1KB | 10KB | 100KB | 1MB |
|---|---:|---:|---:|---:|---:|
| `merge/indexed` | 108 MiB/s | 311 MiB/s | 557 MiB/s | 647 MiB/s | 562 MiB/s |
| `merge/linear` | 78 MiB/s | 267 MiB/s | 392 MiB/s | 444 MiB/s | 477 MiB/s |
| `filter/indexed` | 123 MiB/s | 353 MiB/s | 775 MiB/s | 930 MiB/s | 882 MiB/s |
| `filter/linear` | 104 MiB/s | 353 MiB/s | 821 MiB/s | 946 MiB/s | 1011 MiB/s |
| `decompress/indexed` | 15.6 MiB/s | 132 MiB/s | 715 MiB/s | 1.34 GiB/s | 1.45 GiB/s |
| `decompress/linear` | 15.7 MiB/s | 154 MiB/s | 633 MiB/s | 1.04 GiB/s | 988 MiB/s |
| `sort/indexed` | 74.6 MiB/s | 197 MiB/s | 482 MiB/s | 587 MiB/s | 709 MiB/s |
| `sort/linear` | 54.9 MiB/s | 142 MiB/s | 334 MiB/s | 401 MiB/s | 428 MiB/s |
| `compress/indexed` | 72.5 MiB/s | 208 MiB/s | 492 MiB/s | 607 MiB/s | 711 MiB/s |
| `compress/linear` | 72.3 MiB/s | 194 MiB/s | 482 MiB/s | 576 MiB/s | 647 MiB/s |

### Testing
- [x] Run `cargo build --release -p mcap-cli` and confirm `target/release/mcap` is created.
- [x] Run `MCAP_CLI_BENCH_TOTAL_MB=1 MCAP_CLI_BENCH_SAMPLE_SIZE=10 MCAP_CLI_BENCH_WARMUP_MS=50 MCAP_CLI_BENCH_MEASUREMENT_SECS=1 cargo bench -p mcap-cli --bench commands -- merge/indexed/100KB` and confirm the SI env var and payload label work.
- [x] Run `MCAP_CLI_BENCH_SAMPLE_SIZE=10 MCAP_CLI_BENCH_WARMUP_MS=50 MCAP_CLI_BENCH_MEASUREMENT_SECS=1 cargo bench -p mcap-cli --bench commands -- merge/indexed/1MB` and confirm the 250 MB default workload is used.
- [x] Run `cargo fmt --all -- --check`.
- [x] Run `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`.
- [x] Run `yarn prettier --check rust/cli/benches/README.md rust/cli/AGENTS.md`.
- [x] Run `cargo bench -p mcap-cli --bench commands` and confirm the full 250 MB default matrix completes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-927ad453-f9df-40ff-bf85-a9f0863526ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-927ad453-f9df-40ff-bf85-a9f0863526ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

