### PR TITLE
cli: reduce compress chunk default

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -31,6 +31,8 @@ pub(crate) static LIBRARY_IDENTIFIER: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
+pub(crate) const DEFAULT_COMPRESS_CHUNK_SIZE: u64 = 768 * 1024;
+
 #[derive(Parser, Debug, PartialEq, Eq)]
 #[command(
     name = "mcap",
@@ -120,7 +122,7 @@ pub struct CompressCommand {
     pub output: Option<PathBuf>,
 
     /// Target uncompressed chunk size for output
-    #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
+    #[arg(long = "chunk-size", default_value_t = DEFAULT_COMPRESS_CHUNK_SIZE)]
     pub chunk_size: u64,
 
     /// Compression algorithm for output file: zstd, lz4, or none

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -471,7 +471,7 @@ mod tests {
             Command::Compress(CompressCommand {
                 file: Some("in.mcap".into()),
                 output: None,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                chunk_size: 768 * 1024,
                 compression: "zstd".to_string(),
             })
         );


### PR DESCRIPTION
### Changelog
`mcap compress` now defaults to a 768 KiB target chunk size.

### Docs

None

### Description

`mcap compress` previously inherited the shared writer default chunk size of 1 MiB. For index-in-place use cases, smaller chunks avoid requiring readers to fetch and decompress larger ranges than needed. This changes only the `compress` command default to 768 KiB while preserving explicit `--chunk-size` behavior and other writer command defaults.

Validated with `cargo test -p mcap-cli` and `cargo fmt --all -- --check`. `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings` could not run because this environment does not have the `clippy` cargo command installed and does not include `rustup` to add it.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

`mcap compress` defaulted `--chunk-size` to 1048576 bytes.

</td><td>

`mcap compress` defaults `--chunk-size` to 786432 bytes.

</td></tr></table>
