### PR TITLE
cli: add Apache Arrow IPC support to mcap convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +112,180 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
+name = "arrow"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ee4d470eab1a021bc4b63fa2b2c15d572892bf227b0a982d3b755a6c662b5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
+
+[[package]]
+name = "arrow-select"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +300,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -363,6 +560,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +822,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +997,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1149,6 +1377,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1444,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1260,6 +1551,7 @@ name = "mcap-cli"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "binrw",
  "bzip2",
  "chrono",
@@ -1320,10 +1612,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1332,6 +1652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1883,6 +2204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2581,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "arrow-cast",
  "arrow-data",
  "arrow-ipc",
+ "arrow-json",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
@@ -155,6 +156,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -220,6 +222,31 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f47e0e7a284e1f3707a780dc8cd5451b1614e9e398ea2d9ca03c7a2fe9a9ed"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
@@ -475,6 +502,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -1799,6 +1836,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2479,12 @@ dependencies = [
  "termcolor",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -32,6 +32,7 @@ object_store = { version = "0.13.2", features = ["aws", "gcp", "azure", "http"] 
 tokio = { version = "1.52.3", features = ["net", "rt", "time"] }
 url = "2.5.8"
 futures-util = "0.3.32"
+arrow = { version = "59.0.0", default-features = false, features = ["ipc"] }
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -32,7 +32,7 @@ object_store = { version = "0.13.2", features = ["aws", "gcp", "azure", "http"] 
 tokio = { version = "1.52.3", features = ["net", "rt", "time"] }
 url = "2.5.8"
 futures-util = "0.3.32"
-arrow = { version = "59.0.0", default-features = false, features = ["ipc"] }
+arrow = { version = "59.0.0", default-features = false, features = ["ipc", "json", "chrono-tz"] }
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -78,7 +78,7 @@ pub enum Command {
     Compress(CompressCommand),
     /// Convert supported input files to MCAP
     #[command(
-        long_about = "Convert supported input files to MCAP.\n\nSupported inputs:\n  .bag  ROS 1 bag\n  .db3  ROS 2 SQLite db3"
+        long_about = "Convert supported input files to MCAP.\n\nSupported inputs:\n  .bag                   ROS 1 bag\n  .db3                   ROS 2 SQLite db3\n  .arrow/.feather/.ipc   Apache Arrow IPC (file or stream)"
     )]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file
@@ -310,6 +310,35 @@ pub enum CompressionFormat {
     None,
 }
 
+/// Unit for interpreting integer-typed time fields when converting Arrow inputs.
+///
+/// Arrow `Timestamp`/`Date` fields carry their own unit and ignore this flag; it
+/// only applies when the selected time field is a plain integer column.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimestampUnit {
+    /// Seconds since the Unix epoch
+    S,
+    /// Milliseconds since the Unix epoch
+    Ms,
+    /// Microseconds since the Unix epoch
+    Us,
+    /// Nanoseconds since the Unix epoch
+    Ns,
+}
+
+impl TimestampUnit {
+    /// Number of nanoseconds represented by one unit, used to scale
+    /// integer-typed time fields to MCAP nanosecond timestamps.
+    pub fn nanos_per_unit(self) -> i128 {
+        match self {
+            Self::S => 1_000_000_000,
+            Self::Ms => 1_000_000,
+            Self::Us => 1_000,
+            Self::Ns => 1,
+        }
+    }
+}
+
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct ConvertCommand {
     /// Local path to the input file
@@ -333,6 +362,32 @@ pub struct ConvertCommand {
     /// Write records outside of chunks
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
+
+    /// [Arrow inputs] Topic name for the converted channel. Defaults to the input file stem.
+    #[arg(long)]
+    pub topic: Option<String>,
+
+    /// [Arrow inputs] Schema name recorded in the MCAP Schema record. Defaults to the topic.
+    #[arg(long)]
+    pub schema_name: Option<String>,
+
+    /// [Arrow inputs] Field used for each message's log_time. Defaults to a field named
+    /// `log_time`, otherwise the first timestamp/date field in schema order.
+    #[arg(long)]
+    pub log_time_field: Option<String>,
+
+    /// [Arrow inputs] Field used for each message's publish_time. Defaults to a field named
+    /// `publish_time`, otherwise the resolved log_time.
+    #[arg(long)]
+    pub publish_time_field: Option<String>,
+
+    /// [Arrow inputs] Unit for integer-typed time fields (timestamp/date fields ignore this).
+    #[arg(long, value_enum, default_value = "ns")]
+    pub timestamp_unit: TimestampUnit,
+
+    /// [Arrow inputs] Number of input rows packed into each MCAP message.
+    #[arg(long, default_value_t = 1)]
+    pub rows_per_message: u64,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -2204,28 +2204,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn arrow_json_encodes_record_batch_rows() {
-        use arrow::array::{ArrayRef, Int64Array, StringArray};
+    // Produce the encapsulated schema + record batch messages exactly as
+    // `mcap convert` writes them (a bare encapsulated `RecordBatch`, with the
+    // schema stored separately).
+    fn arrow_message_bytes(batch: &arrow::record_batch::RecordBatch) -> (Vec<u8>, Vec<u8>) {
         use arrow::ipc::writer::{
             write_message, CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions,
         };
-        use arrow::record_batch::RecordBatch;
 
-        let batch = RecordBatch::try_from_iter(vec![
-            (
-                "value",
-                Arc::new(Int64Array::from(vec![10, 20])) as ArrayRef,
-            ),
-            (
-                "label",
-                Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef,
-            ),
-        ])
-        .expect("record batch");
-
-        // Produce the encapsulated schema + record batch messages exactly as
-        // `mcap convert` writes them.
         let generator = IpcDataGenerator {};
         let options = IpcWriteOptions::default();
         let mut tracker = DictionaryTracker::new(false);
@@ -2239,24 +2225,47 @@ mod tests {
         write_message(&mut schema_bytes, enc_schema, &options).expect("schema message");
         let mut compression = CompressionContext::default();
         let (_dictionaries, enc_batch) = generator
-            .encode(&batch, &mut tracker, &options, &mut compression)
+            .encode(batch, &mut tracker, &options, &mut compression)
             .expect("encode batch");
         let mut batch_bytes = Vec::new();
         write_message(&mut batch_bytes, enc_batch, &options).expect("batch message");
+        (schema_bytes, batch_bytes)
+    }
 
+    fn arrow_channel(schema_bytes: Vec<u8>) -> Arc<mcap::Channel<'static>> {
         let schema = Arc::new(mcap::Schema {
             id: 1,
             name: "events".to_string(),
             encoding: "arrow".to_string(),
             data: Cow::Owned(schema_bytes),
         });
-        let channel = Arc::new(mcap::Channel {
+        Arc::new(mcap::Channel {
             id: 1,
             topic: "/arrow".to_string(),
             schema: Some(schema),
             message_encoding: "arrow".to_string(),
             metadata: BTreeMap::new(),
-        });
+        })
+    }
+
+    #[test]
+    fn arrow_json_encodes_record_batch_rows() {
+        use arrow::array::{ArrayRef, Int64Array, StringArray};
+        use arrow::record_batch::RecordBatch;
+
+        let batch = RecordBatch::try_from_iter(vec![
+            (
+                "value",
+                Arc::new(Int64Array::from(vec![10, 20])) as ArrayRef,
+            ),
+            (
+                "label",
+                Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef,
+            ),
+        ])
+        .expect("record batch");
+        let (schema_bytes, batch_bytes) = arrow_message_bytes(&batch);
+        let channel = arrow_channel(schema_bytes);
 
         let mut transcoders = JsonTranscoders::default();
         let encoded = transcoders
@@ -2265,6 +2274,44 @@ mod tests {
         assert_eq!(
             String::from_utf8(encoded.into_owned()).expect("valid utf8"),
             r#"[{"value":10,"label":"a"},{"value":20,"label":"b"}]"#
+        );
+    }
+
+    #[test]
+    fn arrow_json_reuses_cached_decoder_across_messages() {
+        use arrow::array::{ArrayRef, Int64Array, StringArray};
+        use arrow::record_batch::RecordBatch;
+
+        let make_batch = |values: Vec<i64>, labels: Vec<&'static str>| {
+            RecordBatch::try_from_iter(vec![
+                ("value", Arc::new(Int64Array::from(values)) as ArrayRef),
+                ("label", Arc::new(StringArray::from(labels)) as ArrayRef),
+            ])
+            .expect("record batch")
+        };
+
+        // Both messages share one schema record / channel (same schema id), so
+        // the second decode must reuse the decoder primed by the first.
+        let batch1 = make_batch(vec![10, 20], vec!["a", "b"]);
+        let batch2 = make_batch(vec![30], vec!["c"]);
+        let (schema_bytes, batch1_bytes) = arrow_message_bytes(&batch1);
+        let (_schema_bytes2, batch2_bytes) = arrow_message_bytes(&batch2);
+        let channel = arrow_channel(schema_bytes);
+
+        let mut transcoders = JsonTranscoders::default();
+        let first = transcoders
+            .encode(&channel, &batch1_bytes)
+            .expect("first arrow message should encode");
+        assert_eq!(
+            String::from_utf8(first.into_owned()).expect("valid utf8"),
+            r#"[{"value":10,"label":"a"},{"value":20,"label":"b"}]"#
+        );
+        let second = transcoders
+            .encode(&channel, &batch2_bytes)
+            .expect("second arrow message should encode via cached decoder");
+        assert_eq!(
+            String::from_utf8(second.into_owned()).expect("valid utf8"),
+            r#"[{"value":30,"label":"c"}]"#
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -774,11 +774,58 @@ impl JsonTranscoders {
                     .with_context(|| format!("failed to transcode {} record on {}", schema.name, channel.topic))?;
                 Ok(Cow::Owned(json))
             }
+            "arrow" => {
+                let json = encode_arrow_json(schema.data.as_ref(), data).with_context(|| {
+                    format!("failed to encode Arrow message on {} as JSON", channel.topic)
+                })?;
+                Ok(Cow::Owned(json))
+            }
             encoding => bail!(
-                "JSON output only supported for ros1msg, protobuf, and jsonschema schemas. Found: {encoding}"
+                "JSON output only supported for ros1msg, protobuf, jsonschema, and arrow schemas. Found: {encoding}"
             ),
         }
     }
+}
+
+/// Arrow IPC stream end-of-stream marker (continuation + zero metadata length).
+const ARROW_EOS: [u8; 8] = [0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0];
+
+/// Decode an `arrow`-encoded message (a bare encapsulated `RecordBatch`) against
+/// its Schema record and render the rows as a JSON array.
+///
+/// The MCAP Schema record holds an encapsulated Arrow IPC `Schema` message and
+/// each message holds an encapsulated `RecordBatch`; concatenating them with a
+/// stream terminator reconstructs a minimal Arrow IPC stream we can decode.
+fn encode_arrow_json(schema_data: &[u8], data: &[u8]) -> Result<Vec<u8>> {
+    use std::io::Cursor;
+
+    use arrow::ipc::reader::StreamReader;
+    use arrow::json::writer::{JsonArray, WriterBuilder};
+
+    let mut stream = Vec::with_capacity(schema_data.len() + data.len() + ARROW_EOS.len());
+    stream.extend_from_slice(schema_data);
+    stream.extend_from_slice(data);
+    stream.extend_from_slice(&ARROW_EOS);
+
+    let reader = StreamReader::try_new(Cursor::new(stream), None)
+        .context("failed to read Arrow schema and message")?;
+
+    let mut buf = Vec::new();
+    {
+        let mut json_writer = WriterBuilder::new()
+            .with_explicit_nulls(true)
+            .build::<_, JsonArray>(&mut buf);
+        for batch in reader {
+            let batch = batch.context("failed to decode Arrow record batch")?;
+            json_writer
+                .write(&batch)
+                .context("failed to encode Arrow record batch as JSON")?;
+        }
+        json_writer
+            .finish()
+            .context("failed to finalize Arrow JSON")?;
+    }
+    Ok(buf)
 }
 
 fn encode_schemaless_json<'a>(message_encoding: &str, data: &'a [u8]) -> Result<Cow<'a, [u8]>> {
@@ -2123,6 +2170,70 @@ mod tests {
             r#"{"topic":"/demo","sequence":1,"log_time":0.000000042,"publish_time":0.000000043,"data":{"value":1}}"#
                 .to_string()
                 + "\n"
+        );
+    }
+
+    #[test]
+    fn arrow_json_encodes_record_batch_rows() {
+        use arrow::array::{ArrayRef, Int64Array, StringArray};
+        use arrow::ipc::writer::{
+            write_message, CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions,
+        };
+        use arrow::record_batch::RecordBatch;
+
+        let batch = RecordBatch::try_from_iter(vec![
+            (
+                "value",
+                Arc::new(Int64Array::from(vec![10, 20])) as ArrayRef,
+            ),
+            (
+                "label",
+                Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef,
+            ),
+        ])
+        .expect("record batch");
+
+        // Produce the encapsulated schema + record batch messages exactly as
+        // `mcap convert` writes them.
+        let generator = IpcDataGenerator {};
+        let options = IpcWriteOptions::default();
+        let mut tracker = DictionaryTracker::new(false);
+        let arrow_schema = batch.schema();
+        let enc_schema = generator.schema_to_bytes_with_dictionary_tracker(
+            arrow_schema.as_ref(),
+            &mut tracker,
+            &options,
+        );
+        let mut schema_bytes = Vec::new();
+        write_message(&mut schema_bytes, enc_schema, &options).expect("schema message");
+        let mut compression = CompressionContext::default();
+        let (_dictionaries, enc_batch) = generator
+            .encode(&batch, &mut tracker, &options, &mut compression)
+            .expect("encode batch");
+        let mut batch_bytes = Vec::new();
+        write_message(&mut batch_bytes, enc_batch, &options).expect("batch message");
+
+        let schema = Arc::new(mcap::Schema {
+            id: 1,
+            name: "events".to_string(),
+            encoding: "arrow".to_string(),
+            data: Cow::Owned(schema_bytes),
+        });
+        let channel = Arc::new(mcap::Channel {
+            id: 1,
+            topic: "/arrow".to_string(),
+            schema: Some(schema),
+            message_encoding: "arrow".to_string(),
+            metadata: BTreeMap::new(),
+        });
+
+        let mut transcoders = JsonTranscoders::default();
+        let encoded = transcoders
+            .encode(&channel, &batch_bytes)
+            .expect("arrow should encode");
+        assert_eq!(
+            String::from_utf8(encoded.into_owned()).expect("valid utf8"),
+            r#"[{"value":10,"label":"a"},{"value":20,"label":"b"}]"#
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::io::{self, IsTerminal as _, Write as _};
 use std::sync::Arc;
 
-use anyhow::{bail, Context as _, Result};
+use anyhow::{bail, ensure, Context as _, Result};
 use mcap::sans_io::indexed_reader::ReadOrder;
 use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
 
@@ -723,6 +723,9 @@ fn flush_or_ignore_broken_pipe(writer: &mut impl std::io::Write) -> Result<()> {
 struct JsonTranscoders {
     protobuf_descriptors: HashMap<u16, MessageDescriptor>,
     ros1_transcoders: HashMap<u16, Ros1MessageDef>,
+    // One Arrow stream decoder per schema id, primed with the Schema record so
+    // the schema flatbuffer is parsed once rather than per message.
+    arrow_decoders: HashMap<u16, arrow::ipc::reader::StreamDecoder>,
 }
 
 impl JsonTranscoders {
@@ -775,7 +778,7 @@ impl JsonTranscoders {
                 Ok(Cow::Owned(json))
             }
             "arrow" => {
-                let json = encode_arrow_json(schema.data.as_ref(), data).with_context(|| {
+                let json = self.encode_arrow_json(schema, data).with_context(|| {
                     format!("failed to encode Arrow message on {} as JSON", channel.topic)
                 })?;
                 Ok(Cow::Owned(json))
@@ -785,42 +788,70 @@ impl JsonTranscoders {
             ),
         }
     }
+
+    /// Decode an `arrow`-encoded message (a bare encapsulated `RecordBatch`)
+    /// against its Schema record and render the rows as a JSON array.
+    ///
+    /// The MCAP Schema record holds an encapsulated Arrow IPC `Schema` message
+    /// and each message holds an encapsulated `RecordBatch`. A
+    /// [`StreamDecoder`](arrow::ipc::reader::StreamDecoder) primed with the
+    /// schema (cached per schema id) decodes each message without re-parsing the
+    /// schema flatbuffer.
+    fn encode_arrow_json(&mut self, schema: &mcap::Schema<'_>, data: &[u8]) -> Result<Vec<u8>> {
+        use std::collections::hash_map::Entry;
+
+        use arrow::buffer::Buffer;
+        use arrow::ipc::reader::StreamDecoder;
+
+        let decoder = match self.arrow_decoders.entry(schema.id) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                // Prime a decoder with the Schema record. An Arrow schema
+                // message has a zero-length body, so the decoder only finalizes
+                // it once the first message's bytes arrive — hence we don't (and
+                // can't) assert `schema()` is populated here.
+                let mut decoder = StreamDecoder::new();
+                let mut schema_buf = Buffer::from(schema.data.as_ref());
+                while !schema_buf.is_empty() {
+                    let produced = decoder
+                        .decode(&mut schema_buf)
+                        .context("failed to read Arrow schema record")?;
+                    ensure!(
+                        produced.is_none(),
+                        "Arrow schema record unexpectedly produced a record batch"
+                    );
+                }
+                entry.insert(decoder)
+            }
+        };
+
+        let mut batch_buf = Buffer::from(data);
+        let mut batch = None;
+        while !batch_buf.is_empty() {
+            if let Some(decoded) = decoder
+                .decode(&mut batch_buf)
+                .context("failed to decode Arrow record batch")?
+            {
+                batch = Some(decoded);
+            }
+        }
+        let batch = batch.context("Arrow message did not contain a record batch")?;
+        arrow_batch_to_json(&batch)
+    }
 }
 
-/// Arrow IPC stream end-of-stream marker (continuation + zero metadata length).
-const ARROW_EOS: [u8; 8] = [0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0];
-
-/// Decode an `arrow`-encoded message (a bare encapsulated `RecordBatch`) against
-/// its Schema record and render the rows as a JSON array.
-///
-/// The MCAP Schema record holds an encapsulated Arrow IPC `Schema` message and
-/// each message holds an encapsulated `RecordBatch`; concatenating them with a
-/// stream terminator reconstructs a minimal Arrow IPC stream we can decode.
-fn encode_arrow_json(schema_data: &[u8], data: &[u8]) -> Result<Vec<u8>> {
-    use std::io::Cursor;
-
-    use arrow::ipc::reader::StreamReader;
+/// Render an Arrow `RecordBatch` as a JSON array of row objects.
+fn arrow_batch_to_json(batch: &arrow::record_batch::RecordBatch) -> Result<Vec<u8>> {
     use arrow::json::writer::{JsonArray, WriterBuilder};
-
-    let mut stream = Vec::with_capacity(schema_data.len() + data.len() + ARROW_EOS.len());
-    stream.extend_from_slice(schema_data);
-    stream.extend_from_slice(data);
-    stream.extend_from_slice(&ARROW_EOS);
-
-    let reader = StreamReader::try_new(Cursor::new(stream), None)
-        .context("failed to read Arrow schema and message")?;
 
     let mut buf = Vec::new();
     {
         let mut json_writer = WriterBuilder::new()
             .with_explicit_nulls(true)
             .build::<_, JsonArray>(&mut buf);
-        for batch in reader {
-            let batch = batch.context("failed to decode Arrow record batch")?;
-            json_writer
-                .write(&batch)
-                .context("failed to encode Arrow record batch as JSON")?;
-        }
+        json_writer
+            .write(batch)
+            .context("failed to encode Arrow record batch as JSON")?;
         json_writer
             .finish()
             .context("failed to finalize Arrow JSON")?;

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -1,3 +1,4 @@
+mod arrow_ipc;
 mod ros1_bag;
 mod ros2_db3;
 
@@ -34,13 +35,14 @@ pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
         input.profile(),
     );
 
-    input.convert(materialized_input.path(), &args.output, opts)
+    input.convert(materialized_input.path(), &args.output, opts, &args)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ConvertInput {
     Ros1Bag,
     Ros2Db3,
+    ArrowIpc,
 }
 
 impl ConvertInput {
@@ -53,9 +55,16 @@ impl ConvertInput {
         if extension.eq_ignore_ascii_case("db3") {
             return Ok(Self::Ros2Db3);
         }
+        if extension.eq_ignore_ascii_case("arrow")
+            || extension.eq_ignore_ascii_case("feather")
+            || extension.eq_ignore_ascii_case("ipc")
+            || extension.eq_ignore_ascii_case("arrows")
+        {
+            return Ok(Self::ArrowIpc);
+        }
 
         bail!(
-            "unsupported input file extension for '{}' (expected .bag for ROS 1 bag or .db3 for ROS 2 SQLite db3 input)",
+            "unsupported input file extension for '{}' (expected .bag for ROS 1 bag, .db3 for ROS 2 SQLite db3, or .arrow/.feather/.ipc for Apache Arrow IPC input)",
             path.display()
         );
     }
@@ -64,13 +73,27 @@ impl ConvertInput {
         match self {
             Self::Ros1Bag => "ros1",
             Self::Ros2Db3 => "ros2",
+            // Arrow has no MCAP profile; leave it empty.
+            Self::ArrowIpc => "",
         }
     }
 
-    fn convert(self, input_path: &Path, output_path: &Path, opts: WriteOptions) -> Result<()> {
+    fn convert(
+        self,
+        input_path: &Path,
+        output_path: &Path,
+        opts: WriteOptions,
+        args: &ConvertCommand,
+    ) -> Result<()> {
         match self {
             Self::Ros1Bag => ros1_bag::convert_ros1_bag_file(input_path, output_path, opts),
             Self::Ros2Db3 => ros2_db3::convert_ros2_db3_file(input_path, output_path, opts),
+            Self::ArrowIpc => arrow_ipc::convert_arrow_file(
+                input_path,
+                output_path,
+                opts,
+                &arrow_ipc::ArrowConvertOptions::from_command(args),
+            ),
         }
     }
 }
@@ -286,6 +309,12 @@ size 123\n",
                 chunk_size: 8 * 1024 * 1024,
                 no_crc: true,
                 no_chunks: false,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             },
         )
         .expect_err("missing input should fail");
@@ -306,6 +335,12 @@ size 123\n",
                 chunk_size: 8 * 1024 * 1024,
                 no_crc: true,
                 no_chunks: false,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             },
         )
         .expect_err("same input/output should fail");
@@ -329,6 +364,12 @@ size 123\n",
                 chunk_size: 8 * 1024 * 1024,
                 no_crc: true,
                 no_chunks: false,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             },
         )
         .expect_err("remote convert should require opt-in");
@@ -348,6 +389,12 @@ size 123\n",
                 chunk_size: 8 * 1024 * 1024,
                 no_crc: true,
                 no_chunks: false,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             },
         )
         .expect_err("cloud convert should require opt-in");
@@ -387,6 +434,12 @@ size 123\n",
                 chunk_size: 8 * 1024 * 1024,
                 no_crc: true,
                 no_chunks: false,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             },
         )
         .expect_err("invalid ROS 1 bag should fail");
@@ -422,6 +475,12 @@ size 123\n",
                     chunk_size: 8 * 1024 * 1024,
                     no_crc: true,
                     no_chunks: false,
+                    topic: None,
+                    schema_name: None,
+                    log_time_field: None,
+                    publish_time_field: None,
+                    timestamp_unit: crate::cli::TimestampUnit::Ns,
+                    rows_per_message: 1,
                 },
             )?;
 

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -9,13 +9,14 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use mcap::{Compression, WriteOptions};
 
-use crate::cli::{CompressionFormat, ConvertCommand};
+use crate::cli::{CompressionFormat, ConvertCommand, TimestampUnit};
 use crate::context::CommandContext;
 
 const GIT_LFS_POINTER_PREFIX: &[u8] = b"version https://git-lfs.github.com";
 
 pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
     let input = ConvertInput::detect(&args.input)?;
+    warn_unused_arrow_flags(&input, &args);
     let is_remote = crate::source::is_remote_url(&args.input);
     if !is_remote {
         reject_lfs_pointer(&args.input)?;
@@ -38,6 +39,39 @@ pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
     input.convert(materialized_input.path(), &args.output, opts, &args)
 }
 
+/// Warn when Arrow-only flags are set for a non-Arrow input, since clap accepts
+/// them on the shared `convert` command but the ROS converters ignore them.
+fn warn_unused_arrow_flags(input: &ConvertInput, args: &ConvertCommand) {
+    if matches!(input, ConvertInput::ArrowIpc) {
+        return;
+    }
+    let mut ignored = Vec::new();
+    if args.topic.is_some() {
+        ignored.push("--topic");
+    }
+    if args.schema_name.is_some() {
+        ignored.push("--schema-name");
+    }
+    if args.log_time_field.is_some() {
+        ignored.push("--log-time-field");
+    }
+    if args.publish_time_field.is_some() {
+        ignored.push("--publish-time-field");
+    }
+    if args.rows_per_message != 1 {
+        ignored.push("--rows-per-message");
+    }
+    if !matches!(args.timestamp_unit, TimestampUnit::Ns) {
+        ignored.push("--timestamp-unit");
+    }
+    if !ignored.is_empty() {
+        eprintln!(
+            "Warning: Arrow-only flag(s) {} are ignored for non-Arrow inputs",
+            ignored.join(", ")
+        );
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ConvertInput {
     Ros1Bag,
@@ -58,7 +92,6 @@ impl ConvertInput {
         if extension.eq_ignore_ascii_case("arrow")
             || extension.eq_ignore_ascii_case("feather")
             || extension.eq_ignore_ascii_case("ipc")
-            || extension.eq_ignore_ascii_case("arrows")
         {
             return Ok(Self::ArrowIpc);
         }

--- a/rust/cli/src/commands/convert/arrow_ipc.rs
+++ b/rust/cli/src/commands/convert/arrow_ipc.rs
@@ -1,0 +1,862 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use arrow::array::{
+    Array, Date32Array, Date64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::compute::cast;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow::error::ArrowError;
+use arrow::ipc::reader::{FileReader, StreamReader};
+use arrow::ipc::writer::{
+    write_message, CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions,
+};
+
+use crate::cli::{ConvertCommand, TimestampUnit};
+
+/// Apache Arrow IPC file magic. An IPC *file* starts with these bytes; an IPC
+/// *stream* does not, which is how we tell the two framings apart.
+const ARROW_FILE_MAGIC: &[u8] = b"ARROW1";
+
+const MESSAGE_ENCODING: &str = "arrow";
+const SCHEMA_ENCODING: &str = "arrow";
+
+/// Options that control how an Arrow input is mapped onto MCAP records.
+#[derive(Debug, Clone)]
+pub struct ArrowConvertOptions {
+    pub topic: Option<String>,
+    pub schema_name: Option<String>,
+    pub log_time_field: Option<String>,
+    pub publish_time_field: Option<String>,
+    pub timestamp_unit: TimestampUnit,
+    pub rows_per_message: u64,
+}
+
+impl ArrowConvertOptions {
+    pub fn from_command(args: &ConvertCommand) -> Self {
+        Self {
+            topic: args.topic.clone(),
+            schema_name: args.schema_name.clone(),
+            log_time_field: args.log_time_field.clone(),
+            publish_time_field: args.publish_time_field.clone(),
+            timestamp_unit: args.timestamp_unit,
+            rows_per_message: args.rows_per_message,
+        }
+    }
+}
+
+pub fn convert_arrow_file(
+    input_path: &Path,
+    output_path: &Path,
+    write_options: mcap::WriteOptions,
+    opts: &ArrowConvertOptions,
+) -> Result<()> {
+    ensure!(
+        opts.rows_per_message >= 1,
+        "--rows-per-message must be at least 1"
+    );
+
+    let mut input = File::open(input_path)
+        .with_context(|| format!("failed to open input '{}'", input_path.display()))?;
+    let is_file_format = detect_arrow_file_format(&mut input)
+        .with_context(|| format!("failed to read Arrow magic from '{}'", input_path.display()))?;
+    input
+        .seek(SeekFrom::Start(0))
+        .context("failed to rewind Arrow input")?;
+
+    let output = File::create(output_path)
+        .with_context(|| format!("failed to open output '{}'", output_path.display()))?;
+    let mut writer = write_options
+        .create(BufWriter::new(output))
+        .context("failed to create MCAP writer")?;
+
+    if is_file_format {
+        let reader = FileReader::try_new(BufReader::new(input), None)
+            .context("failed to open Arrow IPC file")?;
+        let schema = reader.schema();
+        convert_batches(&mut writer, schema, reader, opts, input_path)?;
+    } else {
+        let reader = StreamReader::try_new(BufReader::new(input), None)
+            .context("failed to open Arrow IPC stream")?;
+        let schema = reader.schema();
+        convert_batches(&mut writer, schema, reader, opts, input_path)?;
+    }
+
+    writer.finish().context("failed to finalize MCAP writer")?;
+    Ok(())
+}
+
+/// Returns true if the input is an Arrow IPC *file* (begins with the `ARROW1`
+/// magic), false if it should be read as an Arrow IPC *stream*.
+fn detect_arrow_file_format(input: &mut File) -> Result<bool> {
+    let mut magic = [0u8; ARROW_FILE_MAGIC.len()];
+    let mut filled = 0;
+    while filled < magic.len() {
+        let read = input.read(&mut magic[filled..])?;
+        if read == 0 {
+            break;
+        }
+        filled += read;
+    }
+    Ok(&magic[..filled] == ARROW_FILE_MAGIC)
+}
+
+fn convert_batches<W, I>(
+    writer: &mut mcap::Writer<W>,
+    source_schema: SchemaRef,
+    batches: I,
+    opts: &ArrowConvertOptions,
+    input_path: &Path,
+) -> Result<()>
+where
+    W: Write + Seek,
+    I: Iterator<Item = std::result::Result<RecordBatch, ArrowError>>,
+{
+    // The spec forbids dictionary-encoded columns so each RecordBatch decodes
+    // independently. Hydrate them away up front and use the hydrated schema for
+    // both the Schema record and every emitted RecordBatch.
+    let hydrated_schema = Arc::new(hydrate_schema(&source_schema)?);
+    let plan = TimePlan::resolve(&hydrated_schema, opts)?;
+
+    let schema_bytes = encode_schema(&hydrated_schema)?;
+    let topic = opts
+        .topic
+        .clone()
+        .unwrap_or_else(|| default_topic(input_path));
+    let schema_name = opts.schema_name.clone().unwrap_or_else(|| topic.clone());
+
+    let schema_id = writer
+        .add_schema(&schema_name, SCHEMA_ENCODING, &schema_bytes)
+        .context("failed to write Arrow schema")?;
+    let channel_id = writer
+        .add_channel(schema_id, &topic, MESSAGE_ENCODING, &BTreeMap::new())
+        .context("failed to write Arrow channel")?;
+
+    let rows_per_message = opts.rows_per_message as usize;
+    let mut sequence: u32 = 0;
+
+    for batch in batches {
+        let batch = batch.context("failed to read Arrow record batch")?;
+        let batch = hydrate_batch(&batch, &hydrated_schema)?;
+
+        let log_times = plan.log_times(&batch)?;
+        let publish_times = plan.publish_times(&batch, &log_times)?;
+
+        let num_rows = batch.num_rows();
+        let mut start = 0;
+        while start < num_rows {
+            let len = rows_per_message.min(num_rows - start);
+            let slice = batch.slice(start, len);
+            let data = encode_record_batch(&slice)?;
+
+            writer
+                .write_to_known_channel(
+                    &mcap::records::MessageHeader {
+                        channel_id,
+                        sequence,
+                        log_time: log_times[start],
+                        publish_time: publish_times[start],
+                    },
+                    &data,
+                )
+                .context("failed to write converted Arrow message")?;
+
+            ensure!(
+                sequence < u32::MAX,
+                "too many messages to assign monotonic u32 sequence numbers"
+            );
+            sequence += 1;
+            start += len;
+        }
+    }
+
+    Ok(())
+}
+
+/// Where each message's log_time / publish_time comes from.
+struct TimePlan {
+    log_index: usize,
+    publish: PublishSource,
+    unit: TimestampUnit,
+}
+
+enum PublishSource {
+    Column(usize),
+    SameAsLog,
+}
+
+impl TimePlan {
+    fn resolve(schema: &Schema, opts: &ArrowConvertOptions) -> Result<Self> {
+        let log_index = resolve_log_index(schema, opts)?;
+        validate_time_field(schema.field(log_index))?;
+
+        let publish = if let Some(name) = &opts.publish_time_field {
+            let index = index_of_field(schema, name)?;
+            validate_time_field(schema.field(index))?;
+            PublishSource::Column(index)
+        } else if let Ok(index) = schema.index_of("publish_time") {
+            // A field literally named `publish_time` is treated as an explicit
+            // selection: commit to it and error if it is not a time field.
+            validate_time_field(schema.field(index))?;
+            PublishSource::Column(index)
+        } else {
+            PublishSource::SameAsLog
+        };
+
+        Ok(Self {
+            log_index,
+            publish,
+            unit: opts.timestamp_unit,
+        })
+    }
+
+    fn log_times(&self, batch: &RecordBatch) -> Result<Vec<u64>> {
+        let field = batch.schema_ref().field(self.log_index);
+        field_to_nanos(batch.column(self.log_index), self.unit, field.name())
+    }
+
+    fn publish_times(&self, batch: &RecordBatch, log_times: &[u64]) -> Result<Vec<u64>> {
+        match self.publish {
+            PublishSource::SameAsLog => Ok(log_times.to_vec()),
+            PublishSource::Column(index) => {
+                let field = batch.schema_ref().field(index);
+                field_to_nanos(batch.column(index), self.unit, field.name())
+            }
+        }
+    }
+}
+
+fn resolve_log_index(schema: &Schema, opts: &ArrowConvertOptions) -> Result<usize> {
+    if let Some(name) = &opts.log_time_field {
+        return index_of_field(schema, name);
+    }
+    if let Ok(index) = schema.index_of("log_time") {
+        return Ok(index);
+    }
+    for (index, field) in schema.fields().iter().enumerate() {
+        if is_temporal(field.data_type()) {
+            return Ok(index);
+        }
+    }
+    bail!(
+        "could not determine a log_time field: the Arrow schema has no field named 'log_time' \
+         and no timestamp/date field. Pass --log-time-field (and --timestamp-unit if it is an \
+         integer column)."
+    )
+}
+
+fn index_of_field(schema: &Schema, name: &str) -> Result<usize> {
+    schema
+        .index_of(name)
+        .map_err(|_| anyhow!("field '{name}' was not found in the Arrow schema"))
+}
+
+fn validate_time_field(field: &Field) -> Result<()> {
+    let dt = field.data_type();
+    ensure!(
+        is_temporal(dt) || is_integer(dt),
+        "field '{}' has type {dt:?}, which cannot be interpreted as a timestamp (expected a \
+         timestamp, date, or integer field)",
+        field.name()
+    );
+    Ok(())
+}
+
+fn is_temporal(dt: &DataType) -> bool {
+    matches!(
+        dt,
+        DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64
+    )
+}
+
+fn is_integer(dt: &DataType) -> bool {
+    matches!(
+        dt,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+    )
+}
+
+fn default_topic(input_path: &Path) -> String {
+    input_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("arrow")
+        .to_string()
+}
+
+/// Convert an Arrow time column to MCAP nanosecond timestamps, one per row.
+fn field_to_nanos(array: &dyn Array, unit: TimestampUnit, field_name: &str) -> Result<Vec<u64>> {
+    let integer_scale = unit.nanos_per_unit();
+
+    macro_rules! scaled {
+        ($ty:ty, $scale:expr) => {{
+            let typed = array
+                .as_any()
+                .downcast_ref::<$ty>()
+                .expect("array data type checked before downcast");
+            let mut out = Vec::with_capacity(typed.len());
+            for row in 0..typed.len() {
+                ensure!(
+                    !typed.is_null(row),
+                    "field '{field_name}' has a null value at row {row}; cannot determine a \
+                     message time"
+                );
+                out.push(checked_nanos(
+                    typed.value(row) as i128,
+                    $scale,
+                    field_name,
+                    row,
+                )?);
+            }
+            out
+        }};
+    }
+
+    let values = match array.data_type() {
+        DataType::Timestamp(TimeUnit::Second, _) => scaled!(TimestampSecondArray, 1_000_000_000),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
+            scaled!(TimestampMillisecondArray, 1_000_000)
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, _) => scaled!(TimestampMicrosecondArray, 1_000),
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => scaled!(TimestampNanosecondArray, 1),
+        DataType::Date32 => scaled!(Date32Array, 86_400_000_000_000),
+        DataType::Date64 => scaled!(Date64Array, 1_000_000),
+        DataType::Int8 => scaled!(Int8Array, integer_scale),
+        DataType::Int16 => scaled!(Int16Array, integer_scale),
+        DataType::Int32 => scaled!(Int32Array, integer_scale),
+        DataType::Int64 => scaled!(Int64Array, integer_scale),
+        DataType::UInt8 => scaled!(UInt8Array, integer_scale),
+        DataType::UInt16 => scaled!(UInt16Array, integer_scale),
+        DataType::UInt32 => scaled!(UInt32Array, integer_scale),
+        DataType::UInt64 => scaled!(UInt64Array, integer_scale),
+        other => bail!(
+            "field '{field_name}' has type {other:?}, which cannot be interpreted as a timestamp"
+        ),
+    };
+    Ok(values)
+}
+
+fn checked_nanos(value: i128, scale: i128, field_name: &str, row: usize) -> Result<u64> {
+    let nanos = value.checked_mul(scale).ok_or_else(|| {
+        anyhow!("field '{field_name}' row {row} overflows when scaled to nanoseconds")
+    })?;
+    u64::try_from(nanos).map_err(|_| {
+        anyhow!(
+            "field '{field_name}' row {row} has an out-of-range time value (must be \
+             non-negative and fit in u64 nanoseconds since the Unix epoch)"
+        )
+    })
+}
+
+/// Produce a schema with all dictionary-encoded fields replaced by their value
+/// type. Errors if a dictionary is nested inside another type, which v1 does
+/// not hydrate.
+fn hydrate_schema(schema: &Schema) -> Result<Schema> {
+    let mut fields = Vec::with_capacity(schema.fields().len());
+    for field in schema.fields() {
+        fields.push(hydrate_field(field)?);
+    }
+    Ok(Schema::new(fields).with_metadata(schema.metadata().clone()))
+}
+
+fn hydrate_field(field: &Field) -> Result<Field> {
+    match field.data_type() {
+        DataType::Dictionary(_, value_type) => {
+            ensure!(
+                !contains_dictionary(value_type),
+                "field '{}' is a dictionary whose value type also contains a dictionary, which \
+                 is not supported; hydrate it before converting",
+                field.name()
+            );
+            Ok(Field::new(
+                field.name(),
+                value_type.as_ref().clone(),
+                field.is_nullable(),
+            )
+            .with_metadata(field.metadata().clone()))
+        }
+        other => {
+            ensure!(
+                !contains_dictionary(other),
+                "field '{}' contains a nested dictionary-encoded value, which is not supported; \
+                 hydrate it before converting",
+                field.name()
+            );
+            Ok(field.clone())
+        }
+    }
+}
+
+fn contains_dictionary(dt: &DataType) -> bool {
+    match dt {
+        DataType::Dictionary(_, _) => true,
+        DataType::List(f)
+        | DataType::LargeList(f)
+        | DataType::FixedSizeList(f, _)
+        | DataType::Map(f, _)
+        | DataType::RunEndEncoded(_, f) => contains_dictionary(f.data_type()),
+        DataType::Struct(fields) => fields.iter().any(|f| contains_dictionary(f.data_type())),
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, f)| contains_dictionary(f.data_type())),
+        _ => false,
+    }
+}
+
+/// Cast any dictionary columns to their value type so the emitted RecordBatch
+/// matches the hydrated schema.
+fn hydrate_batch(batch: &RecordBatch, hydrated_schema: &SchemaRef) -> Result<RecordBatch> {
+    let source_schema = batch.schema();
+    let mut columns = Vec::with_capacity(batch.num_columns());
+    for (index, column) in batch.columns().iter().enumerate() {
+        if matches!(
+            source_schema.field(index).data_type(),
+            DataType::Dictionary(_, _)
+        ) {
+            let target = hydrated_schema.field(index).data_type();
+            columns.push(
+                cast(column, target)
+                    .with_context(|| format!("failed to hydrate dictionary column {index}"))?,
+            );
+        } else {
+            columns.push(column.clone());
+        }
+    }
+    RecordBatch::try_new(hydrated_schema.clone(), columns)
+        .context("failed to assemble hydrated Arrow record batch")
+}
+
+fn encode_schema(schema: &Schema) -> Result<Vec<u8>> {
+    let generator = IpcDataGenerator {};
+    let mut tracker = DictionaryTracker::new(false);
+    let options = IpcWriteOptions::default();
+    let encoded = generator.schema_to_bytes_with_dictionary_tracker(schema, &mut tracker, &options);
+    encapsulate(encoded, &options).context("failed to encode Arrow schema message")
+}
+
+fn encode_record_batch(batch: &RecordBatch) -> Result<Vec<u8>> {
+    let generator = IpcDataGenerator {};
+    let mut tracker = DictionaryTracker::new(false);
+    let options = IpcWriteOptions::default();
+    let mut compression = CompressionContext::default();
+    let (dictionaries, encoded) = generator
+        .encode(batch, &mut tracker, &options, &mut compression)
+        .context("failed to encode Arrow record batch")?;
+    ensure!(
+        dictionaries.is_empty(),
+        "unexpected dictionary batch after hydration"
+    );
+    encapsulate(encoded, &options).context("failed to encode Arrow record batch message")
+}
+
+fn encapsulate(
+    encoded: arrow::ipc::writer::EncodedData,
+    options: &IpcWriteOptions,
+) -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    write_message(&mut buffer, encoded, options)?;
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    use arrow::array::{
+        Array, ArrayRef, Date32Array, Float64Array, Int32Array, Int64Array, StringArray,
+        StringDictionaryBuilder, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampSecondArray,
+    };
+    use arrow::datatypes::{DataType, Int32Type, SchemaRef};
+    use arrow::ipc::reader::StreamReader;
+    use arrow::ipc::writer::{FileWriter, StreamWriter};
+    use arrow::record_batch::RecordBatch;
+
+    use super::*;
+
+    // Arrow IPC stream end-of-stream marker: continuation + zero metadata length.
+    const EOS: [u8; 8] = [0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0];
+
+    fn default_opts() -> ArrowConvertOptions {
+        ArrowConvertOptions {
+            topic: None,
+            schema_name: None,
+            log_time_field: None,
+            publish_time_field: None,
+            timestamp_unit: TimestampUnit::Ns,
+            rows_per_message: 1,
+        }
+    }
+
+    fn test_write_options() -> mcap::WriteOptions {
+        mcap::WriteOptions::new()
+            .profile("")
+            .compression(None)
+            .chunk_size(Some(1024))
+    }
+
+    fn batch(columns: Vec<(&str, ArrayRef)>) -> RecordBatch {
+        RecordBatch::try_from_iter(columns).expect("build record batch")
+    }
+
+    fn ipc_file_bytes(batches: &[RecordBatch]) -> Vec<u8> {
+        let schema = batches[0].schema();
+        let mut buf = Vec::new();
+        {
+            let mut writer = FileWriter::try_new(&mut buf, schema.as_ref()).expect("file writer");
+            for b in batches {
+                writer.write(b).expect("write batch");
+            }
+            writer.finish().expect("finish file");
+        }
+        buf
+    }
+
+    fn ipc_stream_bytes(batches: &[RecordBatch]) -> Vec<u8> {
+        let schema = batches[0].schema();
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                StreamWriter::try_new(&mut buf, schema.as_ref()).expect("stream writer");
+            for b in batches {
+                writer.write(b).expect("write batch");
+            }
+            writer.finish().expect("finish stream");
+        }
+        buf
+    }
+
+    fn convert_bytes(bytes: &[u8], ext: &str, opts: &ArrowConvertOptions) -> Result<Vec<u8>> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join(format!("fixture.{ext}"));
+        std::fs::write(&input, bytes).expect("write fixture");
+        let output = dir.path().join("out.mcap");
+        convert_arrow_file(&input, &output, test_write_options(), opts)?;
+        Ok(std::fs::read(&output).expect("read output"))
+    }
+
+    struct DecodedMessage {
+        sequence: u32,
+        log_time: u64,
+        publish_time: u64,
+        data: Vec<u8>,
+    }
+
+    fn read_messages(mcap_bytes: &[u8]) -> Vec<DecodedMessage> {
+        let mut messages: Vec<DecodedMessage> = mcap::MessageStream::new(mcap_bytes)
+            .expect("message stream")
+            .map(|m| {
+                let m = m.expect("message");
+                DecodedMessage {
+                    sequence: m.sequence,
+                    log_time: m.log_time,
+                    publish_time: m.publish_time,
+                    data: m.data.into_owned(),
+                }
+            })
+            .collect();
+        messages.sort_by_key(|m| m.sequence);
+        messages
+    }
+
+    fn schema_record_bytes(mcap_bytes: &[u8]) -> (String, Vec<u8>) {
+        let summary = mcap::Summary::read(mcap_bytes)
+            .expect("summary read")
+            .expect("summary present");
+        let schema = summary.schemas.values().next().expect("one schema");
+        assert_eq!(schema.encoding, super::SCHEMA_ENCODING);
+        (schema.name.clone(), schema.data.to_vec())
+    }
+
+    fn decode_schema(schema_msg: &[u8]) -> SchemaRef {
+        let mut stream = Vec::new();
+        stream.extend_from_slice(schema_msg);
+        stream.extend_from_slice(&EOS);
+        StreamReader::try_new(Cursor::new(stream), None)
+            .expect("schema stream reader")
+            .schema()
+    }
+
+    fn decode_batch(schema_msg: &[u8], batch_msg: &[u8]) -> RecordBatch {
+        let mut stream = Vec::new();
+        stream.extend_from_slice(schema_msg);
+        stream.extend_from_slice(batch_msg);
+        stream.extend_from_slice(&EOS);
+        let mut reader =
+            StreamReader::try_new(Cursor::new(stream), None).expect("batch stream reader");
+        reader
+            .next()
+            .expect("at least one batch")
+            .expect("decode batch")
+    }
+
+    fn assert_channel(mcap_bytes: &[u8], expected_topic: &str) {
+        let summary = mcap::Summary::read(mcap_bytes)
+            .expect("summary read")
+            .expect("summary present");
+        let channel = summary.channels.values().next().expect("one channel");
+        assert_eq!(channel.message_encoding, super::MESSAGE_ENCODING);
+        assert_eq!(channel.topic, expected_topic);
+    }
+
+    #[test]
+    fn auto_detects_first_timestamp_and_scales_milliseconds() {
+        let batch = batch(vec![
+            (
+                "value",
+                Arc::new(Int64Array::from(vec![10, 20])) as ArrayRef,
+            ),
+            (
+                "ts",
+                Arc::new(TimestampMillisecondArray::from(vec![1000, 2000])) as ArrayRef,
+            ),
+        ]);
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect("convert should succeed");
+
+        assert_channel(&mcap_bytes, "fixture");
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].log_time, 1_000_000_000);
+        assert_eq!(messages[0].publish_time, 1_000_000_000);
+        assert_eq!(messages[1].log_time, 2_000_000_000);
+
+        // The emitted message must decode against the Schema record as a one-row RecordBatch.
+        let (_name, schema_msg) = schema_record_bytes(&mcap_bytes);
+        let decoded = decode_batch(&schema_msg, &messages[0].data);
+        assert_eq!(decoded.num_rows(), 1);
+        let value = decoded
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(value.value(0), 10);
+    }
+
+    #[test]
+    fn uses_named_log_time_and_publish_time_microseconds() {
+        let batch = batch(vec![
+            (
+                "log_time",
+                Arc::new(TimestampMicrosecondArray::from(vec![1, 2])) as ArrayRef,
+            ),
+            (
+                "publish_time",
+                Arc::new(TimestampMicrosecondArray::from(vec![5, 6])) as ArrayRef,
+            ),
+            (
+                "x",
+                Arc::new(Float64Array::from(vec![1.5, 2.5])) as ArrayRef,
+            ),
+        ]);
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect("convert should succeed");
+
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].log_time, 1_000);
+        assert_eq!(messages[0].publish_time, 5_000);
+        assert_eq!(messages[1].log_time, 2_000);
+        assert_eq!(messages[1].publish_time, 6_000);
+    }
+
+    #[test]
+    fn integer_log_time_uses_timestamp_unit() {
+        let batch = batch(vec![
+            (
+                "log_time",
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ),
+            ("v", Arc::new(Int32Array::from(vec![7, 8, 9])) as ArrayRef),
+        ]);
+        let mut opts = default_opts();
+        opts.timestamp_unit = TimestampUnit::Us;
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &opts)
+            .expect("convert should succeed");
+
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(
+            messages.iter().map(|m| m.log_time).collect::<Vec<_>>(),
+            vec![1_000, 2_000, 3_000]
+        );
+    }
+
+    #[test]
+    fn auto_detects_date32_field() {
+        let batch = batch(vec![(
+            "d",
+            Arc::new(Date32Array::from(vec![1, 2])) as ArrayRef,
+        )]);
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect("convert should succeed");
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(messages[0].log_time, 86_400_000_000_000);
+        assert_eq!(messages[1].log_time, 2 * 86_400_000_000_000);
+    }
+
+    #[test]
+    fn hydrates_dictionary_columns() {
+        let mut labels = StringDictionaryBuilder::<Int32Type>::new();
+        labels.append_value("a");
+        labels.append_value("b");
+        let batch = batch(vec![
+            (
+                "ts",
+                Arc::new(TimestampSecondArray::from(vec![1, 2])) as ArrayRef,
+            ),
+            ("label", Arc::new(labels.finish()) as ArrayRef),
+        ]);
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect("convert should succeed");
+
+        let (_name, schema_msg) = schema_record_bytes(&mcap_bytes);
+        let decoded_schema = decode_schema(&schema_msg);
+        assert_eq!(
+            decoded_schema.field_with_name("label").unwrap().data_type(),
+            &DataType::Utf8,
+            "dictionary column should be hydrated to its value type"
+        );
+
+        let messages = read_messages(&mcap_bytes);
+        let decoded = decode_batch(&schema_msg, &messages[0].data);
+        let label = decoded
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("hydrated label column is Utf8");
+        assert_eq!(label.value(0), "a");
+    }
+
+    #[test]
+    fn rows_per_message_packs_rows() {
+        let batch = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![1, 2, 3, 4])) as ArrayRef,
+        )]);
+        let mut opts = default_opts();
+        opts.rows_per_message = 2;
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &opts)
+            .expect("convert should succeed");
+
+        let (_name, schema_msg) = schema_record_bytes(&mcap_bytes);
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(messages.len(), 2);
+        // Each message carries the log_time of its first row.
+        assert_eq!(messages[0].log_time, 1_000_000_000);
+        assert_eq!(messages[1].log_time, 3_000_000_000);
+        assert_eq!(decode_batch(&schema_msg, &messages[0].data).num_rows(), 2);
+    }
+
+    #[test]
+    fn reads_arrow_ipc_stream_format() {
+        let batch = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![1, 2])) as ArrayRef,
+        )]);
+        let mcap_bytes = convert_bytes(&ipc_stream_bytes(&[batch]), "ipc", &default_opts())
+            .expect("convert stream should succeed");
+        assert_eq!(read_messages(&mcap_bytes).len(), 2);
+    }
+
+    #[test]
+    fn converts_multiple_record_batches() {
+        let b1 = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![1, 2])) as ArrayRef,
+        )]);
+        let b2 = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![3])) as ArrayRef,
+        )]);
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[b1, b2]), "arrow", &default_opts())
+            .expect("convert should succeed");
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(
+            messages.iter().map(|m| m.sequence).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn honors_topic_and_schema_name_overrides() {
+        let batch = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![1])) as ArrayRef,
+        )]);
+        let mut opts = default_opts();
+        opts.topic = Some("/sensors/imu".to_string());
+        opts.schema_name = Some("ImuBatch".to_string());
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &opts)
+            .expect("convert should succeed");
+
+        assert_channel(&mcap_bytes, "/sensors/imu");
+        let (name, _data) = schema_record_bytes(&mcap_bytes);
+        assert_eq!(name, "ImuBatch");
+    }
+
+    #[test]
+    fn errors_when_no_time_field_can_be_resolved() {
+        let batch = batch(vec![(
+            "x",
+            Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+        )]);
+        let err = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect_err("missing time field should fail");
+        assert!(err
+            .to_string()
+            .contains("could not determine a log_time field"));
+    }
+
+    #[test]
+    fn errors_on_null_time_value() {
+        let batch = batch(vec![(
+            "log_time",
+            Arc::new(TimestampSecondArray::from(vec![Some(1), None])) as ArrayRef,
+        )]);
+        let err = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect_err("null time should fail");
+        assert!(err.to_string().contains("null value at row 1"));
+    }
+
+    #[test]
+    fn errors_on_negative_integer_time() {
+        let batch = batch(vec![(
+            "log_time",
+            Arc::new(Int64Array::from(vec![-1])) as ArrayRef,
+        )]);
+        let err = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &default_opts())
+            .expect_err("negative time should fail");
+        assert!(err.to_string().contains("out-of-range time value"));
+    }
+
+    #[test]
+    fn errors_when_named_log_time_field_missing() {
+        let batch = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![1])) as ArrayRef,
+        )]);
+        let mut opts = default_opts();
+        opts.log_time_field = Some("nonexistent".to_string());
+        let err = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &opts)
+            .expect_err("missing named field should fail");
+        assert!(err
+            .to_string()
+            .contains("was not found in the Arrow schema"));
+    }
+}

--- a/rust/cli/src/commands/convert/arrow_ipc.rs
+++ b/rust/cli/src/commands/convert/arrow_ipc.rs
@@ -36,6 +36,9 @@ pub struct ArrowConvertOptions {
     pub publish_time_field: Option<String>,
     pub timestamp_unit: TimestampUnit,
     pub rows_per_message: u64,
+    /// Default topic when `topic` is unset, derived from the original input
+    /// name (not the materialized temp file used for remote inputs).
+    default_topic: String,
 }
 
 impl ArrowConvertOptions {
@@ -47,6 +50,7 @@ impl ArrowConvertOptions {
             publish_time_field: args.publish_time_field.clone(),
             timestamp_unit: args.timestamp_unit,
             rows_per_message: args.rows_per_message,
+            default_topic: default_topic(&args.input),
         }
     }
 }
@@ -70,25 +74,130 @@ pub fn convert_arrow_file(
         .seek(SeekFrom::Start(0))
         .context("failed to rewind Arrow input")?;
 
+    // Open the reader (which validates the Arrow framing and parses the schema)
+    // before touching the output path, so malformed input never clobbers an
+    // existing output file.
+    if is_file_format {
+        let reader = FileReader::try_new(BufReader::new(input), None)
+            .context("failed to open Arrow IPC file")?;
+        let schema = reader.schema();
+        run_conversion(schema, reader, output_path, write_options, opts)
+    } else {
+        let reader = StreamReader::try_new(BufReader::new(input), None)
+            .context("failed to open Arrow IPC stream")?;
+        let schema = reader.schema();
+        run_conversion(schema, reader, output_path, write_options, opts)
+    }
+}
+
+fn run_conversion<I>(
+    source_schema: SchemaRef,
+    batches: I,
+    output_path: &Path,
+    write_options: mcap::WriteOptions,
+    opts: &ArrowConvertOptions,
+) -> Result<()>
+where
+    I: Iterator<Item = std::result::Result<RecordBatch, ArrowError>>,
+{
+    // Resolve everything that can fail from the schema alone before creating the
+    // output file.
+    let hydrated_schema = Arc::new(hydrate_schema(&source_schema)?);
+    let plan = TimePlan::resolve(&hydrated_schema, opts)?;
+    let schema_bytes = encode_schema(&hydrated_schema)?;
+    let topic = opts
+        .topic
+        .clone()
+        .unwrap_or_else(|| opts.default_topic.clone());
+    let schema_name = opts.schema_name.clone().unwrap_or_else(|| topic.clone());
+
     let output = File::create(output_path)
         .with_context(|| format!("failed to open output '{}'", output_path.display()))?;
     let mut writer = write_options
         .create(BufWriter::new(output))
         .context("failed to create MCAP writer")?;
 
-    if is_file_format {
-        let reader = FileReader::try_new(BufReader::new(input), None)
-            .context("failed to open Arrow IPC file")?;
-        let schema = reader.schema();
-        convert_batches(&mut writer, schema, reader, opts, input_path)?;
-    } else {
-        let reader = StreamReader::try_new(BufReader::new(input), None)
-            .context("failed to open Arrow IPC stream")?;
-        let schema = reader.schema();
-        convert_batches(&mut writer, schema, reader, opts, input_path)?;
+    let outcome = write_messages(
+        &mut writer,
+        &hydrated_schema,
+        &schema_bytes,
+        &topic,
+        &schema_name,
+        &plan,
+        batches,
+    )
+    .and_then(|()| writer.finish().context("failed to finalize MCAP writer"));
+    drop(writer);
+
+    if let Err(err) = outcome {
+        // A failure (e.g. a bad timestamp deep in the file) leaves a partial,
+        // never-finalized MCAP; remove it rather than leaving a truncated file.
+        let _ = std::fs::remove_file(output_path);
+        return Err(err);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_messages<W, I>(
+    writer: &mut mcap::Writer<W>,
+    hydrated_schema: &SchemaRef,
+    schema_bytes: &[u8],
+    topic: &str,
+    schema_name: &str,
+    plan: &TimePlan,
+    batches: I,
+) -> Result<()>
+where
+    W: Write + Seek,
+    I: Iterator<Item = std::result::Result<RecordBatch, ArrowError>>,
+{
+    let schema_id = writer
+        .add_schema(schema_name, SCHEMA_ENCODING, schema_bytes)
+        .context("failed to write Arrow schema")?;
+    let channel_id = writer
+        .add_channel(schema_id, topic, MESSAGE_ENCODING, &BTreeMap::new())
+        .context("failed to write Arrow channel")?;
+
+    let rows_per_message = plan.rows_per_message;
+    let mut sequence: u32 = 0;
+
+    for batch in batches {
+        let batch = batch.context("failed to read Arrow record batch")?;
+        let batch = hydrate_batch(&batch, hydrated_schema)?;
+
+        let num_rows = batch.num_rows();
+        let mut start = 0;
+        while start < num_rows {
+            let len = rows_per_message.min(num_rows - start);
+            // All rows in a batch share the message's log_time, so only the
+            // group's first row contributes the message timestamps.
+            let log_time = plan.log_time_at(&batch, start)?;
+            let publish_time = plan.publish_time_at(&batch, start, log_time)?;
+            let slice = batch.slice(start, len);
+            let data = encode_record_batch(&slice)?;
+
+            writer
+                .write_to_known_channel(
+                    &mcap::records::MessageHeader {
+                        channel_id,
+                        sequence,
+                        log_time,
+                        publish_time,
+                    },
+                    &data,
+                )
+                .context("failed to write converted Arrow message")?;
+
+            ensure!(
+                sequence < u32::MAX,
+                "too many messages to assign monotonic u32 sequence numbers"
+            );
+            sequence += 1;
+            start += len;
+        }
     }
 
-    writer.finish().context("failed to finalize MCAP writer")?;
     Ok(())
 }
 
@@ -107,83 +216,12 @@ fn detect_arrow_file_format(input: &mut File) -> Result<bool> {
     Ok(&magic[..filled] == ARROW_FILE_MAGIC)
 }
 
-fn convert_batches<W, I>(
-    writer: &mut mcap::Writer<W>,
-    source_schema: SchemaRef,
-    batches: I,
-    opts: &ArrowConvertOptions,
-    input_path: &Path,
-) -> Result<()>
-where
-    W: Write + Seek,
-    I: Iterator<Item = std::result::Result<RecordBatch, ArrowError>>,
-{
-    // The spec forbids dictionary-encoded columns so each RecordBatch decodes
-    // independently. Hydrate them away up front and use the hydrated schema for
-    // both the Schema record and every emitted RecordBatch.
-    let hydrated_schema = Arc::new(hydrate_schema(&source_schema)?);
-    let plan = TimePlan::resolve(&hydrated_schema, opts)?;
-
-    let schema_bytes = encode_schema(&hydrated_schema)?;
-    let topic = opts
-        .topic
-        .clone()
-        .unwrap_or_else(|| default_topic(input_path));
-    let schema_name = opts.schema_name.clone().unwrap_or_else(|| topic.clone());
-
-    let schema_id = writer
-        .add_schema(&schema_name, SCHEMA_ENCODING, &schema_bytes)
-        .context("failed to write Arrow schema")?;
-    let channel_id = writer
-        .add_channel(schema_id, &topic, MESSAGE_ENCODING, &BTreeMap::new())
-        .context("failed to write Arrow channel")?;
-
-    let rows_per_message = opts.rows_per_message as usize;
-    let mut sequence: u32 = 0;
-
-    for batch in batches {
-        let batch = batch.context("failed to read Arrow record batch")?;
-        let batch = hydrate_batch(&batch, &hydrated_schema)?;
-
-        let log_times = plan.log_times(&batch)?;
-        let publish_times = plan.publish_times(&batch, &log_times)?;
-
-        let num_rows = batch.num_rows();
-        let mut start = 0;
-        while start < num_rows {
-            let len = rows_per_message.min(num_rows - start);
-            let slice = batch.slice(start, len);
-            let data = encode_record_batch(&slice)?;
-
-            writer
-                .write_to_known_channel(
-                    &mcap::records::MessageHeader {
-                        channel_id,
-                        sequence,
-                        log_time: log_times[start],
-                        publish_time: publish_times[start],
-                    },
-                    &data,
-                )
-                .context("failed to write converted Arrow message")?;
-
-            ensure!(
-                sequence < u32::MAX,
-                "too many messages to assign monotonic u32 sequence numbers"
-            );
-            sequence += 1;
-            start += len;
-        }
-    }
-
-    Ok(())
-}
-
 /// Where each message's log_time / publish_time comes from.
 struct TimePlan {
     log_index: usize,
     publish: PublishSource,
     unit: TimestampUnit,
+    rows_per_message: usize,
 }
 
 enum PublishSource {
@@ -213,20 +251,21 @@ impl TimePlan {
             log_index,
             publish,
             unit: opts.timestamp_unit,
+            rows_per_message: opts.rows_per_message.max(1) as usize,
         })
     }
 
-    fn log_times(&self, batch: &RecordBatch) -> Result<Vec<u64>> {
+    fn log_time_at(&self, batch: &RecordBatch, row: usize) -> Result<u64> {
         let field = batch.schema_ref().field(self.log_index);
-        field_to_nanos(batch.column(self.log_index), self.unit, field.name())
+        value_to_nanos(batch.column(self.log_index), row, self.unit, field.name())
     }
 
-    fn publish_times(&self, batch: &RecordBatch, log_times: &[u64]) -> Result<Vec<u64>> {
+    fn publish_time_at(&self, batch: &RecordBatch, row: usize, log_time: u64) -> Result<u64> {
         match self.publish {
-            PublishSource::SameAsLog => Ok(log_times.to_vec()),
+            PublishSource::SameAsLog => Ok(log_time),
             PublishSource::Column(index) => {
                 let field = batch.schema_ref().field(index);
-                field_to_nanos(batch.column(index), self.unit, field.name())
+                value_to_nanos(batch.column(index), row, self.unit, field.name())
             }
         }
     }
@@ -298,8 +337,13 @@ fn default_topic(input_path: &Path) -> String {
         .to_string()
 }
 
-/// Convert an Arrow time column to MCAP nanosecond timestamps, one per row.
-fn field_to_nanos(array: &dyn Array, unit: TimestampUnit, field_name: &str) -> Result<Vec<u64>> {
+/// Convert a single row of an Arrow time column to an MCAP nanosecond timestamp.
+fn value_to_nanos(
+    array: &dyn Array,
+    row: usize,
+    unit: TimestampUnit,
+    field_name: &str,
+) -> Result<u64> {
     let integer_scale = unit.nanos_per_unit();
 
     macro_rules! scaled {
@@ -308,25 +352,16 @@ fn field_to_nanos(array: &dyn Array, unit: TimestampUnit, field_name: &str) -> R
                 .as_any()
                 .downcast_ref::<$ty>()
                 .expect("array data type checked before downcast");
-            let mut out = Vec::with_capacity(typed.len());
-            for row in 0..typed.len() {
-                ensure!(
-                    !typed.is_null(row),
-                    "field '{field_name}' has a null value at row {row}; cannot determine a \
-                     message time"
-                );
-                out.push(checked_nanos(
-                    typed.value(row) as i128,
-                    $scale,
-                    field_name,
-                    row,
-                )?);
-            }
-            out
+            ensure!(
+                !typed.is_null(row),
+                "field '{field_name}' has a null value at row {row}; cannot determine a \
+                 message time"
+            );
+            checked_nanos(typed.value(row) as i128, $scale, field_name, row)?
         }};
     }
 
-    let values = match array.data_type() {
+    let value = match array.data_type() {
         DataType::Timestamp(TimeUnit::Second, _) => scaled!(TimestampSecondArray, 1_000_000_000),
         DataType::Timestamp(TimeUnit::Millisecond, _) => {
             scaled!(TimestampMillisecondArray, 1_000_000)
@@ -347,7 +382,7 @@ fn field_to_nanos(array: &dyn Array, unit: TimestampUnit, field_name: &str) -> R
             "field '{field_name}' has type {other:?}, which cannot be interpreted as a timestamp"
         ),
     };
-    Ok(values)
+    Ok(value)
 }
 
 fn checked_nanos(value: i128, scale: i128, field_name: &str, row: usize) -> Result<u64> {
@@ -500,6 +535,7 @@ mod tests {
             publish_time_field: None,
             timestamp_unit: TimestampUnit::Ns,
             rows_per_message: 1,
+            default_topic: "fixture".to_string(),
         }
     }
 
@@ -760,6 +796,53 @@ mod tests {
         assert_eq!(messages[0].log_time, 1_000_000_000);
         assert_eq!(messages[1].log_time, 3_000_000_000);
         assert_eq!(decode_batch(&schema_msg, &messages[0].data).num_rows(), 2);
+    }
+
+    #[test]
+    fn rows_per_message_ignores_non_leader_row_times() {
+        // Only the first row of each group sets the message time, so null
+        // values in non-leader rows must not fail the conversion.
+        let batch = batch(vec![(
+            "ts",
+            Arc::new(TimestampSecondArray::from(vec![
+                Some(1),
+                None,
+                Some(3),
+                None,
+            ])) as ArrayRef,
+        )]);
+        let mut opts = default_opts();
+        opts.rows_per_message = 2;
+        let mcap_bytes = convert_bytes(&ipc_file_bytes(&[batch]), "arrow", &opts)
+            .expect("non-leader nulls should not fail conversion");
+        let messages = read_messages(&mcap_bytes);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].log_time, 1_000_000_000);
+        assert_eq!(messages[1].log_time, 3_000_000_000);
+    }
+
+    #[test]
+    fn default_topic_uses_original_input_not_materialized_path() {
+        use std::path::PathBuf;
+
+        use crate::cli::{CompressionFormat, ConvertCommand};
+
+        let args = ConvertCommand {
+            input: PathBuf::from("s3://bucket/path/imu.arrow"),
+            output: PathBuf::from("out.mcap"),
+            compression: CompressionFormat::None,
+            chunk_size: 1024,
+            no_crc: true,
+            no_chunks: false,
+            topic: None,
+            schema_name: None,
+            log_time_field: None,
+            publish_time_field: None,
+            timestamp_unit: TimestampUnit::Ns,
+            rows_per_message: 1,
+        };
+        let opts = ArrowConvertOptions::from_command(&args);
+        assert_eq!(opts.default_topic, "imu");
     }
 
     #[test]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -404,6 +404,12 @@ mod tests {
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 no_crc: false,
                 no_chunks: false,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             })
         );
     }
@@ -432,6 +438,12 @@ mod tests {
                 chunk_size: 1024,
                 no_crc: true,
                 no_chunks: true,
+                topic: None,
+                schema_name: None,
+                log_time_field: None,
+                publish_time_field: None,
+                timestamp_unit: crate::cli::TimestampUnit::Ns,
+                rows_per_message: 1,
             })
         );
     }

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -91,6 +91,26 @@ The `mcap` CLI dispatches on the input file extension (`.bag` for ROS 1, `.db3` 
 
 Bags recorded before ROS 2 Iron do not contain embedded message definitions and cannot be converted directly. Use the [`ros2 bag convert`](https://github.com/ros2/rosbag2#converting-bags-merge-split-etc-) utility instead (with the original ROS 2 workspace sourced) to convert between `.db3` and MCAP.
 
+### Apache Arrow to MCAP conversion
+
+<!-- cspell: disable -->
+
+Convert an [Apache Arrow](https://arrow.apache.org/docs/format/Columnar.html) IPC file or stream (`.arrow`, `.feather`, `.ipc`) to MCAP:
+
+    $ mcap convert data.arrow data.mcap
+
+<!-- cspell: enable -->
+
+Each input row becomes one MCAP message (an [Arrow IPC](https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc) encapsulated `RecordBatch`) on a single channel using the [`arrow`](https://mcap.dev/spec/registry#arrow) message and schema encodings. Dictionary-encoded columns are hydrated to their value type, as required by the encoding.
+
+Each message's `log_time` is taken from a timestamp/date column:
+
+- Pass `--log-time-field <NAME>` to choose the column explicitly.
+- Otherwise a column named `log_time` is used, falling back to the first timestamp/date column in schema order.
+- `publish_time` uses `--publish-time-field <NAME>`, then a column named `publish_time`, and otherwise defaults to `log_time`.
+
+Arrow `Timestamp`/`Date` columns carry their own unit. For integer-typed time columns, pass `--timestamp-unit {s,ms,us,ns}` (default `ns`) to declare the unit. Other useful flags: `--topic` (defaults to the input file stem), `--schema-name`, and `--rows-per-message` (default `1`) to pack multiple rows into each message.
+
 ### File summarization
 
 Report summary statistics on an MCAP file:

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -111,6 +111,15 @@ Each message's `log_time` is taken from a timestamp/date column:
 
 Arrow `Timestamp`/`Date` columns carry their own unit. For integer-typed time columns, pass `--timestamp-unit {s,ms,us,ns}` (default `ns`) to declare the unit. Other useful flags: `--topic` (defaults to the input file stem), `--schema-name`, and `--rows-per-message` (default `1`) to pack multiple rows into each message.
 
+`mcap cat --json` decodes `arrow` messages by reading each `RecordBatch` against the channel's Schema record. Because a message may hold multiple rows, the `data` field is a JSON array of row objects (one element per row):
+
+<!-- cspell: disable -->
+
+    $ mcap cat --json data.mcap
+    {"topic":"events","sequence":0,"log_time":1704067200.000000000,"publish_time":1704067200.000000000,"data":[{"timestamp":"2024-01-01T00:00:00Z","category":"imu","temperature":20.5}]}
+
+<!-- cspell: enable -->
+
 ### File summarization
 
 Report summary statistics on an MCAP file:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Apache Arrow support to the Rust CLI for the `arrow` message/schema encodings proposed in #1748, on both the write and read paths:

- **`mcap convert`** reads an Arrow IPC **file** or **stream** (`.arrow`, `.feather`, `.ipc`, `.arrows`) and writes a single channel using the `arrow` message encoding, with the Arrow IPC `Schema` stored once in the Schema record (`arrow` schema encoding). Each input row becomes one message containing a bare encapsulated `RecordBatch` (matching `pyarrow.RecordBatch.serialize()`) — no stream framing, no embedded schema, no Arrow body compression. Dictionary-encoded columns are hydrated to their value type so every `RecordBatch` decodes independently.
- **`mcap cat --json`** now decodes `arrow` messages: it reads each `RecordBatch` against the channel's Schema record and emits the rows. Because a message may hold multiple rows, the `data` field is a JSON array of row objects.

### Timestamp handling

`log_time`/`publish_time` are derived from Arrow columns:

- `--log-time-field <NAME>` selects the column; otherwise a column named `log_time` is used, falling back to the first timestamp/date column in schema order (Arrow field order is well-defined and preserved through IPC).
- `--publish-time-field <NAME>`, then a column named `publish_time`, otherwise defaults to `log_time`.
- Arrow `Timestamp`/`Date32`/`Date64` columns are scaled from their intrinsic unit to nanoseconds. Integer columns use `--timestamp-unit {s,ms,us,ns}` (default `ns`).
- Null, negative, or out-of-`u64` times are hard errors.

### New flags on `convert`

`--topic` (defaults to the input file stem), `--schema-name`, `--log-time-field`, `--publish-time-field`, `--timestamp-unit`, `--rows-per-message` (default `1`, for opt-in row batching).

### Dependency

Adds `arrow` (`ipc`, `json`, `chrono-tz` features). `json` powers `cat --json` via `arrow-json`'s writer; `chrono-tz` is required so named timezones (e.g. `timestamp[us, tz=UTC]`) render correctly.

## Testing

- 14 new unit tests (13 for `convert` in `arrow_ipc.rs`, 1 for `cat --json` in `cat.rs`). The `convert` tests generate Arrow IPC fixtures dynamically (no committed binaries / LFS), covering unit scaling, auto-detection, named/explicit/default field resolution, dictionary hydration, row batching, stream vs file framing, multi-batch files, and error paths; each round-trips the emitted bytes back through an Arrow `StreamReader`.
- Manual end-to-end: converted a `timestamp[us, tz=UTC]` + dictionary Arrow file and a real third-party Arrow file (samplefile.com), verified with `mcap info`/`list`, `mcap cat --json`, and a pyarrow round-trip decode.

Depends conceptually on #1748 (registry entry); this PR is the implementation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aab16c5-d98a-4d61-96d0-3b7ffa677d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aab16c5-d98a-4d61-96d0-3b7ffa677d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

