### PR TITLE
cli: rename filter --output-compression to --compression

### DIFF
--- a/rust/cli/benches/commands.rs
+++ b/rust/cli/benches/commands.rs
@@ -243,7 +243,7 @@ fn bench_filter(c: &mut Criterion, config: &BenchConfig, mode: InputMode, cases:
                             OsString::from("/bench/selected"),
                             OsString::from("--output"),
                             output.as_os_str().to_owned(),
-                            OsString::from("--output-compression"),
+                            OsString::from("--compression"),
                             OsString::from("zstd"),
                             OsString::from("--chunk-size"),
                             OsString::from(config.chunk_bytes.to_string()),

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -484,11 +484,11 @@ pub struct FilterCommand {
     #[arg(long = "include-attachments", default_value_t = false, hide = true)]
     pub include_attachments: bool,
 
-    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
-    #[arg(long = "compression", value_enum, default_value = "zstd")]
-    pub compression: CompressionFormat,
+    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none (default: zstd)
+    #[arg(long = "compression", value_enum)]
+    pub compression: Option<CompressionFormat>,
 
-    /// Deprecated: use --compression. Overrides --compression when set.
+    /// Deprecated: use --compression. Ignored when --compression is set.
     #[arg(long = "output-compression", value_enum, hide = true)]
     pub output_compression: Option<CompressionFormat>,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -310,6 +310,16 @@ pub enum CompressionFormat {
     None,
 }
 
+impl CompressionFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CompressionFormat::Zstd => "zstd",
+            CompressionFormat::Lz4 => "lz4",
+            CompressionFormat::None => "none",
+        }
+    }
+}
+
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct ConvertCommand {
     /// Local path to the input file
@@ -474,9 +484,13 @@ pub struct FilterCommand {
     #[arg(long = "include-attachments", default_value_t = false, hide = true)]
     pub include_attachments: bool,
 
-    /// Compression algorithm for output file: zstd, lz4, or none
-    #[arg(long = "output-compression", default_value = "zstd")]
-    pub output_compression: String,
+    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
+    #[arg(long = "compression", value_enum, default_value = "zstd")]
+    pub compression: CompressionFormat,
+
+    /// Deprecated: use --compression. Overrides --compression when set.
+    #[arg(long = "output-compression", hide = true)]
+    pub output_compression: Option<String>,
 
     /// Target uncompressed chunk size for output
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -489,8 +489,8 @@ pub struct FilterCommand {
     pub compression: CompressionFormat,
 
     /// Deprecated: use --compression. Overrides --compression when set.
-    #[arg(long = "output-compression", hide = true)]
-    pub output_compression: Option<String>,
+    #[arg(long = "output-compression", value_enum, hide = true)]
+    pub output_compression: Option<CompressionFormat>,
 
     /// Target uncompressed chunk size for output
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -16,6 +16,9 @@ pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
     if args.include_attachments {
         warn!("--include-attachments is deprecated and has no effect; attachments are included by default (use --exclude-attachments to drop them)");
     }
+    if args.output_compression.is_some() {
+        warn!("--output-compression is deprecated; use --compression instead");
+    }
     rewrite::run(
         RewriteOptions::from(&args),
         source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -17,7 +17,7 @@ pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
         warn!("--include-attachments is deprecated and has no effect; attachments are included by default (use --exclude-attachments to drop them)");
     }
     if args.output_compression.is_some() {
-        warn!("--output-compression is deprecated; use --compression instead");
+        warn!("--output-compression is deprecated and takes precedence over --compression; use --compression instead");
     }
     rewrite::run(
         RewriteOptions::from(&args),

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -17,7 +17,7 @@ pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
         warn!("--include-attachments is deprecated and has no effect; attachments are included by default (use --exclude-attachments to drop them)");
     }
     if args.output_compression.is_some() {
-        warn!("--output-compression is deprecated and takes precedence over --compression; use --compression instead");
+        warn!("--output-compression is deprecated; use --compression instead");
     }
     rewrite::run(
         RewriteOptions::from(&args),

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -595,9 +595,9 @@ mod tests {
                 .expect("filter should parse");
         match args.command {
             Command::Filter(filter) => {
-                // The deprecated alias is captured verbatim and leaves --compression at its default.
+                // The deprecated alias is captured separately and leaves --compression at its default.
                 assert_eq!(filter.compression, CompressionFormat::Zstd);
-                assert_eq!(filter.output_compression, Some("none".to_string()));
+                assert_eq!(filter.output_compression, Some(CompressionFormat::None));
             }
             other => panic!("expected filter command, got {other:?}"),
         }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -581,7 +581,7 @@ mod tests {
                 exclude_attachments: false,
                 include_metadata: true,
                 include_attachments: true,
-                compression: CompressionFormat::Lz4,
+                compression: Some(CompressionFormat::Lz4),
                 output_compression: None,
                 chunk_size: 2048,
             })
@@ -595,8 +595,8 @@ mod tests {
                 .expect("filter should parse");
         match args.command {
             Command::Filter(filter) => {
-                // The deprecated alias is captured separately and leaves --compression at its default.
-                assert_eq!(filter.compression, CompressionFormat::Zstd);
+                // The deprecated alias is captured separately and leaves --compression unset.
+                assert_eq!(filter.compression, None);
                 assert_eq!(filter.output_compression, Some(CompressionFormat::None));
             }
             other => panic!("expected filter command, got {other:?}"),

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -557,7 +557,7 @@ mod tests {
             "200",
             "--include-metadata",
             "--include-attachments",
-            "--output-compression",
+            "--compression",
             "lz4",
             "--chunk-size",
             "2048",
@@ -581,10 +581,23 @@ mod tests {
                 exclude_attachments: false,
                 include_metadata: true,
                 include_attachments: true,
-                output_compression: "lz4".to_string(),
+                compression: CompressionFormat::Lz4,
+                output_compression: None,
                 chunk_size: 2048,
             })
         );
+    }
+
+    #[test]
+    fn parses_filter_deprecated_output_compression_alias() {
+        let args =
+            Args::try_parse_from(["mcap", "filter", "in.mcap", "--output-compression", "none"])
+                .expect("filter should parse");
+        let Command::Filter(filter) = args.command else {
+            panic!("expected filter command");
+        };
+        assert_eq!(filter.compression, CompressionFormat::Zstd);
+        assert_eq!(filter.output_compression, Some("none".to_string()));
     }
 
     #[test]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -593,11 +593,14 @@ mod tests {
         let args =
             Args::try_parse_from(["mcap", "filter", "in.mcap", "--output-compression", "none"])
                 .expect("filter should parse");
-        let Command::Filter(filter) = args.command else {
-            panic!("expected filter command");
-        };
-        assert_eq!(filter.compression, CompressionFormat::Zstd);
-        assert_eq!(filter.output_compression, Some("none".to_string()));
+        match args.command {
+            Command::Filter(filter) => {
+                // The deprecated alias is captured verbatim and leaves --compression at its default.
+                assert_eq!(filter.compression, CompressionFormat::Zstd);
+                assert_eq!(filter.output_compression, Some("none".to_string()));
+            }
+            other => panic!("expected filter command, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 use regex::Regex;
 
-use crate::cli::{parse_output_compression, parse_timestamp_or_nanos, FilterCommand};
+use crate::cli::{
+    parse_output_compression, parse_timestamp_or_nanos, CompressionFormat, FilterCommand,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct RewriteOptions {
@@ -44,8 +46,9 @@ impl From<&FilterCommand> for RewriteOptions {
             include_metadata: !args.exclude_metadata,
             include_attachments: !args.exclude_attachments,
             output_compression: args
-                .output_compression
-                .unwrap_or(args.compression)
+                .compression
+                .or(args.output_compression)
+                .unwrap_or(CompressionFormat::Zstd)
                 .as_str()
                 .to_string(),
             chunk_size: args.chunk_size,
@@ -226,7 +229,7 @@ mod tests {
             exclude_attachments: false,
             include_metadata: false,
             include_attachments: false,
-            compression: CompressionFormat::Zstd,
+            compression: None,
             output_compression: None,
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
         }
@@ -330,29 +333,44 @@ mod tests {
     }
 
     #[test]
+    fn compression_defaults_to_zstd_when_unset() {
+        let opts = build_filter_options(&default_filter_command()).expect("options");
+        assert!(matches!(opts.compression, Some(mcap::Compression::Zstd)));
+    }
+
+    #[test]
     fn compression_flag_resolves_each_format() {
         // Guards the CompressionFormat -> str -> mcap::Compression bridge for every variant.
         let mut args = default_filter_command();
 
-        args.compression = CompressionFormat::Zstd;
+        args.compression = Some(CompressionFormat::Zstd);
         let opts = build_filter_options(&args).expect("options");
         assert!(matches!(opts.compression, Some(mcap::Compression::Zstd)));
 
-        args.compression = CompressionFormat::Lz4;
+        args.compression = Some(CompressionFormat::Lz4);
         let opts = build_filter_options(&args).expect("options");
         assert!(matches!(opts.compression, Some(mcap::Compression::Lz4)));
 
-        args.compression = CompressionFormat::None;
+        args.compression = Some(CompressionFormat::None);
         let opts = build_filter_options(&args).expect("options");
         assert!(opts.compression.is_none());
     }
 
     #[test]
-    fn deprecated_output_compression_overrides_compression() {
+    fn deprecated_output_compression_applies_when_compression_unset() {
         let mut args = default_filter_command();
-        args.compression = CompressionFormat::Zstd;
+        args.compression = None;
         args.output_compression = Some(CompressionFormat::None);
         let opts = build_filter_options(&args).expect("options");
         assert!(opts.compression.is_none());
+    }
+
+    #[test]
+    fn compression_takes_precedence_over_deprecated_output_compression() {
+        let mut args = default_filter_command();
+        args.compression = Some(CompressionFormat::Lz4);
+        args.output_compression = Some(CompressionFormat::None);
+        let opts = build_filter_options(&args).expect("options");
+        assert!(matches!(opts.compression, Some(mcap::Compression::Lz4)));
     }
 }

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -316,6 +316,19 @@ mod tests {
     }
 
     #[test]
+    fn deprecated_include_flags_do_not_re_enable_excluded_records() {
+        // The deprecated --include-* flags are no-ops; --exclude-* still wins.
+        let mut args = default_filter_command();
+        args.include_metadata = true;
+        args.include_attachments = true;
+        args.exclude_metadata = true;
+        args.exclude_attachments = true;
+        let opts = build_filter_options(&args).expect("options");
+        assert!(!opts.include_metadata);
+        assert!(!opts.include_attachments);
+    }
+
+    #[test]
     fn compression_flag_resolves_to_selected_format() {
         let mut args = default_filter_command();
         args.compression = CompressionFormat::Lz4;
@@ -330,18 +343,5 @@ mod tests {
         args.output_compression = Some("none".to_string());
         let opts = build_filter_options(&args).expect("options");
         assert!(opts.compression.is_none());
-    }
-
-    #[test]
-    fn deprecated_include_flags_do_not_re_enable_excluded_records() {
-        // The deprecated --include-* flags are no-ops; --exclude-* still wins.
-        let mut args = default_filter_command();
-        args.include_metadata = true;
-        args.include_attachments = true;
-        args.exclude_metadata = true;
-        args.exclude_attachments = true;
-        let opts = build_filter_options(&args).expect("options");
-        assert!(!opts.include_metadata);
-        assert!(!opts.include_attachments);
     }
 }

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -43,7 +43,10 @@ impl From<&FilterCommand> for RewriteOptions {
             end_nsecs: args.end_nsecs,
             include_metadata: !args.exclude_metadata,
             include_attachments: !args.exclude_attachments,
-            output_compression: args.output_compression.clone(),
+            output_compression: args
+                .output_compression
+                .clone()
+                .unwrap_or_else(|| args.compression.as_str().to_string()),
             chunk_size: args.chunk_size,
             use_chunks: true,
         }
@@ -203,7 +206,7 @@ mod tests {
     use regex::Regex;
 
     use super::{build_filter_options, include_topic, ResolvedOptions};
-    use crate::cli::FilterCommand;
+    use crate::cli::{CompressionFormat, FilterCommand};
 
     fn default_filter_command() -> FilterCommand {
         FilterCommand {
@@ -222,7 +225,8 @@ mod tests {
             exclude_attachments: false,
             include_metadata: false,
             include_attachments: false,
-            output_compression: "zstd".to_string(),
+            compression: CompressionFormat::Zstd,
+            output_compression: None,
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
         }
     }
@@ -309,6 +313,23 @@ mod tests {
         let opts = build_filter_options(&args).expect("options");
         assert!(!opts.include_metadata);
         assert!(!opts.include_attachments);
+    }
+
+    #[test]
+    fn compression_flag_resolves_to_selected_format() {
+        let mut args = default_filter_command();
+        args.compression = CompressionFormat::Lz4;
+        let opts = build_filter_options(&args).expect("options");
+        assert!(matches!(opts.compression, Some(mcap::Compression::Lz4)));
+    }
+
+    #[test]
+    fn deprecated_output_compression_overrides_compression() {
+        let mut args = default_filter_command();
+        args.compression = CompressionFormat::Zstd;
+        args.output_compression = Some("none".to_string());
+        let opts = build_filter_options(&args).expect("options");
+        assert!(opts.compression.is_none());
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -329,11 +329,21 @@ mod tests {
     }
 
     #[test]
-    fn compression_flag_resolves_to_selected_format() {
+    fn compression_flag_resolves_each_format() {
+        // Guards the CompressionFormat -> str -> mcap::Compression bridge for every variant.
         let mut args = default_filter_command();
+
+        args.compression = CompressionFormat::Zstd;
+        let opts = build_filter_options(&args).expect("options");
+        assert!(matches!(opts.compression, Some(mcap::Compression::Zstd)));
+
         args.compression = CompressionFormat::Lz4;
         let opts = build_filter_options(&args).expect("options");
         assert!(matches!(opts.compression, Some(mcap::Compression::Lz4)));
+
+        args.compression = CompressionFormat::None;
+        let opts = build_filter_options(&args).expect("options");
+        assert!(opts.compression.is_none());
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -45,8 +45,9 @@ impl From<&FilterCommand> for RewriteOptions {
             include_attachments: !args.exclude_attachments,
             output_compression: args
                 .output_compression
-                .clone()
-                .unwrap_or_else(|| args.compression.as_str().to_string()),
+                .unwrap_or(args.compression)
+                .as_str()
+                .to_string(),
             chunk_size: args.chunk_size,
             use_chunks: true,
         }
@@ -350,7 +351,7 @@ mod tests {
     fn deprecated_output_compression_overrides_compression() {
         let mut args = default_filter_command();
         args.compression = CompressionFormat::Zstd;
-        args.output_compression = Some("none".to_string());
+        args.output_compression = Some(CompressionFormat::None);
         let opts = build_filter_options(&args).expect("options");
         assert!(opts.compression.is_none());
     }

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -191,13 +191,7 @@ fn stdin_pipe_filter() {
     let dir = TempDir::new().unwrap();
     let out_path = dir.path().join("filtered.mcap");
     let output = mcap_with_stdin(
-        &[
-            "filter",
-            "-o",
-            path_str(&out_path),
-            "--output-compression",
-            "none",
-        ],
+        &["filter", "-o", path_str(&out_path), "--compression", "none"],
         &build_mcap(3),
     );
     assert!(output.status.success());

--- a/rust/mcap/tests/data/generate.sh
+++ b/rust/mcap/tests/data/generate.sh
@@ -8,13 +8,13 @@ DEMO_MCAP_PATH="$SCRIPT_DIR/../../../../testdata/mcap/demo.mcap"
 mcap filter "$DEMO_MCAP_PATH" \
     --include-topic-regex "/diagnostics" \
     --include-topic-regex "/tf" \
-    --output-compression "zstd" \
+    --compression "zstd" \
     --chunk-size 4096 \
     --output "$SCRIPT_DIR/compressed.mcap"
 
 mcap filter "$DEMO_MCAP_PATH" \
     --include-topic-regex "/diagnostics" \
     --include-topic-regex "/tf" \
-    --output-compression "none" \
+    --compression "none" \
     --chunk-size 4096 \
     --output "$SCRIPT_DIR/uncompressed.mcap"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

`mcap filter`'s compression flag is now `--compression` (matching the other rewriting commands: `convert`, `merge`, `sort`, `compress`). The old `--output-compression` is accepted as a hidden, deprecated alias that prints a deprecation warning; when both flags are supplied, `--compression` takes precedence.

### Docs

None. The renamed flag is documented in `filter --help`.

### Description

Extracts just the compression-flag rename from #1757 so `filter` is consistent with the other commands, without pulling in that PR's larger `sort`/engine refactor.

- `FilterCommand` gains `--compression` as an `Option<CompressionFormat>` value-enum (`zstd`/`lz4`/`none`, default `zstd`), the same type and validation the other commands use. Invalid values are rejected at parse time (exit code 2) instead of at runtime. It's an `Option` so an explicit `--compression` is distinguishable from the default.
- `--output-compression` is retained as a hidden `Option<CompressionFormat>` alias that emits `--output-compression is deprecated; use --compression instead`. Precedence: `--compression` if set, else `--output-compression`, else the `zstd` default — so a stray `--output-compression` never silently overrides an explicit `--compression`.
- Internal callers updated to the new flag: the Rust fixture generator (`rust/mcap/tests/data/generate.sh`), the CLI benchmark, and the stdin-pipe integration test. The shared `RewriteOptions` engine is unchanged (still String-based internally); `sort`/`compress`/`decompress` are untouched.

### Testing

- ✅ `cargo test -p mcap-cli` (adds unit coverage: `--compression` resolves each format through the `CompressionFormat -> str -> mcap::Compression` bridge, defaults to zstd when unset, the deprecated alias applies only when `--compression` is unset, and `--compression` wins when both are set)
- ✅ `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`
- ✅ `cargo fmt -p mcap-cli -- --check`
- ✅ Manual on `testdata/mcap/demo.mcap`: `--compression lz4 --output-compression none` yields lz4 output (274 B) with the warning; `--output-compression none` alone yields uncompressed (411 B) with the warning; no flag yields zstd (205 B); `--compression snappy` / `--output-compression snappy` both rejected with exit code 2.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48f574af-c050-4b71-84c4-afcabef5151f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48f574af-c050-4b71-84c4-afcabef5151f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

