### PR TITLE
cli: remove --order from compress and decompress

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -114,8 +114,9 @@ pub struct CompletionCommand {
 }
 
 /// Options shared by every rewrite-based command (`filter`, `compress`, `decompress`, `sort`).
-/// Each command flattens these and adds only the knobs that apply to it, so the common definitions
-/// (and their help text) live in one place.
+/// `filter`, `compress`, and `sort` flatten these and add the knobs that apply to them; `decompress`
+/// needs nothing more and is an alias for this struct. Keeping the common definitions (and their
+/// help text) in one place keeps the commands consistent.
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CommonRewriteArgs {
     /// Input MCAP file path. If omitted, reads from stdin.
@@ -164,11 +165,9 @@ pub struct CompressCommand {
     pub compression: CompressionFormat,
 }
 
-#[derive(clap::Args, Debug, PartialEq, Eq)]
-pub struct DecompressCommand {
-    #[command(flatten)]
-    pub common: CommonRewriteArgs,
-}
+/// `decompress` adds no knobs of its own (it just forces compression off), so it is the shared
+/// rewrite args directly rather than an empty wrapper around them.
+pub type DecompressCommand = CommonRewriteArgs;
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 #[command(arg_required_else_help = true)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -162,20 +162,12 @@ pub struct CompressCommand {
     /// Compression algorithm for output file: zstd, lz4, or none
     #[arg(long = "compression", value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
-
-    /// Message order in the output: preserve (keep the input order), log_time, or topic
-    #[arg(long = "order", value_enum, default_value = "preserve")]
-    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct DecompressCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
-
-    /// Message order in the output: preserve (keep the input order), log_time, or topic
-    #[arg(long = "order", value_enum, default_value = "preserve")]
-    pub order: MessageOrder,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -357,7 +349,10 @@ impl CompressionFormat {
     }
 }
 
-/// Output message order for the rewrite commands (`filter`, `compress`, `decompress`, `sort`).
+/// Output message order for the rewrite commands that reorder messages (`filter` and `sort`).
+/// `compress` and `decompress` don't reorder — they preserve the input's stored order. To reorder
+/// and recompress in one pass, use `sort --compression=…`; to reorder while selecting a subset,
+/// use `filter --order=…`.
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MessageOrder {
     /// Keep the input's stored message order.
@@ -608,7 +603,8 @@ pub struct SortCommand {
     ///   channel ID), placing every channel in its own chunk(s), which speeds up single-topic
     ///   range reads
     ///
-    /// `sort` defaults to log_time; it accepts the same flag as the other rewrite commands.
+    /// `sort` defaults to log_time; `filter` accepts the same `--order` flag (defaulting to
+    /// preserve) to reorder while selecting a subset.
     #[arg(long = "order", value_enum, default_value = "log_time")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -350,9 +350,7 @@ impl CompressionFormat {
 }
 
 /// Output message order for the rewrite commands that reorder messages (`filter` and `sort`).
-/// `compress` and `decompress` don't reorder — they preserve the input's stored order. To reorder
-/// and recompress in one pass, use `sort --compression=…`; to reorder while selecting a subset,
-/// use `filter --order=…`.
+/// `compress` and `decompress` don't reorder; they preserve the input's stored order.
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MessageOrder {
     /// Keep the input's stored message order.
@@ -603,8 +601,8 @@ pub struct SortCommand {
     ///   channel ID), placing every channel in its own chunk(s), which speeds up single-topic
     ///   range reads
     ///
-    /// `sort` defaults to log_time; `filter` accepts the same `--order` flag (defaulting to
-    /// preserve) to reorder while selecting a subset.
+    /// `sort` defaults to log_time; `filter` accepts the same `--order` flag (which defaults to
+    /// preserve).
     #[arg(long = "order", value_enum, default_value = "log_time")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -6,10 +6,9 @@ use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
     args.common.warn_deprecations();
-    // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata
-    // and attachments in their stored order. Paths, chunk size, and `--no-crc` come from the shared
-    // args. `compress` doesn't reorder (use `sort --compression=…` for that), so this only changes
-    // compression.
+    // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata and
+    // attachments and preserving the input's message order (`compress` doesn't reorder). Paths,
+    // chunk size, and `--no-crc` come from the shared args.
     let options = RewriteOptions::from(&args.common).compression(args.compression.to_compression());
     rewrite::run(
         options,

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -7,10 +7,10 @@ use crate::rewrite::{self, RewriteOptions};
 pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
     args.common.warn_deprecations();
     // `filter`-style rewrite with a preset: chunk with the chosen compression, keeping metadata
-    // and attachments. Paths, chunk size, and `--no-crc` come from the shared args.
-    let options = RewriteOptions::from(&args.common)
-        .compression(args.compression.to_compression())
-        .order(args.order);
+    // and attachments in their stored order. Paths, chunk size, and `--no-crc` come from the shared
+    // args. `compress` doesn't reorder (use `sort --compression=…` for that), so this only changes
+    // compression.
+    let options = RewriteOptions::from(&args.common).compression(args.compression.to_compression());
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -6,9 +6,9 @@ use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
     args.common.warn_deprecations();
-    // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and
-    // attachments in their stored order. Paths, chunk size, and `--no-crc` come from the shared
-    // args. `decompress` doesn't reorder (use `sort` for that), so this only drops compression.
+    // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and attachments
+    // and preserving the input's message order (`decompress` doesn't reorder). Paths, chunk size,
+    // and `--no-crc` come from the shared args.
     let options = RewriteOptions::from(&args.common).compression(None);
     rewrite::run(
         options,

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -5,11 +5,11 @@ use crate::context::CommandContext;
 use crate::rewrite::{self, RewriteOptions};
 
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
-    args.common.warn_deprecations();
+    args.warn_deprecations();
     // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and attachments
-    // and preserving the input's message order (`decompress` doesn't reorder). Paths, chunk size,
-    // and `--no-crc` come from the shared args.
-    let options = RewriteOptions::from(&args.common).compression(None);
+    // and preserving the input's message order (`decompress` doesn't reorder). `decompress` takes
+    // only the shared rewrite args (paths, chunk size, `--no-crc`) and forces compression off.
+    let options = RewriteOptions::from(&args).compression(None);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -7,10 +7,9 @@ use crate::rewrite::{self, RewriteOptions};
 pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
     args.common.warn_deprecations();
     // `filter`-style rewrite with a preset: rechunk uncompressed, keeping metadata and
-    // attachments. Paths, chunk size, and `--no-crc` come from the shared args.
-    let options = RewriteOptions::from(&args.common)
-        .compression(None)
-        .order(args.order);
+    // attachments in their stored order. Paths, chunk size, and `--no-crc` come from the shared
+    // args. `decompress` doesn't reorder (use `sort` for that), so this only drops compression.
+    let options = RewriteOptions::from(&args.common).compression(None);
     rewrite::run(
         options,
         crate::source::SourceOptions::new(ctx.allow_remote_scan()),

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -478,7 +478,6 @@ mod tests {
                     no_crc: false,
                 },
                 compression: CompressionFormat::Zstd,
-                order: MessageOrder::Preserve,
             })
         );
     }
@@ -496,8 +495,6 @@ mod tests {
             "--compression",
             "lz4",
             "--no-crc",
-            "--order",
-            "log-time",
         ])
         .expect("compress with flags should parse");
         assert_eq!(
@@ -511,9 +508,16 @@ mod tests {
                     no_crc: true,
                 },
                 compression: CompressionFormat::Lz4,
-                order: MessageOrder::LogTime,
             })
         );
+    }
+
+    #[test]
+    fn rejects_compress_order_flag() {
+        // Reordering was removed from `compress`; only `sort` reorders now.
+        let err = Args::try_parse_from(["mcap", "compress", "in.mcap", "--order", "log_time"])
+            .expect_err("compress should no longer accept --order");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]
@@ -537,7 +541,6 @@ mod tests {
                     chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
                     no_crc: false,
                 },
-                order: MessageOrder::Preserve,
             })
         );
     }
@@ -553,8 +556,6 @@ mod tests {
             "--chunk-size",
             "2048",
             "--no-crc",
-            "--order",
-            "log-time",
         ])
         .expect("decompress with flags should parse");
         assert_eq!(
@@ -567,9 +568,16 @@ mod tests {
                     chunk_size: 2048,
                     no_crc: true,
                 },
-                order: MessageOrder::LogTime,
             })
         );
+    }
+
+    #[test]
+    fn rejects_decompress_order_flag() {
+        // Reordering was removed from `decompress`; only `sort` reorders now.
+        let err = Args::try_parse_from(["mcap", "decompress", "in.mcap", "--order", "log_time"])
+            .expect_err("decompress should no longer accept --order");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]
@@ -668,9 +676,9 @@ mod tests {
 
     #[test]
     fn filter_order_defaults_to_preserve_and_parses_log_time() {
-        // Each rewrite command owns its `--order` (so its default shows in --help): filter defaults
-        // to preserve; sort defaults to log_time. The flag name and values are identical across
-        // commands.
+        // `filter` and `sort` are the reordering commands and share the `--order` flag (name and
+        // values). `filter` defaults to preserve; `sort` defaults to log_time. (`compress` and
+        // `decompress` don't accept `--order` at all.)
         let default = Args::try_parse_from(["mcap", "filter", "in.mcap"])
             .expect("filter should parse without --order");
         match default.command {

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn rejects_compress_order_flag() {
-        // Reordering was removed from `compress`; only `sort` reorders now.
+        // `--order` was removed from `compress`; reordering now lives on `filter`/`sort`.
         let err = Args::try_parse_from(["mcap", "compress", "in.mcap", "--order", "log_time"])
             .expect_err("compress should no longer accept --order");
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn rejects_decompress_order_flag() {
-        // Reordering was removed from `decompress`; only `sort` reorders now.
+        // `--order` was removed from `decompress`; reordering now lives on `filter`/`sort`.
         let err = Args::try_parse_from(["mcap", "decompress", "in.mcap", "--order", "log_time"])
             .expect_err("decompress should no longer accept --order");
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -42,9 +42,9 @@ mod tests {
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
         CoalesceChannels, Command, CommonRewriteArgs, CompletionCommand, CompressCommand,
-        CompressionFormat, ConvertCommand, DecompressCommand, DoctorCommand, DuCommand,
-        FilterCommand, GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand,
-        InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
+        CompressionFormat, ConvertCommand, DoctorCommand, DuCommand, FilterCommand,
+        GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand, InfoCommand,
+        ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
         ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, MessageOrder,
         RecoverCommand, SortCommand,
     };
@@ -533,14 +533,12 @@ mod tests {
             .expect("decompress should parse");
         assert_eq!(
             args.command,
-            Command::Decompress(DecompressCommand {
-                common: CommonRewriteArgs {
-                    file: Some("in.mcap".into()),
-                    output: None,
-                    output_file: None,
-                    chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
-                    no_crc: false,
-                },
+            Command::Decompress(CommonRewriteArgs {
+                file: Some("in.mcap".into()),
+                output: None,
+                output_file: None,
+                chunk_size: mcap::WriteOptions::DEFAULT_CHUNK_SIZE,
+                no_crc: false,
             })
         );
     }
@@ -560,14 +558,12 @@ mod tests {
         .expect("decompress with flags should parse");
         assert_eq!(
             args.command,
-            Command::Decompress(DecompressCommand {
-                common: CommonRewriteArgs {
-                    file: Some("in.mcap".into()),
-                    output: Some("out.mcap".into()),
-                    output_file: None,
-                    chunk_size: 2048,
-                    no_crc: true,
-                },
+            Command::Decompress(CommonRewriteArgs {
+                file: Some("in.mcap".into()),
+                output: Some("out.mcap".into()),
+                output_file: None,
+                chunk_size: 2048,
+                no_crc: true,
             })
         );
     }

--- a/rust/cli/src/rewrite/options.rs
+++ b/rust/cli/src/rewrite/options.rs
@@ -37,9 +37,9 @@ pub(crate) struct RewriteOptions {
 /// and attachments are included by default (all rewrite commands keep them; `filter` opts out via
 /// `--exclude-*`), and output is chunked with zstd compression unless a command overrides those.
 ///
-/// Message order is *not* shared here — each command owns its `--order` (with its own default) and
-/// applies it via [`RewriteOptions::order`] or the `From` overrides, so this base uses `preserve`
-/// as a neutral placeholder.
+/// Message order defaults to `preserve`: `compress` and `decompress` keep the input's stored order,
+/// while `filter` and `sort` supply their own `--order` via their `From` overrides (defaulting to
+/// preserve and log_time respectively).
 impl From<&CommonRewriteArgs> for RewriteOptions {
     fn from(args: &CommonRewriteArgs) -> Self {
         Self {
@@ -108,11 +108,6 @@ impl From<&SortCommand> for RewriteOptions {
 impl RewriteOptions {
     pub(crate) fn compression(mut self, value: Option<mcap::Compression>) -> Self {
         self.compression = value;
-        self
-    }
-
-    pub(crate) fn order(mut self, order: MessageOrder) -> Self {
-        self.order = order;
         self
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changelog

- Removed the `--order` flag from `mcap compress` and `mcap decompress`. (Introduced by #1762 but never released, so release notes should not mention it at all.)

## Summary

Drops the `--order` flag from `mcap compress` and `mcap decompress`. These are single-knob "change the compression" presets, and bolting reordering onto them is overkill: to reorder *and* recompress in one pass, use `sort --compression=…`.

`--order` stays on `filter` and `sort`:

- **`filter`** is a combined *select + transform* command, and "drop a topic and sort it in the same pass" is a genuine efficiency win. `mcap filter -y foo in.mcap | mcap sort` does two full decode/encode passes, and because the piped intermediate isn't seekable, `sort` has to spool it to a temp file (especially for `topic` order). `filter --order=log_time` streams through in a single memory-bounded pass instead.
- **`sort`** is unchanged (still defaults to `log_time`).

The shared rewrite engine's ordering logic is untouched — only the CLI surface of the two copy commands changed. `compress`/`decompress` now preserve the input's stored message order.

## Compatibility

Not a breaking change: `--order` on `compress`/`decompress` was added in #1762 (2026-07-05) and has never shipped in a tagged CLI release (latest is `mcap-cli/v0.2.0`, tagged 2026-06-15, which predates it). This only removes unreleased in-flight surface, so no release note is needed.

## Changes

- `cli.rs`: removed the `order` field from `CompressCommand` and `DecompressCommand`; updated the `MessageOrder` and `sort --order` doc comments to reflect that only `filter`/`sort` reorder.
- `cli.rs`: with `--order` gone, `DecompressCommand` had no fields of its own, so collapsed it into a `pub type DecompressCommand = CommonRewriteArgs;` alias (matching the file's existing alias pattern) instead of an empty wrapper. CLI surface unchanged.
- `commands/compress.rs`, `commands/decompress.rs`: stopped applying `--order`; `decompress` now uses the shared args directly.
- `rewrite/options.rs`: removed the now-unused `RewriteOptions::order()` builder and updated the shared-args docs (`filter`/`sort` still supply `order` via their `From` overrides).
- Tests: added `rejects_compress_order_flag` / `rejects_decompress_order_flag`; updated the compress/decompress parse tests; kept filter's `--order` coverage.

## Testing

- ✅ `cargo build -p mcap-cli`
- ✅ `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`
- ✅ `cargo fmt -p mcap-cli -- --check`
- ✅ `cargo test -p mcap-cli` (351 unit + 13 integration)
- ✅ Manual: `compress --order`/`decompress --order` now exit `2` (unknown argument); `compress`/`decompress` still work without it; `decompress --help` surface unchanged; `filter -y /diagnostics --order log_time` selects one topic and sorts by log time in a single pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a325789-e87f-4ed1-8df9-afe2bc5ec0db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a325789-e87f-4ed1-8df9-afe2bc5ec0db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

