### PR TITLE
cli: Add help header/footer

### DIFF
--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -1,6 +1,6 @@
 # MCAP CLI
 
-A command line tool for inspecting, editing, and converting [MCAP](https://mcap.dev) files.
+A command line tool for inspecting and manipulating [MCAP](https://mcap.dev) files.
 
 ## Getting started
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -37,6 +37,8 @@ pub(crate) static LIBRARY_IDENTIFIER: LazyLock<String> = LazyLock::new(|| {
     name = "mcap",
     bin_name = "mcap",
     version = VERSION.as_str(),
+    about = "A command line tool for inspecting and manipulating MCAP files.",
+    after_help = help_footer(),
 )]
 pub struct Args {
     #[arg(
@@ -626,6 +628,29 @@ pub(crate) fn parse_timestamp_or_nanos(value: &str) -> Result<u64> {
         .checked_mul(1_000_000_000)
         .and_then(|v| v.checked_add(nanos))
         .with_context(|| format!("timestamp is out of range: '{value}'"))
+}
+
+/// Footer shown at the bottom of the root `mcap --help`.
+///
+/// Built as a `StyledStr` so the heading uses clap's default section-header style
+/// (bold + underline), matching the generated `Commands:`/`Options:` headings.
+/// clap strips the embedded styling when color is disabled or the output isn't a terminal.
+fn help_footer() -> clap::builder::StyledStr {
+    use std::fmt::Write as _;
+
+    use clap::builder::styling::Style;
+
+    const HEADER: Style = Style::new().bold().underline();
+
+    let mut footer = clap::builder::StyledStr::new();
+    let _ = write!(
+        footer,
+        "{HEADER}Learn more:{HEADER:#}\n  \
+         Homepage       https://mcap.dev\n  \
+         Specification  https://mcap.dev/spec\n\n\
+         MCAP is an open source project by Foxglove (https://foxglove.dev)."
+    );
+    footer
 }
 
 #[cfg(test)]

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # CLI
 
-The MCAP command line tool is useful for working with MCAP files.
+A command line tool for inspecting and manipulating MCAP files.
 
 ## Installation
 
@@ -36,6 +36,8 @@ Run `mcap --help` for detailed usage information, or `mcap <command> --help` for
 
     $ mcap --help
 
+    A command line tool for inspecting and manipulating MCAP files.
+
     Usage: mcap [OPTIONS] <COMMAND>
 
     Commands:
@@ -62,6 +64,12 @@ Run `mcap --help` for detailed usage information, or `mcap <command> --help` for
       -v, --verbose...         Verbosity (-v, -vv, -vvv, etc.)
       -h, --help               Print help
       -V, --version            Print version
+
+    Learn more:
+      Homepage       https://mcap.dev
+      Specification  https://mcap.dev/spec
+
+    MCAP is an open source project by Foxglove (https://foxglove.dev).
 
 ### Shell completion
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Add header and footer to `--help` text.