### PR TITLE
cli: add --order preserve|log_time to filter/compress/decompress

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -415,7 +415,7 @@ pub enum MessageOrder {
     #[value(name = "preserve")]
     Preserve,
     /// Sort messages by log time.
-    #[value(name = "log_time", alias = "log-time")]
+    #[value(name = "log-time", alias = "log_time")]
     LogTime,
 }
 
@@ -498,7 +498,7 @@ pub struct FilterCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log_time (sort by
+    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by
     /// log time). See `mcap sort` for sorting by log time as a standalone operation.
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -310,6 +310,18 @@ pub enum CompressionFormat {
     None,
 }
 
+/// Message ordering applied by the file-rewriting commands.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MessageOrder {
+    /// Keep the input's stored message order.
+    #[default]
+    #[value(name = "preserve")]
+    Preserve,
+    /// Sort messages by log time.
+    #[value(name = "log_time", alias = "log-time")]
+    LogTime,
+}
+
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct ConvertCommand {
     /// Local path to the input file
@@ -481,6 +493,10 @@ pub struct FilterCommand {
     /// Target uncompressed chunk size for output
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
+
+    /// Message order in the output: preserve (keep the input's stored order) or log_time (sort by log time)
+    #[arg(long = "order", value_enum, default_value = "preserve")]
+    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -127,7 +127,7 @@ pub struct CompressCommand {
     #[arg(long = "compression", default_value = "zstd")]
     pub compression: String,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log_time
+    /// Message order in the output: preserve (keep the input order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }
@@ -145,7 +145,7 @@ pub struct DecompressCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log_time
+    /// Message order in the output: preserve (keep the input order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }
@@ -516,7 +516,7 @@ pub struct FilterCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log_time
+    /// Message order in the output: preserve (keep the input order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -310,18 +310,6 @@ pub enum CompressionFormat {
     None,
 }
 
-/// Message ordering applied by the file-rewriting commands.
-#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum MessageOrder {
-    /// Keep the input's stored message order.
-    #[default]
-    #[value(name = "preserve")]
-    Preserve,
-    /// Sort messages by log time.
-    #[value(name = "log_time", alias = "log-time")]
-    LogTime,
-}
-
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct ConvertCommand {
     /// Local path to the input file
@@ -413,6 +401,18 @@ pub struct DuCommand {
 
     /// Local path to the MCAP file
     pub file: PathBuf,
+}
+
+/// Message order applied by `filter` (and the shared rewrite engine) to the output.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MessageOrder {
+    /// Keep the input's stored message order.
+    #[default]
+    #[value(name = "preserve")]
+    Preserve,
+    /// Sort messages by log time.
+    #[value(name = "log_time", alias = "log-time")]
+    LogTime,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -127,7 +127,7 @@ pub struct CompressCommand {
     #[arg(long = "compression", default_value = "zstd")]
     pub compression: String,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by log time)
+    /// Message order in the output: preserve (keep the input's stored order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }
@@ -145,7 +145,7 @@ pub struct DecompressCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by log time)
+    /// Message order in the output: preserve (keep the input's stored order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }
@@ -336,7 +336,7 @@ pub enum MessageOrder {
     #[value(name = "preserve")]
     Preserve,
     /// Sort messages by log time.
-    #[value(name = "log-time", alias = "log_time")]
+    #[value(name = "log_time", alias = "log-time")]
     LogTime,
 }
 
@@ -516,7 +516,7 @@ pub struct FilterCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by log time)
+    /// Message order in the output: preserve (keep the input's stored order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -334,6 +334,18 @@ impl CompressionFormat {
     }
 }
 
+/// Output message order for the rewrite commands (`filter`, `compress`, `decompress`).
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MessageOrder {
+    /// Keep the input's stored message order.
+    #[default]
+    #[value(name = "preserve")]
+    Preserve,
+    /// Sort messages by log time.
+    #[value(name = "log-time", alias = "log_time")]
+    LogTime,
+}
+
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct ConvertCommand {
     /// Local path to the input file
@@ -425,18 +437,6 @@ pub struct DuCommand {
 
     /// Local path to the MCAP file
     pub file: PathBuf,
-}
-
-/// Message order applied by `filter` (and the shared rewrite engine) to the output.
-#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum MessageOrder {
-    /// Keep the input's stored message order.
-    #[default]
-    #[value(name = "preserve")]
-    Preserve,
-    /// Sort messages by log time.
-    #[value(name = "log-time", alias = "log_time")]
-    LogTime,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -75,6 +75,8 @@ pub enum Command {
     #[command(verbatim_doc_comment)]
     Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file
+    ///
+    /// Messages are copied in the input's stored order; use `mcap sort` to reorder by log time.
     Compress(CompressCommand),
     /// Convert supported input files to MCAP
     #[command(
@@ -82,6 +84,8 @@ pub enum Command {
     )]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file
+    ///
+    /// Messages are copied in the input's stored order; use `mcap sort` to reorder by log time.
     Decompress(DecompressCommand),
     /// Check an MCAP file structure
     Doctor(DoctorCommand),
@@ -494,7 +498,8 @@ pub struct FilterCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log_time (sort by log time)
+    /// Message order in the output: preserve (keep the input's stored order) or log_time (sort by
+    /// log time). See `mcap sort` for sorting by log time as a standalone operation.
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -75,9 +75,6 @@ pub enum Command {
     #[command(verbatim_doc_comment)]
     Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file
-    ///
-    /// Messages are copied in the input's stored order by default; pass `--order log-time` (or use
-    /// `mcap filter`) to reorder.
     Compress(CompressCommand),
     /// Convert supported input files to MCAP
     #[command(
@@ -85,9 +82,6 @@ pub enum Command {
     )]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file
-    ///
-    /// Messages are copied in the input's stored order by default; pass `--order log-time` (or use
-    /// `mcap filter`) to reorder.
     Decompress(DecompressCommand),
     /// Check an MCAP file structure
     Doctor(DoctorCommand),

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -76,7 +76,8 @@ pub enum Command {
     Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file
     ///
-    /// Messages are copied in the input's stored order; use `mcap sort` to reorder by log time.
+    /// Messages are copied in the input's stored order by default; pass `--order log-time` (or use
+    /// `mcap filter`) to reorder.
     Compress(CompressCommand),
     /// Convert supported input files to MCAP
     #[command(
@@ -85,7 +86,8 @@ pub enum Command {
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file
     ///
-    /// Messages are copied in the input's stored order; use `mcap sort` to reorder by log time.
+    /// Messages are copied in the input's stored order by default; pass `--order log-time` (or use
+    /// `mcap filter`) to reorder.
     Decompress(DecompressCommand),
     /// Check an MCAP file structure
     Doctor(DoctorCommand),
@@ -130,6 +132,10 @@ pub struct CompressCommand {
     /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long = "compression", default_value = "zstd")]
     pub compression: String,
+
+    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by log time)
+    #[arg(long = "order", value_enum, default_value = "preserve")]
+    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -144,6 +150,10 @@ pub struct DecompressCommand {
     /// Target uncompressed chunk size for output
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
+
+    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by log time)
+    #[arg(long = "order", value_enum, default_value = "preserve")]
+    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -516,6 +526,14 @@ pub struct FilterCommand {
     /// log time). See `mcap sort` for sorting by log time as a standalone operation.
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
+
+    /// Disable all output CRC fields
+    #[arg(long = "no-crc", default_value_t = false)]
+    pub no_crc: bool,
+
+    /// Write records outside of chunks
+    #[arg(long = "no-chunks", default_value_t = false)]
+    pub no_chunks: bool,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -526,14 +526,6 @@ pub struct FilterCommand {
     /// log time). See `mcap sort` for sorting by log time as a standalone operation.
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
-
-    /// Disable all output CRC fields
-    #[arg(long = "no-crc", default_value_t = false)]
-    pub no_crc: bool,
-
-    /// Write records outside of chunks
-    #[arg(long = "no-chunks", default_value_t = false)]
-    pub no_chunks: bool,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -516,8 +516,7 @@ pub struct FilterCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by
-    /// log time). See `mcap sort` for sorting by log time as a standalone operation.
+    /// Message order in the output: preserve (keep the input's stored order) or log-time (sort by log time)
     #[arg(long = "order", value_enum, default_value = "preserve")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -86,7 +86,8 @@ mod tests {
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Command,
         CompressCommand, DoctorCommand, DuCommand, GetAttachmentCommand, GetMetadataCommand,
         InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
-        ListMetadataCommand, ListSchemasCommand, ListSubcommand, RecoverCommand, SortCommand,
+        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MessageOrder, RecoverCommand,
+        SortCommand,
     };
     use crate::context::CommandContext;
 
@@ -256,6 +257,7 @@ mod tests {
                 output: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 compression: "invalid".to_string(),
+                order: MessageOrder::Preserve,
             }),
         )
         .expect_err("compress should reject invalid compression");

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::cli::CompressCommand;
+use crate::cli::{CompressCommand, MessageOrder};
 use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
@@ -11,7 +11,7 @@ pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
         .include_metadata(true)
         .include_attachments(true)
         // A compressed copy preserves the input's message order; use `mcap sort` to reorder.
-        .order_by_log_time(false);
+        .order(MessageOrder::Preserve);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -9,7 +9,9 @@ pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
         .compression(args.compression)
         .use_chunks(true)
         .include_metadata(true)
-        .include_attachments(true);
+        .include_attachments(true)
+        // A compressed copy preserves the input's message order; use `mcap sort` to reorder.
+        .order_by_log_time(false);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::cli::{CompressCommand, MessageOrder};
+use crate::cli::CompressCommand;
 use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
@@ -10,8 +10,7 @@ pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
         .use_chunks(true)
         .include_metadata(true)
         .include_attachments(true)
-        // A compressed copy preserves the input's message order; use `mcap sort` to reorder.
-        .order(MessageOrder::Preserve);
+        .order(args.order);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -9,7 +9,9 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
         .compression("none")
         .include_metadata(true)
         .include_attachments(true)
-        .use_chunks(true);
+        .use_chunks(true)
+        // An uncompressed copy preserves the input's message order; use `mcap sort` to reorder.
+        .order_by_log_time(false);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::cli::DecompressCommand;
+use crate::cli::{DecompressCommand, MessageOrder};
 use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
@@ -11,7 +11,7 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
         .include_attachments(true)
         .use_chunks(true)
         // An uncompressed copy preserves the input's message order; use `mcap sort` to reorder.
-        .order_by_log_time(false);
+        .order(MessageOrder::Preserve);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::cli::{DecompressCommand, MessageOrder};
+use crate::cli::DecompressCommand;
 use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
@@ -10,8 +10,7 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
         .include_metadata(true)
         .include_attachments(true)
         .use_chunks(true)
-        // An uncompressed copy preserves the input's message order; use `mcap sort` to reorder.
-        .order(MessageOrder::Preserve);
+        .order(args.order);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -474,6 +474,7 @@ mod tests {
                 output: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                 compression: "zstd".to_string(),
+                order: MessageOrder::Preserve,
             })
         );
     }
@@ -490,6 +491,8 @@ mod tests {
             "1024",
             "--compression",
             "lz4",
+            "--order",
+            "log-time",
         ])
         .expect("compress with flags should parse");
         assert_eq!(
@@ -499,6 +502,7 @@ mod tests {
                 output: Some("out.mcap".into()),
                 chunk_size: 1024,
                 compression: "lz4".to_string(),
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -513,6 +517,7 @@ mod tests {
                 file: Some("in.mcap".into()),
                 output: None,
                 chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                order: MessageOrder::Preserve,
             })
         );
     }
@@ -527,6 +532,8 @@ mod tests {
             "out.mcap",
             "--chunk-size",
             "2048",
+            "--order",
+            "log-time",
         ])
         .expect("decompress with flags should parse");
         assert_eq!(
@@ -535,6 +542,7 @@ mod tests {
                 file: Some("in.mcap".into()),
                 output: Some("out.mcap".into()),
                 chunk_size: 2048,
+                order: MessageOrder::LogTime,
             })
         );
     }
@@ -585,6 +593,8 @@ mod tests {
                 output_compression: None,
                 chunk_size: 2048,
                 order: MessageOrder::Preserve,
+                no_crc: false,
+                no_chunks: false,
             })
         );
     }
@@ -621,6 +631,29 @@ mod tests {
                 // Deprecated include flags default off and are no-ops.
                 assert!(!filter.include_metadata);
                 assert!(!filter.include_attachments);
+            }
+            other => panic!("expected filter command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_filter_no_crc_and_no_chunks() {
+        let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
+            .expect("filter should parse without transcode flags");
+        match default.command {
+            Command::Filter(filter) => {
+                assert!(!filter.no_crc);
+                assert!(!filter.no_chunks);
+            }
+            other => panic!("expected filter command, got {other:?}"),
+        }
+
+        let args = Args::try_parse_from(["mcap", "filter", "in.mcap", "--no-crc", "--no-chunks"])
+            .expect("filter should parse --no-crc/--no-chunks");
+        match args.command {
+            Command::Filter(filter) => {
+                assert!(filter.no_crc);
+                assert!(filter.no_chunks);
             }
             other => panic!("expected filter command, got {other:?}"),
         }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -593,8 +593,6 @@ mod tests {
                 output_compression: None,
                 chunk_size: 2048,
                 order: MessageOrder::Preserve,
-                no_crc: false,
-                no_chunks: false,
             })
         );
     }
@@ -631,29 +629,6 @@ mod tests {
                 // Deprecated include flags default off and are no-ops.
                 assert!(!filter.include_metadata);
                 assert!(!filter.include_attachments);
-            }
-            other => panic!("expected filter command, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parses_filter_no_crc_and_no_chunks() {
-        let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
-            .expect("filter should parse without transcode flags");
-        match default.command {
-            Command::Filter(filter) => {
-                assert!(!filter.no_crc);
-                assert!(!filter.no_chunks);
-            }
-            other => panic!("expected filter command, got {other:?}"),
-        }
-
-        let args = Args::try_parse_from(["mcap", "filter", "in.mcap", "--no-crc", "--no-chunks"])
-            .expect("filter should parse --no-crc/--no-chunks");
-        match args.command {
-            Command::Filter(filter) => {
-                assert!(filter.no_crc);
-                assert!(filter.no_chunks);
             }
             other => panic!("expected filter command, got {other:?}"),
         }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -45,8 +45,8 @@ mod tests {
         ConvertCommand, DecompressCommand, DoctorCommand, DuCommand, FilterCommand,
         GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand,
         ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
-        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, RecoverCommand,
-        SortCommand,
+        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, MessageOrder,
+        RecoverCommand, SortCommand,
     };
 
     #[test]
@@ -583,6 +583,7 @@ mod tests {
                 include_attachments: true,
                 output_compression: "lz4".to_string(),
                 chunk_size: 2048,
+                order: MessageOrder::Preserve,
             })
         );
     }
@@ -607,6 +608,30 @@ mod tests {
             }
             other => panic!("expected filter command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn filter_order_defaults_to_preserve_and_parses_log_time() {
+        let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
+            .expect("filter should parse without --order");
+        match default.command {
+            Command::Filter(filter) => assert_eq!(filter.order, MessageOrder::Preserve),
+            other => panic!("expected filter command, got {other:?}"),
+        }
+
+        for value in ["log_time", "log-time"] {
+            let args = Args::try_parse_from(["mcap", "filter", "in.mcap", "--order", value])
+                .unwrap_or_else(|_| panic!("filter should parse --order {value}"));
+            match args.command {
+                Command::Filter(filter) => assert_eq!(filter.order, MessageOrder::LogTime),
+                other => panic!("expected filter command, got {other:?}"),
+            }
+        }
+
+        assert!(
+            Args::try_parse_from(["mcap", "filter", "in.mcap", "--order", "bogus"]).is_err(),
+            "an unknown --order value should be rejected"
+        );
     }
 
     #[test]

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -354,6 +354,15 @@ fn checked_slice(input: &[u8], offset: u64, length: usize) -> Result<&[u8]> {
     })
 }
 
+/// A message buffered during the linear path so summaryless input can be re-sorted by log time.
+struct BufferedMessage {
+    channel: Arc<mcap::Channel<'static>>,
+    sequence: u32,
+    log_time: u64,
+    publish_time: u64,
+    data: Vec<u8>,
+}
+
 fn filter_linear<W: Write + Seek>(
     input: &[u8],
     writer: &mut mcap::Writer<W>,
@@ -478,15 +487,6 @@ fn filter_linear<W: Write + Seek>(
     }
 
     Ok(())
-}
-
-/// A message buffered during the linear path so summaryless input can be re-sorted by log time.
-struct BufferedMessage {
-    channel: Arc<mcap::Channel<'static>>,
-    sequence: u32,
-    log_time: u64,
-    publish_time: u64,
-    data: Vec<u8>,
 }
 
 fn build_channel(

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -680,6 +680,20 @@ mod tests {
         stats
     }
 
+    /// Collects each output message's `(log_time, sequence)` in the order it appears, so ordering
+    /// (including the tie-break among equal log times) can be asserted.
+    fn output_message_identity(output: &[u8]) -> Vec<(u64, u32)> {
+        mcap::read::ChunkFlattener::new(output)
+            .expect("reader")
+            .filter_map(|record| match record.expect("record") {
+                mcap::records::Record::Message { header, .. } => {
+                    Some((header.log_time, header.sequence))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     fn include_all_options() -> ResolvedOptions {
         ResolvedOptions {
             output: None,
@@ -743,6 +757,51 @@ mod tests {
                         &mcap::records::MessageHeader {
                             channel_id: channel,
                             sequence: sequence as u32,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        b"x",
+                    )
+                    .expect("write");
+            }
+            writer.finish().expect("finish");
+        }
+        output.into_inner()
+    }
+
+    /// Writes one channel's messages in the exact `(log_time, sequence)` file order given, so the
+    /// log-time sort's tie-break among equal log times can be asserted.
+    fn write_messages_with_log_times(
+        chunked: bool,
+        summaryless: bool,
+        entries: &[(u64, u32)],
+    ) -> Vec<u8> {
+        let mut output = Cursor::new(Vec::new());
+        {
+            let mut options = mcap::WriteOptions::new()
+                .use_chunks(chunked)
+                .library("test-recorder/0.0");
+            if chunked {
+                options = options.chunk_size(Some(1 << 20));
+            }
+            if summaryless {
+                options = options
+                    .emit_summary_records(false)
+                    .emit_summary_offsets(false);
+            }
+            let mut writer = options.create(&mut output).expect("writer");
+            let schema_id = writer
+                .add_schema("schema", "jsonschema", br#"{}"#)
+                .expect("schema");
+            let channel = writer
+                .add_channel(schema_id, "camera_a", "json", &BTreeMap::new())
+                .expect("channel");
+            for &(log_time, sequence) in entries {
+                writer
+                    .write_to_known_channel(
+                        &mcap::records::MessageHeader {
+                            channel_id: channel,
+                            sequence,
                             log_time,
                             publish_time: log_time,
                         },
@@ -1316,6 +1375,25 @@ mod tests {
                 analyze_output(&sorted).log_times,
                 vec![5, 10, 20, 25, 30],
                 "log_time should sort messages by log time (chunked={chunked})"
+            );
+        }
+    }
+
+    #[test]
+    fn log_time_sort_is_stable_for_equal_log_times() {
+        // Three messages share log_time 10 but appear in scrambled sequence order in the file. A
+        // log-time sort must be stable — keeping their file order (sequences 2, 0, 1) — matching
+        // the indexed reader's "earlier in the file wins" tie-break for equal log times. This holds
+        // across the indexed path and both linear (summaryless) paths.
+        let entries = [(20, 0), (10, 2), (10, 0), (10, 1), (5, 3)];
+        let expected = vec![(5, 3), (10, 2), (10, 0), (10, 1), (20, 0)];
+        for (chunked, summaryless) in [(true, false), (true, true), (false, true)] {
+            let input = write_messages_with_log_times(chunked, summaryless, &entries);
+            let output = run_filter(&input, &ordered_options(true));
+            assert_eq!(
+                output_message_identity(&output),
+                expected,
+                "equal log_times must preserve file order (chunked={chunked}, summaryless={summaryless})"
             );
         }
     }

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 
 use super::options::{include_topic, resolve_options, ResolvedOptions, RewriteOptions};
+use crate::cli::MessageOrder;
 use crate::{parse, source};
 
 pub(crate) fn run(args: RewriteOptions, source_options: source::SourceOptions) -> Result<()> {
@@ -230,10 +231,9 @@ fn filter_indexed<W: Write + Seek>(
 
     if !(has_topic_filters && included_topics.is_empty()) {
         // `preserve` reads the input in its stored order; `log_time` re-sorts into log-time order.
-        let read_order = if opts.order_by_log_time {
-            mcap::sans_io::indexed_reader::ReadOrder::LogTime
-        } else {
-            mcap::sans_io::indexed_reader::ReadOrder::File
+        let read_order = match opts.order {
+            MessageOrder::Preserve => mcap::sans_io::indexed_reader::ReadOrder::File,
+            MessageOrder::LogTime => mcap::sans_io::indexed_reader::ReadOrder::LogTime,
         };
         let mut indexed_opts = mcap::sans_io::IndexedReaderOptions::new()
             .with_order(read_order)
@@ -372,6 +372,13 @@ fn filter_linear<W: Write + Seek>(
         bail!("including last-per-channel topics is not supported for non-indexed input");
     }
 
+    // A summaryless input cannot be streamed in log-time order, so when sorting is requested its
+    // messages are buffered (owning their payloads) and sorted before being written.
+    let sort_by_log_time = match opts.order {
+        MessageOrder::Preserve => false,
+        MessageOrder::LogTime => true,
+    };
+
     // Metadata is written first, before any messages (see module docs). Metadata records are never
     // stored inside chunks, so a top-level linear scan surfaces them without decompressing chunks.
     if opts.include_metadata {
@@ -387,10 +394,8 @@ fn filter_linear<W: Write + Seek>(
     let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
     // Collected during the message pass (borrowing from `input`, no copy) and written last.
     let mut pending_attachments = Vec::<mcap::Attachment>::new();
-    // When `order_by_log_time` is set we cannot stream a summaryless input in order, so messages
-    // are buffered here (owning their payloads) and sorted before being written. This buffers the
-    // whole selected message set in memory; making the summaryless ordered path memory-bounded is a
-    // known follow-up.
+    // Messages buffered for the sorted path. This holds the whole selected message set in memory;
+    // making the summaryless ordered path memory-bounded is a known follow-up.
     let mut buffered_messages = Vec::<BufferedMessage>::new();
 
     for record in mcap::read::ChunkFlattener::new(input)? {
@@ -431,7 +436,7 @@ fn filter_linear<W: Write + Seek>(
                     continue;
                 }
 
-                if opts.order_by_log_time {
+                if sort_by_log_time {
                     buffered_messages.push(BufferedMessage {
                         channel,
                         sequence: header.sequence,
@@ -468,7 +473,7 @@ fn filter_linear<W: Write + Seek>(
     // Messages buffered for log-time ordering are sorted and written before the attachments. The
     // sort is stable in log time, matching the indexed reader's tie-break (log_time, then the
     // record's file position, approximated here by insertion order).
-    if opts.order_by_log_time {
+    if sort_by_log_time {
         buffered_messages.sort_by_key(|message| message.log_time);
         for message in &buffered_messages {
             writer.write(&mcap::Message {
@@ -521,7 +526,7 @@ mod tests {
 
     use regex::Regex;
 
-    use super::{filter_to_writer, ResolvedOptions};
+    use super::{filter_to_writer, MessageOrder, ResolvedOptions};
 
     fn write_filter_test_input(chunked: bool, summaryless: bool) -> Vec<u8> {
         write_filter_test_input_with_options(chunked, summaryless, true, true, true, true)
@@ -707,7 +712,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         }
     }
 
@@ -719,9 +724,9 @@ mod tests {
         }
     }
 
-    fn ordered_options(order_by_log_time: bool) -> ResolvedOptions {
+    fn ordered_options(order: MessageOrder) -> ResolvedOptions {
         ResolvedOptions {
-            order_by_log_time,
+            order,
             ..include_all_options()
         }
     }
@@ -914,7 +919,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -940,7 +945,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -967,7 +972,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -996,7 +1001,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1023,7 +1028,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1048,7 +1053,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1072,7 +1077,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1096,7 +1101,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1119,7 +1124,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1142,7 +1147,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1165,7 +1170,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         // The CLI is the writer of the output, so it stamps its own identity, not the source's.
         let output = run_filter(&input, &opts);
@@ -1265,8 +1270,9 @@ mod tests {
         )
         .include_metadata(true)
         .include_attachments(true);
-        assert!(
-            !options.order_by_log_time,
+        assert_eq!(
+            options.order,
+            MessageOrder::Preserve,
             "RewriteOptions::new should default to preserve"
         );
         super::run(options, crate::source::SourceOptions::default())
@@ -1342,14 +1348,14 @@ mod tests {
             .expect("summary present");
         assert!(!summary.chunk_indexes.is_empty());
 
-        let preserved = run_filter(&input, &ordered_options(false));
+        let preserved = run_filter(&input, &ordered_options(MessageOrder::Preserve));
         assert_eq!(
             analyze_output(&preserved).log_times,
             vec![30, 10, 20, 5, 25],
             "preserve should keep the input's stored order"
         );
 
-        let sorted = run_filter(&input, &ordered_options(true));
+        let sorted = run_filter(&input, &ordered_options(MessageOrder::LogTime));
         assert_eq!(
             analyze_output(&sorted).log_times,
             vec![5, 10, 20, 25, 30],
@@ -1363,14 +1369,14 @@ mod tests {
         for (chunked, summaryless) in [(true, true), (false, true)] {
             let input = write_unsorted_input(chunked, summaryless);
 
-            let preserved = run_filter(&input, &ordered_options(false));
+            let preserved = run_filter(&input, &ordered_options(MessageOrder::Preserve));
             assert_eq!(
                 analyze_output(&preserved).log_times,
                 vec![30, 10, 20, 5, 25],
                 "preserve should keep the input's stored order (chunked={chunked})"
             );
 
-            let sorted = run_filter(&input, &ordered_options(true));
+            let sorted = run_filter(&input, &ordered_options(MessageOrder::LogTime));
             assert_eq!(
                 analyze_output(&sorted).log_times,
                 vec![5, 10, 20, 25, 30],
@@ -1389,7 +1395,7 @@ mod tests {
         let expected = vec![(5, 3), (10, 2), (10, 0), (10, 1), (20, 0)];
         for (chunked, summaryless) in [(true, false), (true, true), (false, true)] {
             let input = write_messages_with_log_times(chunked, summaryless, &entries);
-            let output = run_filter(&input, &ordered_options(true));
+            let output = run_filter(&input, &ordered_options(MessageOrder::LogTime));
             assert_eq!(
                 output_message_identity(&output),
                 expected,

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -1189,6 +1189,39 @@ mod tests {
     }
 
     #[test]
+    fn rewrite_new_default_preserves_message_order() {
+        // `compress`/`decompress` build their options via `RewriteOptions::new`, which defaults to
+        // `preserve`. Lock in that an out-of-order indexed input is copied in its stored order
+        // rather than silently re-sorted to log time.
+        let input = write_unsorted_input(true, false);
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let input_path = dir.path().join("in.mcap");
+        let output_path = dir.path().join("out.mcap");
+        std::fs::write(&input_path, &input).expect("write input");
+
+        let options = super::RewriteOptions::new(
+            Some(input_path),
+            Some(output_path.clone()),
+            mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+        )
+        .include_metadata(true)
+        .include_attachments(true);
+        assert!(
+            !options.order_by_log_time,
+            "RewriteOptions::new should default to preserve"
+        );
+        super::run(options, crate::source::SourceOptions::default())
+            .expect("rewrite should succeed");
+
+        let output = std::fs::read(&output_path).expect("read output");
+        assert_eq!(
+            analyze_output(&output).log_times,
+            vec![30, 10, 20, 5, 25],
+            "the shared engine default must preserve the input's stored order"
+        );
+    }
+
+    #[test]
     fn indexed_attachments_are_not_time_filtered() {
         // The fixture's attachment has log_time 50; a [0, 10) window excludes it from the message
         // range but the attachment is still kept.

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -42,6 +42,10 @@ fn filter_to_writer<W: Write + Seek>(
         .use_chunks(opts.use_chunks)
         .chunk_size(Some(opts.chunk_size))
         .compression(opts.compression)
+        .calculate_chunk_crcs(opts.include_crc)
+        .calculate_data_section_crc(opts.include_crc)
+        .calculate_summary_section_crc(opts.include_crc)
+        .calculate_attachment_crcs(opts.include_crc)
         .disable_seeking(disable_seeking);
 
     write_options = write_options.library(crate::cli::LIBRARY_IDENTIFIER.clone());
@@ -713,6 +717,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         }
     }
 
@@ -920,6 +925,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -946,6 +952,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -973,6 +980,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1002,6 +1010,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1029,6 +1038,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1054,6 +1064,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1078,6 +1089,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1102,6 +1114,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1125,6 +1138,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1148,6 +1162,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1171,6 +1186,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         // The CLI is the writer of the output, so it stamps its own identity, not the source's.
         let output = run_filter(&input, &opts);
@@ -1383,6 +1399,40 @@ mod tests {
                 "log_time should sort messages by log time (chunked={chunked})"
             );
         }
+    }
+
+    fn data_section_crc(output: &[u8]) -> u32 {
+        for record in mcap::read::LinearReader::new(output).expect("reader") {
+            if let mcap::records::Record::DataEnd(data_end) = record.expect("record") {
+                return data_end.data_section_crc;
+            }
+        }
+        panic!("output has no DataEnd record");
+    }
+
+    #[test]
+    fn include_crc_false_disables_output_crcs() {
+        let input = write_filter_test_input(true, false);
+
+        let with_crc = run_filter(&input, &include_all_options());
+        assert_ne!(
+            data_section_crc(&with_crc),
+            0,
+            "CRCs are emitted by default"
+        );
+
+        let without_crc = run_filter(
+            &input,
+            &ResolvedOptions {
+                include_crc: false,
+                ..include_all_options()
+            },
+        );
+        assert_eq!(
+            data_section_crc(&without_crc),
+            0,
+            "include_crc=false must zero output CRCs"
+        );
     }
 
     #[test]

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -229,8 +229,14 @@ fn filter_indexed<W: Write + Seek>(
     }
 
     if !(has_topic_filters && included_topics.is_empty()) {
+        // `preserve` reads the input in its stored order; `log_time` re-sorts into log-time order.
+        let read_order = if opts.order_by_log_time {
+            mcap::sans_io::indexed_reader::ReadOrder::LogTime
+        } else {
+            mcap::sans_io::indexed_reader::ReadOrder::File
+        };
         let mut indexed_opts = mcap::sans_io::IndexedReaderOptions::new()
-            .with_order(mcap::sans_io::indexed_reader::ReadOrder::LogTime)
+            .with_order(read_order)
             .log_time_on_or_after(opts.start);
         if opts.end != u64::MAX {
             indexed_opts = indexed_opts.log_time_before(opts.end);
@@ -372,6 +378,11 @@ fn filter_linear<W: Write + Seek>(
     let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
     // Collected during the message pass (borrowing from `input`, no copy) and written last.
     let mut pending_attachments = Vec::<mcap::Attachment>::new();
+    // When `order_by_log_time` is set we cannot stream a summaryless input in order, so messages
+    // are buffered here (owning their payloads) and sorted before being written. This buffers the
+    // whole selected message set in memory; making the summaryless ordered path memory-bounded is a
+    // known follow-up.
+    let mut buffered_messages = Vec::<BufferedMessage>::new();
 
     for record in mcap::read::ChunkFlattener::new(input)? {
         match record? {
@@ -411,13 +422,23 @@ fn filter_linear<W: Write + Seek>(
                     continue;
                 }
 
-                writer.write(&mcap::Message {
-                    channel,
-                    sequence: header.sequence,
-                    log_time: header.log_time,
-                    publish_time: header.publish_time,
-                    data: Cow::Borrowed(data.as_ref()),
-                })?;
+                if opts.order_by_log_time {
+                    buffered_messages.push(BufferedMessage {
+                        channel,
+                        sequence: header.sequence,
+                        log_time: header.log_time,
+                        publish_time: header.publish_time,
+                        data: data.into_owned(),
+                    });
+                } else {
+                    writer.write(&mcap::Message {
+                        channel,
+                        sequence: header.sequence,
+                        log_time: header.log_time,
+                        publish_time: header.publish_time,
+                        data: Cow::Borrowed(data.as_ref()),
+                    })?;
+                }
             }
             mcap::records::Record::Attachment { header, data, .. } if opts.include_attachments => {
                 // Kept regardless of the message time range.
@@ -435,12 +456,37 @@ fn filter_linear<W: Write + Seek>(
         }
     }
 
+    // Messages buffered for log-time ordering are sorted and written before the attachments. The
+    // sort is stable in log time, matching the indexed reader's tie-break (log_time, then the
+    // record's file position, approximated here by insertion order).
+    if opts.order_by_log_time {
+        buffered_messages.sort_by_key(|message| message.log_time);
+        for message in &buffered_messages {
+            writer.write(&mcap::Message {
+                channel: message.channel.clone(),
+                sequence: message.sequence,
+                log_time: message.log_time,
+                publish_time: message.publish_time,
+                data: Cow::Borrowed(message.data.as_slice()),
+            })?;
+        }
+    }
+
     // Attachments are written last, after all messages (see module docs).
     for attachment in &pending_attachments {
         writer.attach(attachment)?;
     }
 
     Ok(())
+}
+
+/// A message buffered during the linear path so summaryless input can be re-sorted by log time.
+struct BufferedMessage {
+    channel: Arc<mcap::Channel<'static>>,
+    sequence: u32,
+    log_time: u64,
+    publish_time: u64,
+    data: Vec<u8>,
 }
 
 fn build_channel(
@@ -647,6 +693,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         }
     }
 
@@ -656,6 +703,56 @@ mod tests {
             end,
             ..include_all_options()
         }
+    }
+
+    fn ordered_options(order_by_log_time: bool) -> ResolvedOptions {
+        ResolvedOptions {
+            order_by_log_time,
+            ..include_all_options()
+        }
+    }
+
+    /// Writes a single channel whose messages are stored out of log-time order, so `preserve`
+    /// (stored order) and `log_time` (sorted) produce observably different outputs.
+    fn write_unsorted_input(chunked: bool, summaryless: bool) -> Vec<u8> {
+        let log_times = [30u64, 10, 20, 5, 25];
+        let mut output = Cursor::new(Vec::new());
+        {
+            let mut options = mcap::WriteOptions::new()
+                .use_chunks(chunked)
+                .library("test-recorder/0.0");
+            if chunked {
+                // A large chunk keeps every message in one chunk, so file order is the write order.
+                options = options.chunk_size(Some(1 << 20));
+            }
+            if summaryless {
+                options = options
+                    .emit_summary_records(false)
+                    .emit_summary_offsets(false);
+            }
+            let mut writer = options.create(&mut output).expect("writer");
+            let schema_id = writer
+                .add_schema("schema", "jsonschema", br#"{}"#)
+                .expect("schema");
+            let channel = writer
+                .add_channel(schema_id, "camera_a", "json", &BTreeMap::new())
+                .expect("channel");
+            for (sequence, &log_time) in log_times.iter().enumerate() {
+                writer
+                    .write_to_known_channel(
+                        &mcap::records::MessageHeader {
+                            channel_id: channel,
+                            sequence: sequence as u32,
+                            log_time,
+                            publish_time: log_time,
+                        },
+                        b"x",
+                    )
+                    .expect("write");
+            }
+            writer.finish().expect("finish");
+        }
+        output.into_inner()
     }
 
     /// Builds a chunk-indexed file whose summary omits metadata/attachment index records — a
@@ -758,6 +855,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -783,6 +881,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -809,6 +908,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -837,6 +937,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -863,6 +964,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -887,6 +989,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -910,6 +1013,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -933,6 +1037,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -955,6 +1060,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -977,6 +1083,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -999,6 +1106,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         // The CLI is the writer of the output, so it stamps its own identity, not the source's.
         let output = run_filter(&input, &opts);
@@ -1131,5 +1239,51 @@ mod tests {
         let input = write_filter_test_input(false, true);
         let output = run_filter(&input, &include_all_options());
         assert_standard_placement(&output);
+    }
+
+    #[test]
+    fn indexed_preserve_keeps_stored_order_while_log_time_sorts() {
+        let input = write_unsorted_input(true, false);
+        // Sanity: this fixture takes the indexed path.
+        let summary = mcap::Summary::read(&input)
+            .expect("summary read")
+            .expect("summary present");
+        assert!(!summary.chunk_indexes.is_empty());
+
+        let preserved = run_filter(&input, &ordered_options(false));
+        assert_eq!(
+            analyze_output(&preserved).log_times,
+            vec![30, 10, 20, 5, 25],
+            "preserve should keep the input's stored order"
+        );
+
+        let sorted = run_filter(&input, &ordered_options(true));
+        assert_eq!(
+            analyze_output(&sorted).log_times,
+            vec![5, 10, 20, 25, 30],
+            "log_time should sort messages by log time"
+        );
+    }
+
+    #[test]
+    fn linear_preserve_keeps_stored_order_while_log_time_sorts() {
+        // Both a chunked-summaryless and a fully unchunked input take the linear path.
+        for (chunked, summaryless) in [(true, true), (false, true)] {
+            let input = write_unsorted_input(chunked, summaryless);
+
+            let preserved = run_filter(&input, &ordered_options(false));
+            assert_eq!(
+                analyze_output(&preserved).log_times,
+                vec![30, 10, 20, 5, 25],
+                "preserve should keep the input's stored order (chunked={chunked})"
+            );
+
+            let sorted = run_filter(&input, &ordered_options(true));
+            assert_eq!(
+                analyze_output(&sorted).log_times,
+                vec![5, 10, 20, 25, 30],
+                "log_time should sort messages by log time (chunked={chunked})"
+            );
+        }
     }
 }

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -42,10 +42,6 @@ fn filter_to_writer<W: Write + Seek>(
         .use_chunks(opts.use_chunks)
         .chunk_size(Some(opts.chunk_size))
         .compression(opts.compression)
-        .calculate_chunk_crcs(opts.include_crc)
-        .calculate_data_section_crc(opts.include_crc)
-        .calculate_summary_section_crc(opts.include_crc)
-        .calculate_attachment_crcs(opts.include_crc)
         .disable_seeking(disable_seeking);
 
     write_options = write_options.library(crate::cli::LIBRARY_IDENTIFIER.clone());
@@ -725,7 +721,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         }
     }
 
@@ -933,7 +928,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -960,7 +954,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -988,7 +981,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1018,7 +1010,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1046,7 +1037,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1072,7 +1062,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1097,7 +1086,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let output = run_filter(&input, &opts);
         let stats = analyze_output(&output);
@@ -1122,7 +1110,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1146,7 +1133,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1170,7 +1156,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         let mut output = Cursor::new(Vec::new());
         let err = filter_to_writer(&input, &mut output, &opts, false)
@@ -1194,7 +1179,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         // The CLI is the writer of the output, so it stamps its own identity, not the source's.
         let output = run_filter(&input, &opts);
@@ -1407,40 +1391,6 @@ mod tests {
                 "log_time should sort messages by log time (chunked={chunked})"
             );
         }
-    }
-
-    fn data_section_crc(output: &[u8]) -> u32 {
-        for record in mcap::read::LinearReader::new(output).expect("reader") {
-            if let mcap::records::Record::DataEnd(data_end) = record.expect("record") {
-                return data_end.data_section_crc;
-            }
-        }
-        panic!("output has no DataEnd record");
-    }
-
-    #[test]
-    fn include_crc_false_disables_output_crcs() {
-        let input = write_filter_test_input(true, false);
-
-        let with_crc = run_filter(&input, &include_all_options());
-        assert_ne!(
-            data_section_crc(&with_crc),
-            0,
-            "CRCs are emitted by default"
-        );
-
-        let without_crc = run_filter(
-            &input,
-            &ResolvedOptions {
-                include_crc: false,
-                ..include_all_options()
-            },
-        );
-        assert_eq!(
-            data_section_crc(&without_crc),
-            0,
-            "include_crc=false must zero output CRCs"
-        );
     }
 
     #[test]

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -210,6 +210,14 @@ fn filter_indexed<W: Write + Seek>(
                 }
             }
 
+            // These per-channel seed messages are always emitted as a log-time-sorted preamble
+            // ahead of the window, independent of `opts.order`. `--last-per-channel` is a
+            // log-time-window feature (the latest value on each topic as of `--start`), and its
+            // records are relocated here from their original positions before the window, so there
+            // is no meaningful stored order to "preserve" for them; log-time order keeps the
+            // preamble deterministic and monotonic up to the window boundary. (The `IndexedReader`
+            // does not surface per-message file offsets, so honoring `preserve` here would require
+            // a library change or an extra pass for no practical benefit.)
             pre_start_messages.sort_by_key(|message| {
                 (
                     message.log_time,

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -28,8 +28,9 @@ pub(crate) struct RewriteOptions {
     pub(crate) output_compression: String,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
-    /// Sort output messages by log time; when false the input's stored order is preserved.
-    pub(crate) order_by_log_time: bool,
+    /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
+    /// time).
+    pub(crate) order: MessageOrder,
 }
 
 impl From<&FilterCommand> for RewriteOptions {
@@ -56,7 +57,7 @@ impl From<&FilterCommand> for RewriteOptions {
                 .to_string(),
             chunk_size: args.chunk_size,
             use_chunks: true,
-            order_by_log_time: matches!(args.order, MessageOrder::LogTime),
+            order: args.order,
         }
     }
 }
@@ -80,7 +81,7 @@ impl RewriteOptions {
             output_compression: "zstd".to_string(),
             chunk_size,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         }
     }
 
@@ -104,8 +105,8 @@ impl RewriteOptions {
         self
     }
 
-    pub(crate) fn order_by_log_time(mut self, value: bool) -> Self {
-        self.order_by_log_time = value;
+    pub(crate) fn order(mut self, value: MessageOrder) -> Self {
+        self.order = value;
         self
     }
 }
@@ -125,8 +126,9 @@ pub(crate) struct ResolvedOptions {
     pub(crate) compression: Option<mcap::Compression>,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
-    /// Sort output messages by log time; when false the input's stored order is preserved.
-    pub(crate) order_by_log_time: bool,
+    /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
+    /// time).
+    pub(crate) order: MessageOrder,
 }
 
 pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> {
@@ -160,7 +162,7 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         compression: parse_output_compression(&args.output_compression)?,
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
-        order_by_log_time: args.order_by_log_time,
+        order: args.order,
     })
 }
 
@@ -287,7 +289,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
-            order_by_log_time: false,
+            order: MessageOrder::Preserve,
         };
         assert!(include_topic("camera_a", &opts));
         assert!(!include_topic("radar_a", &opts));
@@ -335,19 +337,26 @@ mod tests {
     }
 
     #[test]
-    fn order_maps_to_order_by_log_time() {
+    fn order_is_copied_from_filter_command() {
         let mut args = default_filter_command();
-        // preserve (the default) does not sort.
-        assert!(!RewriteOptions::from(&args).order_by_log_time);
+        // preserve is the default.
+        assert_eq!(RewriteOptions::from(&args).order, MessageOrder::Preserve);
         args.order = MessageOrder::LogTime;
-        assert!(RewriteOptions::from(&args).order_by_log_time);
+        assert_eq!(RewriteOptions::from(&args).order, MessageOrder::LogTime);
     }
 
     #[test]
-    fn order_by_log_time_builder_sets_flag() {
+    fn order_builder_sets_order() {
         let opts = RewriteOptions::new(None, None, mcap::WriteOptions::DEFAULT_CHUNK_SIZE);
-        assert!(!opts.order_by_log_time, "new() defaults to preserve");
-        assert!(opts.order_by_log_time(true).order_by_log_time);
+        assert_eq!(
+            opts.order,
+            MessageOrder::Preserve,
+            "new() defaults to preserve"
+        );
+        assert_eq!(
+            opts.order(MessageOrder::LogTime).order,
+            MessageOrder::LogTime
+        );
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -103,6 +103,11 @@ impl RewriteOptions {
         self.include_attachments = value;
         self
     }
+
+    pub(crate) fn order_by_log_time(mut self, value: bool) -> Self {
+        self.order_by_log_time = value;
+        self
+    }
 }
 
 /// Validated, engine-ready form of [`RewriteOptions`]: regexes compiled, timestamps parsed, and the
@@ -336,6 +341,13 @@ mod tests {
         assert!(!RewriteOptions::from(&args).order_by_log_time);
         args.order = MessageOrder::LogTime;
         assert!(RewriteOptions::from(&args).order_by_log_time);
+    }
+
+    #[test]
+    fn order_by_log_time_builder_sets_flag() {
+        let opts = RewriteOptions::new(None, None, mcap::WriteOptions::DEFAULT_CHUNK_SIZE);
+        assert!(!opts.order_by_log_time, "new() defaults to preserve");
+        assert!(opts.order_by_log_time(true).order_by_log_time);
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -31,6 +31,8 @@ pub(crate) struct RewriteOptions {
     /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
     /// time).
     pub(crate) order: MessageOrder,
+    /// Emit CRC fields in the output; when false all output CRCs are disabled.
+    pub(crate) include_crc: bool,
 }
 
 impl From<&FilterCommand> for RewriteOptions {
@@ -56,8 +58,9 @@ impl From<&FilterCommand> for RewriteOptions {
                 .as_str()
                 .to_string(),
             chunk_size: args.chunk_size,
-            use_chunks: true,
+            use_chunks: !args.no_chunks,
             order: args.order,
+            include_crc: !args.no_crc,
         }
     }
 }
@@ -82,6 +85,7 @@ impl RewriteOptions {
             chunk_size,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         }
     }
 
@@ -129,6 +133,8 @@ pub(crate) struct ResolvedOptions {
     /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
     /// time).
     pub(crate) order: MessageOrder,
+    /// Emit CRC fields in the output; when false all output CRCs are disabled.
+    pub(crate) include_crc: bool,
 }
 
 pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> {
@@ -163,6 +169,7 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
         order: args.order,
+        include_crc: args.include_crc,
     })
 }
 
@@ -248,6 +255,8 @@ mod tests {
             output_compression: None,
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             order: MessageOrder::Preserve,
+            no_crc: false,
+            no_chunks: false,
         }
     }
 
@@ -290,6 +299,7 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
+            include_crc: true,
         };
         assert!(include_topic("camera_a", &opts));
         assert!(!include_topic("radar_a", &opts));
@@ -343,6 +353,21 @@ mod tests {
         assert_eq!(RewriteOptions::from(&args).order, MessageOrder::Preserve);
         args.order = MessageOrder::LogTime;
         assert_eq!(RewriteOptions::from(&args).order, MessageOrder::LogTime);
+    }
+
+    #[test]
+    fn no_crc_and_no_chunks_map_to_engine_options() {
+        let mut args = default_filter_command();
+        // Defaults keep CRCs and chunking on.
+        let opts = RewriteOptions::from(&args);
+        assert!(opts.include_crc);
+        assert!(opts.use_chunks);
+
+        args.no_crc = true;
+        args.no_chunks = true;
+        let opts = RewriteOptions::from(&args);
+        assert!(!opts.include_crc);
+        assert!(!opts.use_chunks);
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -28,8 +28,6 @@ pub(crate) struct RewriteOptions {
     pub(crate) output_compression: String,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
-    /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
-    /// time).
     pub(crate) order: MessageOrder,
 }
 
@@ -126,8 +124,6 @@ pub(crate) struct ResolvedOptions {
     pub(crate) compression: Option<mcap::Compression>,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
-    /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
-    /// time).
     pub(crate) order: MessageOrder,
 }
 

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 use regex::Regex;
 
-use crate::cli::{parse_output_compression, parse_timestamp_or_nanos, FilterCommand};
+use crate::cli::{parse_output_compression, parse_timestamp_or_nanos, FilterCommand, MessageOrder};
 
 #[derive(Debug, Clone)]
 pub(crate) struct RewriteOptions {
@@ -25,6 +25,8 @@ pub(crate) struct RewriteOptions {
     pub(crate) output_compression: String,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
+    /// Sort output messages by log time; when false the input's stored order is preserved.
+    pub(crate) order_by_log_time: bool,
 }
 
 impl From<&FilterCommand> for RewriteOptions {
@@ -46,6 +48,7 @@ impl From<&FilterCommand> for RewriteOptions {
             output_compression: args.output_compression.clone(),
             chunk_size: args.chunk_size,
             use_chunks: true,
+            order_by_log_time: matches!(args.order, MessageOrder::LogTime),
         }
     }
 }
@@ -69,6 +72,7 @@ impl RewriteOptions {
             output_compression: "zstd".to_string(),
             chunk_size,
             use_chunks: true,
+            order_by_log_time: false,
         }
     }
 
@@ -108,6 +112,8 @@ pub(crate) struct ResolvedOptions {
     pub(crate) compression: Option<mcap::Compression>,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
+    /// Sort output messages by log time; when false the input's stored order is preserved.
+    pub(crate) order_by_log_time: bool,
 }
 
 pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> {
@@ -141,6 +147,7 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         compression: parse_output_compression(&args.output_compression)?,
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
+        order_by_log_time: args.order_by_log_time,
     })
 }
 
@@ -224,6 +231,7 @@ mod tests {
             include_attachments: false,
             output_compression: "zstd".to_string(),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+            order: crate::cli::MessageOrder::Preserve,
         }
     }
 
@@ -265,6 +273,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            order_by_log_time: false,
         };
         assert!(include_topic("camera_a", &opts));
         assert!(!include_topic("radar_a", &opts));
@@ -309,6 +318,18 @@ mod tests {
         let opts = build_filter_options(&args).expect("options");
         assert!(!opts.include_metadata);
         assert!(!opts.include_attachments);
+    }
+
+    #[test]
+    fn order_maps_to_order_by_log_time() {
+        use super::RewriteOptions;
+        use crate::cli::MessageOrder;
+
+        let mut args = default_filter_command();
+        // preserve (the default) does not sort.
+        assert!(!RewriteOptions::from(&args).order_by_log_time);
+        args.order = MessageOrder::LogTime;
+        assert!(RewriteOptions::from(&args).order_by_log_time);
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -209,8 +209,8 @@ fn build_filter_options(args: &FilterCommand) -> Result<ResolvedOptions> {
 mod tests {
     use regex::Regex;
 
-    use super::{build_filter_options, include_topic, ResolvedOptions};
-    use crate::cli::FilterCommand;
+    use super::{build_filter_options, include_topic, ResolvedOptions, RewriteOptions};
+    use crate::cli::{FilterCommand, MessageOrder};
 
     fn default_filter_command() -> FilterCommand {
         FilterCommand {
@@ -231,7 +231,7 @@ mod tests {
             include_attachments: false,
             output_compression: "zstd".to_string(),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-            order: crate::cli::MessageOrder::Preserve,
+            order: MessageOrder::Preserve,
         }
     }
 
@@ -322,9 +322,6 @@ mod tests {
 
     #[test]
     fn order_maps_to_order_by_log_time() {
-        use super::RewriteOptions;
-        use crate::cli::MessageOrder;
-
         let mut args = default_filter_command();
         // preserve (the default) does not sort.
         assert!(!RewriteOptions::from(&args).order_by_log_time);

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -31,8 +31,6 @@ pub(crate) struct RewriteOptions {
     /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
     /// time).
     pub(crate) order: MessageOrder,
-    /// Emit CRC fields in the output; when false all output CRCs are disabled.
-    pub(crate) include_crc: bool,
 }
 
 impl From<&FilterCommand> for RewriteOptions {
@@ -58,9 +56,8 @@ impl From<&FilterCommand> for RewriteOptions {
                 .as_str()
                 .to_string(),
             chunk_size: args.chunk_size,
-            use_chunks: !args.no_chunks,
+            use_chunks: true,
             order: args.order,
-            include_crc: !args.no_crc,
         }
     }
 }
@@ -85,7 +82,6 @@ impl RewriteOptions {
             chunk_size,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         }
     }
 
@@ -133,8 +129,6 @@ pub(crate) struct ResolvedOptions {
     /// Message order applied to the output (e.g. preserve the input's stored order, or sort by log
     /// time).
     pub(crate) order: MessageOrder,
-    /// Emit CRC fields in the output; when false all output CRCs are disabled.
-    pub(crate) include_crc: bool,
 }
 
 pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> {
@@ -169,7 +163,6 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
         order: args.order,
-        include_crc: args.include_crc,
     })
 }
 
@@ -255,8 +248,6 @@ mod tests {
             output_compression: None,
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             order: MessageOrder::Preserve,
-            no_crc: false,
-            no_chunks: false,
         }
     }
 
@@ -299,7 +290,6 @@ mod tests {
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
             order: MessageOrder::Preserve,
-            include_crc: true,
         };
         assert!(include_topic("camera_a", &opts));
         assert!(!include_topic("radar_a", &opts));
@@ -353,21 +343,6 @@ mod tests {
         assert_eq!(RewriteOptions::from(&args).order, MessageOrder::Preserve);
         args.order = MessageOrder::LogTime;
         assert_eq!(RewriteOptions::from(&args).order, MessageOrder::LogTime);
-    }
-
-    #[test]
-    fn no_crc_and_no_chunks_map_to_engine_options() {
-        let mut args = default_filter_command();
-        // Defaults keep CRCs and chunking on.
-        let opts = RewriteOptions::from(&args);
-        assert!(opts.include_crc);
-        assert!(opts.use_chunks);
-
-        args.no_crc = true;
-        args.no_chunks = true;
-        let opts = RewriteOptions::from(&args);
-        assert!(!opts.include_crc);
-        assert!(!opts.use_chunks);
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -337,15 +337,6 @@ mod tests {
     }
 
     #[test]
-    fn order_is_copied_from_filter_command() {
-        let mut args = default_filter_command();
-        // preserve is the default.
-        assert_eq!(RewriteOptions::from(&args).order, MessageOrder::Preserve);
-        args.order = MessageOrder::LogTime;
-        assert_eq!(RewriteOptions::from(&args).order, MessageOrder::LogTime);
-    }
-
-    #[test]
     fn order_builder_sets_order() {
         let opts = RewriteOptions::new(None, None, mcap::WriteOptions::DEFAULT_CHUNK_SIZE);
         assert_eq!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

- `mcap filter`, `mcap compress`, and `mcap decompress` gain `--order <preserve|log_time>` (default `preserve`): keep the input's stored message order, or sort messages by log time. (`log-time` is accepted as an alias for `log_time`.)
- `mcap compress` and `mcap decompress` no longer silently re-sort an out-of-order **indexed** file to log time — they now preserve the input's message order by default (already-ordered files are unaffected). Pass `--order log_time` to sort. Unindexed files were never automatically sorted.
- `--order log_time` can now sort **summaryless** (unindexed) files, which these commands previously always copied in stored order.

### Docs

None. The new flag is documented in each command's `--help`.

### Description

The shared rewrite engine (used by `filter`, `compress`, and `decompress`) routes each input down one of two paths: an **indexed** path (input has usable chunk indexes) or a **linear** path (summaryless input — chunked or unchunked). Previously the indexed path always read with `ReadOrder::LogTime` (re-sorting), while the linear path always streamed in stored order. So message ordering was an implicit, path-dependent side effect. This PR makes ordering an explicit `--order` knob and changes the indexed path's default to preserve.

**Behavior by input type (before → after):**

| Input type | Before (on `main`) | After — `--order preserve` (default) | After — `--order log_time` |
| --- | --- | --- | --- |
| Indexed (chunk indexes present) | re-sorted to log time | **preserves stored order** (change) | sorts to log time (same as old default) |
| Chunked, summaryless | preserved (stored order) | preserved (unchanged) | **sorts to log time** (newly possible) |
| Unchunked | preserved (stored order) | preserved (unchanged) | **sorts to log time** (newly possible) |

So the only behavior change at the default is for indexed inputs (they were silently re-sorted, now preserved); summaryless inputs were already preserved and stay that way. `--order log_time` reproduces the old default for indexed inputs and newly enables sorting summaryless inputs (which the rewrite commands could not sort before).

Implementation:
- **Indexed path:** `preserve` reads via `ReadOrder::File`; `log_time` via `ReadOrder::LogTime`. Time-range and topic filtering are applied per-message and are unaffected by read order.
- **Linear (summaryless) path:** `preserve` streams messages in stored order (unchanged); `log_time` buffers the selected messages and stably sorts them by log time (equal log times keep file order). Buffering the whole selected set is a documented memory caveat that matches `sort`'s existing linear path (`copy_linear_messages_in_log_time_order`) — making the summaryless ordered path memory-bounded is a known follow-up that should land once in a shared place.

Ordering is carried end-to-end as the `MessageOrder` enum (`RewriteOptions`/`ResolvedOptions` hold the enum, not a bool), and the engine maps it with exhaustive `match`es, so future order modes extend one enum and the compiler flags every site that must handle a new variant.

For conformant (already log-time-ordered) files the output is unchanged; only genuinely out-of-order indexed inputs differ at the default. The `sort` command is intentionally left untouched.

Design notes:
- The canonical flag value is `log_time` (matching the MCAP spec's serialized field name, and the Python/Rust field name); `log-time` is accepted as an alias.
- `compress`/`decompress` get `--order` but no selection flags — `filter` is the place for selecting + transcoding.
- The `--last-per-channel-topic-regex` seed messages remain a log-time-sorted preamble ahead of the window regardless of `--order` (documented in-code): they are a log-time-window state snapshot relocated from before the window, so there is no stored order to preserve for them.

Follow-ups (separate PRs): completing `filter` as a transcode superset (`--no-crc`/`--no-chunks`); and memory-bounded summaryless ordered rewrite (synthesized chunk index for chunked inputs, `(log_time, offset)` pointer list for unchunked), landed alongside porting `sort` onto the engine.

### Testing

- [x] `cargo test -p mcap-cli` — engine tests cover indexed + linear (chunked/unchunked) `preserve` vs `log_time`, stable tie-break for equal log times, and the shared-engine default (`RewriteOptions::new`, used by compress/decompress) preserving order on an out-of-order indexed input; plus CLI parse tests for `--order` (both spellings) on filter/compress/decompress and invalid-value rejection.
- [x] On an out-of-order file: `mcap filter in.mcap -o out.mcap` (default) keeps input order; `mcap filter --order log_time` / `mcap compress --order log_time` / `mcap decompress --order log_time` produce output that passes `mcap doctor --strict-message-order`.
- [x] Confirm `mcap compress in.mcap -o out.mcap` no longer re-sorts an out-of-order indexed input.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ea18c6d-204e-47ad-875c-3700e26cf87f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ea18c6d-204e-47ad-875c-3700e26cf87f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

