### PR TITLE
fix __init__ import

### DIFF
--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -2,11 +2,16 @@ import struct
 import zlib
 from collections import defaultdict
 from enum import Enum, Flag, auto
+from importlib.metadata import PackageNotFoundError, version
 from io import BufferedWriter, RawIOBase
 from typing import IO, Any, Dict, List, OrderedDict, Union
 
-from . import __version__
 from .exceptions import UnsupportedCompressionError
+
+try:
+    __version__ = version("mcap")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 try:
     import lz4.frame  # type: ignore

--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -5,7 +5,7 @@ from enum import Enum, Flag, auto
 from io import BufferedWriter, RawIOBase
 from typing import IO, Any, Dict, List, OrderedDict, Union
 
-from .__init__ import __version__
+from mcap import __version__
 from .exceptions import UnsupportedCompressionError
 
 try:

--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -5,7 +5,7 @@ from enum import Enum, Flag, auto
 from io import BufferedWriter, RawIOBase
 from typing import IO, Any, Dict, List, OrderedDict, Union
 
-from mcap import __version__
+from . import __version__
 from .exceptions import UnsupportedCompressionError
 
 try:


### PR DESCRIPTION
### Changelog
Fixes an import issue that was causing mypy errors

### Docs

None

### Description
Fixes: DB-675

https://github.com/foxglove/mcap/pull/1536 introduced a change that causes mypy to fail due to loading the same module under two names. This PR reverts the import change that causes that error.

### Testing

```
# One-time: scratch venv with just the relevant packages
python3 -m venv /tmp/mypy-mcap-env
/tmp/mypy-mcap-env/bin/pip install "mypy==1.15" "./python/mcap"

# Repro file
printf 'import mcap\nfrom mcap.writer import Writer\n' > /tmp/mcap_repro.py

# Repro mypy invocation
/tmp/mypy-mcap-env/bin/mypy --follow-imports=normal /tmp/mcap_repro.py
Success: no issues found in 1 source file
```

