### PR TITLE
cli: v0.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log fil
 - **Conformance tests** orchestrate cross-language testing via the TypeScript harness: `yarn test:conformance:generate-inputs && yarn test:conformance`. They require Git LFS data and pre-built binaries for each target language.
 - **Releasing** — see [RELEASING.md](./RELEASING.md) for the release process for each language.
 
+## Pull requests
+
+PR titles should start with a lowercase keyword prefix followed by a colon, usually the package or subsystem being edited, such as `cli:`, `rust:`, `python:`, `go:`, `typescript:`, `cpp:`, `swift:`, `ci:`, or `docs:`.
+
 ## TypeScript
 
 **Prerequisites:** Node.js ≥ 18.12 with `corepack enable` (activates the Yarn version pinned via `packageManager` in `package.json`). Yarn Classic (1.x) is incompatible — the repo requires Yarn 4.x.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "mcap-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "binrw",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ CI will build the appropriate packages once tags are pushed, as described below.
 
 ## Release notes
 
-Draft release notes from the diff between the previous package tag and the new release commit. Review the actual changes and PR discussions rather than relying on commit titles alone, omit unrelated commits, and group user-facing bullets under "New features", "Bug fixes", and "Performance" when applicable. Include the relevant PR number(s) in each bullet.
+Draft release notes from the diff between the previous package tag and the new release commit. Review the actual diffs rather than relying on commit titles alone, omit unrelated commits, and group user-facing bullets under "New features", "Bug fixes", and "Performance" when applicable. Include the relevant PR number(s) in parentheses after each bullet.
 
 ## Go library
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,10 @@ Release numbering follows a major.minor.patch format, abbreviated as "X.Y.Z" bel
 
 CI will build the appropriate packages once tags are pushed, as described below.
 
+## Release notes
+
+Draft release notes from the diff between the previous package tag and the new release commit. Review the actual changes and PR discussions rather than relying on commit titles alone, omit unrelated commits, and group user-facing bullets under "New features", "Bug fixes", and "Performance" when applicable. Include the relevant PR number(s) in each bullet.
+
 ## Go library
 
 1. Update the `Version` in go/mcap/version.go

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mcap-cli"
 description = "MCAP CLI"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -98,7 +98,7 @@ Report summary statistics on an MCAP file:
 <!-- cspell: disable -->
 
     $ mcap info demo.mcap
-    library:     mcap-cli/0.1.0 mcap-rust/0.25.0
+    library:     mcap-cli/0.2.0 mcap-rust/0.25.0
     profile:     ros1
     messages:    1606
     duration:    7.780758504s
@@ -147,7 +147,7 @@ The `mcap` CLI can read files over **HTTP(S)** and from object stores: **Amazon 
 <!-- cspell: disable -->
 
     $ mcap info gs://your-remote-bucket/demo.mcap
-    library:     mcap-cli/0.1.0 mcap-rust/0.25.0
+    library:     mcap-cli/0.2.0 mcap-rust/0.25.0
     profile:     ros1
     messages:    1606
     duration:    7.780758504s


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
Release `mcap-cli` 0.2.0.

### Docs
Updated the CLI guide `mcap info` examples to show `mcap-cli/0.2.0`, added concise `RELEASING.md` guidance for drafting release notes from tag diffs, and documented the root `AGENTS.md` PR title prefix convention.

### Description
Bumps the Rust CLI crate and workspace lockfile from 0.1.0 to 0.2.0.

Release notes reviewed from `releases/mcap-cli/v0.1.0..HEAD`:

#### New features
- `mcap list attachments`, `mcap list metadata`, `mcap get attachment`, and `mcap get metadata` can read local MCAP files that omit summary/index records by scanning when needed. (#1723)
- `mcap merge` now guarantees log-time ordered output, using command-line file order and per-file input order as stable tie-breakers for equal timestamps. (#1730)

#### Bug fixes
- `mcap doctor` now reports invalid `Statistics` channel counts that lack prior summary `Channel` records. (#1722)
- `mcap info` now reports numeric counts for files without a `Statistics` record instead of `unknown` when the data can be derived. (#1725)
- `mcap doctor` now treats spec-legal out-of-order top-level message times as warnings by default, while `--strict-message-order` still errors. (#1724)
- Output-writing commands now reject local output paths that resolve to the input file before truncating or writing. (#1729)
- Tarball/source-archive builds now stamp the short commit SHA into `mcap --version` instead of reporting `unknown`. (#1727)
- `mcap doctor -v` no longer emits the low-value `Examining ...` progress line on clean diagnostics. (#1731)
- Human-readable byte output now consistently uses decimal SI units (`kB`, `MB`, `GB`), and throughput labels use `/s`. (#1733)

#### Performance
- Added Criterion command benchmarks for `merge`, `filter`, `sort`, `compress`, and `decompress`; this is benchmark coverage rather than a runtime performance change. (#1732)

Reviewed and excluded `go: Bump version to 1.9.0` because it has no CLI behavior or packaging impact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e22f9c36-c871-4f87-a3e9-3c22712aec75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e22f9c36-c871-4f87-a3e9-3c22712aec75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

