### PR TITLE
cli: Consistent units in output

### DIFF
--- a/rust/cli/src/commands/convert/ros1_bag.rs
+++ b/rust/cli/src/commands/convert/ros1_bag.rs
@@ -24,7 +24,7 @@ const KEY_TIME: &str = "time";
 const KEY_TYPE: &str = "type";
 const KEY_MD5SUM: &str = "md5sum";
 const KEY_MESSAGE_DEFINITION: &str = "message_definition";
-const MAX_RECORD_SECTION_SIZE: u32 = 1 << 30; // 1.07 GB
+const MAX_RECORD_SECTION_SIZE: u32 = 1_000_000_000; // 1 GB
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct SchemaKey {

--- a/rust/cli/src/commands/convert/ros1_bag.rs
+++ b/rust/cli/src/commands/convert/ros1_bag.rs
@@ -24,7 +24,7 @@ const KEY_TIME: &str = "time";
 const KEY_TYPE: &str = "type";
 const KEY_MD5SUM: &str = "md5sum";
 const KEY_MESSAGE_DEFINITION: &str = "message_definition";
-const MAX_RECORD_SECTION_SIZE: u32 = 1 << 30; // 1 GiB
+const MAX_RECORD_SECTION_SIZE: u32 = 1 << 30; // 1.07 GB
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct SchemaKey {

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -9,7 +9,7 @@ use crate::{parse, source};
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
     let metadata = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        merged_remote_metadata_for_name(&remote, &args.name)?
+        merged_remote_metadata_for_name(&remote, &args.name, source_options)?
     } else {
         let mcap = source::load_path(&args.file, source_options)?;
         let parsed = parse::parse_mcap(&mcap)?;
@@ -25,6 +25,7 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
 fn merged_remote_metadata_for_name(
     remote: &source::RemoteMcap,
     name: &str,
+    source_options: source::SourceOptions,
 ) -> Result<BTreeMap<String, String>> {
     let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
         .summary()
@@ -36,6 +37,17 @@ fn merged_remote_metadata_for_name(
         anyhow::bail!("metadata {name} does not exist");
     }
     matching_indexes.sort_by_key(|index| index.offset);
+    if matching_indexes.len() > 1 {
+        let total_bytes = matching_indexes
+            .iter()
+            .map(|index| index.length)
+            .sum::<u64>();
+        source::require_remote_indexed_read_budget(
+            total_bytes,
+            source_options,
+            "remote metadata records",
+        )?;
+    }
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -40,8 +40,7 @@ fn merged_remote_metadata_for_name(
     if matching_indexes.len() > 1 {
         let total_bytes = matching_indexes
             .iter()
-            .map(|index| index.length)
-            .sum::<u64>();
+            .fold(0u64, |total, index| total.saturating_add(index.length));
         source::require_remote_indexed_read_budget(
             total_bytes,
             source_options,

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -9,7 +9,7 @@ use crate::{parse, source};
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
     let metadata = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        merged_remote_metadata_for_name(&remote, &args.name, source_options)?
+        merged_remote_metadata_for_name(&remote, &args.name)?
     } else {
         let mcap = source::load_path(&args.file, source_options)?;
         let parsed = parse::parse_mcap(&mcap)?;
@@ -25,7 +25,6 @@ pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
 fn merged_remote_metadata_for_name(
     remote: &source::RemoteMcap,
     name: &str,
-    source_options: source::SourceOptions,
 ) -> Result<BTreeMap<String, String>> {
     let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
         .summary()
@@ -37,13 +36,6 @@ fn merged_remote_metadata_for_name(
         anyhow::bail!("metadata {name} does not exist");
     }
     matching_indexes.sort_by_key(|index| index.offset);
-    if matching_indexes.len() > 1 {
-        let total_bytes = matching_indexes
-            .iter()
-            .map(|index| index.length)
-            .sum::<u64>();
-        source::require_remote_metadata_budget(total_bytes, source_options, "metadata records")?;
-    }
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -87,11 +87,7 @@ fn render_info(parsed: &parse::ParsedMcap) -> String {
             );
             if duration_seconds > 0.0 {
                 let throughput = (stats.compressed_size as f64 / duration_seconds).max(0.0);
-                let _ = write!(
-                    &mut out,
-                    " [{}/sec]",
-                    render::human_bytes(throughput as u64)
-                );
+                let _ = write!(&mut out, " [{}/s]", render::human_bytes(throughput as u64));
             }
             let _ = writeln!(&mut out);
         }
@@ -463,11 +459,24 @@ mod tests {
                 metadata: BTreeMap::new(),
             },
         );
+        parsed.chunk_indexes.push(ChunkIndex {
+            message_start_time: 1_000_000_000,
+            message_end_time: 2_500_000_000,
+            chunk_start_offset: 0,
+            chunk_length: 0,
+            message_index_offsets: BTreeMap::new(),
+            message_index_length: 0,
+            compression: "zstd".to_string(),
+            compressed_size: 1_500_000,
+            uncompressed_size: 3_000_000,
+        });
 
         let rendered = render_info(&parsed);
         assert!(rendered.contains(&format!("library:     {}", mcap::LIBRARY_IDENTIFIER)));
         assert!(rendered.contains("profile:     demo"));
         assert!(rendered.contains("messages:    2"));
+        assert!(rendered.contains("zstd: [1/1 chunks] [3.00 MB/1.50 MB (50.00%)] [1.00 MB/s]"));
+        assert!(rendered.contains("max uncompressed size: 3.00 MB"));
         assert!(rendered.contains("channels:"));
         assert!(rendered.contains("/demo"));
     }

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -24,8 +24,7 @@ fn collect_remote_metadata_records(
         .summary()
         .metadata_indexes
         .iter()
-        .map(|index| index.length)
-        .sum::<u64>();
+        .fold(0u64, |total, index| total.saturating_add(index.length));
     source::require_remote_indexed_read_budget(
         total_bytes,
         source_options,

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -7,7 +7,7 @@ use crate::{parse, render, source};
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
     let records = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        collect_remote_metadata_records(&remote)?
+        collect_remote_metadata_records(&remote, source_options)?
     } else {
         let mcap = source::load_path(&args.file, source_options)?;
         collect_metadata_records(&mcap)?
@@ -18,7 +18,20 @@ pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
 
 fn collect_remote_metadata_records(
     remote: &source::RemoteMcap,
+    source_options: source::SourceOptions,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
+    let total_bytes = remote
+        .summary()
+        .metadata_indexes
+        .iter()
+        .map(|index| index.length)
+        .sum::<u64>();
+    source::require_remote_indexed_read_budget(
+        total_bytes,
+        source_options,
+        "remote metadata records",
+    )?;
+
     let mut records = Vec::new();
     for index in &remote.summary().metadata_indexes {
         let bytes = remote.read_range(

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -7,7 +7,7 @@ use crate::{parse, render, source};
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
     let records = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        collect_remote_metadata_records(&remote, source_options)?
+        collect_remote_metadata_records(&remote)?
     } else {
         let mcap = source::load_path(&args.file, source_options)?;
         collect_metadata_records(&mcap)?
@@ -18,16 +18,7 @@ pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
 
 fn collect_remote_metadata_records(
     remote: &source::RemoteMcap,
-    source_options: source::SourceOptions,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
-    let total_bytes = remote
-        .summary()
-        .metadata_indexes
-        .iter()
-        .map(|index| index.length)
-        .sum::<u64>();
-    source::require_remote_metadata_budget(total_bytes, source_options, "metadata records")?;
-
     let mut records = Vec::new();
     for index in &remote.summary().metadata_indexes {
         let bytes = remote.read_range(

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -12,10 +12,10 @@ use crate::commands::CommandOutcome;
 use crate::context::CommandContext;
 use crate::source;
 
-// 1.07 GB upper limit on top-level record lengths while scanning the stream. This only bounds
+// 1 GB upper limit on top-level record lengths while scanning the stream. This only bounds
 // records read by the linear reader (including a compressed chunk record's own length); it does
 // not bound chunk decompression, so a chunk's decoded `uncompressed_size` can still exceed this.
-const RECOVER_RECORD_LENGTH_LIMIT: usize = 1024 * 1024 * 1024;
+const RECOVER_RECORD_LENGTH_LIMIT: usize = 1_000_000_000;
 
 #[derive(Debug, Clone, Copy)]
 enum CompressionSelection {

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -12,7 +12,7 @@ use crate::commands::CommandOutcome;
 use crate::context::CommandContext;
 use crate::source;
 
-// 1 GiB upper limit on top-level record lengths while scanning the stream. This only bounds
+// 1.07 GB upper limit on top-level record lengths while scanning the stream. This only bounds
 // records read by the linear reader (including a compressed chunk record's own length); it does
 // not bound chunk decompression, so a chunk's decoded `uncompressed_size` can still exceed this.
 const RECOVER_RECORD_LENGTH_LIMIT: usize = 1024 * 1024 * 1024;

--- a/rust/cli/src/render.rs
+++ b/rust/cli/src/render.rs
@@ -50,16 +50,16 @@ fn format_rfc3339_trimmed(dt: chrono::DateTime<chrono::Utc>) -> String {
 }
 
 pub fn human_bytes(num_bytes: u64) -> String {
-    let prefixes = ["B", "KiB", "MiB", "GiB"];
+    let prefixes = ["B", "kB", "MB", "GB", "TB", "PB"];
     for (index, prefix) in prefixes.iter().enumerate() {
-        let displayed = num_bytes as f64 / 1024f64.powi(index as i32);
-        if displayed <= 1024.0 {
+        let displayed = num_bytes as f64 / 1000f64.powi(index as i32);
+        if displayed < 1000.0 {
             return format!("{displayed:.2} {prefix}");
         }
     }
 
     let last = prefixes.len() - 1;
-    let displayed = num_bytes as f64 / 1024f64.powi(last as i32);
+    let displayed = num_bytes as f64 / 1000f64.powi(last as i32);
     format!("{displayed:.2} {}", prefixes[last])
 }
 
@@ -174,6 +174,9 @@ mod tests {
     #[test]
     fn human_bytes_scales_units() {
         assert_eq!(human_bytes(2), "2.00 B");
-        assert_eq!(human_bytes(2 * 1024), "2.00 KiB");
+        assert_eq!(human_bytes(999), "999.00 B");
+        assert_eq!(human_bytes(1000), "1.00 kB");
+        assert_eq!(human_bytes(2 * 1000), "2.00 kB");
+        assert_eq!(human_bytes(2 * 1000 * 1000), "2.00 MB");
     }
 }

--- a/rust/cli/src/render.rs
+++ b/rust/cli/src/render.rs
@@ -53,8 +53,9 @@ pub fn human_bytes(num_bytes: u64) -> String {
     let prefixes = ["B", "kB", "MB", "GB", "TB", "PB"];
     for (index, prefix) in prefixes.iter().enumerate() {
         let displayed = num_bytes as f64 / 1000f64.powi(index as i32);
-        if displayed < 1000.0 {
-            return format!("{displayed:.2} {prefix}");
+        let rounded = (displayed * 100.0).round() / 100.0;
+        if rounded < 1000.0 {
+            return format!("{rounded:.2} {prefix}");
         }
     }
 
@@ -178,5 +179,6 @@ mod tests {
         assert_eq!(human_bytes(1000), "1.00 kB");
         assert_eq!(human_bytes(2 * 1000), "2.00 kB");
         assert_eq!(human_bytes(2 * 1000 * 1000), "2.00 MB");
+        assert_eq!(human_bytes(999_996), "1.00 MB");
     }
 }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1212,7 +1212,6 @@ mod tests {
     use std::thread;
 
     use super::load_path;
-    use crate::render::human_bytes;
     use mcap::records;
     use object_store::ObjectStoreExt;
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -30,11 +30,7 @@ const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
 // Guards remote summary discovery against corrupt or hostile footers that point
 // `summary_start` near the beginning of a large file, which would otherwise turn
 // an index-only operation into a near-full-file range read without opt-in.
-const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 20_000_000;
-// Bounds aggregate metadata body reads for list/multi-match metadata commands.
-// Single indexed metadata/attachment records are deliberately uncapped beyond
-// the remote file size because they are explicit user-selected record reads.
-pub(crate) const MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
+const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 100_000_000;
 
 pub enum InputData {
     Mapped(Mmap),
@@ -1001,22 +997,6 @@ pub(crate) fn remote_scan_opt_in_suffix() -> &'static str {
     "pass --allow-remote-scan to continue"
 }
 
-pub(crate) fn require_remote_metadata_budget(
-    total_bytes: u64,
-    options: SourceOptions,
-    description: &str,
-) -> Result<()> {
-    if options.allow_remote_scan || total_bytes <= MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN {
-        return Ok(());
-    }
-    bail!(
-        "remote {description} would read {} (exceeds {} cap without --allow-remote-scan); {}",
-        human_bytes(total_bytes),
-        human_bytes(MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN),
-        remote_scan_opt_in_suffix()
-    );
-}
-
 fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()> {
     if options.allow_remote_scan {
         return Ok(());
@@ -1798,21 +1778,6 @@ mod tests {
         let message = format!("{err:#}");
         assert!(message.contains("Remote summary section"));
         assert!(message.contains("--allow-remote-scan"));
-    }
-
-    #[test]
-    fn remote_metadata_budget_requires_scan_for_oversized_total() {
-        let err = super::require_remote_metadata_budget(
-            super::MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN + 1,
-            super::SourceOptions::default(),
-            "metadata records",
-        )
-        .expect_err("oversized metadata range total should require scan opt-in");
-        assert!(err.to_string().contains("metadata records"));
-        assert!(err
-            .to_string()
-            .contains(&human_bytes(super::MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN)));
-        assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
     #[test]

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -27,10 +27,9 @@ pub const PLEASE_SUPPLY_FILE: &str = "please supply a file. see --help for usage
 // comfortably covers the summaries of typical multi-hundred-MB to low-GB files while
 // keeping the per-open transfer small on bandwidth-constrained links.
 const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
-// Guards remote summary discovery against corrupt or hostile footers that point
-// `summary_start` near the beginning of a large file, which would otherwise turn
-// an index-only operation into a near-full-file range read without opt-in.
-const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 100_000_000;
+// Guards aggregate remote reads that should stay index-like (summary bytes, or
+// multiple metadata records selected from indexes) from becoming unexpectedly large.
+pub(crate) const MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
 
 pub enum InputData {
     Mapped(Mmap),
@@ -997,6 +996,22 @@ pub(crate) fn remote_scan_opt_in_suffix() -> &'static str {
     "pass --allow-remote-scan to continue"
 }
 
+pub(crate) fn require_remote_indexed_read_budget(
+    total_bytes: u64,
+    options: SourceOptions,
+    description: &str,
+) -> Result<()> {
+    if options.allow_remote_scan || total_bytes <= MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN {
+        return Ok(());
+    }
+    bail!(
+        "{description} would read {} (exceeds {} cap without --allow-remote-scan); {}",
+        human_bytes(total_bytes),
+        human_bytes(MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN),
+        remote_scan_opt_in_suffix()
+    );
+}
+
 fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()> {
     if options.allow_remote_scan {
         return Ok(());
@@ -1092,14 +1107,7 @@ fn read_summary_bytes_from_remote(
     }
     let summary_len = usize::try_from(footer_start - footer.summary_start)
         .context("remote summary section is too large to read on this platform")?;
-    if summary_len > MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN && !options.allow_remote_scan {
-        bail!(
-            "remote summary section is {} (exceeds {} cap without --allow-remote-scan); {}",
-            human_bytes(summary_len as u64),
-            human_bytes(MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN as u64),
-            remote_scan_opt_in_suffix()
-        );
-    }
+    require_remote_indexed_read_budget(summary_len as u64, options, "Remote summary section")?;
 
     // `[summary_start, footer_start)` is the summary + summary offset region. The
     // portion at or after `tail.start` is already in the prefetched tail; only the
@@ -1212,6 +1220,7 @@ mod tests {
     use std::thread;
 
     use super::load_path;
+    use crate::render::human_bytes;
     use mcap::records;
     use object_store::ObjectStoreExt;
 
@@ -1753,7 +1762,8 @@ mod tests {
 
     #[test]
     fn remote_summary_read_requires_scan_for_oversized_summary_section() {
-        let len = super::MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN
+        let len = usize::try_from(super::MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN)
+            .expect("remote indexed budget should fit usize")
             + crate::parse::FOOTER_RECORD_AND_END_MAGIC_LEN
             + mcap::MAGIC.len()
             + 1;
@@ -1777,6 +1787,21 @@ mod tests {
         let message = format!("{err:#}");
         assert!(message.contains("Remote summary section"));
         assert!(message.contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn remote_indexed_read_budget_requires_scan_for_oversized_total() {
+        let err = super::require_remote_indexed_read_budget(
+            super::MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN + 1,
+            super::SourceOptions::default(),
+            "remote metadata records",
+        )
+        .expect_err("oversized indexed read should require scan opt-in");
+        assert!(err.to_string().contains("remote metadata records"));
+        assert!(err
+            .to_string()
+            .contains(&human_bytes(super::MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN)));
+        assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
     #[test]

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1785,7 +1785,7 @@ mod tests {
                 Err(err) => err,
             };
         let message = format!("{err:#}");
-        assert!(message.contains("remote summary section"));
+        assert!(message.contains("Remote summary section"));
         assert!(message.contains("--allow-remote-scan"));
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -23,7 +23,7 @@ pub const PLEASE_SUPPLY_FILE: &str = "please supply a file. see --help for usage
 // the summary section. One read proves range support (for HTTP), discovers the file
 // size via `Content-Range`, and in the common case already contains the whole summary
 // section (footer + summary + summary offset records). When the summary is larger than
-// this, exactly one additional range request back-fills the missing prefix. 256 KiB
+// this, exactly one additional range request back-fills the missing prefix. Roughly 262 kB
 // comfortably covers the summaries of typical multi-hundred-MB to low-GB files while
 // keeping the per-open transfer small on bandwidth-constrained links.
 const REMOTE_SUMMARY_TAIL_BYTES: u64 = 256 * 1024;

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1107,7 +1107,7 @@ fn read_summary_bytes_from_remote(
     }
     let summary_len = usize::try_from(footer_start - footer.summary_start)
         .context("remote summary section is too large to read on this platform")?;
-    require_remote_indexed_read_budget(summary_len as u64, options, "Remote summary section")?;
+    require_remote_indexed_read_budget(summary_len as u64, options, "remote summary section")?;
 
     // `[summary_start, footer_start)` is the summary + summary offset region. The
     // portion at or after `tail.start` is already in the prefetched tail; only the
@@ -1785,7 +1785,7 @@ mod tests {
                 Err(err) => err,
             };
         let message = format!("{err:#}");
-        assert!(message.contains("Remote summary section"));
+        assert!(message.contains("remote summary section"));
         assert!(message.contains("--allow-remote-scan"));
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -23,18 +23,18 @@ pub const PLEASE_SUPPLY_FILE: &str = "please supply a file. see --help for usage
 // the summary section. One read proves range support (for HTTP), discovers the file
 // size via `Content-Range`, and in the common case already contains the whole summary
 // section (footer + summary + summary offset records). When the summary is larger than
-// this, exactly one additional range request back-fills the missing prefix. Roughly 262 kB
+// this, exactly one additional range request back-fills the missing prefix. 250 kB
 // comfortably covers the summaries of typical multi-hundred-MB to low-GB files while
 // keeping the per-open transfer small on bandwidth-constrained links.
-const REMOTE_SUMMARY_TAIL_BYTES: u64 = 256 * 1024;
+const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
 // Guards remote summary discovery against corrupt or hostile footers that point
 // `summary_start` near the beginning of a large file, which would otherwise turn
 // an index-only operation into a near-full-file range read without opt-in.
-const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 16 * 1024 * 1024;
+const MAX_REMOTE_SUMMARY_BYTES_WITHOUT_SCAN: usize = 20_000_000;
 // Bounds aggregate metadata body reads for list/multi-match metadata commands.
 // Single indexed metadata/attachment records are deliberately uncapped beyond
 // the remote file size because they are explicit user-selected record reads.
-pub(crate) const MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN: u64 = 64 * 1024 * 1024;
+pub(crate) const MAX_REMOTE_METADATA_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
 
 pub enum InputData {
     Mapped(Mmap),

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -68,7 +68,7 @@ fn mcap(args: &[&str]) -> Output {
 /// Run the `mcap` binary with `args`, feeding `stdin` through a (non-seekable) pipe.
 ///
 /// Writes the whole payload before draining stdout, so it must only be used with small inputs:
-/// a payload large enough to fill the OS pipe buffer (~66 kB) while the child is blocked
+/// a payload large enough to fill the OS pipe buffer while the child is blocked
 /// writing stdout would deadlock. All current callers pipe a few hundred bytes.
 fn mcap_with_stdin(args: &[&str], stdin: &[u8]) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_mcap"))

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -68,7 +68,7 @@ fn mcap(args: &[&str]) -> Output {
 /// Run the `mcap` binary with `args`, feeding `stdin` through a (non-seekable) pipe.
 ///
 /// Writes the whole payload before draining stdout, so it must only be used with small inputs:
-/// a payload large enough to fill the OS pipe buffer (~64 KiB) while the child is blocked
+/// a payload large enough to fill the OS pipe buffer (~66 kB) while the child is blocked
 /// writing stdout would deadlock. All current callers pipe a few hundred bytes.
 fn mcap_with_stdin(args: &[&str], stdin: &[u8]) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_mcap"))

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -105,10 +105,10 @@ Report summary statistics on an MCAP file:
     start:       2017-03-22T02:26:20.103843113Z (1490149580.103843113)
     end:         2017-03-22T02:26:27.884601617Z (1490149587.884601617)
     compression:
-    	zstd: [14/14 chunks] [119.10 MiB/58.61 MiB (50.79%)] [7.53 MiB/sec]
+    	zstd: [14/14 chunks] [124.89 MB/61.46 MB (50.79%)] [7.90 MB/s]
     chunks:
-    	max uncompressed size: 9.20 MiB
-    	max compressed size: 4.54 MiB
+    	max uncompressed size: 9.65 MB
+    	max compressed size: 4.76 MB
     	overlaps: no
     channels:
     	(0) /diagnostics              52 msgs (6.6..6.7Hz)    : diagnostic_msgs/DiagnosticArray [ros1msg]
@@ -154,10 +154,10 @@ The `mcap` CLI can read files over **HTTP(S)** and from object stores: **Amazon 
     start:       2017-03-22T02:26:20.103843113Z (1490149580.103843113)
     end:         2017-03-22T02:26:27.884601617Z (1490149587.884601617)
     compression:
-    	zstd: [14/14 chunks] [119.10 MiB/58.61 MiB (50.79%)] [7.53 MiB/sec]
+    	zstd: [14/14 chunks] [124.89 MB/61.46 MB (50.79%)] [7.90 MB/s]
     chunks:
-    	max uncompressed size: 9.20 MiB
-    	max compressed size: 4.54 MiB
+    	max uncompressed size: 9.65 MB
+    	max compressed size: 4.76 MB
     	overlaps: no
     channels:
     	(0) /diagnostics              52 msgs (6.6..6.7Hz)    : diagnostic_msgs/DiagnosticArray [ros1msg]


### PR DESCRIPTION
### Changelog

CLI now consistently uses SI units (`kB`, `MB`, `GB`) and throughput uses `/s` in all output.

### Docs

Updated CLI guide examples to match SI output.

### Description

Standardizes CLI human-readable byte formatter on decimal SI prefixes and updates `mcap info` throughput labels from `/sec` to `/s`. This aligns CLI output with modern conventions.

Additionally, update CLI-owned policy and safety values to use use decimal byte counts.
- Remote indexed-read cap is now 100 MB, shared by the summary section and aggregate metadata body reads. Summaries should normally be only a few MB, and metadata is usually tiny, but corrupt or unusual indexes should not make an indexed command silently fetch a very large range without `--allow-remote-scan`.
- Metadata uses the same cap rather than a separate metadata-specific limit. `list metadata` is aggregate, so it checks the total indexed metadata record bytes; `get metadata NAME` checks the total only when multiple matching records are merged.
- Single indexed metadata reads and attachment reads remain uncapped because they are explicit user-selected records. Raw byte-count columns and writer chunk-size defaults remain unchanged.
- Default chunk size for writing is still 1 MiB, set by library defaults.