### PR TITLE
cli: read stdin via temp file + mmap and document bounded-memory reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,21 @@ This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log fil
 
 **MCAP** is a modular container file format for recording timestamped pub/sub messages with arbitrary serialization formats. It is designed to work well under various workloads, resource constraints, and durability requirements. The format specification lives in `website/docs/spec/index.md`, with the well-known registry in `website/docs/spec/registry.md`, and feature notes in `website/docs/spec/notes.md`.
 
+## Design principles
+
+### Bounded memory when reading
+
+MCAP files can be arbitrarily large (many GB). **Reader code paths must never require buffering an entire MCAP file into memory at once.** Memory use should stay bounded relative to the file size — it should scale with the current record/chunk being processed and any explicit caches, not with the total file length.
+
+Practically, this means:
+
+- **Prefer memory-mapping (`mmap`) for local files** in languages that support it (e.g. the Rust CLI maps files via `memmap2`). An mmap keeps the resident working set bounded because the OS pages data in on demand.
+- **Prefer seek + bounded range reads** for random-access/indexed reads, and **streaming** (incremental record-by-record parsing) for sequential reads, over reading the whole file into a heap buffer.
+- **For non-seekable inputs (e.g. a stdin pipe), spool the stream to a temporary file and mmap that**, rather than reading it all into a `Vec`/`Buffer`/`bytes`/`Data`. See `rust/cli/src/source.rs` (`load_input`) for the reference implementation.
+- Reading a single record, chunk, or attachment into memory is acceptable (these are bounded by the data being requested), but avoid materializing _all_ messages/records of a file at once unless the caller explicitly opts in (e.g. Python's `NonSeekingReader` with `log_time_order=True`, which documents the whole-file cost).
+
+When adding or changing a reader path, keep it within these bounds; if a full-file or full-collection read is unavoidable, make it explicit and opt-in.
+
 ## General prerequisites
 
 - **Git LFS** — test data under `tests/conformance/data/` and `rust/mcap/tests/data/` is stored in Git LFS. Tests will fail with `InvalidMagic` errors if LFS pointers haven't been pulled. Run `git lfs pull` before running tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,18 +8,12 @@ This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log fil
 
 ## Design principles
 
-### Bounded memory when reading
+**Bounded memory when reading.** This applies to both the language libraries and the CLI. MCAP files can be many GB, so reader memory must scale with the record/chunk being processed, not with the file length — never read (or force a consumer to read) a whole file into memory. Holding one record, chunk, or attachment at a time is fine; buffering the whole file, or all of a file's messages, is an out-of-memory foot-gun.
 
-MCAP files can be arbitrarily large (many GB). **Reader code paths must never require buffering an entire MCAP file into memory at once.** Memory use should stay bounded relative to the file size — it should scale with the current record/chunk being processed and any explicit caches, not with the total file length.
-
-Practically, this means:
-
-- **Prefer memory-mapping (`mmap`) for local files** in languages that support it (e.g. the Rust CLI maps files via `memmap2`). An mmap keeps the resident working set bounded because the OS pages data in on demand.
-- **Prefer seek + bounded range reads** for random-access/indexed reads, and **streaming** (incremental record-by-record parsing) for sequential reads, over reading the whole file into a heap buffer.
-- **For non-seekable inputs (e.g. a stdin pipe), spool the stream to a temporary file and mmap that**, rather than reading it all into a `Vec`/`Buffer`/`bytes`/`Data`. See `rust/cli/src/source.rs` (`load_input`) for the reference implementation.
-- Reading a single record, chunk, or attachment into memory is acceptable (these are bounded by the data being requested), but avoid materializing _all_ messages/records of a file at once unless the caller explicitly opts in (e.g. Python's `NonSeekingReader` with `log_time_order=True`, which documents the whole-file cost).
-
-When adding or changing a reader path, keep it within these bounds; if a full-file or full-collection read is unavoidable, make it explicit and opt-in.
+- Memory-map (`mmap`) seekable local files where the language supports it (e.g. the Rust CLI's `map_file` in `rust/cli/src/source.rs`); use seek + bounded range reads for indexed access and streaming for sequential scans.
+- For non-seekable inputs such as a stdin pipe, spool to a temporary file and mmap it rather than reading into a `Vec`/`Buffer`/`bytes`/`Data` — see `load_input` in `rust/cli/src/source.rs`.
+- A library may leave byte access to the caller (e.g. the `mcap` Rust crate parses a `&[u8]`), but only when mmap is the clear, documented path, so a consumer can't accidentally load the whole file into a heap buffer.
+- Materializing every message at once is allowed only as an explicit, documented opt-in (e.g. Python's `NonSeekingReader` with `log_time_order=True`).
 
 ## General prerequisites
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,10 @@ This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log fil
 
 ## Design principles
 
-**Bounded memory when reading.** This applies to both the language libraries and the CLI. MCAP files can be many GB, so reader memory must scale with the record/chunk being processed, not with the file length — never read (or force a consumer to read) a whole file into memory. Holding one record, chunk, or attachment at a time is fine; buffering the whole file, or all of a file's messages, is an out-of-memory foot-gun.
+**Bounded memory when reading.** Neither the language libraries nor the CLI may read (or force a consumer to read) an entire MCAP file into memory — files can be many GB. Reader memory should scale with the record or chunk being processed, not with the file length: holding one record, chunk, or attachment at a time is fine, but buffering the whole file, or all of its messages, is an out-of-memory foot-gun.
 
-- Memory-map (`mmap`) seekable local files where the language supports it (e.g. the Rust CLI's `map_file` in `rust/cli/src/source.rs`); use seek + bounded range reads for indexed access and streaming for sequential scans.
-- For non-seekable inputs such as a stdin pipe, spool to a temporary file and mmap it rather than reading into a `Vec`/`Buffer`/`bytes`/`Data` — see `load_input` in `rust/cli/src/source.rs`. This assumes a disk-backed temp dir; a tmpfs `$TMPDIR` keeps the spool in RAM.
-- A library may leave byte access to the caller (e.g. the `mcap` Rust crate parses a `&[u8]`), but only when mmap is the clear, documented path, so a consumer can't accidentally load the whole file into a heap buffer.
-- Materializing every message at once is allowed only as an explicit, documented opt-in (e.g. Python's `NonSeekingReader` with `log_time_order=True`).
+- Memory-map (`mmap`) seekable local files where the language supports it, or have the API consumer supply the bytes (e.g. via their own mmap); use seek + bounded range reads for random access and streaming for sequential scans.
+- When input isn't seekable (e.g. a stdin pipe) or an operation needs random access over a stream (e.g. sorting), spool to a temporary file and mmap it rather than buffering in memory. A tmpfs temp dir keeps the spool resident, though that is typically swap-backed.
 
 ## General prerequisites
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log fil
 **Bounded memory when reading.** This applies to both the language libraries and the CLI. MCAP files can be many GB, so reader memory must scale with the record/chunk being processed, not with the file length — never read (or force a consumer to read) a whole file into memory. Holding one record, chunk, or attachment at a time is fine; buffering the whole file, or all of a file's messages, is an out-of-memory foot-gun.
 
 - Memory-map (`mmap`) seekable local files where the language supports it (e.g. the Rust CLI's `map_file` in `rust/cli/src/source.rs`); use seek + bounded range reads for indexed access and streaming for sequential scans.
-- For non-seekable inputs such as a stdin pipe, spool to a temporary file and mmap it rather than reading into a `Vec`/`Buffer`/`bytes`/`Data` — see `load_input` in `rust/cli/src/source.rs`.
+- For non-seekable inputs such as a stdin pipe, spool to a temporary file and mmap it rather than reading into a `Vec`/`Buffer`/`bytes`/`Data` — see `load_input` in `rust/cli/src/source.rs`. This assumes a disk-backed temp dir; a tmpfs `$TMPDIR` keeps the spool in RAM.
 - A library may leave byte access to the caller (e.g. the `mcap` Rust crate parses a `&[u8]`), but only when mmap is the clear, documented path, so a consumer can't accidentally load the whole file into a heap buffer.
 - Materializing every message at once is allowed only as an explicit, documented opt-in (e.g. Python's `NonSeekingReader` with `log_time_order=True`).
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -192,6 +192,9 @@ overrides:
       - addopts
       - xfail
       - pyyaml
+      - mmap
+      - memmap
+      - seekable
 
   - filename: "python/**/*.rst"
     words:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -195,7 +195,6 @@ overrides:
       - mmap
       - seekable
       - tmpfs
-      - TMPDIR
 
   - filename: "python/**/*.rst"
     words:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -195,6 +195,8 @@ overrides:
       - mmap
       - memmap
       - seekable
+      - tmpfs
+      - TMPDIR
 
   - filename: "python/**/*.rst"
     words:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -193,7 +193,6 @@ overrides:
       - xfail
       - pyyaml
       - mmap
-      - memmap
       - seekable
       - tmpfs
       - TMPDIR

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -308,9 +308,14 @@ pub fn load_input(file: Option<&Path>, options: SourceOptions) -> Result<InputDa
 }
 
 /// Spool a non-seekable stdin stream to a temporary file and memory-map it, rather
-/// than buffering the whole input in a `Vec`. This keeps process memory bounded (the
-/// OS pages the mapping on demand) so piping an arbitrarily large MCAP into the CLI
-/// does not require holding the entire file in RAM.
+/// than buffering the whole input in a `Vec`. When the temp dir is disk-backed the OS
+/// pages the mapping on demand, so piping an arbitrarily large MCAP into the CLI does
+/// not require holding the entire file in RAM.
+///
+/// The temp file is created in `$TMPDIR` (else `/tmp`). If that is a tmpfs — as `/tmp`
+/// is on many modern Linux setups — the spooled bytes stay resident in RAM/swap and the
+/// paging benefit is lost, so point `$TMPDIR` at real storage for very large piped
+/// inputs. This mirrors the remote `materialize_input` path, which spools the same way.
 fn read_stdin_to_mapped_input(reader: &mut impl std::io::Read) -> Result<InputData> {
     let mut temp_file = tempfile::Builder::new()
         .prefix("mcap-cli-stdin-input-")

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -307,15 +307,13 @@ pub fn load_input(file: Option<&Path>, options: SourceOptions) -> Result<InputDa
     read_stdin_to_mapped_input(&mut stdin.lock())
 }
 
-/// Spool a non-seekable stdin stream to a temporary file and memory-map it, rather
-/// than buffering the whole input in a `Vec`. When the temp dir is disk-backed the OS
-/// pages the mapping on demand, so piping an arbitrarily large MCAP into the CLI does
-/// not require holding the entire file in RAM.
+/// Spool a non-seekable stdin stream to a temporary file and memory-map it instead of
+/// buffering the whole input in a `Vec`, so piping an arbitrarily large MCAP keeps
+/// process memory bounded (the OS pages a disk-backed mapping on demand).
 ///
-/// The temp file is created in `$TMPDIR` (else `/tmp`). If that is a tmpfs — as `/tmp`
-/// is on many modern Linux setups — the spooled bytes stay resident in RAM/swap and the
-/// paging benefit is lost, so point `$TMPDIR` at real storage for very large piped
-/// inputs. This mirrors the remote `materialize_input` path, which spools the same way.
+/// The temp file lives in `$TMPDIR` (else `/tmp`); if that is a tmpfs — common on modern
+/// Linux — the spool stays in RAM and the paging benefit is lost, so point `$TMPDIR` at
+/// real storage for very large inputs. Mirrors the remote `materialize_input` path.
 fn read_stdin_to_mapped_input(reader: &mut impl std::io::Read) -> Result<InputData> {
     let mut temp_file = tempfile::Builder::new()
         .prefix("mcap-cli-stdin-input-")

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal as _, Read as _, SeekFrom};
+use std::io::{IsTerminal as _, SeekFrom};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -304,12 +304,29 @@ pub fn load_input(file: Option<&Path>, options: SourceOptions) -> Result<InputDa
         bail!("{PLEASE_SUPPLY_FILE}");
     }
 
-    let mut buf = Vec::new();
-    stdin
-        .lock()
-        .read_to_end(&mut buf)
+    read_stdin_to_mapped_input(&mut stdin.lock())
+}
+
+/// Spool a non-seekable stdin stream to a temporary file and memory-map it, rather
+/// than buffering the whole input in a `Vec`. This keeps process memory bounded (the
+/// OS pages the mapping on demand) so piping an arbitrarily large MCAP into the CLI
+/// does not require holding the entire file in RAM.
+fn read_stdin_to_mapped_input(reader: &mut impl std::io::Read) -> Result<InputData> {
+    let mut temp_file = tempfile::Builder::new()
+        .prefix("mcap-cli-stdin-input-")
+        .tempfile()
+        .context("failed to create temporary file for stdin input")?;
+    let bytes_copied = std::io::copy(reader, temp_file.as_file_mut())
         .context("failed to read input from stdin")?;
-    Ok(InputData::Buffered(buf))
+    std::io::Write::flush(temp_file.as_file_mut())
+        .context("failed to flush temporary stdin input file")?;
+    if bytes_copied == 0 {
+        // memmap2 refuses to map a zero-length file, so fall back to an empty buffer.
+        // Callers then get the usual empty-input MCAP parse error.
+        return Ok(InputData::Buffered(Vec::new()));
+    }
+    let mmap = map_file(temp_file.path())?;
+    Ok(InputData::TempMapped { temp_file, mmap })
 }
 
 pub(crate) fn open_streaming_input(
@@ -1303,6 +1320,29 @@ mod tests {
 
         super::ensure_distinct_local_input_output(&input, &output)
             .expect("missing input should be left to command open errors");
+    }
+
+    #[test]
+    fn stdin_input_is_spooled_to_temp_file_and_mapped() {
+        let (buffer, _) = summary_mcap_with_channel();
+        let mut reader = std::io::Cursor::new(buffer.clone());
+        let input = super::read_stdin_to_mapped_input(&mut reader).expect("stdin spool");
+        assert!(
+            matches!(input, super::InputData::TempMapped { .. }),
+            "non-empty stdin should be memory-mapped from a temp file, not buffered in RAM"
+        );
+        assert_eq!(input.as_slice(), buffer.as_slice());
+    }
+
+    #[test]
+    fn empty_stdin_input_falls_back_to_empty_buffer() {
+        let mut reader = std::io::Cursor::new(Vec::new());
+        let input = super::read_stdin_to_mapped_input(&mut reader).expect("empty stdin spool");
+        assert!(
+            matches!(input, super::InputData::Buffered(ref buf) if buf.is_empty()),
+            "empty stdin cannot be mmap'd and should fall back to an empty buffer"
+        );
+        assert!(input.as_slice().is_empty());
     }
 
     fn serve_http(body: &'static [u8], supports_ranges: bool) -> String {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

MCAP files can be arbitrarily large (hundreds or even thousands of GBs in some cases). The Rust CLI's stdin path violated bounded-memory reading: `load_input` in `rust/cli/src/source.rs` read the entire piped MCAP into a `Vec<u8>` (`InputData::Buffered`), so `mcap filter < huge.mcap` (and other commands using `load_input`) held the whole file in RAM.

## Changes

- **`rust/cli/src/source.rs`** — `load_input` now spools non-seekable stdin to a temporary file and memory-maps it (returning the existing `InputData::TempMapped` variant), keeping process memory bounded (the OS pages a disk-backed mapping on demand). Empty stdin falls back to an empty buffer since `memmap2` cannot map a zero-length file. The doc comment notes the tmpfs `$TMPDIR` caveat. Added two unit tests asserting the temp-mapped path and the empty fallback.
- **`AGENTS.md`** — added a "Design principles → Bounded memory when reading" section: neither the language libraries nor the CLI may read (or force a consumer to read) a whole MCAP into memory. Prefer mmap (or consumer-supplied bytes) for seekable local files, seek + bounded range reads for random access, and streaming for sequential scans; spool to a temp file + mmap for non-seekable input or operations needing random access (e.g. sorting), noting the tmpfs (typically swap-backed) caveat.
- **`cspell.config.yaml`** — allow `mmap`, `seekable`, `tmpfs` in the `AGENTS.md`/`README.md` override.

## Audit of other reader memory behavior

No other code path reads a whole MCAP into memory by default. Notable findings from auditing all six languages:

- **Rust CLI**: `cat`/`recover` already stream stdin; other commands (`sort`, `merge`, `du`, `doctor`, `get`, `list`) require a path and mmap via `load_path`. Remote inputs already materialize to a temp file + mmap.
- **Libraries** (TS, Python, Go, Rust, C++, Swift): default indexed/seeking paths are seek + bounded range reads; sequential paths are streaming. None load the entire file by default when backed by a file handle/slice.
- **Existing whole-collection reads (left as-is for now, not endorsed as exceptions)**: Python `NonSeekingReader.iter_messages(log_time_order=True)` loads all messages into memory; Rust `MessageStream` copies each message payload to owned memory (per-message, not whole-file). Worth revisiting separately.
- **Whole-file reads live only in conformance runners / examples / test helpers** (e.g. Rust `examples/conformance_reader.rs` `std::fs::read`, TS conformance `fs.readFile`), not in shipped library or CLI read paths.
- **Chunk decompression** across languages decompresses a whole chunk at a time — bounded by chunk size, consistent with the principle (single record/chunk in memory is acceptable).

## Testing

- `cargo test -p mcap-cli` — full unit + integration suite passes, including new `source::tests::stdin_input_is_spooled_to_temp_file_and_mapped` / `empty_stdin_input_falls_back_to_empty_buffer` and existing `stdin_pipe_*` e2e tests.
- `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings` and `cargo fmt --all -- --check` pass.
- Manually piped a real MCAP: `cat testdata/mcap/demo.mcap | mcap filter -o out.mcap --output-compression none` produced a valid MCAP.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d00b046-5789-4582-9e8e-2338b4567532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d00b046-5789-4582-9e8e-2338b4567532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

