### PR TITLE
docs(python): add a metadata-records example (writer + reader)

### DIFF
--- a/python/examples/metadata/reader.py
+++ b/python/examples/metadata/reader.py
@@ -1,0 +1,24 @@
+"""Read metadata records back from an MCAP file.
+
+Iterates the file's metadata records and prints each one, decoding any
+JSON-encoded value (see writer.py) back into structured data.
+
+Usage:
+
+    python reader.py input.mcap
+"""
+import json
+import sys
+
+from mcap.reader import make_reader
+
+with open(sys.argv[1], "rb") as f:
+    reader = make_reader(f)
+    for metadata in reader.iter_metadata():
+        print(f"metadata '{metadata.name}':")
+        for key, value in metadata.metadata.items():
+            try:
+                decoded = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                decoded = value
+            print(f"  {key} = {decoded}")

--- a/python/examples/metadata/writer.py
+++ b/python/examples/metadata/writer.py
@@ -1,0 +1,39 @@
+"""Write an MCAP file with a metadata record carrying a structured record.
+
+MCAP metadata records are a lightweight, message-independent way to attach
+named key-value information to a file: run configuration, calibration, or, as
+here, a robot's intent / capability manifest. Metadata values are strings, so a
+structured (nested) record is stored as a single JSON-encoded string value.
+
+Usage:
+
+    python writer.py output.mcap
+"""
+import json
+import sys
+from time import time_ns
+
+from mcap.writer import Writer
+
+with open(sys.argv[1], "wb") as stream:
+    writer = Writer(stream)
+    writer.start()
+
+    # A structured record to attach to the file. Because metadata values must
+    # be strings, nested data is JSON-encoded into a single field; flat string
+    # fields can be stored directly.
+    intent_record = {
+        "robot_id": "demo-1",
+        "capabilities": ["move_to", "grasp"],
+        "max_velocity_m_s": 1.5,
+    }
+    writer.add_metadata(
+        "robot_intent",
+        {
+            "schema": "example/robot-intent@1",
+            "created_ns": str(time_ns()),
+            "record": json.dumps(intent_record),
+        },
+    )
+
+    writer.finish()


### PR DESCRIPTION
### What

Adds a small Python example, `python/examples/metadata/{writer,reader}.py`, demonstrating MCAP **metadata records**.

### Why

Metadata records are a lightweight, message-independent way to attach named key-value information to a file (run configuration, calibration, a robot intent / capability manifest). The Python API (`Writer.add_metadata`, `reader.iter_metadata()`) already supports them, but there is no example showing the round-trip, so the feature is easy to miss. This mirrors the existing `raw/` example pair and requires no library change.

### Details

- `writer.py`: writes a file with a `robot_intent` metadata record. Since metadata values are strings, a nested record is JSON-encoded into one field, with flat string fields (`schema`, `created_ns`) stored directly.
- `reader.py`: iterates `reader.iter_metadata()` and decodes any JSON-encoded value back to structured data.

### Verified

Running `python writer.py out.mcap && python reader.py out.mcap` round-trips the record:

```
metadata 'robot_intent':
  schema = example/robot-intent@1
  created_ns = 1781613179758918100
  record = {'robot_id': 'demo-1', 'capabilities': ['move_to', 'grasp'], 'max_velocity_m_s': 1.5}
```
