### PR TITLE
cli: use enum for --compression args

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -375,7 +375,7 @@ pub struct ConvertCommand {
     /// Local path for the destination MCAP file
     pub output: PathBuf,
 
-    /// Chunk compression algorithm for output MCAP
+    /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long, value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
 
@@ -410,7 +410,7 @@ pub struct MergeCommand {
     #[arg(short = 'o', long = "output-file")]
     pub output_file: Option<PathBuf>,
 
-    /// Chunk compression algorithm for output MCAP
+    /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long, value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
 
@@ -567,7 +567,7 @@ pub struct RecoverCommand {
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
-    /// Compression for the output file: preserve, none, zstd, or lz4.
+    /// Compression algorithm for output file: zstd, lz4, none, or preserve
     ///
     /// `preserve` (the default) keeps the input file's compression (uncompressed if the input is
     /// unchunked).

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -157,7 +157,7 @@ pub struct CompressCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
 
-    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
+    /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long = "compression", value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
 
@@ -527,7 +527,7 @@ pub struct FilterCommand {
     #[arg(long = "include-attachments", default_value_t = false, hide = true)]
     pub include_attachments: bool,
 
-    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none (default: zstd)
+    /// Compression algorithm for output file: zstd, lz4, or none (default: zstd)
     #[arg(long = "compression", value_enum)]
     pub compression: Option<CompressionFormat>,
 
@@ -580,7 +580,7 @@ pub struct SortCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
 
-    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
+    /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long, value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use clap::{ArgAction, Parser, Subcommand};
 use clap_complete::Shell;
 use log::warn;
@@ -157,9 +157,9 @@ pub struct CompressCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
 
-    /// Compression algorithm for output file: zstd, lz4, or none
-    #[arg(long = "compression", default_value = "zstd")]
-    pub compression: String,
+    /// Chunk compression algorithm for output MCAP: zstd, lz4, or none
+    #[arg(long = "compression", value_enum, default_value = "zstd")]
+    pub compression: CompressionFormat,
 
     /// Message order in the output: preserve (keep the input order) or log_time
     #[arg(long = "order", value_enum, default_value = "preserve")]
@@ -345,11 +345,12 @@ pub enum CompressionFormat {
 }
 
 impl CompressionFormat {
-    pub fn as_str(self) -> &'static str {
+    /// Convert to the library's compression enum, where `None` means uncompressed.
+    pub fn to_compression(self) -> Option<mcap::Compression> {
         match self {
-            CompressionFormat::Zstd => "zstd",
-            CompressionFormat::Lz4 => "lz4",
-            CompressionFormat::None => "none",
+            CompressionFormat::Zstd => Some(mcap::Compression::Zstd),
+            CompressionFormat::Lz4 => Some(mcap::Compression::Lz4),
+            CompressionFormat::None => None,
         }
     }
 }
@@ -602,18 +603,6 @@ pub type ListChunksCommand = FileCommand;
 pub type ListMetadataCommand = FileCommand;
 pub type ListSchemasCommand = FileCommand;
 
-/// Parse a CLI-supplied output compression value, where `none` disables compression.
-pub(crate) fn parse_output_compression(value: &str) -> Result<Option<mcap::Compression>> {
-    match value {
-        "zstd" => Ok(Some(mcap::Compression::Zstd)),
-        "lz4" => Ok(Some(mcap::Compression::Lz4)),
-        "none" | "" => Ok(None),
-        _ => bail!(
-            "unrecognized compression format '{value}': valid options are 'lz4', 'zstd', or 'none'"
-        ),
-    }
-}
-
 /// Parse a CLI-supplied timestamp as either integer nanoseconds or an RFC3339 string.
 ///
 /// Shared by commands that accept timestamps on the command line (for example
@@ -645,33 +634,6 @@ mod tests {
         assert!(library.starts_with("mcap-cli/"));
         assert!(library.ends_with(mcap::LIBRARY_IDENTIFIER));
         assert!(library.contains(" mcap-rust/"));
-    }
-
-    #[test]
-    fn parse_output_compression_supports_known_values() {
-        assert!(matches!(
-            super::parse_output_compression("zstd").expect("zstd should parse"),
-            Some(mcap::Compression::Zstd)
-        ));
-        assert!(matches!(
-            super::parse_output_compression("lz4").expect("lz4 should parse"),
-            Some(mcap::Compression::Lz4)
-        ));
-        assert!(super::parse_output_compression("none")
-            .expect("none should parse")
-            .is_none());
-        assert!(super::parse_output_compression("")
-            .expect("empty should parse")
-            .is_none());
-    }
-
-    #[test]
-    fn parse_output_compression_rejects_unknown_values() {
-        let err =
-            super::parse_output_compression("snappy").expect_err("unknown compression should fail");
-        assert!(err
-            .to_string()
-            .contains("unrecognized compression format 'snappy'"));
     }
 
     #[test]

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -84,10 +84,10 @@ mod tests {
     use super::dispatch;
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Command,
-        CommonRewriteArgs, DoctorCommand, DuCommand, GetAttachmentCommand,
-        GetMetadataCommand, InfoCommand, ListAttachmentsCommand, ListChannelsCommand,
-        ListChunksCommand, ListCommand, ListMetadataCommand, ListSchemasCommand, ListSubcommand,
-        MessageOrder, RecoverCommand, SortCommand,
+        CommonRewriteArgs, DoctorCommand, DuCommand, GetAttachmentCommand, GetMetadataCommand,
+        InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
+        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MessageOrder, RecoverCommand,
+        SortCommand,
     };
     use crate::context::CommandContext;
 

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -249,23 +249,26 @@ mod tests {
     }
 
     #[test]
-    fn compress_rejects_invalid_compression() {
+    fn compress_requires_existing_file() {
         let err = dispatch(
             &CommandContext::default(),
             Command::Compress(CompressCommand {
                 common: CommonRewriteArgs {
-                    file: None,
-                    output: None,
+                    file: Some(PathBuf::from("does-not-exist.mcap")),
+                    output: Some(PathBuf::from("compressed.mcap")),
                     output_file: None,
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
                 },
-                compression: "invalid".to_string(),
+                compression: crate::cli::CompressionFormat::Zstd,
                 order: MessageOrder::Preserve,
             }),
         )
-        .expect_err("compress should reject invalid compression");
-        assert!(err.to_string().contains("unrecognized compression format"));
+        .expect_err("compress should fail on missing input file");
+        assert!(
+            err.to_string().contains("couldn't open")
+                || err.to_string().contains("failed to canonicalize input")
+        );
     }
 
     #[test]

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -265,10 +265,7 @@ mod tests {
             }),
         )
         .expect_err("compress should fail on missing input file");
-        assert!(
-            err.to_string().contains("couldn't open")
-                || err.to_string().contains("failed to canonicalize input")
-        );
+        assert!(err.to_string().contains("couldn't open"));
     }
 
     #[test]
@@ -289,9 +286,6 @@ mod tests {
             }),
         )
         .expect_err("sort should fail on missing input file");
-        assert!(
-            err.to_string().contains("couldn't open")
-                || err.to_string().contains("failed to canonicalize input")
-        );
+        assert!(err.to_string().contains("couldn't open"));
     }
 }

--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -84,7 +84,7 @@ mod tests {
     use super::dispatch;
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Command,
-        CommonRewriteArgs, CompressCommand, DoctorCommand, DuCommand, GetAttachmentCommand,
+        CommonRewriteArgs, DoctorCommand, DuCommand, GetAttachmentCommand,
         GetMetadataCommand, InfoCommand, ListAttachmentsCommand, ListChannelsCommand,
         ListChunksCommand, ListCommand, ListMetadataCommand, ListSchemasCommand, ListSubcommand,
         MessageOrder, RecoverCommand, SortCommand,
@@ -245,26 +245,6 @@ mod tests {
             }),
         )
         .expect_err("recover should fail on missing file");
-        assert!(err.to_string().contains("couldn't open"));
-    }
-
-    #[test]
-    fn compress_requires_existing_file() {
-        let err = dispatch(
-            &CommandContext::default(),
-            Command::Compress(CompressCommand {
-                common: CommonRewriteArgs {
-                    file: Some(PathBuf::from("does-not-exist.mcap")),
-                    output: Some(PathBuf::from("compressed.mcap")),
-                    output_file: None,
-                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                    no_crc: false,
-                },
-                compression: crate::cli::CompressionFormat::Zstd,
-                order: MessageOrder::Preserve,
-            }),
-        )
-        .expect_err("compress should fail on missing input file");
         assert!(err.to_string().contains("couldn't open"));
     }
 

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -9,7 +9,7 @@ pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
     // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata
     // and attachments. Paths, chunk size, and `--no-crc` come from the shared args.
     let options = RewriteOptions::from(&args.common)
-        .compression(args.compression)
+        .compression(args.compression.to_compression())
         .order(args.order);
     rewrite::run(
         options,

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use mcap::{Compression, WriteOptions};
+use mcap::WriteOptions;
 
 use crate::cli::{CompressionFormat, ConvertCommand};
 use crate::context::CommandContext;
@@ -82,11 +82,7 @@ fn build_write_options(
     chunked: bool,
     profile: &str,
 ) -> WriteOptions {
-    let compression = match compression {
-        CompressionFormat::Zstd => Some(Compression::Zstd),
-        CompressionFormat::Lz4 => Some(Compression::Lz4),
-        CompressionFormat::None => None,
-    };
+    let compression = compression.to_compression();
 
     WriteOptions::new()
         .profile(profile)

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -9,7 +9,7 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
     // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and
     // attachments. Paths, chunk size, and `--no-crc` come from the shared args.
     let options = RewriteOptions::from(&args.common)
-        .compression("none")
+        .compression(None)
         .order(args.order);
     rewrite::run(
         options,

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use mcap::records::{MessageHeader, Record};
 
-use crate::cli::{CoalesceChannels, CompressionFormat, MergeCommand};
+use crate::cli::{CoalesceChannels, MergeCommand};
 use crate::context::CommandContext;
 
 #[derive(Debug, Clone)]
@@ -194,16 +194,10 @@ pub fn run(ctx: &CommandContext, args: MergeCommand) -> Result<()> {
 }
 
 fn build_merge_options(args: MergeCommand) -> MergeOptions {
-    let compression = match args.compression {
-        CompressionFormat::Zstd => Some(mcap::Compression::Zstd),
-        CompressionFormat::Lz4 => Some(mcap::Compression::Lz4),
-        CompressionFormat::None => None,
-    };
-
     MergeOptions {
         files: args.files,
         output_file: args.output_file,
-        compression,
+        compression: args.compression.to_compression(),
         chunk_size: args.chunk_size,
         include_crc: !args.no_crc,
         chunked: !args.no_chunks,
@@ -884,6 +878,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+    use crate::cli::CompressionFormat;
 
     #[derive(Debug, Clone)]
     struct TestMessage {

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -477,7 +477,7 @@ mod tests {
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
                 },
-                compression: "zstd".to_string(),
+                compression: CompressionFormat::Zstd,
                 order: MessageOrder::Preserve,
             })
         );
@@ -510,10 +510,17 @@ mod tests {
                     chunk_size: 1024,
                     no_crc: true,
                 },
-                compression: "lz4".to_string(),
+                compression: CompressionFormat::Lz4,
                 order: MessageOrder::LogTime,
             })
         );
+    }
+
+    #[test]
+    fn rejects_compress_invalid_compression() {
+        let err = Args::try_parse_from(["mcap", "compress", "in.mcap", "--compression", "invalid"])
+            .expect_err("invalid compression should be rejected at parse time");
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -1254,7 +1254,7 @@ mod tests {
         let mut options =
             rewrite_options(Some(input_path.clone()), Some(output_path.clone()), 1024);
         options.use_chunks = false;
-        options.output_compression = "none".to_string();
+        options.output_compression = None;
 
         super::run(options, crate::source::SourceOptions::default())
             .expect("rewrite should succeed");

--- a/rust/cli/src/rewrite/engine.rs
+++ b/rust/cli/src/rewrite/engine.rs
@@ -1254,7 +1254,7 @@ mod tests {
         let mut options =
             rewrite_options(Some(input_path.clone()), Some(output_path.clone()), 1024);
         options.use_chunks = false;
-        options.output_compression = None;
+        options.compression = None;
 
         super::run(options, crate::source::SourceOptions::default())
             .expect("rewrite should succeed");

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -6,8 +6,8 @@ use anyhow::{bail, Context, Result};
 use regex::Regex;
 
 use crate::cli::{
-    parse_output_compression, parse_timestamp_or_nanos, CommonRewriteArgs, CompressionFormat,
-    FilterCommand, MessageOrder, SortCommand,
+    parse_timestamp_or_nanos, CommonRewriteArgs, CompressionFormat, FilterCommand, MessageOrder,
+    SortCommand,
 };
 
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ pub(crate) struct RewriteOptions {
     pub(crate) end_nsecs: u64,
     pub(crate) include_metadata: bool,
     pub(crate) include_attachments: bool,
-    pub(crate) output_compression: String,
+    pub(crate) output_compression: Option<mcap::Compression>,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
     pub(crate) include_crc: bool,
@@ -56,7 +56,7 @@ impl From<&CommonRewriteArgs> for RewriteOptions {
             end_nsecs: 0,
             include_metadata: true,
             include_attachments: true,
-            output_compression: "zstd".to_string(),
+            output_compression: Some(mcap::Compression::Zstd),
             chunk_size: args.chunk_size,
             use_chunks: true,
             include_crc: !args.no_crc,
@@ -83,8 +83,7 @@ impl From<&FilterCommand> for RewriteOptions {
                 .compression
                 .or(args.output_compression)
                 .unwrap_or(CompressionFormat::Zstd)
-                .as_str()
-                .to_string(),
+                .to_compression(),
             use_chunks: !args.no_chunks,
             order: args.order,
             ..RewriteOptions::from(&args.common)
@@ -98,7 +97,7 @@ impl From<&FilterCommand> for RewriteOptions {
 impl From<&SortCommand> for RewriteOptions {
     fn from(args: &SortCommand) -> Self {
         Self {
-            output_compression: args.compression.as_str().to_string(),
+            output_compression: args.compression.to_compression(),
             use_chunks: !args.no_chunks,
             order: args.order,
             ..RewriteOptions::from(&args.common)
@@ -107,8 +106,8 @@ impl From<&SortCommand> for RewriteOptions {
 }
 
 impl RewriteOptions {
-    pub(crate) fn compression(mut self, value: impl Into<String>) -> Self {
-        self.output_compression = value.into();
+    pub(crate) fn compression(mut self, value: Option<mcap::Compression>) -> Self {
+        self.output_compression = value;
         self
     }
 
@@ -165,7 +164,7 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         end,
         include_metadata: args.include_metadata,
         include_attachments: args.include_attachments,
-        compression: parse_output_compression(&args.output_compression)?,
+        compression: args.output_compression,
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
         include_crc: args.include_crc,
@@ -419,7 +418,7 @@ mod tests {
 
     #[test]
     fn compression_flag_resolves_each_format() {
-        // Guards the CompressionFormat -> str -> mcap::Compression bridge for every variant.
+        // Guards the CompressionFormat -> mcap::Compression bridge for every variant.
         let mut args = default_filter_command();
 
         args.compression = Some(CompressionFormat::Zstd);
@@ -478,7 +477,10 @@ mod tests {
             MessageOrder::Preserve,
             "sort honors an explicit --order override"
         );
-        assert_eq!(opts.output_compression, "lz4");
+        assert!(matches!(
+            opts.output_compression,
+            Some(mcap::Compression::Lz4)
+        ));
         assert_eq!(opts.chunk_size, 4096);
         assert!(!opts.use_chunks, "--no-chunks should write outside chunks");
         assert!(!opts.include_crc, "--no-crc should disable CRC fields");

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -25,7 +25,7 @@ pub(crate) struct RewriteOptions {
     pub(crate) end_nsecs: u64,
     pub(crate) include_metadata: bool,
     pub(crate) include_attachments: bool,
-    pub(crate) output_compression: Option<mcap::Compression>,
+    pub(crate) compression: Option<mcap::Compression>,
     pub(crate) chunk_size: u64,
     pub(crate) use_chunks: bool,
     pub(crate) include_crc: bool,
@@ -56,7 +56,7 @@ impl From<&CommonRewriteArgs> for RewriteOptions {
             end_nsecs: 0,
             include_metadata: true,
             include_attachments: true,
-            output_compression: Some(mcap::Compression::Zstd),
+            compression: Some(mcap::Compression::Zstd),
             chunk_size: args.chunk_size,
             use_chunks: true,
             include_crc: !args.no_crc,
@@ -79,7 +79,7 @@ impl From<&FilterCommand> for RewriteOptions {
             end_nsecs: args.end_nsecs,
             include_metadata: !args.exclude_metadata,
             include_attachments: !args.exclude_attachments,
-            output_compression: args
+            compression: args
                 .compression
                 .or(args.output_compression)
                 .unwrap_or(CompressionFormat::Zstd)
@@ -97,7 +97,7 @@ impl From<&FilterCommand> for RewriteOptions {
 impl From<&SortCommand> for RewriteOptions {
     fn from(args: &SortCommand) -> Self {
         Self {
-            output_compression: args.compression.to_compression(),
+            compression: args.compression.to_compression(),
             use_chunks: !args.no_chunks,
             order: args.order,
             ..RewriteOptions::from(&args.common)
@@ -107,7 +107,7 @@ impl From<&SortCommand> for RewriteOptions {
 
 impl RewriteOptions {
     pub(crate) fn compression(mut self, value: Option<mcap::Compression>) -> Self {
-        self.output_compression = value;
+        self.compression = value;
         self
     }
 
@@ -164,7 +164,7 @@ pub(crate) fn resolve_options(args: &RewriteOptions) -> Result<ResolvedOptions> 
         end,
         include_metadata: args.include_metadata,
         include_attachments: args.include_attachments,
-        compression: args.output_compression,
+        compression: args.compression,
         chunk_size: args.chunk_size,
         use_chunks: args.use_chunks,
         include_crc: args.include_crc,
@@ -477,10 +477,7 @@ mod tests {
             MessageOrder::Preserve,
             "sort honors an explicit --order override"
         );
-        assert!(matches!(
-            opts.output_compression,
-            Some(mcap::Compression::Lz4)
-        ));
+        assert!(matches!(opts.compression, Some(mcap::Compression::Lz4)));
         assert_eq!(opts.chunk_size, 4096);
         assert!(!opts.use_chunks, "--no-chunks should write outside chunks");
         assert!(!opts.include_crc, "--no-crc should disable CRC fields");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changelog

No changes worth calling out in changelog. 

`mcap compress --compression` flag is now validated as an enum, invalid value returns a parse error with exit code `2`, instead of exit code `1`.

## Summary

Tightens the `--compression` handling shared by the rewrite-engine commands (`filter`, `compress`, `decompress`, `sort`) and aligns the closely-related copy commands (`merge`, `convert`, `recover`) where it's cheap. No behavior change beyond the `compress` validation noted in the changelog.

**1. `compress --compression` is now an enum.** It was a `String` while `sort`/`filter` used the `CompressionFormat` value_enum. It's now `CompressionFormat`, so:
- invalid values are rejected at clap parse time (exit code `2`) instead of a late handler error (exit code `1`), matching `sort`;
- the flag gets shell completion and `[possible values: zstd, lz4, none]` in `--help`;
- meaningless input like `--compression ""` is no longer silently accepted.

**2. The rewrite engine boundary is now typed.** `RewriteOptions`'s output compression was a `String`, forcing an enum → string → enum round-trip (`filter`/`sort` did `.as_str().to_string()`, then the engine re-parsed via `parse_output_compression`). It's now an `Option<mcap::Compression>` field, converted once at the CLI edge via the new `CompressionFormat::to_compression`; the redundant `parse_output_compression` re-parse (and its tests) are removed. The field is also renamed from `output_compression` to `compression` — it was fed by the modern `--compression` yet echoed the deprecated `--output-compression` flag, and it now matches its own builder method and the downstream `ResolvedOptions.compression`. `filter` keeps its `Option<CompressionFormat>` for the deprecated `--output-compression` fallback.

**3. Shared the `to_compression` helper.** `merge`'s `build_merge_options` and `convert`'s `build_write_options` hand-rolled the identical three-arm `CompressionFormat → Option<mcap::Compression>` match; both now call `CompressionFormat::to_compression`.

**4. Standardized `--compression` help text.** All commands that expose the flag now use one wording, `Compression algorithm for output file: zstd, lz4, or none` (`filter` keeps a trailing `(default: zstd)` since its `Option` has no clap-rendered default; `recover` keeps its extra `preserve` value). Help text only — no behavior change, and `recover` stays a `String` for now.

## Testing

- `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`
- `cargo test -p mcap-cli` (331 unit + 13 integration tests pass; added `rejects_compress_invalid_compression` at the parse boundary, removed the redundant `compress` dispatch-wiring test)
- `cargo fmt --all -- --check`
- Manual, against `tests/conformance/data/OneMessage/OneMessage.mcap`:
  - `mcap compress --compression bogus` → `error: invalid value 'bogus' ... [possible values: zstd, lz4, none]`, exit code `2`
  - `mcap compress --compression lz4` → chunk compression `lz4`; `--compression none` and `mcap decompress` → uncompressed chunk
  - `mcap compress --help` shows `[possible values: zstd, lz4, none]`, identical to `sort`

<!-- CURSOR_AGENT_PR_BODY_END -->