### PR TITLE
docs: remove remaining Go CLI references

### DIFF
--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -20,7 +20,7 @@ For more installation options and full usage documentation, see https://mcap.dev
 
 ## Development
 
-The CLI is written in Rust using the [mcap crate](../mcap).
+The CLI is built on the [mcap crate](../mcap).
 
 To build from source:
 

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -20,7 +20,7 @@ For more installation options and full usage documentation, see https://mcap.dev
 
 ## Development
 
-The CLI is built on the [mcap crate](../mcap).
+The CLI is written in Rust using the [mcap crate](../mcap).
 
 To build from source:
 

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -12,8 +12,8 @@ Run the full benchmark target:
 cargo bench -p mcap-cli --bench commands
 ```
 
-Cargo provides the bench-built `mcap` binary by default. Set `MCAP_CLI_BENCH_BIN` to compare a
-different binary. Criterion writes reports under `target/criterion/`. Use Criterion's benchmark
+Cargo provides the bench-built `mcap` binary by default. Set `MCAP_CLI_BENCH_BIN` to use a
+different `mcap` binary path. Criterion writes reports under `target/criterion/`. Use Criterion's benchmark
 filter to run a single command, input mode, or specific case:
 
 ```sh

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -127,13 +127,13 @@ fn exit_code_2_on_unknown_global_flag() {
     let dir = TempDir::new().unwrap();
     let path = write_temp(&dir, "in.mcap", &build_mcap(1));
     // Unknown global flags are rejected before command dispatch.
-    let output = mcap(&["--config", "x.yaml", "info", path_str(&path)]);
+    let output = mcap(&["--not-a-real-flag", "info", path_str(&path)]);
     assert_eq!(output.status.code(), Some(2));
 }
 
 #[test]
 fn exit_code_2_on_version_subcommand() {
-    // Version is exposed as a global flag, so `version` is an unrecognized argument (exit 2).
+    // `version` is not a subcommand; use the global `--version` flag instead.
     assert_eq!(mcap(&["version"]).status.code(), Some(2));
     assert!(mcap(&["--version"]).status.success());
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

None

### Docs

- Reword CLI benchmark docs so `MCAP_CLI_BENCH_BIN` is documented as a custom binary path, not a comparison hook against another implementation.
- Update CLI end-to-end tests to use a generic unknown flag instead of the legacy Go-only `--config` flag.

### Description

The legacy Go CLI was already removed from the repository in #1721, with public docs updated in #1683. This change finishes the cleanup by removing the last references that still implied a migration or Go-specific compatibility behavior in developer-facing docs and tests.

No functional CLI behavior changes; this is documentation and test-comment cleanup only.

### Testing

- [ ] `cargo test -p mcap-cli --test cli exit_code_2_on` passes locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ea27755-a434-4dff-84a3-53c99eb006e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ea27755-a434-4dff-84a3-53c99eb006e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

