### PR TITLE
cli: add --no-crc/--no-chunks to the rewrite engine and DRY filter/compress/decompress options

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -149,10 +149,6 @@ pub struct CompressCommand {
 pub struct DecompressCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
-
-    /// Write records outside of chunks
-    #[arg(long = "no-chunks", default_value_t = false)]
-    pub no_chunks: bool,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -110,8 +110,11 @@ pub struct CompletionCommand {
     pub shell: Shell,
 }
 
+/// Options shared by every rewrite-based command (`filter`, `compress`, `decompress`). Each
+/// command flattens these and adds only the knobs that apply to it, so the common definitions
+/// (and their help text / defaults) live in one place.
 #[derive(clap::Args, Debug, PartialEq, Eq)]
-pub struct CompressCommand {
+pub struct CommonRewriteArgs {
     /// Input MCAP file path. If omitted, reads from stdin.
     pub file: Option<PathBuf>,
 
@@ -123,9 +126,9 @@ pub struct CompressCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Compression algorithm for output file: zstd, lz4, or none
-    #[arg(long = "compression", default_value = "zstd")]
-    pub compression: String,
+    /// Disable all output CRC fields
+    #[arg(long = "no-crc", default_value_t = false)]
+    pub no_crc: bool,
 
     /// Message order in the output: preserve (keep the input order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
@@ -133,21 +136,23 @@ pub struct CompressCommand {
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
+pub struct CompressCommand {
+    #[command(flatten)]
+    pub common: CommonRewriteArgs,
+
+    /// Compression algorithm for output file: zstd, lz4, or none
+    #[arg(long = "compression", default_value = "zstd")]
+    pub compression: String,
+}
+
+#[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct DecompressCommand {
-    /// Input MCAP file path. If omitted, reads from stdin.
-    pub file: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: CommonRewriteArgs,
 
-    /// Output file path. If omitted, writes to stdout.
-    #[arg(short = 'o', long = "output")]
-    pub output: Option<PathBuf>,
-
-    /// Target uncompressed chunk size for output
-    #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
-    pub chunk_size: u64,
-
-    /// Message order in the output: preserve (keep the input order) or log_time
-    #[arg(long = "order", value_enum, default_value = "preserve")]
-    pub order: MessageOrder,
+    /// Write records outside of chunks
+    #[arg(long = "no-chunks", default_value_t = false)]
+    pub no_chunks: bool,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -435,12 +440,8 @@ pub struct DuCommand {
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct FilterCommand {
-    /// Input MCAP file path. If omitted, reads from stdin.
-    pub file: Option<PathBuf>,
-
-    /// Output file path. If omitted, writes to stdout.
-    #[arg(short = 'o', long = "output")]
-    pub output: Option<PathBuf>,
+    #[command(flatten)]
+    pub common: CommonRewriteArgs,
 
     /// Include topics matching this regex (repeatable)
     #[arg(short = 'y', long = "include-topic-regex")]
@@ -512,13 +513,9 @@ pub struct FilterCommand {
     #[arg(long = "output-compression", value_enum, hide = true)]
     pub output_compression: Option<CompressionFormat>,
 
-    /// Target uncompressed chunk size for output
-    #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
-    pub chunk_size: u64,
-
-    /// Message order in the output: preserve (keep the input order) or log_time
-    #[arg(long = "order", value_enum, default_value = "preserve")]
-    pub order: MessageOrder,
+    /// Write records outside of chunks
+    #[arg(long = "no-chunks", default_value_t = false)]
+    pub no_chunks: bool,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -84,10 +84,10 @@ mod tests {
     use super::dispatch;
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Command,
-        CompressCommand, DoctorCommand, DuCommand, GetAttachmentCommand, GetMetadataCommand,
-        InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
-        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MessageOrder, RecoverCommand,
-        SortCommand,
+        CommonRewriteArgs, CompressCommand, DoctorCommand, DuCommand, GetAttachmentCommand,
+        GetMetadataCommand, InfoCommand, ListAttachmentsCommand, ListChannelsCommand,
+        ListChunksCommand, ListCommand, ListMetadataCommand, ListSchemasCommand, ListSubcommand,
+        MessageOrder, RecoverCommand, SortCommand,
     };
     use crate::context::CommandContext;
 
@@ -253,11 +253,14 @@ mod tests {
         let err = dispatch(
             &CommandContext::default(),
             Command::Compress(CompressCommand {
-                file: None,
-                output: None,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                common: CommonRewriteArgs {
+                    file: None,
+                    output: None,
+                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                    no_crc: false,
+                    order: MessageOrder::Preserve,
+                },
                 compression: "invalid".to_string(),
-                order: MessageOrder::Preserve,
             }),
         )
         .expect_err("compress should reject invalid compression");

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -5,12 +5,13 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
-    let options = RewriteOptions::new(args.file, args.output, args.chunk_size)
+    let options = RewriteOptions::new(args.common.file, args.common.output, args.common.chunk_size)
         .compression(args.compression)
         .use_chunks(true)
+        .include_crc(!args.common.no_crc)
         .include_metadata(true)
         .include_attachments(true)
-        .order(args.order);
+        .order(args.common.order);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -5,13 +5,9 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
-    let options = RewriteOptions::new(args.common.file, args.common.output, args.common.chunk_size)
-        .compression(args.compression)
-        .use_chunks(true)
-        .include_crc(!args.common.no_crc)
-        .include_metadata(true)
-        .include_attachments(true)
-        .order(args.common.order);
+    // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata
+    // and attachments. Paths, chunk size, `--no-crc`, and order come from the shared args.
+    let options = RewriteOptions::from(&args.common).compression(args.compression);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -9,7 +9,7 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
         .compression("none")
         .include_metadata(true)
         .include_attachments(true)
-        .use_chunks(!args.no_chunks)
+        .use_chunks(true)
         .include_crc(!args.common.no_crc)
         .order(args.common.order);
     rewrite::run(

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -5,13 +5,9 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
-    let options = RewriteOptions::new(args.common.file, args.common.output, args.common.chunk_size)
-        .compression("none")
-        .include_metadata(true)
-        .include_attachments(true)
-        .use_chunks(true)
-        .include_crc(!args.common.no_crc)
-        .order(args.common.order);
+    // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and
+    // attachments. Paths, chunk size, `--no-crc`, and order come from the shared args.
+    let options = RewriteOptions::from(&args.common).compression("none");
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -5,12 +5,13 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
-    let options = RewriteOptions::new(args.file, args.output, args.chunk_size)
+    let options = RewriteOptions::new(args.common.file, args.common.output, args.common.chunk_size)
         .compression("none")
         .include_metadata(true)
         .include_attachments(true)
-        .use_chunks(true)
-        .order(args.order);
+        .use_chunks(!args.no_chunks)
+        .include_crc(!args.common.no_crc)
+        .order(args.common.order);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -41,8 +41,9 @@ mod tests {
 
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
-        CoalesceChannels, Command, CompletionCommand, CompressCommand, CompressionFormat,
-        ConvertCommand, DecompressCommand, DoctorCommand, DuCommand, FilterCommand,
+        CoalesceChannels, Command, CommonRewriteArgs, CompletionCommand, CompressCommand,
+        CompressionFormat, ConvertCommand, DecompressCommand, DoctorCommand, DuCommand,
+        FilterCommand,
         GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand,
         ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
         ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, MessageOrder,
@@ -470,11 +471,14 @@ mod tests {
         assert_eq!(
             args.command,
             Command::Compress(CompressCommand {
-                file: Some("in.mcap".into()),
-                output: None,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: None,
+                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                    no_crc: false,
+                    order: MessageOrder::Preserve,
+                },
                 compression: "zstd".to_string(),
-                order: MessageOrder::Preserve,
             })
         );
     }
@@ -491,6 +495,7 @@ mod tests {
             "1024",
             "--compression",
             "lz4",
+            "--no-crc",
             "--order",
             "log-time",
         ])
@@ -498,11 +503,14 @@ mod tests {
         assert_eq!(
             args.command,
             Command::Compress(CompressCommand {
-                file: Some("in.mcap".into()),
-                output: Some("out.mcap".into()),
-                chunk_size: 1024,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: Some("out.mcap".into()),
+                    chunk_size: 1024,
+                    no_crc: true,
+                    order: MessageOrder::LogTime,
+                },
                 compression: "lz4".to_string(),
-                order: MessageOrder::LogTime,
             })
         );
     }
@@ -514,10 +522,14 @@ mod tests {
         assert_eq!(
             args.command,
             Command::Decompress(DecompressCommand {
-                file: Some("in.mcap".into()),
-                output: None,
-                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                order: MessageOrder::Preserve,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: None,
+                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                    no_crc: false,
+                    order: MessageOrder::Preserve,
+                },
+                no_chunks: false,
             })
         );
     }
@@ -532,6 +544,8 @@ mod tests {
             "out.mcap",
             "--chunk-size",
             "2048",
+            "--no-crc",
+            "--no-chunks",
             "--order",
             "log-time",
         ])
@@ -539,10 +553,14 @@ mod tests {
         assert_eq!(
             args.command,
             Command::Decompress(DecompressCommand {
-                file: Some("in.mcap".into()),
-                output: Some("out.mcap".into()),
-                chunk_size: 2048,
-                order: MessageOrder::LogTime,
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: Some("out.mcap".into()),
+                    chunk_size: 2048,
+                    no_crc: true,
+                    order: MessageOrder::LogTime,
+                },
+                no_chunks: true,
             })
         );
     }
@@ -569,13 +587,20 @@ mod tests {
             "lz4",
             "--chunk-size",
             "2048",
+            "--no-crc",
+            "--no-chunks",
         ])
         .expect("filter should parse");
         assert_eq!(
             args.command,
             Command::Filter(FilterCommand {
-                file: Some("in.mcap".into()),
-                output: Some("out.mcap".into()),
+                common: CommonRewriteArgs {
+                    file: Some("in.mcap".into()),
+                    output: Some("out.mcap".into()),
+                    chunk_size: 2048,
+                    no_crc: true,
+                    order: MessageOrder::Preserve,
+                },
                 include_topic_regex: vec!["camera.*".to_string()],
                 exclude_topic_regex: vec![],
                 last_per_channel_topic_regex: vec!["camera_.*".to_string()],
@@ -591,8 +616,7 @@ mod tests {
                 include_attachments: true,
                 compression: Some(CompressionFormat::Lz4),
                 output_compression: None,
-                chunk_size: 2048,
-                order: MessageOrder::Preserve,
+                no_chunks: true,
             })
         );
     }
@@ -639,7 +663,7 @@ mod tests {
         let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
             .expect("filter should parse without --order");
         match default.command {
-            Command::Filter(filter) => assert_eq!(filter.order, MessageOrder::Preserve),
+            Command::Filter(filter) => assert_eq!(filter.common.order, MessageOrder::Preserve),
             other => panic!("expected filter command, got {other:?}"),
         }
 
@@ -647,7 +671,7 @@ mod tests {
             let args = Args::try_parse_from(["mcap", "filter", "in.mcap", "--order", value])
                 .unwrap_or_else(|_| panic!("filter should parse --order {value}"));
             match args.command {
-                Command::Filter(filter) => assert_eq!(filter.order, MessageOrder::LogTime),
+                Command::Filter(filter) => assert_eq!(filter.common.order, MessageOrder::LogTime),
                 other => panic!("expected filter command, got {other:?}"),
             }
         }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -528,7 +528,6 @@ mod tests {
                     no_crc: false,
                     order: MessageOrder::Preserve,
                 },
-                no_chunks: false,
             })
         );
     }
@@ -544,7 +543,6 @@ mod tests {
             "--chunk-size",
             "2048",
             "--no-crc",
-            "--no-chunks",
             "--order",
             "log-time",
         ])
@@ -559,7 +557,6 @@ mod tests {
                     no_crc: true,
                     order: MessageOrder::LogTime,
                 },
-                no_chunks: true,
             })
         );
     }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -43,9 +43,8 @@ mod tests {
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
         CoalesceChannels, Command, CommonRewriteArgs, CompletionCommand, CompressCommand,
         CompressionFormat, ConvertCommand, DecompressCommand, DoctorCommand, DuCommand,
-        FilterCommand,
-        GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand,
-        ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
+        FilterCommand, GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand,
+        InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
         ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, MessageOrder,
         RecoverCommand, SortCommand,
     };

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -544,6 +544,23 @@ mod tests {
     use regex::Regex;
 
     use super::{filter_to_writer, MessageOrder, ResolvedOptions};
+    use crate::cli::CommonRewriteArgs;
+
+    /// Builds the shared rewrite options the way `compress`/`decompress` do — from the common CLI
+    /// args, so the engine defaults (CRC on, chunked, metadata/attachments kept) are exercised.
+    fn rewrite_options(
+        file: Option<std::path::PathBuf>,
+        output: Option<std::path::PathBuf>,
+        chunk_size: u64,
+    ) -> super::RewriteOptions {
+        super::RewriteOptions::from(&CommonRewriteArgs {
+            file,
+            output,
+            chunk_size,
+            no_crc: false,
+            order: MessageOrder::Preserve,
+        })
+    }
 
     fn write_filter_test_input(chunked: bool, summaryless: bool) -> Vec<u8> {
         write_filter_test_input_with_options(chunked, summaryless, true, true, true, true)
@@ -1235,9 +1252,7 @@ mod tests {
         ));
 
         let mut options =
-            super::RewriteOptions::new(Some(input_path.clone()), Some(output_path.clone()), 1024);
-        options.include_metadata = true;
-        options.include_attachments = true;
+            rewrite_options(Some(input_path.clone()), Some(output_path.clone()), 1024);
         options.use_chunks = false;
         options.output_compression = "none".to_string();
 
@@ -1269,7 +1284,7 @@ mod tests {
         let path = dir.path().join("same-path.mcap");
         std::fs::write(&path, &input).expect("write input");
 
-        let options = super::RewriteOptions::new(
+        let options = rewrite_options(
             Some(path.clone()),
             Some(path.clone()),
             mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
@@ -1282,8 +1297,8 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_new_default_preserves_message_order() {
-        // `compress`/`decompress` build their options via `RewriteOptions::new`, which defaults to
+    fn rewrite_common_args_default_preserves_message_order() {
+        // `compress`/`decompress` build their options from the shared args, which default to
         // `preserve`. Lock in that an out-of-order indexed input is copied in its stored order
         // rather than silently re-sorted to log time.
         let input = write_unsorted_input(true, false);
@@ -1292,17 +1307,15 @@ mod tests {
         let output_path = dir.path().join("out.mcap");
         std::fs::write(&input_path, &input).expect("write input");
 
-        let options = super::RewriteOptions::new(
+        let options = rewrite_options(
             Some(input_path),
             Some(output_path.clone()),
             mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-        )
-        .include_metadata(true)
-        .include_attachments(true);
+        );
         assert_eq!(
             options.order,
             MessageOrder::Preserve,
-            "RewriteOptions::new should default to preserve"
+            "the shared rewrite defaults should preserve order"
         );
         super::run(options, crate::source::SourceOptions::default())
             .expect("rewrite should succeed");

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -546,8 +546,8 @@ mod tests {
     use super::{filter_to_writer, MessageOrder, ResolvedOptions};
     use crate::cli::CommonRewriteArgs;
 
-    /// Builds the shared rewrite options the way `compress`/`decompress` do — from the common CLI
-    /// args, so the engine defaults (CRC on, chunked, metadata/attachments kept) are exercised.
+    /// Builds rewrite options from the shared CLI args, exercising the engine defaults (CRC on,
+    /// chunked, metadata/attachments kept).
     fn rewrite_options(
         file: Option<std::path::PathBuf>,
         output: Option<std::path::PathBuf>,

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -1469,7 +1469,10 @@ mod tests {
         let input = write_filter_test_input(true, false);
         let output = run_filter(&input, &include_all_options());
         let crcs = collect_output_crcs(&output);
-        assert!(!crcs.chunk_crcs.is_empty(), "the fixture should produce chunks");
+        assert!(
+            !crcs.chunk_crcs.is_empty(),
+            "the fixture should produce chunks"
+        );
         assert!(
             crcs.chunk_crcs.iter().all(|&crc| crc != 0),
             "chunk CRCs should be written by default"
@@ -1478,7 +1481,10 @@ mod tests {
             crcs.attachment_crcs.iter().all(|&crc| crc != 0),
             "attachment CRCs should be written by default"
         );
-        assert_ne!(crcs.data_section_crc, 0, "data section CRC should be written");
+        assert_ne!(
+            crcs.data_section_crc, 0,
+            "data section CRC should be written"
+        );
         assert_ne!(crcs.summary_crc, 0, "summary CRC should be written");
     }
 
@@ -1503,7 +1509,10 @@ mod tests {
             crcs.attachment_crcs.iter().all(|&crc| crc == 0),
             "attachment CRCs should be omitted"
         );
-        assert_eq!(crcs.data_section_crc, 0, "data section CRC should be omitted");
+        assert_eq!(
+            crcs.data_section_crc, 0,
+            "data section CRC should be omitted"
+        );
         assert_eq!(crcs.summary_crc, 0, "summary CRC should be omitted");
     }
 

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -42,7 +42,16 @@ fn filter_to_writer<W: Write + Seek>(
         .use_chunks(opts.use_chunks)
         .chunk_size(Some(opts.chunk_size))
         .compression(opts.compression)
+        .calculate_chunk_crcs(opts.include_crc)
+        .calculate_data_section_crc(opts.include_crc)
+        .calculate_summary_section_crc(opts.include_crc)
+        .calculate_attachment_crcs(opts.include_crc)
         .disable_seeking(disable_seeking);
+
+    // Message indexes only accompany chunks; skip them for unchunked output (mirrors `merge`).
+    if !opts.use_chunks {
+        write_options = write_options.emit_message_indexes(false);
+    }
 
     write_options = write_options.library(crate::cli::LIBRARY_IDENTIFIER.clone());
     if let Some(header) = read_header(input)? {
@@ -720,6 +729,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         }
     }
@@ -927,6 +937,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
@@ -953,6 +964,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
@@ -980,6 +992,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
@@ -1009,6 +1022,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
@@ -1036,6 +1050,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
@@ -1061,6 +1076,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
@@ -1085,6 +1101,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let output = run_filter(&input, &opts);
@@ -1109,6 +1126,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
@@ -1132,6 +1150,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
@@ -1155,6 +1174,7 @@ mod tests {
             compression: Some(mcap::Compression::Lz4),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         let mut output = Cursor::new(Vec::new());
@@ -1178,6 +1198,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         // The CLI is the writer of the output, so it stamps its own identity, not the source's.
@@ -1410,5 +1431,107 @@ mod tests {
                 "equal log_times must preserve file order (chunked={chunked}, summaryless={summaryless})"
             );
         }
+    }
+
+    /// Every CRC-bearing field written to an output MCAP, so a test can assert whether CRCs were
+    /// calculated. `LinearReader` yields top-level records (chunks are not flattened), so the
+    /// chunk `uncompressed_crc` is observable here.
+    struct OutputCrcs {
+        chunk_crcs: Vec<u32>,
+        attachment_crcs: Vec<u32>,
+        data_section_crc: u32,
+        summary_crc: u32,
+    }
+
+    fn collect_output_crcs(output: &[u8]) -> OutputCrcs {
+        let mut crcs = OutputCrcs {
+            chunk_crcs: Vec::new(),
+            attachment_crcs: Vec::new(),
+            data_section_crc: 0,
+            summary_crc: 0,
+        };
+        for record in mcap::read::LinearReader::new(output).expect("reader") {
+            match record.expect("record") {
+                mcap::records::Record::Chunk { header, .. } => {
+                    crcs.chunk_crcs.push(header.uncompressed_crc);
+                }
+                mcap::records::Record::Attachment { crc, .. } => crcs.attachment_crcs.push(crc),
+                mcap::records::Record::DataEnd(end) => crcs.data_section_crc = end.data_section_crc,
+                mcap::records::Record::Footer(footer) => crcs.summary_crc = footer.summary_crc,
+                _ => {}
+            }
+        }
+        crcs
+    }
+
+    #[test]
+    fn include_crc_writes_nonzero_crc_fields() {
+        let input = write_filter_test_input(true, false);
+        let output = run_filter(&input, &include_all_options());
+        let crcs = collect_output_crcs(&output);
+        assert!(!crcs.chunk_crcs.is_empty(), "the fixture should produce chunks");
+        assert!(
+            crcs.chunk_crcs.iter().all(|&crc| crc != 0),
+            "chunk CRCs should be written by default"
+        );
+        assert!(
+            crcs.attachment_crcs.iter().all(|&crc| crc != 0),
+            "attachment CRCs should be written by default"
+        );
+        assert_ne!(crcs.data_section_crc, 0, "data section CRC should be written");
+        assert_ne!(crcs.summary_crc, 0, "summary CRC should be written");
+    }
+
+    #[test]
+    fn no_crc_zeroes_every_crc_field() {
+        let input = write_filter_test_input(true, false);
+        let opts = ResolvedOptions {
+            include_crc: false,
+            ..include_all_options()
+        };
+        let output = run_filter(&input, &opts);
+        let crcs = collect_output_crcs(&output);
+        assert!(
+            !crcs.chunk_crcs.is_empty(),
+            "output should still be chunked when only CRCs are disabled"
+        );
+        assert!(
+            crcs.chunk_crcs.iter().all(|&crc| crc == 0),
+            "chunk CRCs should be omitted"
+        );
+        assert!(
+            crcs.attachment_crcs.iter().all(|&crc| crc == 0),
+            "attachment CRCs should be omitted"
+        );
+        assert_eq!(crcs.data_section_crc, 0, "data section CRC should be omitted");
+        assert_eq!(crcs.summary_crc, 0, "summary CRC should be omitted");
+    }
+
+    #[test]
+    fn no_chunks_writes_records_outside_of_chunks_losslessly() {
+        let input = write_filter_test_input(true, false);
+        let opts = ResolvedOptions {
+            use_chunks: false,
+            ..include_all_options()
+        };
+        let output = run_filter(&input, &opts);
+
+        let opcodes = top_level_opcodes(&output);
+        assert!(
+            !opcodes.contains(&mcap::records::op::CHUNK),
+            "no chunk records should be written"
+        );
+        assert!(
+            opcodes.contains(&mcap::records::op::MESSAGE),
+            "messages should be written at the top level"
+        );
+
+        // Records survive the unchunked rewrite unchanged.
+        let stats = analyze_output(&output);
+        assert_eq!(stats.topic_counts["camera_a"], 100);
+        assert_eq!(stats.topic_counts["camera_b"], 100);
+        assert_eq!(stats.topic_counts["radar_a"], 100);
+        assert_eq!(stats.metadata_count, 1);
+        assert_eq!(stats.attachment_count, 1);
     }
 }

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -28,14 +28,15 @@ pub(crate) struct RewriteOptions {
     pub(crate) output_compression: String,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
+    pub(crate) include_crc: bool,
     pub(crate) order: MessageOrder,
 }
 
 impl From<&FilterCommand> for RewriteOptions {
     fn from(args: &FilterCommand) -> Self {
         Self {
-            file: args.file.clone(),
-            output: args.output.clone(),
+            file: args.common.file.clone(),
+            output: args.common.output.clone(),
             include_topic_regex: args.include_topic_regex.clone(),
             exclude_topic_regex: args.exclude_topic_regex.clone(),
             last_per_channel_topic_regex: args.last_per_channel_topic_regex.clone(),
@@ -53,9 +54,10 @@ impl From<&FilterCommand> for RewriteOptions {
                 .unwrap_or(CompressionFormat::Zstd)
                 .as_str()
                 .to_string(),
-            chunk_size: args.chunk_size,
-            use_chunks: true,
-            order: args.order,
+            chunk_size: args.common.chunk_size,
+            use_chunks: !args.no_chunks,
+            include_crc: !args.common.no_crc,
+            order: args.common.order,
         }
     }
 }
@@ -79,6 +81,7 @@ impl RewriteOptions {
             output_compression: "zstd".to_string(),
             chunk_size,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         }
     }
@@ -90,6 +93,11 @@ impl RewriteOptions {
 
     pub(crate) fn use_chunks(mut self, value: bool) -> Self {
         self.use_chunks = value;
+        self
+    }
+
+    pub(crate) fn include_crc(mut self, value: bool) -> Self {
+        self.include_crc = value;
         self
     }
 
@@ -124,6 +132,7 @@ pub(crate) struct ResolvedOptions {
     pub(crate) compression: Option<mcap::Compression>,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
+    pub(crate) include_crc: bool,
     pub(crate) order: MessageOrder,
 }
 
@@ -158,6 +167,7 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         compression: parse_output_compression(&args.output_compression)?,
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
+        include_crc: args.include_crc,
         order: args.order,
     })
 }
@@ -221,12 +231,17 @@ mod tests {
     use regex::Regex;
 
     use super::{build_filter_options, include_topic, ResolvedOptions, RewriteOptions};
-    use crate::cli::{CompressionFormat, FilterCommand, MessageOrder};
+    use crate::cli::{CommonRewriteArgs, CompressionFormat, FilterCommand, MessageOrder};
 
     fn default_filter_command() -> FilterCommand {
         FilterCommand {
-            file: None,
-            output: None,
+            common: CommonRewriteArgs {
+                file: None,
+                output: None,
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                no_crc: false,
+                order: MessageOrder::Preserve,
+            },
             include_topic_regex: Vec::new(),
             exclude_topic_regex: Vec::new(),
             last_per_channel_topic_regex: Vec::new(),
@@ -242,8 +257,7 @@ mod tests {
             include_attachments: false,
             compression: None,
             output_compression: None,
-            chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-            order: MessageOrder::Preserve,
+            no_chunks: false,
         }
     }
 
@@ -285,6 +299,7 @@ mod tests {
             compression: Some(mcap::Compression::Zstd),
             chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
             use_chunks: true,
+            include_crc: true,
             order: MessageOrder::Preserve,
         };
         assert!(include_topic("camera_a", &opts));
@@ -330,6 +345,23 @@ mod tests {
         let opts = build_filter_options(&args).expect("options");
         assert!(!opts.include_metadata);
         assert!(!opts.include_attachments);
+    }
+
+    #[test]
+    fn defaults_enable_crc_and_chunks() {
+        let opts = build_filter_options(&default_filter_command()).expect("options");
+        assert!(opts.include_crc, "CRC should be on by default");
+        assert!(opts.use_chunks, "chunking should be on by default");
+    }
+
+    #[test]
+    fn no_crc_and_no_chunks_flags_map_to_engine_options() {
+        let mut args = default_filter_command();
+        args.common.no_crc = true;
+        args.no_chunks = true;
+        let opts = build_filter_options(&args).expect("options");
+        assert!(!opts.include_crc, "--no-crc should disable CRC fields");
+        assert!(!opts.use_chunks, "--no-chunks should write records outside of chunks");
     }
 
     #[test]

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -6,8 +6,8 @@ use anyhow::{bail, Context, Result};
 use regex::Regex;
 
 use crate::cli::{
-    parse_output_compression, parse_timestamp_or_nanos, CompressionFormat, FilterCommand,
-    MessageOrder,
+    parse_output_compression, parse_timestamp_or_nanos, CommonRewriteArgs, CompressionFormat,
+    FilterCommand, MessageOrder,
 };
 
 #[derive(Debug, Clone)]
@@ -32,11 +32,38 @@ pub(crate) struct RewriteOptions {
     pub(crate) order: MessageOrder,
 }
 
+/// Maps the arguments shared by every rewrite command onto their engine options: paths, chunk
+/// size, `--no-crc`, and message order. Metadata and attachments are included by default (all
+/// rewrite commands keep them; `filter` opts out via `--exclude-*`), and output is chunked with
+/// zstd compression unless a command overrides those.
+impl From<&CommonRewriteArgs> for RewriteOptions {
+    fn from(args: &CommonRewriteArgs) -> Self {
+        Self {
+            file: args.file.clone(),
+            output: args.output.clone(),
+            include_topic_regex: Vec::new(),
+            exclude_topic_regex: Vec::new(),
+            last_per_channel_topic_regex: Vec::new(),
+            start: None,
+            start_secs: 0,
+            start_nsecs: 0,
+            end: None,
+            end_secs: 0,
+            end_nsecs: 0,
+            include_metadata: true,
+            include_attachments: true,
+            output_compression: "zstd".to_string(),
+            chunk_size: args.chunk_size,
+            use_chunks: true,
+            include_crc: !args.no_crc,
+            order: args.order,
+        }
+    }
+}
+
 impl From<&FilterCommand> for RewriteOptions {
     fn from(args: &FilterCommand) -> Self {
         Self {
-            file: args.common.file.clone(),
-            output: args.common.output.clone(),
             include_topic_regex: args.include_topic_regex.clone(),
             exclude_topic_regex: args.exclude_topic_regex.clone(),
             last_per_channel_topic_regex: args.last_per_channel_topic_regex.clone(),
@@ -54,65 +81,15 @@ impl From<&FilterCommand> for RewriteOptions {
                 .unwrap_or(CompressionFormat::Zstd)
                 .as_str()
                 .to_string(),
-            chunk_size: args.common.chunk_size,
             use_chunks: !args.no_chunks,
-            include_crc: !args.common.no_crc,
-            order: args.common.order,
+            ..RewriteOptions::from(&args.common)
         }
     }
 }
 
 impl RewriteOptions {
-    pub(crate) fn new(file: Option<PathBuf>, output: Option<PathBuf>, chunk_size: u64) -> Self {
-        Self {
-            file,
-            output,
-            include_topic_regex: Vec::new(),
-            exclude_topic_regex: Vec::new(),
-            last_per_channel_topic_regex: Vec::new(),
-            start: None,
-            start_secs: 0,
-            start_nsecs: 0,
-            end: None,
-            end_secs: 0,
-            end_nsecs: 0,
-            include_metadata: false,
-            include_attachments: false,
-            output_compression: "zstd".to_string(),
-            chunk_size,
-            use_chunks: true,
-            include_crc: true,
-            order: MessageOrder::Preserve,
-        }
-    }
-
     pub(crate) fn compression(mut self, value: impl Into<String>) -> Self {
         self.output_compression = value.into();
-        self
-    }
-
-    pub(crate) fn use_chunks(mut self, value: bool) -> Self {
-        self.use_chunks = value;
-        self
-    }
-
-    pub(crate) fn include_crc(mut self, value: bool) -> Self {
-        self.include_crc = value;
-        self
-    }
-
-    pub(crate) fn include_metadata(mut self, value: bool) -> Self {
-        self.include_metadata = value;
-        self
-    }
-
-    pub(crate) fn include_attachments(mut self, value: bool) -> Self {
-        self.include_attachments = value;
-        self
-    }
-
-    pub(crate) fn order(mut self, value: MessageOrder) -> Self {
-        self.order = value;
         self
     }
 }
@@ -368,16 +345,27 @@ mod tests {
     }
 
     #[test]
-    fn order_builder_sets_order() {
-        let opts = RewriteOptions::new(None, None, mcap::WriteOptions::DEFAULT_CHUNK_SIZE);
-        assert_eq!(
-            opts.order,
-            MessageOrder::Preserve,
-            "new() defaults to preserve"
-        );
-        assert_eq!(
-            opts.order(MessageOrder::LogTime).order,
-            MessageOrder::LogTime
+    fn common_args_map_paths_order_and_defaults() {
+        // `compress`/`decompress` build their options from the shared args; this locks in that
+        // mapping (order + `--no-crc`) and the engine defaults (chunked, metadata/attachments kept).
+        let common = CommonRewriteArgs {
+            file: Some("in.mcap".into()),
+            output: Some("out.mcap".into()),
+            chunk_size: 4096,
+            no_crc: true,
+            order: MessageOrder::LogTime,
+        };
+        let opts = RewriteOptions::from(&common);
+        assert_eq!(opts.file, Some("in.mcap".into()));
+        assert_eq!(opts.output, Some("out.mcap".into()));
+        assert_eq!(opts.chunk_size, 4096);
+        assert_eq!(opts.order, MessageOrder::LogTime);
+        assert!(!opts.include_crc, "--no-crc should disable CRC fields");
+        assert!(opts.use_chunks, "output should be chunked by default");
+        assert!(opts.include_metadata, "metadata should be kept by default");
+        assert!(
+            opts.include_attachments,
+            "attachments should be kept by default"
         );
     }
 

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -361,7 +361,10 @@ mod tests {
         args.no_chunks = true;
         let opts = build_filter_options(&args).expect("options");
         assert!(!opts.include_crc, "--no-crc should disable CRC fields");
-        assert!(!opts.use_chunks, "--no-chunks should write records outside of chunks");
+        assert!(
+            !opts.use_chunks,
+            "--no-chunks should write records outside of chunks"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

- Add `--no-crc` (disable all output CRC fields) to `mcap filter`, `mcap compress`, and `mcap decompress`
- Add `--no-chunks` (write records outside of chunks) to `mcap filter`

Behavior matches the flags already offered by `convert`/`merge`/`sort` commands.

### Docs

None

### Description

The rewrite-based commands (`filter`, `compress`, `decompress`) had no way to disable CRC calculation or chunking on their output, even though `convert`/`merge`/`sort` already expose `--no-crc` and `--no-chunks`. This is an inconsistency: a user who wants a CRC-free or unchunked file has to route through a different command. This PR closes that gap and, while it's in there, removes the copy-pasted option definitions across the three rewrite commands.

What changed:

- **Engine.** `RewriteOptions`/`ResolvedOptions` gain an `include_crc` field (default `true`), plumbed through `resolve_options` and applied in `filter_to_writer` via all four `calculate_*_crc` knobs (chunk, data-section, summary, attachment). When output is unchunked, message indexes are disabled (mirrors `merge`). This leaves the engine ready for the planned `sort`/`merge` port (out of scope here).
- **Flags.** `--no-crc` is added to all three commands (CRC is orthogonal to compression/chunking and stays on by default, consistent with the Rust writer and the other CLI commands). `--no-chunks` is added to `filter` only — `compress` can't take it (MCAP compression only happens inside chunks), and `decompress` is kept simple since it's an advanced knob (use `filter` for a fully-flat file).
- **DRY.** A shared `CommonRewriteArgs` (`file`, `output`, `chunk-size`, `no-crc`, `order`) is flattened into all three commands. `filter` remains the superset; `compress`/`decompress` are subsets with presets.

Testing beyond unit tests: ran the built binary against `rust/mcap/tests/data/compressed.mcap` — `compress --no-crc`, `decompress`, and `filter --no-crc --no-chunks` all succeed and pass `mcap doctor`; `filter --no-chunks` yields zero chunks (`mcap list chunks` empty); `compress --no-chunks` and `decompress --no-chunks` are rejected (exit 2). Byte-level check confirmed the footer `summary_crc` is `1741241228` by default and `0` with `--no-crc`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-968d157d-38bf-4109-a134-8edc6beb19ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-968d157d-38bf-4109-a134-8edc6beb19ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

