### PR TITLE
doc: Fix C++ docs

### DIFF
--- a/cpp/docs/CMakeLists.txt
+++ b/cpp/docs/CMakeLists.txt
@@ -8,5 +8,10 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/generators)
 
 find_package(mcap REQUIRED)
 
+# hdoc skips symbols from system headers. CMakeDeps exposes mcap as an IMPORTED
+# target, whose include dirs CMake would otherwise pass as -isystem, hiding
+# every mcap symbol from hdoc. Force normal -I includes instead.
+set(CMAKE_NO_SYSTEM_FROM_IMPORTED ON)
+
 add_library(docs-entrypoint docs-entrypoint.cpp)
 target_link_libraries(docs-entrypoint mcap::mcap)


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
In #1706, we migrated to Conan 2, and broke the publication of C++ docs
in the process. The problem is that hdoc only documents symbols declared
in non-system headers, and that commit changed how the mcap headers are
treated.

This change updates cmake to stop treating imported headers as system
headers. It does that for all imported targets (including lz4 and zstd),
but that's OK, because hdoc filters symbols by directory (/mcap/cpp).

### Links
Fixes: FG-14880