### PR TITLE
cli: reimplement sort as a rewrite-engine preset

### DIFF
--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -280,7 +280,7 @@ fn bench_sort(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases: &
                             OsString::from("zstd"),
                             OsString::from("--chunk-size"),
                             OsString::from(config.chunk_bytes.to_string()),
-                            OsString::from("--output-file"),
+                            OsString::from("--output"),
                             output.as_os_str().to_owned(),
                         ];
                         let duration = run_mcap(&config.mcap_bin, args);

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -134,12 +134,6 @@ pub struct CommonRewriteArgs {
     /// Disable all output CRC fields
     #[arg(long = "no-crc", default_value_t = false)]
     pub no_crc: bool,
-
-    /// Message order in the output: preserve (keep the input order) or log_time.
-    ///
-    /// Defaults to preserve, except `sort`, which defaults to log_time.
-    #[arg(long = "order", value_enum)]
-    pub order: Option<MessageOrder>,
 }
 
 impl CommonRewriteArgs {
@@ -166,12 +160,20 @@ pub struct CompressCommand {
     /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long = "compression", default_value = "zstd")]
     pub compression: String,
+
+    /// Message order in the output: preserve (keep the input order) or log_time
+    #[arg(long = "order", value_enum, default_value = "preserve")]
+    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct DecompressCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
+
+    /// Message order in the output: preserve (keep the input order) or log_time
+    #[arg(long = "order", value_enum, default_value = "preserve")]
+    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -535,6 +537,10 @@ pub struct FilterCommand {
     /// Write records outside of chunks
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
+
+    /// Message order in the output: preserve (keep the input order) or log_time
+    #[arg(long = "order", value_enum, default_value = "preserve")]
+    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -580,6 +586,13 @@ pub struct SortCommand {
     /// Write records outside of chunks
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
+
+    /// Message order in the output: preserve (keep the input order) or log_time.
+    ///
+    /// `sort` defaults to log_time; it accepts the same flag as the other rewrite commands so it
+    /// can be overridden (and future modes such as publish_time will apply here too).
+    #[arg(long = "order", value_enum, default_value = "log_time")]
+    pub order: MessageOrder,
 }
 
 pub type InfoCommand = FileCommand;

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -551,8 +551,12 @@ pub struct SortCommand {
     pub file: PathBuf,
 
     /// Local path for the destination sorted MCAP file
-    #[arg(short = 'o', long = "output-file")]
-    pub output_file: PathBuf,
+    #[arg(short = 'o', long = "output", required_unless_present = "output_file")]
+    pub output: Option<PathBuf>,
+
+    /// Deprecated: use --output.
+    #[arg(long = "output-file", hide = true)]
+    pub output_file: Option<PathBuf>,
 
     /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
     #[arg(long, value_enum, default_value = "zstd")]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -4,6 +4,7 @@ use std::sync::LazyLock;
 use anyhow::{bail, Context, Result};
 use clap::{ArgAction, Parser, Subcommand};
 use clap_complete::Shell;
+use log::warn;
 
 use crate::logsetup;
 
@@ -110,9 +111,9 @@ pub struct CompletionCommand {
     pub shell: Shell,
 }
 
-/// Options shared by every rewrite-based command (`filter`, `compress`, `decompress`). Each
-/// command flattens these and adds only the knobs that apply to it, so the common definitions
-/// (and their help text / defaults) live in one place.
+/// Options shared by every rewrite-based command (`filter`, `compress`, `decompress`, `sort`).
+/// Each command flattens these and adds only the knobs that apply to it, so the common definitions
+/// (and their help text) live in one place.
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CommonRewriteArgs {
     /// Input MCAP file path. If omitted, reads from stdin.
@@ -122,6 +123,10 @@ pub struct CommonRewriteArgs {
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
 
+    /// Deprecated: use --output.
+    #[arg(long = "output-file", hide = true)]
+    pub output_file: Option<PathBuf>,
+
     /// Target uncompressed chunk size for output
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
@@ -130,9 +135,27 @@ pub struct CommonRewriteArgs {
     #[arg(long = "no-crc", default_value_t = false)]
     pub no_crc: bool,
 
-    /// Message order in the output: preserve (keep the input order) or log_time
-    #[arg(long = "order", value_enum, default_value = "preserve")]
-    pub order: MessageOrder,
+    /// Message order in the output: preserve (keep the input order) or log_time.
+    ///
+    /// Defaults to preserve, except `sort`, which defaults to log_time.
+    #[arg(long = "order", value_enum)]
+    pub order: Option<MessageOrder>,
+}
+
+impl CommonRewriteArgs {
+    /// The resolved output path: the `-o/--output` value, falling back to the deprecated
+    /// `--output-file` alias. `None` means write to stdout.
+    pub(crate) fn output(&self) -> Option<PathBuf> {
+        self.output.clone().or_else(|| self.output_file.clone())
+    }
+
+    /// Warns about any deprecated shared flags that were supplied. Called by every rewrite
+    /// command handler.
+    pub(crate) fn warn_deprecations(&self) {
+        if self.output_file.is_some() {
+            warn!("--output-file is deprecated; use --output instead");
+        }
+    }
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -547,36 +570,16 @@ pub struct RecoverCommand {
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct SortCommand {
-    /// Local path to the source MCAP file
-    pub file: PathBuf,
-
-    /// Local path for the destination sorted MCAP file
-    #[arg(short = 'o', long = "output", required_unless_present = "output_file")]
-    pub output: Option<PathBuf>,
-
-    /// Deprecated: use --output.
-    #[arg(long = "output-file", hide = true)]
-    pub output_file: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: CommonRewriteArgs,
 
     /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
     #[arg(long, value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
 
-    /// Target uncompressed chunk size in bytes
-    #[arg(long, default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
-    pub chunk_size: u64,
-
-    /// Disable all output CRC fields
-    #[arg(long = "no-crc", default_value_t = false)]
-    pub no_crc: bool,
-
     /// Write records outside of chunks
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
-
-    /// Message order in the output: log_time (the default) or preserve (keep the input order)
-    #[arg(long = "order", value_enum, default_value = "log_time")]
-    pub order: MessageOrder,
 }
 
 pub type InfoCommand = FileCommand;

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -569,6 +569,10 @@ pub struct SortCommand {
     /// Write records outside of chunks
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
+
+    /// Message order in the output: log_time (the default) or preserve (keep the input order)
+    #[arg(long = "order", value_enum, default_value = "log_time")]
+    pub order: MessageOrder,
 }
 
 pub type InfoCommand = FileCommand;

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -259,9 +259,9 @@ mod tests {
                     output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: None,
                 },
                 compression: "invalid".to_string(),
+                order: MessageOrder::Preserve,
             }),
         )
         .expect_err("compress should reject invalid compression");
@@ -279,10 +279,10 @@ mod tests {
                     output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: Some(MessageOrder::LogTime),
                 },
                 compression: crate::cli::CompressionFormat::Zstd,
                 no_chunks: false,
+                order: MessageOrder::LogTime,
             }),
         )
         .expect_err("sort should fail on missing input file");

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -256,9 +256,10 @@ mod tests {
                 common: CommonRewriteArgs {
                     file: None,
                     output: None,
+                    output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: MessageOrder::Preserve,
+                    order: None,
                 },
                 compression: "invalid".to_string(),
             }),
@@ -272,14 +273,16 @@ mod tests {
         let err = dispatch(
             &CommandContext::default(),
             Command::Sort(SortCommand {
-                file: PathBuf::from("does-not-exist.mcap"),
-                output: Some(PathBuf::from("sorted.mcap")),
-                output_file: None,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                common: CommonRewriteArgs {
+                    file: Some(PathBuf::from("does-not-exist.mcap")),
+                    output: Some(PathBuf::from("sorted.mcap")),
+                    output_file: None,
+                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                    no_crc: false,
+                    order: Some(MessageOrder::LogTime),
+                },
                 compression: crate::cli::CompressionFormat::Zstd,
-                no_crc: false,
                 no_chunks: false,
-                order: MessageOrder::LogTime,
             }),
         )
         .expect_err("sort should fail on missing input file");

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -278,6 +278,7 @@ mod tests {
                 compression: crate::cli::CompressionFormat::Zstd,
                 no_crc: false,
                 no_chunks: false,
+                order: MessageOrder::LogTime,
             }),
         )
         .expect_err("sort should fail on missing input file");

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -273,7 +273,8 @@ mod tests {
             &CommandContext::default(),
             Command::Sort(SortCommand {
                 file: PathBuf::from("does-not-exist.mcap"),
-                output_file: PathBuf::from("sorted.mcap"),
+                output: Some(PathBuf::from("sorted.mcap")),
+                output_file: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 compression: crate::cli::CompressionFormat::Zstd,
                 no_crc: false,

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -7,8 +7,10 @@ use crate::rewrite::{self, RewriteOptions};
 pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
     args.common.warn_deprecations();
     // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata
-    // and attachments. Paths, chunk size, `--no-crc`, and order come from the shared args.
-    let options = RewriteOptions::from(&args.common).compression(args.compression);
+    // and attachments. Paths, chunk size, and `--no-crc` come from the shared args.
+    let options = RewriteOptions::from(&args.common)
+        .compression(args.compression)
+        .order(args.order);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -5,6 +5,7 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
+    args.common.warn_deprecations();
     // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata
     // and attachments. Paths, chunk size, `--no-crc`, and order come from the shared args.
     let options = RewriteOptions::from(&args.common).compression(args.compression);

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -5,6 +5,7 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
+    args.common.warn_deprecations();
     // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and
     // attachments. Paths, chunk size, `--no-crc`, and order come from the shared args.
     let options = RewriteOptions::from(&args.common).compression("none");

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -7,8 +7,10 @@ use crate::rewrite::{self, RewriteOptions};
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
     args.common.warn_deprecations();
     // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and
-    // attachments. Paths, chunk size, `--no-crc`, and order come from the shared args.
-    let options = RewriteOptions::from(&args.common).compression("none");
+    // attachments. Paths, chunk size, and `--no-crc` come from the shared args.
+    let options = RewriteOptions::from(&args.common)
+        .compression("none")
+        .order(args.order);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -10,6 +10,7 @@ use crate::rewrite::{self, RewriteOptions};
 use crate::source;
 
 pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
+    args.common.warn_deprecations();
     if args.include_metadata {
         warn!("--include-metadata is deprecated and has no effect; metadata is included by default (use --exclude-metadata to drop it)");
     }

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -41,10 +41,10 @@ mod tests {
                 output_file: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 no_crc: false,
-                order: None,
             },
             compression: CompressionFormat::Zstd,
             no_chunks: false,
+            order: MessageOrder::LogTime,
         }
     }
 
@@ -230,7 +230,7 @@ mod tests {
         // sorting, so future modes (for example `publish_time`) can slot in the same way.
         let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
             let mut command = sort_command(input.clone(), out.clone());
-            command.common.order = Some(MessageOrder::Preserve);
+            command.order = MessageOrder::Preserve;
             command
         });
         assert_eq!(

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -6,6 +6,7 @@
 //! last); `sort` only supplies the preset options. `--order` stays a real flag so future modes
 //! (for example `publish_time`) apply to `sort` too.
 use anyhow::Result;
+use log::warn;
 
 use crate::cli::SortCommand;
 use crate::context::CommandContext;
@@ -13,6 +14,9 @@ use crate::rewrite::{self, RewriteOptions};
 use crate::source;
 
 pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
+    if args.output_file.is_some() {
+        warn!("--output-file is deprecated; use --output instead");
+    }
     rewrite::run(
         RewriteOptions::from(&args),
         source::SourceOptions::new(ctx.allow_remote_scan()),
@@ -32,10 +36,11 @@ mod tests {
     use crate::cli::{CompressionFormat, MessageOrder, SortCommand};
     use crate::context::CommandContext;
 
-    fn sort_command(file: PathBuf, output_file: PathBuf) -> SortCommand {
+    fn sort_command(file: PathBuf, output: PathBuf) -> SortCommand {
         SortCommand {
             file,
-            output_file,
+            output: Some(output),
+            output_file: None,
             compression: CompressionFormat::Zstd,
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             no_crc: false,
@@ -203,6 +208,25 @@ mod tests {
     fn sorts_summaryless_input() {
         let output = run_sort(build_out_of_order_summaryless_input(), |input, out| {
             sort_command(input.clone(), out.clone())
+        });
+        assert_eq!(output_log_times(&output), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn deprecated_output_file_alias_still_writes_output() {
+        // Passing the deprecated `--output-file` (with `--output` absent) still produces sorted
+        // output; the handler warns but does not fail.
+        let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
+            SortCommand {
+                file: input.clone(),
+                output: None,
+                output_file: Some(out.clone()),
+                compression: CompressionFormat::Zstd,
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                no_crc: false,
+                no_chunks: false,
+                order: MessageOrder::LogTime,
+            }
         });
         assert_eq!(output_log_times(&output), vec![10, 20, 30]);
     }

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -6,7 +6,6 @@
 //! last); `sort` only supplies the preset options. `--order` stays a real flag so future modes
 //! (for example `publish_time`) apply to `sort` too.
 use anyhow::Result;
-use log::warn;
 
 use crate::cli::SortCommand;
 use crate::context::CommandContext;
@@ -14,9 +13,7 @@ use crate::rewrite::{self, RewriteOptions};
 use crate::source;
 
 pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
-    if args.output_file.is_some() {
-        warn!("--output-file is deprecated; use --output instead");
-    }
+    args.common.warn_deprecations();
     rewrite::run(
         RewriteOptions::from(&args),
         source::SourceOptions::new(ctx.allow_remote_scan()),
@@ -33,19 +30,21 @@ mod tests {
     use mcap::records::{op, MessageHeader};
 
     use super::run;
-    use crate::cli::{CompressionFormat, MessageOrder, SortCommand};
+    use crate::cli::{CommonRewriteArgs, CompressionFormat, MessageOrder, SortCommand};
     use crate::context::CommandContext;
 
     fn sort_command(file: PathBuf, output: PathBuf) -> SortCommand {
         SortCommand {
-            file,
-            output: Some(output),
-            output_file: None,
+            common: CommonRewriteArgs {
+                file: Some(file),
+                output: Some(output),
+                output_file: None,
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                no_crc: false,
+                order: None,
+            },
             compression: CompressionFormat::Zstd,
-            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-            no_crc: false,
             no_chunks: false,
-            order: MessageOrder::LogTime,
         }
     }
 
@@ -217,16 +216,10 @@ mod tests {
         // Passing the deprecated `--output-file` (with `--output` absent) still produces sorted
         // output; the handler warns but does not fail.
         let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
-            SortCommand {
-                file: input.clone(),
-                output: None,
-                output_file: Some(out.clone()),
-                compression: CompressionFormat::Zstd,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                no_crc: false,
-                no_chunks: false,
-                order: MessageOrder::LogTime,
-            }
+            let mut command = sort_command(input.clone(), out.clone());
+            command.common.output = None;
+            command.common.output_file = Some(out.clone());
+            command
         });
         assert_eq!(output_log_times(&output), vec![10, 20, 30]);
     }
@@ -237,7 +230,7 @@ mod tests {
         // sorting, so future modes (for example `publish_time`) can slot in the same way.
         let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
             let mut command = sort_command(input.clone(), out.clone());
-            command.order = MessageOrder::Preserve;
+            command.common.order = Some(MessageOrder::Preserve);
             command
         });
         assert_eq!(

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -1,243 +1,22 @@
-use std::borrow::Cow;
-use std::io::{Seek, Write};
+//! `sort` rewrites an MCAP with its messages in log-time order.
+//!
+//! It is a thin preset over the shared [`crate::rewrite`] engine: `sort` is `filter` with
+//! `--order` defaulting to `log_time` instead of `preserve`. The engine handles reading (indexed
+//! or summaryless), ordering, and the standardized record placement (metadata first, attachments
+//! last); `sort` only supplies the preset options. `--order` stays a real flag so future modes
+//! (for example `publish_time`) apply to `sort` too.
+use anyhow::Result;
 
-use anyhow::{Context, Result};
-
-use crate::cli::{CompressionFormat, SortCommand};
+use crate::cli::SortCommand;
 use crate::context::CommandContext;
-use crate::{parse, rewrite, source};
-
-#[derive(Debug, Clone)]
-struct SortOptions {
-    compression: Option<mcap::Compression>,
-    chunk_size: u64,
-    include_crc: bool,
-    chunked: bool,
-}
-
-#[derive(Debug)]
-enum SortInput {
-    Indexed(Box<mcap::Summary>),
-    Linear,
-}
+use crate::rewrite::{self, RewriteOptions};
+use crate::source;
 
 pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
-    let opts = build_sort_options(&args);
-    source::ensure_distinct_local_input_output(&args.file, &args.output_file)?;
-    let input = source::load_path(
-        &args.file,
+    rewrite::run(
+        RewriteOptions::from(&args),
         source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
-    let sort_input = validate_sort_input(input.as_slice())?;
-    let output = std::fs::File::create(&args.output_file)
-        .with_context(|| format!("failed to open output '{}'", args.output_file.display()))?;
-    sort_to_writer(input.as_slice(), output, sort_input, &opts)
-}
-
-fn build_sort_options(args: &SortCommand) -> SortOptions {
-    SortOptions {
-        compression: convert_compression(args.compression),
-        chunk_size: args.chunk_size,
-        include_crc: !args.no_crc,
-        chunked: !args.no_chunks,
-    }
-}
-
-fn convert_compression(value: CompressionFormat) -> Option<mcap::Compression> {
-    match value {
-        CompressionFormat::Zstd => Some(mcap::Compression::Zstd),
-        CompressionFormat::Lz4 => Some(mcap::Compression::Lz4),
-        CompressionFormat::None => None,
-    }
-}
-
-fn sort_to_writer<W: Write + Seek>(
-    input: &[u8],
-    sink: W,
-    sort_input: SortInput,
-    opts: &SortOptions,
-) -> Result<()> {
-    let header = parse::read_header(input)?;
-    let mut write_options = mcap::WriteOptions::new()
-        .use_chunks(opts.chunked)
-        .chunk_size(Some(opts.chunk_size))
-        .compression(opts.compression)
-        .calculate_chunk_crcs(opts.include_crc)
-        .calculate_data_section_crc(opts.include_crc)
-        .calculate_summary_section_crc(opts.include_crc)
-        .calculate_attachment_crcs(opts.include_crc);
-    write_options = write_options.library(crate::cli::LIBRARY_IDENTIFIER.clone());
-    if let Some(header) = header {
-        write_options = write_options.profile(header.profile);
-    }
-
-    let mut writer = write_options
-        .create(sink)
-        .context("failed to create mcap writer")?;
-
-    match &sort_input {
-        SortInput::Indexed(summary) => {
-            copy_attachments_from_summary(input, summary, &mut writer)?;
-            copy_metadata_from_summary(input, summary, &mut writer)?;
-            copy_messages_in_log_time_order(input, summary, &mut writer)?;
-        }
-        SortInput::Linear => {
-            copy_linear_non_message_records(input, &mut writer)?;
-            copy_linear_messages_in_log_time_order(input, &mut writer)?;
-        }
-    }
-
-    writer.finish().context("failed to finish mcap writer")?;
-    Ok(())
-}
-
-fn validate_sort_input(input: &[u8]) -> Result<SortInput> {
-    let summary = match mcap::Summary::read(input) {
-        Ok(summary) => summary,
-        Err(mcap::McapError::UnknownSchema(_, _))
-            if !parse::summary_section_has_chunk_indexes(input)? =>
-        {
-            return Ok(SortInput::Linear);
-        }
-        Err(mcap::McapError::UnknownSchema(_, _)) => {
-            return Err(rewrite::incomplete_indexed_summary_error());
-        }
-        Err(err) => return Err(err).context("failed to read file index"),
-    };
-    match summary {
-        Some(summary) => {
-            if !summary.chunk_indexes.is_empty() {
-                if rewrite::summary_supports_indexed_read(&summary) {
-                    return Ok(SortInput::Indexed(Box::new(summary)));
-                }
-                return Err(rewrite::incomplete_indexed_summary_error());
-            }
-            Ok(SortInput::Linear)
-        }
-        None => Ok(SortInput::Linear),
-    }
-}
-
-fn copy_attachments_from_summary<W: Write + Seek>(
-    input: &[u8],
-    summary: &mcap::Summary,
-    writer: &mut mcap::Writer<W>,
-) -> Result<()> {
-    let mut indexes = summary.attachment_indexes.clone();
-    indexes.sort_by_key(|index| index.offset);
-    for index in &indexes {
-        let attachment = mcap::read::attachment(input, index)
-            .with_context(|| format!("failed to read attachment at offset {}", index.offset))?;
-        writer
-            .attach(&attachment)
-            .with_context(|| format!("failed to write attachment {}", index.name))?;
-    }
-    Ok(())
-}
-
-fn copy_metadata_from_summary<W: Write + Seek>(
-    input: &[u8],
-    summary: &mcap::Summary,
-    writer: &mut mcap::Writer<W>,
-) -> Result<()> {
-    let mut indexes = summary.metadata_indexes.clone();
-    indexes.sort_by_key(|index| index.offset);
-    for index in &indexes {
-        let metadata = mcap::read::metadata(input, index)
-            .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
-        writer
-            .write_metadata(&metadata)
-            .with_context(|| format!("failed to write metadata {}", metadata.name))?;
-    }
-    Ok(())
-}
-
-fn copy_messages_in_log_time_order<W: Write + Seek>(
-    input: &[u8],
-    summary: &mcap::Summary,
-    writer: &mut mcap::Writer<W>,
-) -> Result<()> {
-    let mut reader = mcap::sans_io::IndexedReader::new_with_options(
-        summary,
-        mcap::sans_io::IndexedReaderOptions::new()
-            .with_order(mcap::sans_io::indexed_reader::ReadOrder::LogTime),
-    )?;
-
-    while let Some(event) = reader.next_event() {
-        match event? {
-            mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                let chunk_data = checked_slice(input, offset, length)?;
-                reader.insert_chunk_record_data(offset, chunk_data)?;
-            }
-            mcap::sans_io::IndexedReadEvent::Message { header, data } => {
-                let channel = summary.channels.get(&header.channel_id).ok_or_else(|| {
-                    anyhow::anyhow!("message references unknown channel {}", header.channel_id)
-                })?;
-                writer.write(&mcap::Message {
-                    channel: channel.clone(),
-                    sequence: header.sequence,
-                    log_time: header.log_time,
-                    publish_time: header.publish_time,
-                    data: Cow::Borrowed(data),
-                })?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn copy_linear_messages_in_log_time_order<W: Write + Seek>(
-    input: &[u8],
-    writer: &mut mcap::Writer<W>,
-) -> Result<()> {
-    // Without chunk indexes, sorting necessarily materializes messages before reordering.
-    let mut messages = mcap::MessageStream::new(input)?
-        .enumerate()
-        .map(|(input_order, message)| message.map(|message| (input_order, message)))
-        .collect::<mcap::McapResult<Vec<_>>>()
-        .context("failed to read messages")?;
-    messages.sort_by_key(|(input_order, message)| (message.log_time, *input_order));
-
-    for (_, message) in messages {
-        writer.write(&message)?;
-    }
-
-    Ok(())
-}
-
-fn copy_linear_non_message_records<W: Write + Seek>(
-    input: &[u8],
-    writer: &mut mcap::Writer<W>,
-) -> Result<()> {
-    for record in mcap::read::LinearReader::new(input)? {
-        match record? {
-            mcap::records::Record::Attachment { header, data, .. } => {
-                writer.attach(&mcap::Attachment {
-                    log_time: header.log_time,
-                    create_time: header.create_time,
-                    name: header.name,
-                    media_type: header.media_type,
-                    data: Cow::Borrowed(data.as_ref()),
-                })?;
-            }
-            mcap::records::Record::Metadata(metadata) => {
-                writer.write_metadata(&metadata)?;
-            }
-            _ => {}
-        }
-    }
-    Ok(())
-}
-
-fn checked_slice(input: &[u8], offset: u64, length: usize) -> Result<&[u8]> {
-    let start = usize::try_from(offset)
-        .with_context(|| format!("chunk offset out of range for this platform: {offset}"))?;
-    let end = start
-        .checked_add(length)
-        .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
-    input.get(start..end).ok_or_else(|| {
-        anyhow::anyhow!("chunk read out of bounds at offset {offset} length {length}")
-    })
+    )
 }
 
 #[cfg(test)]
@@ -247,53 +26,46 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{sort_to_writer, validate_sort_input, SortInput, SortOptions};
-    use crate::cli::CompressionFormat;
-    use crate::cli::SortCommand;
+    use mcap::records::{op, MessageHeader};
+
+    use super::run;
+    use crate::cli::{CompressionFormat, MessageOrder, SortCommand};
     use crate::context::CommandContext;
 
-    fn default_sort_options() -> SortOptions {
-        SortOptions {
-            compression: Some(mcap::Compression::Zstd),
+    fn sort_command(file: PathBuf, output_file: PathBuf) -> SortCommand {
+        SortCommand {
+            file,
+            output_file,
+            compression: CompressionFormat::Zstd,
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-            include_crc: true,
-            chunked: true,
+            no_crc: false,
+            no_chunks: false,
+            order: MessageOrder::LogTime,
         }
     }
 
-    fn build_out_of_order_chunked_input(include_records: bool) -> Vec<u8> {
-        build_out_of_order_chunked_input_with_options(include_records, true, true, true, true)
+    fn unique_temp_path(stem: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        path.push(format!(
+            "mcap_cli_sort_test_{stem}_{}_{}",
+            std::process::id(),
+            nonce
+        ));
+        path
     }
 
-    fn build_out_of_order_chunked_input_with_summary_repeats(
-        include_records: bool,
-        repeat_channels: bool,
-        repeat_schemas: bool,
-    ) -> Vec<u8> {
-        build_out_of_order_chunked_input_with_options(
-            include_records,
-            repeat_channels,
-            repeat_schemas,
-            true,
-            true,
-        )
-    }
-
-    fn build_out_of_order_chunked_input_with_options(
-        include_records: bool,
-        repeat_channels: bool,
-        repeat_schemas: bool,
-        emit_message_indexes: bool,
-        emit_chunk_indexes: bool,
-    ) -> Vec<u8> {
+    /// Chunked (indexed) input whose messages are stored out of log-time order, with a metadata
+    /// record and an attachment, so a successful sort is observable and the standardized placement
+    /// can be asserted.
+    fn build_out_of_order_indexed_input() -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut writer = mcap::WriteOptions::new()
                 .chunk_size(Some(1024))
-                .repeat_channels(repeat_channels)
-                .repeat_schemas(repeat_schemas)
-                .emit_message_indexes(emit_message_indexes)
-                .emit_chunk_indexes(emit_chunk_indexes)
                 .library("test-recorder/0.0")
                 .create(&mut output)
                 .expect("writer");
@@ -303,62 +75,49 @@ mod tests {
             let channel_id = writer
                 .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
                 .expect("channel");
-
-            writer
-                .write_to_known_channel(
-                    &mcap::records::MessageHeader {
-                        channel_id,
-                        sequence: 1,
-                        log_time: 30,
-                        publish_time: 30,
-                    },
-                    &[1],
-                )
-                .expect("write message");
-            writer.flush().expect("flush");
-
-            writer
-                .write_to_known_channel(
-                    &mcap::records::MessageHeader {
-                        channel_id,
-                        sequence: 2,
-                        log_time: 10,
-                        publish_time: 10,
-                    },
-                    &[2],
-                )
-                .expect("write message");
-
-            if include_records {
+            for (sequence, log_time) in [(1u32, 30u64), (2, 10), (3, 20)] {
                 writer
-                    .attach(&mcap::Attachment {
-                        log_time: 100,
-                        create_time: 100,
-                        name: "demo.bin".to_string(),
-                        media_type: "application/octet-stream".to_string(),
-                        data: std::borrow::Cow::Borrowed(&[9, 8, 7]),
-                    })
-                    .expect("attachment");
-                writer
-                    .write_metadata(&mcap::records::Metadata {
-                        name: "demo".to_string(),
-                        metadata: BTreeMap::from([("k".to_string(), "v".to_string())]),
-                    })
-                    .expect("metadata");
+                    .write_to_known_channel(
+                        &MessageHeader {
+                            channel_id,
+                            sequence,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        &[sequence as u8],
+                    )
+                    .expect("message");
             }
-
+            writer
+                .attach(&mcap::Attachment {
+                    log_time: 100,
+                    create_time: 100,
+                    name: "demo.bin".to_string(),
+                    media_type: "application/octet-stream".to_string(),
+                    data: std::borrow::Cow::Borrowed(&[9, 8, 7]),
+                })
+                .expect("attachment");
+            writer
+                .write_metadata(&mcap::records::Metadata {
+                    name: "demo".to_string(),
+                    metadata: BTreeMap::from([("k".to_string(), "v".to_string())]),
+                })
+                .expect("metadata");
             writer.finish().expect("finish");
         }
         output.into_inner()
     }
 
-    fn build_summaryless_message_input() -> Vec<u8> {
+    /// Summaryless, unchunked input with out-of-order messages, so the engine's linear (buffered)
+    /// ordering path is exercised end to end through `sort`.
+    fn build_out_of_order_summaryless_input() -> Vec<u8> {
         let mut output = Cursor::new(Vec::new());
         {
             let mut writer = mcap::WriteOptions::new()
                 .use_chunks(false)
                 .emit_summary_records(false)
                 .emit_summary_offsets(false)
+                .library("test-recorder/0.0")
                 .create(&mut output)
                 .expect("writer");
             let schema_id = writer
@@ -367,128 +126,108 @@ mod tests {
             let channel_id = writer
                 .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
                 .expect("channel");
-            writer
-                .write_to_known_channel(
-                    &mcap::records::MessageHeader {
-                        channel_id,
-                        sequence: 1,
-                        log_time: 5,
-                        publish_time: 5,
-                    },
-                    &[1],
-                )
-                .expect("message");
+            for (sequence, log_time) in [(1u32, 30u64), (2, 10), (3, 20)] {
+                writer
+                    .write_to_known_channel(
+                        &MessageHeader {
+                            channel_id,
+                            sequence,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        &[sequence as u8],
+                    )
+                    .expect("message");
+            }
             writer.finish().expect("finish");
         }
         output.into_inner()
     }
 
-    fn build_summaryless_equal_time_message_input() -> Vec<u8> {
-        let mut output = Cursor::new(Vec::new());
-        {
-            let mut writer = mcap::WriteOptions::new()
-                .use_chunks(false)
-                .emit_summary_records(false)
-                .emit_summary_offsets(false)
-                .create(&mut output)
-                .expect("writer");
-            let schema_id = writer
-                .add_schema("Example", "jsonschema", br#"{"type":"object"}"#)
-                .expect("schema");
-            let first_channel_id = writer
-                .add_channel(schema_id, "/first", "json", &BTreeMap::new())
-                .expect("first channel");
-            let second_channel_id = writer
-                .add_channel(schema_id, "/second", "json", &BTreeMap::new())
-                .expect("second channel");
-
-            writer
-                .write_to_known_channel(
-                    &mcap::records::MessageHeader {
-                        channel_id: second_channel_id,
-                        sequence: 1,
-                        log_time: 5,
-                        publish_time: 5,
-                    },
-                    &[2],
-                )
-                .expect("second message");
-            writer
-                .write_to_known_channel(
-                    &mcap::records::MessageHeader {
-                        channel_id: first_channel_id,
-                        sequence: 2,
-                        log_time: 5,
-                        publish_time: 5,
-                    },
-                    &[1],
-                )
-                .expect("first message");
-            writer.finish().expect("finish");
-        }
-        output.into_inner()
-    }
-
-    fn build_summaryless_metadata_only_input() -> Vec<u8> {
-        let mut output = Cursor::new(Vec::new());
-        {
-            let mut writer = mcap::WriteOptions::new()
-                .use_chunks(false)
-                .emit_summary_records(false)
-                .emit_summary_offsets(false)
-                .create(&mut output)
-                .expect("writer");
-            writer
-                .write_metadata(&mcap::records::Metadata {
-                    name: "demo".to_string(),
-                    metadata: BTreeMap::from([("foo".to_string(), "bar".to_string())]),
-                })
-                .expect("metadata");
-            writer.finish().expect("finish");
-        }
-        output.into_inner()
-    }
-
-    #[test]
-    fn sorts_messages_in_log_time_order() {
-        let input = build_out_of_order_chunked_input(false);
-        let mut output = Cursor::new(Vec::new());
-        let summary = mcap::Summary::read(&input)
-            .expect("summary read")
-            .expect("summary should exist");
-        sort_to_writer(
-            &input,
-            &mut output,
-            SortInput::Indexed(Box::new(summary)),
-            &default_sort_options(),
-        )
-        .expect("sort should succeed");
-        let output = output.into_inner();
-
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
+    fn output_log_times(output: &[u8]) -> Vec<u64> {
+        mcap::MessageStream::new(output)
             .expect("message stream")
             .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![10, 30]);
+            .collect()
+    }
+
+    fn run_sort(
+        input: Vec<u8>,
+        mut command: impl FnMut(&PathBuf, &PathBuf) -> SortCommand,
+    ) -> Vec<u8> {
+        let input_path = unique_temp_path("input");
+        let output_path = unique_temp_path("output");
+        std::fs::write(&input_path, input).expect("write input fixture");
+
+        let result = run(
+            &CommandContext::default(),
+            command(&input_path, &output_path),
+        );
+        let output = result.and_then(|()| Ok(std::fs::read(&output_path)?));
+
+        let _ = std::fs::remove_file(&input_path);
+        let _ = std::fs::remove_file(&output_path);
+        output.expect("sort should succeed")
     }
 
     #[test]
-    fn sort_stamps_cli_writer_library() {
-        let input = build_out_of_order_chunked_input(false);
-        let mut output = Cursor::new(Vec::new());
-        let summary = mcap::Summary::read(&input)
-            .expect("summary read")
-            .expect("summary should exist");
-        sort_to_writer(
-            &input,
-            &mut output,
-            SortInput::Indexed(Box::new(summary)),
-            &default_sort_options(),
-        )
-        .expect("sort should succeed");
-        let output = output.into_inner();
+    fn sorts_indexed_input_and_keeps_metadata_and_attachments() {
+        let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
+            sort_command(input.clone(), out.clone())
+        });
 
-        // The fixture's `test-recorder/0.0` library is overwritten with the CLI's own identity.
+        assert_eq!(
+            output_log_times(&output),
+            vec![10, 20, 30],
+            "messages should be re-ordered by log time"
+        );
+
+        let summary = mcap::Summary::read(&output)
+            .expect("summary read")
+            .expect("summary present");
+        assert_eq!(summary.metadata_indexes.len(), 1);
+        assert_eq!(summary.attachment_indexes.len(), 1);
+
+        // Standardized placement: metadata precedes the first chunk, the attachment follows it.
+        let opcodes: Vec<u8> = mcap::read::LinearReader::new(&output)
+            .expect("reader")
+            .map(|record| record.expect("record").opcode())
+            .collect();
+        let position = |target: u8| opcodes.iter().position(|&opcode| opcode == target);
+        assert!(position(op::METADATA) < position(op::CHUNK));
+        assert!(position(op::CHUNK) < position(op::ATTACHMENT));
+        assert!(position(op::ATTACHMENT) < position(op::DATA_END));
+    }
+
+    #[test]
+    fn sorts_summaryless_input() {
+        let output = run_sort(build_out_of_order_summaryless_input(), |input, out| {
+            sort_command(input.clone(), out.clone())
+        });
+        assert_eq!(output_log_times(&output), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn order_preserve_keeps_stored_order() {
+        // `--order` remains a real flag; `preserve` copies the input's stored order rather than
+        // sorting, so future modes (for example `publish_time`) can slot in the same way.
+        let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
+            let mut command = sort_command(input.clone(), out.clone());
+            command.order = MessageOrder::Preserve;
+            command
+        });
+        assert_eq!(
+            output_log_times(&output),
+            vec![30, 10, 20],
+            "preserve should keep the input's stored order"
+        );
+    }
+
+    #[test]
+    fn stamps_cli_writer_library() {
+        let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
+            sort_command(input.clone(), out.clone())
+        });
         let library = crate::parse::read_header(&output)
             .expect("read header")
             .expect("header present")
@@ -497,106 +236,14 @@ mod tests {
     }
 
     #[test]
-    fn copies_attachments_and_metadata() {
-        let input = build_out_of_order_chunked_input(true);
-        let mut output = Cursor::new(Vec::new());
-        let summary = mcap::Summary::read(&input)
-            .expect("summary read")
-            .expect("summary should exist");
-        sort_to_writer(
-            &input,
-            &mut output,
-            SortInput::Indexed(Box::new(summary)),
-            &default_sort_options(),
-        )
-        .expect("sort should succeed");
-        let output = output.into_inner();
-
-        let summary = mcap::Summary::read(&output)
-            .expect("summary read")
-            .expect("summary should exist");
-        assert_eq!(summary.attachment_indexes.len(), 1);
-        assert_eq!(summary.metadata_indexes.len(), 1);
-
-        let attachment = mcap::read::attachment(&output, &summary.attachment_indexes[0])
-            .expect("attachment should parse");
-        assert_eq!(attachment.name, "demo.bin");
-        assert_eq!(attachment.data.as_ref(), &[9, 8, 7]);
-
-        let metadata = mcap::read::metadata(&output, &summary.metadata_indexes[0])
-            .expect("metadata should parse");
-        assert_eq!(metadata.name, "demo");
-        assert_eq!(metadata.metadata.get("k"), Some(&"v".to_string()));
-    }
-
-    #[test]
-    fn run_sorts_summaryless_input_with_messages() {
-        let input = build_summaryless_message_input();
-        let input_path = unique_temp_path("input");
-        let output_path = unique_temp_path("output");
-        std::fs::write(&input_path, input).expect("write input fixture");
-        std::fs::write(&output_path, b"replace-me").expect("write output sentinel");
-
-        super::run(
-            &CommandContext::default(),
-            SortCommand {
-                file: input_path.clone(),
-                output_file: output_path.clone(),
-                compression: CompressionFormat::Zstd,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                no_crc: false,
-                no_chunks: false,
-            },
-        )
-        .expect("summaryless input with messages should sort");
-        let output = std::fs::read(&output_path).expect("read output");
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![5]);
-
-        let _ = std::fs::remove_file(input_path);
-        let _ = std::fs::remove_file(output_path);
-    }
-
-    #[test]
-    fn linear_sort_preserves_input_order_for_equal_log_times() {
-        let input = build_summaryless_equal_time_message_input();
-        let mut output = Cursor::new(Vec::new());
-
-        sort_to_writer(
-            &input,
-            &mut output,
-            SortInput::Linear,
-            &default_sort_options(),
-        )
-        .expect("sort should succeed");
-        let output = output.into_inner();
-
-        let payloads: Vec<Vec<u8>> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").data.to_vec())
-            .collect();
-        assert_eq!(payloads, vec![vec![2], vec![1]]);
-    }
-
-    #[test]
-    fn run_rejects_same_input_and_output_file() {
-        let input = build_out_of_order_chunked_input(false);
+    fn rejects_same_input_and_output_file() {
+        let input = build_out_of_order_indexed_input();
         let file_path = unique_temp_path("same-file");
         std::fs::write(&file_path, &input).expect("write input fixture");
 
-        let err = super::run(
+        let err = run(
             &CommandContext::default(),
-            SortCommand {
-                file: file_path.clone(),
-                output_file: file_path.clone(),
-                compression: CompressionFormat::Zstd,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                no_crc: false,
-                no_chunks: false,
-            },
+            sort_command(file_path.clone(), file_path.clone()),
         )
         .expect_err("same input/output path should fail");
         assert!(err.to_string().contains("input and output paths"));
@@ -606,134 +253,16 @@ mod tests {
     }
 
     #[test]
-    fn run_treats_cloud_input_as_remote() {
-        let err = super::run(
+    fn treats_cloud_input_as_remote() {
+        let err = run(
             &CommandContext::default(),
-            SortCommand {
-                file: PathBuf::from("s3://bucket/input.mcap?token=secret"),
-                output_file: PathBuf::from("/tmp/mcap-cli-cloud-sort-output.mcap"),
-                compression: CompressionFormat::Zstd,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                no_crc: false,
-                no_chunks: false,
-            },
+            sort_command(
+                PathBuf::from("s3://bucket/input.mcap?token=secret"),
+                PathBuf::from("/tmp/mcap-cli-cloud-sort-output.mcap"),
+            ),
         )
         .expect_err("cloud input should require scan opt-in before download");
         assert!(err.to_string().contains("--allow-remote-scan"));
         assert!(!err.to_string().contains("token=secret"));
-    }
-
-    #[test]
-    fn allows_summaryless_inputs_without_messages() {
-        let input = build_summaryless_metadata_only_input();
-        let mut output = Cursor::new(Vec::new());
-        sort_to_writer(
-            &input,
-            &mut output,
-            SortInput::Linear,
-            &default_sort_options(),
-        )
-        .expect("summaryless metadata-only file should sort");
-        let output = output.into_inner();
-
-        let mut metadata_count = 0usize;
-        for record in mcap::read::LinearReader::new(&output)
-            .expect("reader")
-            .map(|record| record.expect("record"))
-        {
-            if matches!(record, mcap::records::Record::Metadata(_)) {
-                metadata_count += 1;
-            }
-        }
-        assert_eq!(metadata_count, 1);
-    }
-
-    #[test]
-    fn convert_compression_maps_variants() {
-        assert!(super::convert_compression(CompressionFormat::None).is_none());
-        assert!(matches!(
-            super::convert_compression(CompressionFormat::Lz4),
-            Some(mcap::Compression::Lz4)
-        ));
-        assert!(matches!(
-            super::convert_compression(CompressionFormat::Zstd),
-            Some(mcap::Compression::Zstd)
-        ));
-    }
-
-    #[test]
-    fn summaryless_input_with_messages_uses_linear_sorting() {
-        let input = build_summaryless_message_input();
-        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
-        assert!(matches!(sort_input, SortInput::Linear));
-    }
-
-    #[test]
-    fn chunked_input_without_chunk_index_uses_linear_sorting() {
-        let input = build_out_of_order_chunked_input_with_options(false, true, true, true, false);
-        let mut output = Cursor::new(Vec::new());
-        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
-        assert!(matches!(sort_input, SortInput::Linear));
-
-        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
-            .expect("sort should succeed");
-        let output = output.into_inner();
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![10, 30]);
-    }
-
-    #[test]
-    fn chunked_input_without_chunk_index_falls_back_to_linear_sorting_on_unknown_schema() {
-        let input = build_out_of_order_chunked_input_with_options(false, true, false, true, false);
-        let mut output = Cursor::new(Vec::new());
-        let sort_input = validate_sort_input(&input).expect("sort input should be valid");
-        assert!(matches!(sort_input, SortInput::Linear));
-
-        sort_to_writer(&input, &mut output, sort_input, &default_sort_options())
-            .expect("sort should succeed");
-        let output = output.into_inner();
-        let log_times: Vec<u64> = mcap::MessageStream::new(&output)
-            .expect("message stream")
-            .map(|message| message.expect("message").log_time)
-            .collect();
-        assert_eq!(log_times, vec![10, 30]);
-    }
-
-    #[test]
-    fn chunk_indexed_input_without_repeated_channels_errors() {
-        let input = build_out_of_order_chunked_input_with_summary_repeats(false, false, false);
-        let err = validate_sort_input(&input).expect_err("invalid indexed summary should fail");
-        assert!(err.to_string().contains("mcap recover"));
-    }
-
-    #[test]
-    fn chunk_indexed_input_without_channels_or_message_indexes_errors() {
-        let input = build_out_of_order_chunked_input_with_options(false, false, false, false, true);
-        let err = validate_sort_input(&input).expect_err("invalid indexed summary should fail");
-        assert!(err.to_string().contains("mcap recover"));
-    }
-
-    #[test]
-    fn chunk_indexed_input_without_repeated_schemas_errors() {
-        let input = build_out_of_order_chunked_input_with_summary_repeats(false, true, false);
-        let err = validate_sort_input(&input).expect_err("invalid indexed summary should fail");
-        assert!(err.to_string().contains("mcap recover"));
-    }
-
-    fn unique_temp_path(stem: &str) -> std::path::PathBuf {
-        let mut path = std::env::temp_dir();
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock should be after epoch")
-            .as_nanos();
-        path.push(format!(
-            "mcap_cli_sort_test_{stem}_{}_{}",
-            std::process::id(),
-            timestamp
-        ));
-        path
     }
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -476,9 +476,9 @@ mod tests {
                     output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: None,
                 },
                 compression: "zstd".to_string(),
+                order: MessageOrder::Preserve,
             })
         );
     }
@@ -509,9 +509,9 @@ mod tests {
                     output_file: None,
                     chunk_size: 1024,
                     no_crc: true,
-                    order: Some(MessageOrder::LogTime),
                 },
                 compression: "lz4".to_string(),
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -529,8 +529,8 @@ mod tests {
                     output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: None,
                 },
+                order: MessageOrder::Preserve,
             })
         );
     }
@@ -559,8 +559,8 @@ mod tests {
                     output_file: None,
                     chunk_size: 2048,
                     no_crc: true,
-                    order: Some(MessageOrder::LogTime),
                 },
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -600,7 +600,6 @@ mod tests {
                     output_file: None,
                     chunk_size: 2048,
                     no_crc: true,
-                    order: None,
                 },
                 include_topic_regex: vec!["camera.*".to_string()],
                 exclude_topic_regex: vec![],
@@ -618,6 +617,7 @@ mod tests {
                 compression: Some(CompressionFormat::Lz4),
                 output_compression: None,
                 no_chunks: true,
+                order: MessageOrder::Preserve,
             })
         );
     }
@@ -660,13 +660,14 @@ mod tests {
     }
 
     #[test]
-    fn filter_order_defaults_to_unset_and_parses_log_time() {
-        // The shared `--order` has no clap default (it is `None` when unset); each command resolves
-        // that to its own default (preserve for filter, log_time for sort) when building options.
+    fn filter_order_defaults_to_preserve_and_parses_log_time() {
+        // Each rewrite command owns its `--order` (so its default shows in --help): filter defaults
+        // to preserve; sort defaults to log_time. The flag name and values are identical across
+        // commands.
         let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
             .expect("filter should parse without --order");
         match default.command {
-            Command::Filter(filter) => assert_eq!(filter.common.order, None),
+            Command::Filter(filter) => assert_eq!(filter.order, MessageOrder::Preserve),
             other => panic!("expected filter command, got {other:?}"),
         }
 
@@ -674,9 +675,7 @@ mod tests {
             let args = Args::try_parse_from(["mcap", "filter", "in.mcap", "--order", value])
                 .unwrap_or_else(|_| panic!("filter should parse --order {value}"));
             match args.command {
-                Command::Filter(filter) => {
-                    assert_eq!(filter.common.order, Some(MessageOrder::LogTime))
-                }
+                Command::Filter(filter) => assert_eq!(filter.order, MessageOrder::LogTime),
                 other => panic!("expected filter command, got {other:?}"),
             }
         }
@@ -715,12 +714,11 @@ mod tests {
                     output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    // `sort` leaves --order unset here and resolves it to log_time at runtime
-                    // (the copy commands resolve an unset --order to preserve).
-                    order: None,
                 },
                 compression: CompressionFormat::Zstd,
                 no_chunks: false,
+                // `sort` defaults --order to log_time; the copy commands default to preserve.
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -740,10 +738,10 @@ mod tests {
                     output_file: Some("out.mcap".into()),
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: None,
                 },
                 compression: CompressionFormat::Zstd,
                 no_chunks: false,
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -800,12 +798,12 @@ mod tests {
                     output_file: None,
                     chunk_size: 1024,
                     no_crc: true,
-                    // `--order` stays a real flag on `sort`, so it can be overridden (and future
-                    // modes like publish_time can be added) rather than being locked to log_time.
-                    order: Some(MessageOrder::Preserve),
                 },
                 compression: CompressionFormat::None,
                 no_chunks: true,
+                // `--order` stays a real flag on `sort`, so it can be overridden (and future
+                // modes like publish_time can be added) rather than being locked to log_time.
+                order: MessageOrder::Preserve,
             })
         );
     }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -701,13 +701,35 @@ mod tests {
             args.command,
             Command::Sort(SortCommand {
                 file: "in.mcap".into(),
-                output_file: "out.mcap".into(),
+                output: Some("out.mcap".into()),
+                output_file: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 compression: CompressionFormat::Zstd,
                 no_crc: false,
                 no_chunks: false,
                 // `sort` defaults `--order` to log_time (the whole point of the command), unlike
                 // the other rewrite commands, which default to preserve.
+                order: MessageOrder::LogTime,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_sort_output_file_deprecated_alias() {
+        // `--output-file` is retained as a hidden deprecated alias for `--output`; it parses into
+        // the separate field so the handler can warn.
+        let args = Args::try_parse_from(["mcap", "sort", "in.mcap", "--output-file", "out.mcap"])
+            .expect("deprecated --output-file should still parse");
+        assert_eq!(
+            args.command,
+            Command::Sort(SortCommand {
+                file: "in.mcap".into(),
+                output: None,
+                output_file: Some("out.mcap".into()),
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                compression: CompressionFormat::Zstd,
+                no_crc: false,
+                no_chunks: false,
                 order: MessageOrder::LogTime,
             })
         );
@@ -760,7 +782,8 @@ mod tests {
             args.command,
             Command::Sort(SortCommand {
                 file: "in.mcap".into(),
-                output_file: "out.mcap".into(),
+                output: Some("out.mcap".into()),
+                output_file: None,
                 chunk_size: 1024,
                 compression: CompressionFormat::None,
                 no_crc: true,
@@ -839,6 +862,7 @@ mod tests {
 
     #[test]
     fn sort_requires_output_file() {
-        Args::try_parse_from(["mcap", "sort", "in.mcap"]).expect_err("sort requires --output-file");
+        Args::try_parse_from(["mcap", "sort", "in.mcap"])
+            .expect_err("sort requires an output path");
     }
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -473,9 +473,10 @@ mod tests {
                 common: CommonRewriteArgs {
                     file: Some("in.mcap".into()),
                     output: None,
+                    output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: MessageOrder::Preserve,
+                    order: None,
                 },
                 compression: "zstd".to_string(),
             })
@@ -505,9 +506,10 @@ mod tests {
                 common: CommonRewriteArgs {
                     file: Some("in.mcap".into()),
                     output: Some("out.mcap".into()),
+                    output_file: None,
                     chunk_size: 1024,
                     no_crc: true,
-                    order: MessageOrder::LogTime,
+                    order: Some(MessageOrder::LogTime),
                 },
                 compression: "lz4".to_string(),
             })
@@ -524,9 +526,10 @@ mod tests {
                 common: CommonRewriteArgs {
                     file: Some("in.mcap".into()),
                     output: None,
+                    output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
-                    order: MessageOrder::Preserve,
+                    order: None,
                 },
             })
         );
@@ -553,9 +556,10 @@ mod tests {
                 common: CommonRewriteArgs {
                     file: Some("in.mcap".into()),
                     output: Some("out.mcap".into()),
+                    output_file: None,
                     chunk_size: 2048,
                     no_crc: true,
-                    order: MessageOrder::LogTime,
+                    order: Some(MessageOrder::LogTime),
                 },
             })
         );
@@ -593,9 +597,10 @@ mod tests {
                 common: CommonRewriteArgs {
                     file: Some("in.mcap".into()),
                     output: Some("out.mcap".into()),
+                    output_file: None,
                     chunk_size: 2048,
                     no_crc: true,
-                    order: MessageOrder::Preserve,
+                    order: None,
                 },
                 include_topic_regex: vec!["camera.*".to_string()],
                 exclude_topic_regex: vec![],
@@ -655,11 +660,13 @@ mod tests {
     }
 
     #[test]
-    fn filter_order_defaults_to_preserve_and_parses_log_time() {
+    fn filter_order_defaults_to_unset_and_parses_log_time() {
+        // The shared `--order` has no clap default (it is `None` when unset); each command resolves
+        // that to its own default (preserve for filter, log_time for sort) when building options.
         let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
             .expect("filter should parse without --order");
         match default.command {
-            Command::Filter(filter) => assert_eq!(filter.common.order, MessageOrder::Preserve),
+            Command::Filter(filter) => assert_eq!(filter.common.order, None),
             other => panic!("expected filter command, got {other:?}"),
         }
 
@@ -667,7 +674,9 @@ mod tests {
             let args = Args::try_parse_from(["mcap", "filter", "in.mcap", "--order", value])
                 .unwrap_or_else(|_| panic!("filter should parse --order {value}"));
             match args.command {
-                Command::Filter(filter) => assert_eq!(filter.common.order, MessageOrder::LogTime),
+                Command::Filter(filter) => {
+                    assert_eq!(filter.common.order, Some(MessageOrder::LogTime))
+                }
                 other => panic!("expected filter command, got {other:?}"),
             }
         }
@@ -700,37 +709,41 @@ mod tests {
         assert_eq!(
             args.command,
             Command::Sort(SortCommand {
-                file: "in.mcap".into(),
-                output: Some("out.mcap".into()),
-                output_file: None,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: Some("out.mcap".into()),
+                    output_file: None,
+                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                    no_crc: false,
+                    // `sort` leaves --order unset here and resolves it to log_time at runtime
+                    // (the copy commands resolve an unset --order to preserve).
+                    order: None,
+                },
                 compression: CompressionFormat::Zstd,
-                no_crc: false,
                 no_chunks: false,
-                // `sort` defaults `--order` to log_time (the whole point of the command), unlike
-                // the other rewrite commands, which default to preserve.
-                order: MessageOrder::LogTime,
             })
         );
     }
 
     #[test]
     fn parses_sort_output_file_deprecated_alias() {
-        // `--output-file` is retained as a hidden deprecated alias for `--output`; it parses into
-        // the separate field so the handler can warn.
+        // `--output-file` is retained as a hidden deprecated alias for `--output` on every rewrite
+        // command; it parses into the separate field so the handler can warn.
         let args = Args::try_parse_from(["mcap", "sort", "in.mcap", "--output-file", "out.mcap"])
             .expect("deprecated --output-file should still parse");
         assert_eq!(
             args.command,
             Command::Sort(SortCommand {
-                file: "in.mcap".into(),
-                output: None,
-                output_file: Some("out.mcap".into()),
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: None,
+                    output_file: Some("out.mcap".into()),
+                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                    no_crc: false,
+                    order: None,
+                },
                 compression: CompressionFormat::Zstd,
-                no_crc: false,
                 no_chunks: false,
-                order: MessageOrder::LogTime,
             })
         );
     }
@@ -781,16 +794,18 @@ mod tests {
         assert_eq!(
             args.command,
             Command::Sort(SortCommand {
-                file: "in.mcap".into(),
-                output: Some("out.mcap".into()),
-                output_file: None,
-                chunk_size: 1024,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: Some("out.mcap".into()),
+                    output_file: None,
+                    chunk_size: 1024,
+                    no_crc: true,
+                    // `--order` stays a real flag on `sort`, so it can be overridden (and future
+                    // modes like publish_time can be added) rather than being locked to log_time.
+                    order: Some(MessageOrder::Preserve),
+                },
                 compression: CompressionFormat::None,
-                no_crc: true,
                 no_chunks: true,
-                // `--order` stays a real flag on `sort`, so it can be overridden (and future
-                // modes like publish_time can be added) rather than being locked to log_time.
-                order: MessageOrder::Preserve,
             })
         );
     }
@@ -861,8 +876,15 @@ mod tests {
     }
 
     #[test]
-    fn sort_requires_output_file() {
-        Args::try_parse_from(["mcap", "sort", "in.mcap"])
-            .expect_err("sort requires an output path");
+    fn parses_sort_without_output_streams_to_stdout() {
+        // `sort` now shares the rewrite args, so (like filter/compress/decompress) omitting the
+        // output is allowed and writes to stdout rather than being a required flag.
+        let args = Args::try_parse_from(["mcap", "sort", "in.mcap"]).expect("sort should parse");
+        let Command::Sort(sort) = args.command else {
+            panic!("expected a sort command");
+        };
+        assert_eq!(sort.common.file, Some("in.mcap".into()));
+        assert_eq!(sort.common.output, None);
+        assert_eq!(sort.common.output_file, None);
     }
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -706,6 +706,9 @@ mod tests {
                 compression: CompressionFormat::Zstd,
                 no_crc: false,
                 no_chunks: false,
+                // `sort` defaults `--order` to log_time (the whole point of the command), unlike
+                // the other rewrite commands, which default to preserve.
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -749,6 +752,8 @@ mod tests {
             "1024",
             "--no-crc",
             "--no-chunks",
+            "--order",
+            "preserve",
         ])
         .expect("sort with flags should parse");
         assert_eq!(
@@ -760,6 +765,9 @@ mod tests {
                 compression: CompressionFormat::None,
                 no_crc: true,
                 no_chunks: true,
+                // `--order` stays a real flag on `sort`, so it can be overridden (and future
+                // modes like publish_time can be added) rather than being locked to log_time.
+                order: MessageOrder::Preserve,
             })
         );
     }

--- a/rust/cli/src/rewrite.rs
+++ b/rust/cli/src/rewrite.rs
@@ -18,5 +18,5 @@
 mod engine;
 mod options;
 
-pub(crate) use engine::{incomplete_indexed_summary_error, run, summary_supports_indexed_read};
+pub(crate) use engine::{run, summary_supports_indexed_read};
 pub(crate) use options::RewriteOptions;

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -556,9 +556,10 @@ mod tests {
         super::RewriteOptions::from(&CommonRewriteArgs {
             file,
             output,
+            output_file: None,
             chunk_size,
             no_crc: false,
-            order: MessageOrder::Preserve,
+            order: None,
         })
     }
 

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -559,7 +559,6 @@ mod tests {
             output_file: None,
             chunk_size,
             no_crc: false,
-            order: None,
         })
     }
 

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 
 use crate::cli::{
     parse_output_compression, parse_timestamp_or_nanos, CommonRewriteArgs, CompressionFormat,
-    FilterCommand, MessageOrder,
+    FilterCommand, MessageOrder, SortCommand,
 };
 
 #[derive(Debug, Clone)]
@@ -83,6 +83,34 @@ impl From<&FilterCommand> for RewriteOptions {
                 .to_string(),
             use_chunks: !args.no_chunks,
             ..RewriteOptions::from(&args.common)
+        }
+    }
+}
+
+/// `sort` is a `filter` preset that defaults `--order` to `log_time` instead of `preserve`,
+/// keeping metadata and attachments. It uses its own flag surface (`<FILE>` + `-o/--output-file`,
+/// plus chunking, compression, CRC, and order knobs) and does not expose topic/time selection.
+impl From<&SortCommand> for RewriteOptions {
+    fn from(args: &SortCommand) -> Self {
+        Self {
+            file: Some(args.file.clone()),
+            output: Some(args.output_file.clone()),
+            include_topic_regex: Vec::new(),
+            exclude_topic_regex: Vec::new(),
+            last_per_channel_topic_regex: Vec::new(),
+            start: None,
+            start_secs: 0,
+            start_nsecs: 0,
+            end: None,
+            end_secs: 0,
+            end_nsecs: 0,
+            include_metadata: true,
+            include_attachments: true,
+            output_compression: args.compression.as_str().to_string(),
+            chunk_size: args.chunk_size,
+            use_chunks: !args.no_chunks,
+            include_crc: !args.no_crc,
+            order: args.order,
         }
     }
 }
@@ -208,7 +236,9 @@ mod tests {
     use regex::Regex;
 
     use super::{build_filter_options, include_topic, ResolvedOptions, RewriteOptions};
-    use crate::cli::{CommonRewriteArgs, CompressionFormat, FilterCommand, MessageOrder};
+    use crate::cli::{
+        CommonRewriteArgs, CompressionFormat, FilterCommand, MessageOrder, SortCommand,
+    };
 
     fn default_filter_command() -> FilterCommand {
         FilterCommand {
@@ -413,6 +443,35 @@ mod tests {
         args.output_compression = Some(CompressionFormat::None);
         let opts = build_filter_options(&args).expect("options");
         assert!(opts.compression.is_none());
+    }
+
+    #[test]
+    fn sort_command_maps_flags_onto_the_engine_preset() {
+        // `sort` keeps metadata/attachments and translates its own flags (order, compression,
+        // chunking, CRC) onto the engine options.
+        let args = SortCommand {
+            file: "in.mcap".into(),
+            output_file: "out.mcap".into(),
+            compression: CompressionFormat::Lz4,
+            chunk_size: 4096,
+            no_crc: true,
+            no_chunks: true,
+            order: MessageOrder::Preserve,
+        };
+        let opts = RewriteOptions::from(&args);
+        assert_eq!(opts.file, Some("in.mcap".into()));
+        assert_eq!(opts.output, Some("out.mcap".into()));
+        assert_eq!(
+            opts.order,
+            MessageOrder::Preserve,
+            "sort honors an explicit --order override"
+        );
+        assert_eq!(opts.output_compression, "lz4");
+        assert_eq!(opts.chunk_size, 4096);
+        assert!(!opts.use_chunks, "--no-chunks should write outside chunks");
+        assert!(!opts.include_crc, "--no-crc should disable CRC fields");
+        assert!(opts.include_metadata, "metadata is kept by default");
+        assert!(opts.include_attachments, "attachments are kept by default");
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -33,10 +33,13 @@ pub(crate) struct RewriteOptions {
 }
 
 /// Maps the arguments shared by every rewrite command onto their engine options: paths, chunk
-/// size, `--no-crc`, and message order. The output falls back to the deprecated `--output-file`
-/// alias, and message order defaults to `preserve` (`sort` overrides this to `log_time`). Metadata
+/// size, and `--no-crc`. The output falls back to the deprecated `--output-file` alias. Metadata
 /// and attachments are included by default (all rewrite commands keep them; `filter` opts out via
 /// `--exclude-*`), and output is chunked with zstd compression unless a command overrides those.
+///
+/// Message order is *not* shared here — each command owns its `--order` (with its own default) and
+/// applies it via [`RewriteOptions::order`] or the `From` overrides, so this base uses `preserve`
+/// as a neutral placeholder.
 impl From<&CommonRewriteArgs> for RewriteOptions {
     fn from(args: &CommonRewriteArgs) -> Self {
         Self {
@@ -57,7 +60,7 @@ impl From<&CommonRewriteArgs> for RewriteOptions {
             chunk_size: args.chunk_size,
             use_chunks: true,
             include_crc: !args.no_crc,
-            order: args.order.unwrap_or(MessageOrder::Preserve),
+            order: MessageOrder::Preserve,
         }
     }
 }
@@ -83,20 +86,21 @@ impl From<&FilterCommand> for RewriteOptions {
                 .as_str()
                 .to_string(),
             use_chunks: !args.no_chunks,
+            order: args.order,
             ..RewriteOptions::from(&args.common)
         }
     }
 }
 
 /// `sort` is a `filter` preset over the shared args: it keeps metadata and attachments and does
-/// not expose topic/time selection, adds `--compression`/`--no-chunks`, and defaults `--order` to
-/// `log_time` instead of `preserve` (still overridable via the shared `--order`).
+/// not expose topic/time selection, adds `--compression`/`--no-chunks`, and its `--order` defaults
+/// to `log_time` instead of `preserve` (still overridable).
 impl From<&SortCommand> for RewriteOptions {
     fn from(args: &SortCommand) -> Self {
         Self {
             output_compression: args.compression.as_str().to_string(),
             use_chunks: !args.no_chunks,
-            order: args.common.order.unwrap_or(MessageOrder::LogTime),
+            order: args.order,
             ..RewriteOptions::from(&args.common)
         }
     }
@@ -105,6 +109,11 @@ impl From<&SortCommand> for RewriteOptions {
 impl RewriteOptions {
     pub(crate) fn compression(mut self, value: impl Into<String>) -> Self {
         self.output_compression = value.into();
+        self
+    }
+
+    pub(crate) fn order(mut self, order: MessageOrder) -> Self {
+        self.order = order;
         self
     }
 }
@@ -235,7 +244,6 @@ mod tests {
                 output_file: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 no_crc: false,
-                order: None,
             },
             include_topic_regex: Vec::new(),
             exclude_topic_regex: Vec::new(),
@@ -253,6 +261,7 @@ mod tests {
             compression: None,
             output_compression: None,
             no_chunks: false,
+            order: MessageOrder::Preserve,
         }
     }
 
@@ -363,22 +372,23 @@ mod tests {
     }
 
     #[test]
-    fn common_args_map_paths_order_and_defaults() {
-        // `compress`/`decompress` build their options from the shared args; this locks in that
-        // mapping (order + `--no-crc`) and the engine defaults (chunked, metadata/attachments kept).
+    fn common_args_map_paths_and_defaults() {
+        // Every rewrite command builds on the shared args; this locks in that mapping
+        // (paths + `--no-crc`) and the engine defaults (chunked, metadata/attachments kept). Order
+        // is not part of the shared args — each command supplies its own — so the base uses the
+        // `preserve` placeholder here.
         let common = CommonRewriteArgs {
             file: Some("in.mcap".into()),
             output: Some("out.mcap".into()),
             output_file: None,
             chunk_size: 4096,
             no_crc: true,
-            order: Some(MessageOrder::LogTime),
         };
         let opts = RewriteOptions::from(&common);
         assert_eq!(opts.file, Some("in.mcap".into()));
         assert_eq!(opts.output, Some("out.mcap".into()));
         assert_eq!(opts.chunk_size, 4096);
-        assert_eq!(opts.order, MessageOrder::LogTime);
+        assert_eq!(opts.order, MessageOrder::Preserve);
         assert!(!opts.include_crc, "--no-crc should disable CRC fields");
         assert!(opts.use_chunks, "output should be chunked by default");
         assert!(opts.include_metadata, "metadata should be kept by default");
@@ -442,10 +452,10 @@ mod tests {
                 output_file: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 no_crc: false,
-                order: None,
             },
             compression: CompressionFormat::Zstd,
             no_chunks: false,
+            order: MessageOrder::LogTime,
         }
     }
 
@@ -456,7 +466,7 @@ mod tests {
         let mut args = default_sort_command();
         args.common.chunk_size = 4096;
         args.common.no_crc = true;
-        args.common.order = Some(MessageOrder::Preserve);
+        args.order = MessageOrder::Preserve;
         args.compression = CompressionFormat::Lz4;
         args.no_chunks = true;
 
@@ -477,9 +487,9 @@ mod tests {
     }
 
     #[test]
-    fn sort_command_defaults_unset_order_to_log_time() {
-        // Unlike the copy commands (which resolve an unset --order to preserve), `sort` resolves
-        // it to log_time.
+    fn sort_command_defaults_order_to_log_time() {
+        // `sort`'s `--order` defaults to log_time (the copy commands default to preserve), and the
+        // mapping carries it through.
         let opts = RewriteOptions::from(&default_sort_command());
         assert_eq!(opts.order, MessageOrder::LogTime);
     }

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -33,14 +33,15 @@ pub(crate) struct RewriteOptions {
 }
 
 /// Maps the arguments shared by every rewrite command onto their engine options: paths, chunk
-/// size, `--no-crc`, and message order. Metadata and attachments are included by default (all
-/// rewrite commands keep them; `filter` opts out via `--exclude-*`), and output is chunked with
-/// zstd compression unless a command overrides those.
+/// size, `--no-crc`, and message order. The output falls back to the deprecated `--output-file`
+/// alias, and message order defaults to `preserve` (`sort` overrides this to `log_time`). Metadata
+/// and attachments are included by default (all rewrite commands keep them; `filter` opts out via
+/// `--exclude-*`), and output is chunked with zstd compression unless a command overrides those.
 impl From<&CommonRewriteArgs> for RewriteOptions {
     fn from(args: &CommonRewriteArgs) -> Self {
         Self {
             file: args.file.clone(),
-            output: args.output.clone(),
+            output: args.output(),
             include_topic_regex: Vec::new(),
             exclude_topic_regex: Vec::new(),
             last_per_channel_topic_regex: Vec::new(),
@@ -56,7 +57,7 @@ impl From<&CommonRewriteArgs> for RewriteOptions {
             chunk_size: args.chunk_size,
             use_chunks: true,
             include_crc: !args.no_crc,
-            order: args.order,
+            order: args.order.unwrap_or(MessageOrder::Preserve),
         }
     }
 }
@@ -87,31 +88,16 @@ impl From<&FilterCommand> for RewriteOptions {
     }
 }
 
-/// `sort` is a `filter` preset that defaults `--order` to `log_time` instead of `preserve`,
-/// keeping metadata and attachments. It uses its own flag surface (`<FILE>` + `-o/--output`, plus
-/// chunking, compression, CRC, and order knobs) and does not expose topic/time selection. The
-/// deprecated `--output-file` alias is honored when `--output` is absent (clap requires one).
+/// `sort` is a `filter` preset over the shared args: it keeps metadata and attachments and does
+/// not expose topic/time selection, adds `--compression`/`--no-chunks`, and defaults `--order` to
+/// `log_time` instead of `preserve` (still overridable via the shared `--order`).
 impl From<&SortCommand> for RewriteOptions {
     fn from(args: &SortCommand) -> Self {
         Self {
-            file: Some(args.file.clone()),
-            output: args.output.clone().or_else(|| args.output_file.clone()),
-            include_topic_regex: Vec::new(),
-            exclude_topic_regex: Vec::new(),
-            last_per_channel_topic_regex: Vec::new(),
-            start: None,
-            start_secs: 0,
-            start_nsecs: 0,
-            end: None,
-            end_secs: 0,
-            end_nsecs: 0,
-            include_metadata: true,
-            include_attachments: true,
             output_compression: args.compression.as_str().to_string(),
-            chunk_size: args.chunk_size,
             use_chunks: !args.no_chunks,
-            include_crc: !args.no_crc,
-            order: args.order,
+            order: args.common.order.unwrap_or(MessageOrder::LogTime),
+            ..RewriteOptions::from(&args.common)
         }
     }
 }
@@ -246,9 +232,10 @@ mod tests {
             common: CommonRewriteArgs {
                 file: None,
                 output: None,
+                output_file: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 no_crc: false,
-                order: MessageOrder::Preserve,
+                order: None,
             },
             include_topic_regex: Vec::new(),
             exclude_topic_regex: Vec::new(),
@@ -382,9 +369,10 @@ mod tests {
         let common = CommonRewriteArgs {
             file: Some("in.mcap".into()),
             output: Some("out.mcap".into()),
+            output_file: None,
             chunk_size: 4096,
             no_crc: true,
-            order: MessageOrder::LogTime,
+            order: Some(MessageOrder::LogTime),
         };
         let opts = RewriteOptions::from(&common);
         assert_eq!(opts.file, Some("in.mcap".into()));
@@ -446,20 +434,32 @@ mod tests {
         assert!(opts.compression.is_none());
     }
 
+    fn default_sort_command() -> SortCommand {
+        SortCommand {
+            common: CommonRewriteArgs {
+                file: Some("in.mcap".into()),
+                output: Some("out.mcap".into()),
+                output_file: None,
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                no_crc: false,
+                order: None,
+            },
+            compression: CompressionFormat::Zstd,
+            no_chunks: false,
+        }
+    }
+
     #[test]
     fn sort_command_maps_flags_onto_the_engine_preset() {
-        // `sort` keeps metadata/attachments and translates its own flags (order, compression,
-        // chunking, CRC) onto the engine options.
-        let args = SortCommand {
-            file: "in.mcap".into(),
-            output: Some("out.mcap".into()),
-            output_file: None,
-            compression: CompressionFormat::Lz4,
-            chunk_size: 4096,
-            no_crc: true,
-            no_chunks: true,
-            order: MessageOrder::Preserve,
-        };
+        // `sort` keeps metadata/attachments and translates the shared args plus its own
+        // (compression, chunking) onto the engine options; an explicit --order is honored.
+        let mut args = default_sort_command();
+        args.common.chunk_size = 4096;
+        args.common.no_crc = true;
+        args.common.order = Some(MessageOrder::Preserve);
+        args.compression = CompressionFormat::Lz4;
+        args.no_chunks = true;
+
         let opts = RewriteOptions::from(&args);
         assert_eq!(opts.file, Some("in.mcap".into()));
         assert_eq!(opts.output, Some("out.mcap".into()));
@@ -477,18 +477,19 @@ mod tests {
     }
 
     #[test]
+    fn sort_command_defaults_unset_order_to_log_time() {
+        // Unlike the copy commands (which resolve an unset --order to preserve), `sort` resolves
+        // it to log_time.
+        let opts = RewriteOptions::from(&default_sort_command());
+        assert_eq!(opts.order, MessageOrder::LogTime);
+    }
+
+    #[test]
     fn sort_command_honors_deprecated_output_file_alias() {
         // When only the deprecated `--output-file` is set, it supplies the output path.
-        let args = SortCommand {
-            file: "in.mcap".into(),
-            output: None,
-            output_file: Some("out.mcap".into()),
-            compression: CompressionFormat::Zstd,
-            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-            no_crc: false,
-            no_chunks: false,
-            order: MessageOrder::LogTime,
-        };
+        let mut args = default_sort_command();
+        args.common.output = None;
+        args.common.output_file = Some("out.mcap".into());
         assert_eq!(RewriteOptions::from(&args).output, Some("out.mcap".into()));
     }
 

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -88,13 +88,14 @@ impl From<&FilterCommand> for RewriteOptions {
 }
 
 /// `sort` is a `filter` preset that defaults `--order` to `log_time` instead of `preserve`,
-/// keeping metadata and attachments. It uses its own flag surface (`<FILE>` + `-o/--output-file`,
-/// plus chunking, compression, CRC, and order knobs) and does not expose topic/time selection.
+/// keeping metadata and attachments. It uses its own flag surface (`<FILE>` + `-o/--output`, plus
+/// chunking, compression, CRC, and order knobs) and does not expose topic/time selection. The
+/// deprecated `--output-file` alias is honored when `--output` is absent (clap requires one).
 impl From<&SortCommand> for RewriteOptions {
     fn from(args: &SortCommand) -> Self {
         Self {
             file: Some(args.file.clone()),
-            output: Some(args.output_file.clone()),
+            output: args.output.clone().or_else(|| args.output_file.clone()),
             include_topic_regex: Vec::new(),
             exclude_topic_regex: Vec::new(),
             last_per_channel_topic_regex: Vec::new(),
@@ -451,7 +452,8 @@ mod tests {
         // chunking, CRC) onto the engine options.
         let args = SortCommand {
             file: "in.mcap".into(),
-            output_file: "out.mcap".into(),
+            output: Some("out.mcap".into()),
+            output_file: None,
             compression: CompressionFormat::Lz4,
             chunk_size: 4096,
             no_crc: true,
@@ -472,6 +474,22 @@ mod tests {
         assert!(!opts.include_crc, "--no-crc should disable CRC fields");
         assert!(opts.include_metadata, "metadata is kept by default");
         assert!(opts.include_attachments, "attachments are kept by default");
+    }
+
+    #[test]
+    fn sort_command_honors_deprecated_output_file_alias() {
+        // When only the deprecated `--output-file` is set, it supplies the output path.
+        let args = SortCommand {
+            file: "in.mcap".into(),
+            output: None,
+            output_file: Some("out.mcap".into()),
+            compression: CompressionFormat::Zstd,
+            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            no_crc: false,
+            no_chunks: false,
+            order: MessageOrder::LogTime,
+        };
+        assert_eq!(RewriteOptions::from(&args).output, Some("out.mcap".into()));
     }
 
     #[test]

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -118,8 +118,11 @@ fn exit_code_0_on_valid_file() {
 fn exit_code_2_on_missing_required_flag() {
     let dir = TempDir::new().unwrap();
     let path = write_temp(&dir, "in.mcap", &build_mcap(1));
-    // `sort` requires `--output-file`; clap reports the missing argument with exit code 2.
-    assert_eq!(mcap(&["sort", path_str(&path)]).status.code(), Some(2));
+    // `get metadata` requires `-n/--name`; clap reports the missing argument with exit code 2.
+    assert_eq!(
+        mcap(&["get", "metadata", path_str(&path)]).status.code(),
+        Some(2)
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

- `mcap sort` gains an `--order <preserve|log_time>` flag (default `log_time`; `preserve` keeps the input's stored message order)
- `mcap sort` output flag is now `-o/--output` to match the other rewrite commands, and omitting the output writes to stdout. Across all rewrite commands (`filter`/`compress`/`decompress`/`sort`), the old `--output-file` name is now accepted as a deprecated alias for `--output` (it warns).
- Sorted output now uses a standardized record layout: metadata at the start of the file (immediately after the header), and attachments at the end of the file (just before the data end record).

### Docs

None. The new `--order` flag is documented in `sort --help`.

### Description

`sort` was ~600 lines of bespoke read / sort / copy / validate code that duplicated the engine's indexed and linear read paths. It is now a thin adapter — like `compress`/`decompress` — that builds `RewriteOptions` and calls `rewrite::run`. The engine already handles indexed vs. summaryless reading, log-time ordering (indexed via `ReadOrder::LogTime`, summaryless via a buffered sort), and the standardized record placement.

`SortCommand` flattens the shared `CommonRewriteArgs` (adding only `--compression`, `--no-chunks`, and its own `--order`), so all four rewrite commands share one definition for the truly common flags. Two knock-on points:

- **`--order` is per-command, by design.** It needs a different default (`log_time` for `sort`, `preserve` for the copy commands), and a single flattened field can't show a per-command default in `--help`. Rather than trade away that clarity, each command declares its own `--order` with the correct default; the flag name, values, and help text are identical across commands, so the user surface stays aligned. `--order` stays overridable everywhere, so future modes (e.g. `publish_time`) apply to `sort` too. `sort` intentionally does not take `filter`'s input-narrowing flags (topic/time selection, `--exclude-*`): `filter` is the superset for reducing a file, while `sort` only reorders it.
- **Output flag.** Every other rewrite command plus `recover`/`get attachment` use `-o/--output`; only `merge` and `sort` used `--output-file`, a historical inconsistency. `sort` now uses `-o/--output`, and the deprecated `--output-file` alias lives on `CommonRewriteArgs`, so `filter`/`compress`/`decompress`/`sort` all accept it and warn uniformly (mirroring how `filter` deprecated `--output-compression`). The short `-o` is unchanged. (`merge` is a separate, multi-input command and is left as-is.)

Behavior notes:
- `sort` now emits the standardized layout (metadata first → messages → attachments last) instead of passing records through in place, so anyone byte-diffing `sort` output or relying on physical record order will see the change.
- `sort`'s output is no longer required: like the other rewrite commands it now streams to stdout when `--output` is omitted (and can read from stdin when the input path is omitted).
- The summaryless ordered path uses the engine's buffered linear sort. Making that path memory-bounded (via a synthesized chunk index) is intentionally left to a separate PR.

### Testing

- [x] `mcap sort <out-of-order.mcap> -o sorted.mcap` then `mcap doctor --strict-message-order sorted.mcap` exits `0`, while the same check on the input exits `1`.
- [x] `mcap sort --order preserve <out-of-order.mcap> -o preserved.mcap` leaves the messages in their original (unsorted) order.
- [x] `mcap sort <in.mcap> > out.mcap` (no `-o`) streams a valid sorted file to stdout.
- [x] `mcap <filter|compress|decompress> --help` shows `--order [default: preserve]` and `mcap sort --help` shows `--order [default: log_time]`.
- [x] `mcap <filter|compress|decompress|sort> <in.mcap> --output-file out.mcap` still works but prints a deprecation warning; `mcap sort --help` shows `-o/--output` and not `--output-file`.
- [x] A sorted file keeps its metadata and attachments, with metadata placed before the message chunks and attachments after them.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22387126-660e-4ae3-b765-eef465e4fd50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22387126-660e-4ae3-b765-eef465e4fd50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

