### PR TITLE
typescript: add McapIndexedReader.readMessageTimestamps

### DIFF
--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -1357,4 +1357,89 @@ describe("McapIndexedReader", () => {
     const reader = await McapIndexedReader.Initialize({ readable: makeReadable(builder.buffer) });
     await expect(collect(reader.readMessages())).resolves.toEqual([message1, message2]);
   });
+
+  describe("readMessageTimestamps", () => {
+    async function writeTwoTopicFile(): Promise<TempBuffer> {
+      const tempBuffer = new TempBuffer();
+      const writer = new McapWriter({ writable: tempBuffer });
+      await writer.start({ library: "", profile: "" });
+      const channelA = await writer.registerChannel({
+        topic: "a",
+        schemaId: 0,
+        messageEncoding: "json",
+        metadata: new Map(),
+      });
+      const channelB = await writer.registerChannel({
+        topic: "b",
+        schemaId: 0,
+        messageEncoding: "json",
+        metadata: new Map(),
+      });
+      for (const logTime of [10n, 20n, 30n, 40n]) {
+        await writer.addMessage({
+          channelId: channelA,
+          sequence: 0,
+          logTime,
+          publishTime: logTime,
+          data: new Uint8Array(),
+        });
+      }
+      for (const logTime of [15n, 25n]) {
+        await writer.addMessage({
+          channelId: channelB,
+          sequence: 0,
+          logTime,
+          publishTime: logTime,
+          data: new Uint8Array(),
+        });
+      }
+      await writer.end();
+      return tempBuffer;
+    }
+
+    it("yields all message log times in merged time order", async () => {
+      const reader = await McapIndexedReader.Initialize({ readable: await writeTwoTopicFile() });
+      await expect(collect(reader.readMessageTimestamps())).resolves.toEqual([
+        10n,
+        15n,
+        20n,
+        25n,
+        30n,
+        40n,
+      ]);
+    });
+
+    it("filters by topic", async () => {
+      const reader = await McapIndexedReader.Initialize({ readable: await writeTwoTopicFile() });
+      await expect(collect(reader.readMessageTimestamps({ topics: ["a"] }))).resolves.toEqual([
+        10n,
+        20n,
+        30n,
+        40n,
+      ]);
+      await expect(collect(reader.readMessageTimestamps({ topics: ["b"] }))).resolves.toEqual([
+        15n,
+        25n,
+      ]);
+    });
+
+    it("filters by time range", async () => {
+      const reader = await McapIndexedReader.Initialize({ readable: await writeTwoTopicFile() });
+      await expect(
+        collect(reader.readMessageTimestamps({ startTime: 15n, endTime: 30n })),
+      ).resolves.toEqual([15n, 20n, 25n, 30n]);
+    });
+
+    it("yields log times in reverse time order", async () => {
+      const reader = await McapIndexedReader.Initialize({ readable: await writeTwoTopicFile() });
+      await expect(collect(reader.readMessageTimestamps({ reverse: true }))).resolves.toEqual([
+        40n,
+        30n,
+        25n,
+        20n,
+        15n,
+        10n,
+      ]);
+    });
+  });
 });

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -1441,5 +1441,60 @@ describe("McapIndexedReader", () => {
         10n,
       ]);
     });
+
+    it("merges across out-of-order and overlapping chunks", async () => {
+      const channel: TypedMcapRecord = {
+        type: "Channel",
+        id: 1,
+        schemaId: 0,
+        topic: "a",
+        messageEncoding: "utf12",
+        metadata: new Map(),
+      };
+      const makeMessage = (logTime: bigint): TypedMcapRecords["Message"] => ({
+        type: "Message",
+        channelId: channel.id,
+        sequence: 0,
+        logTime,
+        publishTime: 0n,
+        data: new Uint8Array(),
+      });
+
+      // Two chunks with overlapping time ranges (1-4 and 2-3), written out of order, so the heap
+      // must interleave them rather than drain one chunk at a time.
+      const chunk1 = new ChunkBuilder({ useMessageIndex: true });
+      chunk1.addChannel(channel);
+      chunk1.addMessage(makeMessage(4n));
+      chunk1.addMessage(makeMessage(1n));
+
+      const chunk2 = new ChunkBuilder({ useMessageIndex: true });
+      chunk2.addChannel(channel);
+      chunk2.addMessage(makeMessage(3n));
+      chunk2.addMessage(makeMessage(2n));
+
+      const builder = new McapRecordBuilder();
+      builder.writeMagic();
+      builder.writeHeader({ profile: "", library: "" });
+      const chunkIndexes = [
+        writeChunkWithMessageIndexes(builder, chunk1),
+        writeChunkWithMessageIndexes(builder, chunk2),
+      ];
+      builder.writeDataEnd({ dataSectionCrc: 0 });
+      const summaryStart = BigInt(builder.length);
+      for (const index of chunkIndexes) {
+        builder.writeChunkIndex(index);
+      }
+      builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+      builder.writeMagic();
+
+      const reader = await McapIndexedReader.Initialize({ readable: makeReadable(builder.buffer) });
+      await expect(collect(reader.readMessageTimestamps())).resolves.toEqual([1n, 2n, 3n, 4n]);
+      await expect(collect(reader.readMessageTimestamps({ reverse: true }))).resolves.toEqual([
+        4n,
+        3n,
+        2n,
+        1n,
+      ]);
+    });
   });
 });

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -480,6 +480,90 @@ export class McapIndexedReader {
     }
   }
 
+  /**
+   * Like {@link readMessages}, but only reads message indexes (never chunk payloads) and yields the
+   * log time of each message in merged time order. This makes it cheap to build a per-topic
+   * timestamp index without decoding message bodies.
+   */
+  async *readMessageTimestamps(
+    args: {
+      topics?: readonly string[];
+      startTime?: bigint;
+      endTime?: bigint;
+      reverse?: boolean;
+    } = {},
+  ): AsyncGenerator<bigint, void, void> {
+    const {
+      topics,
+      startTime = this.#messageStartTime,
+      endTime = this.#messageEndTime,
+      reverse = false,
+    } = args;
+
+    if (startTime == undefined || endTime == undefined) {
+      return;
+    }
+
+    let relevantChannels: Set<number> | undefined;
+    if (topics) {
+      relevantChannels = new Set();
+      for (const channel of this.channelsById.values()) {
+        if (topics.includes(channel.topic)) {
+          relevantChannels.add(channel.id);
+        }
+      }
+    }
+
+    const chunkCursors = new Heap<ChunkCursor>((a, b) => a.compare(b));
+    let chunksOrdered = true;
+    let prevChunkEndTime: bigint | undefined;
+    const readFullMessageIndexRange = this.#messageIndexReadable !== this.#readable;
+    for (const chunkIndex of this.chunkIndexes) {
+      if (chunkIndex.messageStartTime <= endTime && chunkIndex.messageEndTime >= startTime) {
+        chunkCursors.push(
+          new ChunkCursor({
+            chunkIndex,
+            relevantChannels,
+            startTime,
+            endTime,
+            reverse,
+            readFullMessageIndexRange,
+          }),
+        );
+        if (chunksOrdered && prevChunkEndTime != undefined) {
+          chunksOrdered = chunkIndex.messageStartTime >= prevChunkEndTime;
+        }
+        prevChunkEndTime = chunkIndex.messageEndTime;
+      }
+    }
+
+    for (let cursor; (cursor = chunkCursors.peek()); ) {
+      if (!cursor.hasMessageIndexes()) {
+        // Load message indexes on demand and re-sort the heap, just like readMessages — but we
+        // never load or decode the chunk data itself.
+        await cursor.loadMessageIndexes(this.#messageIndexReadable);
+        if (cursor.hasMoreMessages()) {
+          chunkCursors.replace(cursor);
+        } else {
+          chunkCursors.pop();
+        }
+        continue;
+      }
+
+      const [logTime] = cursor.popMessage();
+      yield logTime;
+
+      if (cursor.hasMoreMessages()) {
+        // No need to reorganize the heap when chunks are ordered and non-overlapping.
+        if (!chunksOrdered) {
+          chunkCursors.replace(cursor);
+        }
+      } else {
+        chunkCursors.pop();
+      }
+    }
+  }
+
   async *readMetadata(
     args: {
       name?: string;

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -372,68 +372,14 @@ export class McapIndexedReader {
       validateCrcs?: boolean;
     } = {},
   ): AsyncGenerator<TypedMcapRecords["Message"], void, void> {
-    const {
-      topics,
-      startTime = this.#messageStartTime,
-      endTime = this.#messageEndTime,
-      reverse = false,
-      validateCrcs,
-    } = args;
-
-    if (startTime == undefined || endTime == undefined) {
-      return;
-    }
-
-    let relevantChannels: Set<number> | undefined;
-    if (topics) {
-      relevantChannels = new Set();
-      for (const channel of this.channelsById.values()) {
-        if (topics.includes(channel.topic)) {
-          relevantChannels.add(channel.id);
-        }
-      }
-    }
-
-    const chunkCursors = new Heap<ChunkCursor>((a, b) => a.compare(b));
-    let chunksOrdered = true;
-    let prevChunkEndTime: bigint | undefined;
-    const readFullMessageIndexRange = this.#messageIndexReadable !== this.#readable;
-    for (const chunkIndex of this.chunkIndexes) {
-      if (chunkIndex.messageStartTime <= endTime && chunkIndex.messageEndTime >= startTime) {
-        chunkCursors.push(
-          new ChunkCursor({
-            chunkIndex,
-            relevantChannels,
-            startTime,
-            endTime,
-            reverse,
-            readFullMessageIndexRange,
-          }),
-        );
-        if (chunksOrdered && prevChunkEndTime != undefined) {
-          chunksOrdered = chunkIndex.messageStartTime >= prevChunkEndTime;
-        }
-        prevChunkEndTime = chunkIndex.messageEndTime;
-      }
-    }
+    const { validateCrcs } = args;
 
     // Holds the decompressed chunk data for "active" chunks. Items are added below when a chunk
     // cursor becomes active (i.e. when we first need to access messages from the chunk) and removed
     // when the cursor is removed from the heap.
     const chunkViewCache = new Map<bigint, DataView>();
     const chunkReader = new Reader(new DataView(new ArrayBuffer(0)));
-    for (let cursor; (cursor = chunkCursors.peek()); ) {
-      if (!cursor.hasMessageIndexes()) {
-        // If we encounter a chunk whose message indexes have not been loaded yet, load them and re-organize the heap.
-        await cursor.loadMessageIndexes(this.#messageIndexReadable);
-        if (cursor.hasMoreMessages()) {
-          chunkCursors.replace(cursor);
-        } else {
-          chunkCursors.pop();
-        }
-        continue;
-      }
-
+    for await (const [logTime, offset, cursor] of this.#mergeMessageOffsets(args)) {
       let chunkView = chunkViewCache.get(cursor.chunkIndex.chunkStartOffset);
       if (!chunkView) {
         chunkView = await this.#loadChunkData(cursor.chunkIndex, {
@@ -442,7 +388,6 @@ export class McapIndexedReader {
         chunkViewCache.set(cursor.chunkIndex.chunkStartOffset, chunkView);
       }
 
-      const [logTime, offset] = cursor.popMessage();
       if (offset >= BigInt(chunkView.byteLength)) {
         throw this.#errorWithLibrary(
           `Message offset beyond chunk bounds (log time ${logTime}, offset ${offset}, chunk data length ${chunkView.byteLength}) in chunk at offset ${cursor.chunkIndex.chunkStartOffset}`,
@@ -467,32 +412,26 @@ export class McapIndexedReader {
       }
       yield record;
 
-      if (cursor.hasMoreMessages()) {
-        // There is no need to reorganize the heap when chunks are ordered and not overlapping.
-        // We can simply keep on reading messages from the current chunk.
-        if (!chunksOrdered) {
-          chunkCursors.replace(cursor);
-        }
-      } else {
-        chunkCursors.pop();
+      // Once a cursor is exhausted its chunk data is no longer needed and can be released. This
+      // mirrors the pop in #mergeMessageOffsets, which runs right after this iteration resumes it.
+      if (!cursor.hasMoreMessages()) {
         chunkViewCache.delete(cursor.chunkIndex.chunkStartOffset);
       }
     }
   }
 
   /**
-   * Like {@link readMessages}, but only reads message indexes (never chunk payloads) and yields the
-   * log time of each message in merged time order. This makes it cheap to build a per-topic
-   * timestamp index without decoding message bodies.
+   * Walks the chunk message indexes in merged (time-sorted) order, loading each chunk's message
+   * indexes on demand but never reading or decoding chunk payloads. Yields `[logTime, offset,
+   * cursor]` for every message; consumers that need the message body load and parse the chunk data
+   * themselves via the yielded cursor's chunk index.
    */
-  async *readMessageTimestamps(
-    args: {
-      topics?: readonly string[];
-      startTime?: bigint;
-      endTime?: bigint;
-      reverse?: boolean;
-    } = {},
-  ): AsyncGenerator<bigint, void, void> {
+  async *#mergeMessageOffsets(args: {
+    topics?: readonly string[];
+    startTime?: bigint;
+    endTime?: bigint;
+    reverse?: boolean;
+  }): AsyncGenerator<[logTime: bigint, offset: bigint, cursor: ChunkCursor], void, void> {
     const {
       topics,
       startTime = this.#messageStartTime,
@@ -539,8 +478,7 @@ export class McapIndexedReader {
 
     for (let cursor; (cursor = chunkCursors.peek()); ) {
       if (!cursor.hasMessageIndexes()) {
-        // Load message indexes on demand and re-sort the heap, just like readMessages — but we
-        // never load or decode the chunk data itself.
+        // If we encounter a chunk whose message indexes have not been loaded yet, load them and re-organize the heap.
         await cursor.loadMessageIndexes(this.#messageIndexReadable);
         if (cursor.hasMoreMessages()) {
           chunkCursors.replace(cursor);
@@ -550,17 +488,36 @@ export class McapIndexedReader {
         continue;
       }
 
-      const [logTime] = cursor.popMessage();
-      yield logTime;
+      const [logTime, offset] = cursor.popMessage();
+      yield [logTime, offset, cursor];
 
       if (cursor.hasMoreMessages()) {
-        // No need to reorganize the heap when chunks are ordered and non-overlapping.
+        // There is no need to reorganize the heap when chunks are ordered and not overlapping.
+        // We can simply keep on reading messages from the current chunk.
         if (!chunksOrdered) {
           chunkCursors.replace(cursor);
         }
       } else {
         chunkCursors.pop();
       }
+    }
+  }
+
+  /**
+   * Like {@link readMessages}, but only reads message indexes (never chunk payloads) and yields the
+   * log time of each message in merged time order. This makes it cheap to build a per-topic
+   * timestamp index without decoding message bodies.
+   */
+  async *readMessageTimestamps(
+    args: {
+      topics?: readonly string[];
+      startTime?: bigint;
+      endTime?: bigint;
+      reverse?: boolean;
+    } = {},
+  ): AsyncGenerator<bigint, void, void> {
+    for await (const [logTime] of this.#mergeMessageOffsets(args)) {
+      yield logTime;
     }
   }
 


### PR DESCRIPTION
## Summary

Adds `McapIndexedReader.readMessageTimestamps()` — a generator that reads only message indexes (never chunk payloads) and yields each message's log time in merged time order. This makes it cheap to build a per-topic timestamp index without decoding message bodies.

It mirrors the heap/cursor merge logic of `readMessages`, but loads message indexes on demand and never fetches or decodes chunk data. Supports the same `topics`, `startTime`/`endTime`, and `reverse` options.

## Motivation

Downstream (Foxglove viz message-stepping / prefetch time index) we want a per-topic timestamp index to drive seeking and step navigation without paying to decode message bodies.

## Test plan

New `readMessageTimestamps` tests in `McapIndexedReader.test.ts`:
- yields all log times in merged time order
- filters by topic
- filters by time range
- yields log times in reverse time order

- [x] `yarn jest McapIndexedReader.test.ts` — 30/30 pass
- [x] `yarn tsc --noEmit` clean