### PR TITLE
cli: clarify and correct --help text

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -64,55 +64,55 @@ pub struct Args {
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum Command {
-    /// Add records to an existing MCAP file
+    /// Add records to an existing MCAP file.
     Add(AddCommand),
-    /// Concatenate the messages in one or more MCAP files to stdout
+    /// Concatenate the messages in one or more MCAP files to stdout.
     Cat(CatCommand),
-    /// Generate shell completion scripts
+    /// Generate shell completion scripts.
     ///
     /// To load completions in the current shell session:
     ///   bash:       source <(mcap completion bash)
     ///   zsh:        source <(mcap completion zsh)
     ///   fish:       mcap completion fish | source
     ///   powershell: mcap completion powershell | Out-String | Invoke-Expression
-    #[command(verbatim_doc_comment)]
+    #[command(verbatim_doc_comment, about = "Generate shell completion scripts")]
     Completion(CompletionCommand),
-    /// Create a compressed copy of an MCAP file
+    /// Create a compressed copy of an MCAP file.
     ///
     /// Equivalent to running `mcap filter --compression=zstd` (pick another
     /// algorithm with `--compression`).
     Compress(CompressCommand),
-    /// Convert supported input files to MCAP
+    /// Convert supported input files to MCAP.
     #[command(
         long_about = "Convert supported input files to MCAP.\n\nSupported inputs:\n  .bag  ROS 1 bag\n  .db3  ROS 2 SQLite db3"
     )]
     Convert(ConvertCommand),
-    /// Create an uncompressed copy of an MCAP file
+    /// Create an uncompressed copy of an MCAP file.
     ///
     /// Equivalent to running `mcap filter --compression=none`.
     Decompress(DecompressCommand),
-    /// Check an MCAP file structure
+    /// Check an MCAP file structure.
     Doctor(DoctorCommand),
-    /// Compute byte usage statistics for MCAP records
+    /// Compute byte usage statistics for MCAP records.
     Du(DuCommand),
-    /// Copy filtered MCAP data to a new file
+    /// Copy filtered MCAP data to a new file.
     ///
     /// The general-purpose rewrite command: copies selected records to a new
     /// file, optionally selecting by topic and time range and changing
     /// compression, chunking, and message order. `compress`, `decompress`, and
     /// `sort` are presets over this command.
     Filter(FilterCommand),
-    /// Get a record from an MCAP file
+    /// Get a record from an MCAP file.
     Get(GetCommand),
-    /// Report statistics about an MCAP file
+    /// Report statistics about an MCAP file.
     Info(InfoCommand),
-    /// List records of an MCAP file
+    /// List records of an MCAP file.
     List(ListCommand),
-    /// Merge MCAP files
+    /// Merge MCAP files.
     Merge(MergeCommand),
-    /// Recover data from a potentially corrupt MCAP file
+    /// Recover data from a potentially corrupt MCAP file.
     Recover(RecoverCommand),
-    /// Read an MCAP file and write it back with messages reordered (log_time, preserve, or topic)
+    /// Read an MCAP file and write it back with messages reordered (log_time, preserve, or topic).
     ///
     /// Equivalent to running `mcap filter --order=log_time`.
     Sort(SortCommand),
@@ -233,9 +233,9 @@ pub struct CatCommand {
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum AddSubcommand {
-    /// Add an attachment to an MCAP file
+    /// Add an attachment to an MCAP file.
     Attachment(AddAttachmentCommand),
-    /// Add metadata to an MCAP file
+    /// Add metadata to an MCAP file.
     Metadata(AddMetadataCommand),
 }
 
@@ -296,9 +296,9 @@ pub struct GetCommand {
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum GetSubcommand {
-    /// Get an attachment by name or offset
+    /// Get an attachment by name or offset.
     Attachment(GetAttachmentCommand),
-    /// Get metadata by name
+    /// Get metadata by name.
     Metadata(GetMetadataCommand),
 }
 
@@ -339,15 +339,15 @@ pub struct ListCommand {
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum ListSubcommand {
-    /// List attachments in an MCAP file
+    /// List attachments in an MCAP file.
     Attachments(ListAttachmentsCommand),
-    /// List channels in an MCAP file
+    /// List channels in an MCAP file.
     Channels(ListChannelsCommand),
-    /// List chunks in an MCAP file
+    /// List chunks in an MCAP file.
     Chunks(ListChunksCommand),
-    /// List metadata in an MCAP file
+    /// List metadata in an MCAP file.
     Metadata(ListMetadataCommand),
-    /// List schemas in an MCAP file
+    /// List schemas in an MCAP file.
     Schemas(ListSchemasCommand),
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -78,6 +78,9 @@ pub enum Command {
     #[command(verbatim_doc_comment)]
     Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file
+    ///
+    /// Equivalent to running `mcap filter --compression=zstd` (pick another
+    /// algorithm with `--compression`).
     Compress(CompressCommand),
     /// Convert supported input files to MCAP
     #[command(
@@ -85,12 +88,19 @@ pub enum Command {
     )]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file
+    ///
+    /// Equivalent to running `mcap filter --compression=none`.
     Decompress(DecompressCommand),
     /// Check an MCAP file structure
     Doctor(DoctorCommand),
     /// Compute byte usage statistics for MCAP records
     Du(DuCommand),
     /// Copy filtered MCAP data to a new file
+    ///
+    /// The general-purpose rewrite command: copies selected records to a new
+    /// file, optionally selecting by topic and time range and changing
+    /// compression, chunking, and message order. `compress`, `decompress`, and
+    /// `sort` are presets over this command.
     Filter(FilterCommand),
     /// Get a record from an MCAP file
     Get(GetCommand),
@@ -103,6 +113,8 @@ pub enum Command {
     /// Recover data from a potentially corrupt MCAP file
     Recover(RecoverCommand),
     /// Read an MCAP file and write it back with messages reordered (log_time, preserve, or topic)
+    ///
+    /// Equivalent to running `mcap filter --order=log_time`.
     Sort(SortCommand),
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -41,6 +41,7 @@ pub(crate) static LIBRARY_IDENTIFIER: LazyLock<String> = LazyLock::new(|| {
     after_help = help_footer(),
 )]
 pub struct Args {
+    /// When to color log output on stderr
     #[arg(
         short,
         long,
@@ -50,7 +51,7 @@ pub struct Args {
     )]
     pub color: logsetup::Color,
 
-    /// Allow commands to download/scan remote inputs
+    /// Allow whole-file scans or downloads of remote inputs (http(s):// and object-store URLs: s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads (summary and single-record range reads) work without this flag; larger indexed reads still require it.
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 
@@ -64,9 +65,12 @@ pub struct Args {
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum Command {
-    /// Add records to an existing MCAP file.
+    /// Add an attachment or metadata record to an existing MCAP file (modifies the file in place).
     Add(AddCommand),
     /// Concatenate the messages in one or more MCAP files to stdout.
+    ///
+    /// By default prints one line per message (log time, topic, schema name, and a short byte
+    /// preview). Use --json to print one JSON object per message instead.
     Cat(CatCommand),
     /// Generate shell completion scripts.
     ///
@@ -84,7 +88,7 @@ pub enum Command {
     Compress(CompressCommand),
     /// Convert supported input files to MCAP.
     #[command(
-        long_about = "Convert supported input files to MCAP.\n\nSupported inputs:\n  .bag  ROS 1 bag\n  .db3  ROS 2 SQLite db3"
+        long_about = "Convert supported input files to MCAP.\n\nReads from an input path or URL and writes to an output path; does not use stdin/stdout.\n\nSupported inputs:\n  .bag  ROS 1 bag\n  .db3  ROS 2 SQLite db3"
     )]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file.
@@ -92,29 +96,37 @@ pub enum Command {
     /// Equivalent to running `mcap filter --compression=none`.
     Decompress(DecompressCommand),
     /// Check an MCAP file structure.
+    ///
+    /// Prints diagnostics to stderr; exits non-zero if any structural errors are found.
     Doctor(DoctorCommand),
     /// Compute byte usage statistics for MCAP records.
     Du(DuCommand),
-    /// Copy filtered MCAP data to a new file.
+    /// Copy filtered MCAP data to an output file or stdout.
     ///
     /// The general-purpose rewrite command: copies selected records to a new
     /// file, optionally selecting by topic and time range and changing
     /// compression, chunking, and message order. `compress`, `decompress`, and
     /// `sort` are presets over this command.
     Filter(FilterCommand),
-    /// Get a record from an MCAP file.
+    /// Extract an attachment or metadata record from an MCAP file.
     Get(GetCommand),
     /// Report statistics about an MCAP file.
     Info(InfoCommand),
-    /// List records of an MCAP file.
+    /// List attachments, channels, chunks, metadata, or schemas in an MCAP file.
     List(ListCommand),
     /// Merge MCAP files.
+    ///
+    /// Performs a k-way merge of messages from all inputs into a single output, ordered by log time.
     Merge(MergeCommand),
     /// Recover data from a potentially corrupt MCAP file.
-    Recover(RecoverCommand),
-    /// Read an MCAP file and write it back with messages reordered (log_time, preserve, or topic).
     ///
-    /// Equivalent to running `mcap filter --order=log_time`.
+    /// Scans records sequentially, skipping corrupt records and stopping early on truncated or
+    /// undecodable data, then writes a valid MCAP with indexes and CRCs rebuilt. Diagnostics go to
+    /// stderr; exits with status 3 if any records were discarded or the scan stopped early.
+    Recover(RecoverCommand),
+    /// Rewrite an MCAP file with messages reordered.
+    ///
+    /// With default options, equivalent to `mcap filter --order=log_time`.
     Sort(SortCommand),
 }
 
@@ -130,7 +142,7 @@ pub struct CompletionCommand {
 /// (and their help text) live in one place.
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CommonRewriteArgs {
-    /// Input MCAP file path. If omitted, reads from stdin.
+    /// Input MCAP file path or URL. If omitted, reads from stdin.
     pub file: Option<PathBuf>,
 
     /// Output file path. If omitted, writes to stdout.
@@ -141,7 +153,7 @@ pub struct CommonRewriteArgs {
     #[arg(long = "output-file", hide = true)]
     pub output_file: Option<PathBuf>,
 
-    /// Target uncompressed chunk size for output
+    /// Target uncompressed chunk size in bytes
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
@@ -199,14 +211,14 @@ pub struct AddCommand {
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CatCommand {
-    /// One or more local paths to MCAP files. If omitted, reads from stdin.
+    /// One or more paths or URLs to MCAP files. If omitted, reads from stdin.
     pub files: Vec<PathBuf>,
 
-    /// Comma-separated list of topics to include
-    #[arg(long = "topics", default_value = "")]
+    /// Comma-separated list of topics to include (exact match). If empty (the default), all topics are included.
+    #[arg(long = "topics", default_value = "", hide_default_value = true)]
     pub topics: String,
 
-    /// Include messages at or after this time (seconds)
+    /// Include messages with log time at or after this time (seconds)
     #[arg(
         long = "start-secs",
         default_value_t = 0,
@@ -214,19 +226,19 @@ pub struct CatCommand {
     )]
     pub start_secs: u64,
 
-    /// Include messages at or after this time (nanoseconds)
+    /// Include messages with log time at or after this time (nanoseconds)
     #[arg(long = "start-nsecs", default_value_t = 0)]
     pub start_nsecs: u64,
 
-    /// Include messages before this time (seconds)
+    /// Include messages with log time before this time (seconds); 0 (the default) means no upper bound
     #[arg(long = "end-secs", default_value_t = 0, conflicts_with = "end_nsecs")]
     pub end_secs: u64,
 
-    /// Include messages before this time (nanoseconds)
+    /// Include messages with log time before this time (nanoseconds)
     #[arg(long = "end-nsecs", default_value_t = 0)]
     pub end_nsecs: u64,
 
-    /// Print messages as JSON. Supported message encodings: ros1, protobuf, and json.
+    /// Print messages as JSON, one object per message. Supported schema encodings: ros1msg, protobuf, and jsonschema (or schemaless channels with json message encoding); other encodings error.
     #[arg(long = "json", default_value_t = false)]
     pub json: bool,
 }
@@ -234,21 +246,24 @@ pub struct CatCommand {
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum AddSubcommand {
     /// Add an attachment to an MCAP file.
+    ///
+    /// Rewrites FILE in place. WARNING: interrupting this (for example a process kill or disk full)
+    /// can leave FILE corrupted.
     Attachment(AddAttachmentCommand),
     /// Add metadata to an MCAP file.
+    ///
+    /// Rewrites FILE in place. WARNING: interrupting this (for example a process kill or disk full)
+    /// can leave FILE corrupted.
     Metadata(AddMetadataCommand),
 }
 
-/// Add an attachment to an MCAP file.
-///
-/// WARNING: this command rewrites the MCAP file in place and can leave it
-/// corrupted if interrupted (for example process kill or disk full).
+/// Arguments for `add attachment`.
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct AddAttachmentCommand {
     /// Local path to the MCAP file
     pub file: PathBuf,
 
-    /// Filename of attachment to add
+    /// Path to the local file to attach
     #[arg(short = 'f', long = "file")]
     pub attachment_file: PathBuf,
 
@@ -269,10 +284,7 @@ pub struct AddAttachmentCommand {
     pub creation_time: Option<String>,
 }
 
-/// Add metadata to an MCAP file.
-///
-/// WARNING: this command rewrites the MCAP file in place and can leave it
-/// corrupted if interrupted (for example process kill or disk full).
+/// Arguments for `add metadata`.
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct AddMetadataCommand {
     /// Local path to the MCAP file
@@ -282,7 +294,7 @@ pub struct AddMetadataCommand {
     #[arg(short = 'n', long = "name")]
     pub name: String,
 
-    /// Key-value pair in key=value format
+    /// Key-value pair in key=value format (repeatable)
     #[arg(short = 'k', long = "key")]
     pub key_values: Vec<String>,
 }
@@ -296,7 +308,7 @@ pub struct GetCommand {
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum GetSubcommand {
-    /// Get an attachment by name or offset.
+    /// Get an attachment by name.
     Attachment(GetAttachmentCommand),
     /// Get metadata by name.
     Metadata(GetMetadataCommand),
@@ -304,25 +316,25 @@ pub enum GetSubcommand {
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct GetAttachmentCommand {
-    /// Local path to the MCAP file
+    /// Path or URL to the MCAP file
     pub file: PathBuf,
 
     /// Name of attachment to extract
     #[arg(short = 'n', long = "name")]
     pub name: String,
 
-    /// Offset of attachment to extract
+    /// Byte offset of the attachment record (from `mcap list attachments`), used to disambiguate multiple attachments that share the same name
     #[arg(long = "offset")]
     pub offset: Option<u64>,
 
-    /// Location to write attachment bytes
+    /// Location to write attachment bytes. If omitted, writes to stdout (refuses if stdout is a terminal)
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct GetMetadataCommand {
-    /// Local path to the MCAP file
+    /// Path or URL to the MCAP file
     pub file: PathBuf,
 
     /// Name of metadata record to get
@@ -389,7 +401,7 @@ pub enum MessageOrder {
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct ConvertCommand {
-    /// Local path to the input file
+    /// Path or URL to the input file
     pub input: PathBuf,
 
     /// Local path for the destination MCAP file
@@ -414,15 +426,18 @@ pub struct ConvertCommand {
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoalesceChannels {
+    /// Coalesce channels with matching topic, schema, encoding, and metadata
     Auto,
+    /// Like auto, but ignore metadata differences
     Force,
+    /// Do not coalesce channels
     None,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 #[command(arg_required_else_help = true)]
 pub struct MergeCommand {
-    /// One or more local paths to MCAP files
+    /// One or more paths or URLs to MCAP files
     #[arg(required = true)]
     pub files: Vec<PathBuf>,
 
@@ -456,21 +471,17 @@ pub struct MergeCommand {
     #[arg(long, default_value_t = false)]
     pub allow_duplicate_metadata: bool,
 
-    /// Channel coalescing behavior:
-    /// - auto: coalesce channels with matching topic, schema, encoding, and
-    ///   metadata
-    /// - force: same as auto but ignores metadata
-    /// - none: do not coalesce channels
+    /// Channel coalescing behavior.
     ///
-    /// Note: coalescing channels may produce non-monotonic or colliding
-    /// sequence values within a coalesced output channel.
+    /// Note: coalescing channels may produce non-monotonic or colliding sequence values within a
+    /// coalesced output channel.
     #[arg(long, value_enum, default_value = "auto")]
     pub coalesce_channels: CoalesceChannels,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct FileCommand {
-    /// Local path to the MCAP file
+    /// Path or URL to the MCAP file
     pub file: PathBuf,
 }
 
@@ -480,7 +491,7 @@ pub struct DuCommand {
     #[arg(long, default_value_t = false)]
     pub approximate: bool,
 
-    /// Local path to the MCAP file
+    /// Path or URL to the MCAP file
     pub file: PathBuf,
 }
 
@@ -489,23 +500,23 @@ pub struct FilterCommand {
     #[command(flatten)]
     pub common: CommonRewriteArgs,
 
-    /// Include topics matching this regex (repeatable)
+    /// Include only topics matching this regex, matched against the full topic name (repeatable; cannot be combined with --exclude-topic-regex)
     #[arg(short = 'y', long = "include-topic-regex")]
     pub include_topic_regex: Vec<String>,
 
-    /// Exclude topics matching this regex (repeatable)
+    /// Exclude topics matching this regex, matched against the full topic name (repeatable; cannot be combined with --include-topic-regex)
     #[arg(short = 'n', long = "exclude-topic-regex")]
     pub exclude_topic_regex: Vec<String>,
 
-    /// Include the last pre-start message for matching topics (repeatable)
+    /// For topics matching this regex, also include the most recent message before the start time for each channel (captures latched/initial state). No effect when the start time is unset or 0. Requires an indexed input (errors on non-indexed files). Repeatable.
     #[arg(short = 'l', long = "last-per-channel-topic-regex")]
     pub last_per_channel_topic_regex: Vec<String>,
 
-    /// Include messages at or after this time (nanos or RFC3339)
+    /// Include messages with log time at or after this time (nanoseconds since the Unix epoch, or RFC3339). If omitted, starts at the beginning.
     #[arg(short = 'S', long = "start")]
     pub start: Option<String>,
 
-    /// Include messages at or after this time (seconds)
+    /// Include messages with log time at or after this time (seconds)
     #[arg(
         short = 's',
         long = "start-secs",
@@ -514,15 +525,15 @@ pub struct FilterCommand {
     )]
     pub start_secs: u64,
 
-    /// Deprecated: include messages at or after this time (nanoseconds)
-    #[arg(long = "start-nsecs", default_value_t = 0)]
+    /// Deprecated: include messages with log time at or after this time (nanoseconds)
+    #[arg(long = "start-nsecs", default_value_t = 0, hide = true)]
     pub start_nsecs: u64,
 
-    /// Include messages before this time (nanos or RFC3339)
+    /// Include messages with log time before this time (nanoseconds since the Unix epoch, or RFC3339). If omitted, no upper bound.
     #[arg(short = 'E', long = "end")]
     pub end: Option<String>,
 
-    /// Include messages before this time (seconds)
+    /// Include messages with log time before this time (seconds); 0 (the default) means no upper bound
     #[arg(
         short = 'e',
         long = "end-secs",
@@ -531,8 +542,8 @@ pub struct FilterCommand {
     )]
     pub end_secs: u64,
 
-    /// Deprecated: include messages before this time (nanoseconds)
-    #[arg(long = "end-nsecs", default_value_t = 0)]
+    /// Deprecated: include messages with log time before this time (nanoseconds)
+    #[arg(long = "end-nsecs", default_value_t = 0, hide = true)]
     pub end_nsecs: u64,
 
     /// Exclude metadata records from the output (metadata is included by default)
@@ -570,24 +581,24 @@ pub struct FilterCommand {
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct DoctorCommand {
-    /// Require that messages have a monotonic log time
+    /// Treat decreasing message log times as errors (non-zero exit) instead of warnings
     #[arg(long, default_value_t = false)]
     pub strict_message_order: bool,
 
-    /// Local path to the MCAP file
+    /// Path or URL to the MCAP file
     pub file: PathBuf,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct RecoverCommand {
-    /// Input MCAP file path. If omitted, reads from stdin.
+    /// Input MCAP file path or URL. If omitted, reads from stdin.
     pub file: Option<PathBuf>,
 
     /// Output MCAP file path. If omitted, writes to stdout.
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
 
-    /// Target uncompressed chunk size for output MCAP
+    /// Target uncompressed chunk size in bytes
     #[arg(long = "chunk-size", default_value_t = mcap::WriteOptions::DEFAULT_CHUNK_SIZE)]
     pub chunk_size: u64,
 
@@ -612,15 +623,7 @@ pub struct SortCommand {
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
 
-    /// Message order in the output:
-    ///
-    /// - preserve: keep the input's stored message order
-    /// - log_time: sort all messages by ascending log time (default)
-    /// - topic: group each channel's messages together (channels ordered by topic name, then
-    ///   channel ID), placing every channel in its own chunk(s), which speeds up single-topic
-    ///   range reads
-    ///
-    /// `sort` defaults to log_time; it accepts the same flag as the other rewrite commands.
+    /// Message order in the output (defaults to log_time for `sort`).
     #[arg(long = "order", value_enum, default_value = "log_time")]
     pub order: MessageOrder,
 }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -51,7 +51,10 @@ pub struct Args {
     )]
     pub color: logsetup::Color,
 
-    /// Allow whole-file scans or downloads of remote inputs (http(s):// and object-store URLs: s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads work without this flag.
+    /// Allow whole-file scans or downloads of remote inputs.
+    ///
+    /// Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small
+    /// bounded indexed reads work without this flag.
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -51,7 +51,7 @@ pub struct Args {
     )]
     pub color: logsetup::Color,
 
-    /// Allow whole-file scans or downloads of remote inputs (http(s):// and object-store URLs: s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads (summary and single-record range reads) work without this flag; larger indexed reads still require it.
+    /// Allow whole-file scans or downloads of remote inputs (http(s):// and object-store URLs: s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads work without this flag.
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 
@@ -92,7 +92,7 @@ pub enum Command {
     /// Supported inputs:
     ///   .bag  ROS 1 bag
     ///   .db3  ROS 2 SQLite db3
-    #[command(verbatim_doc_comment, about = "Convert supported input files to MCAP")]
+    #[command(verbatim_doc_comment, about = "Convert supported files (ROS 1 .bag, ROS 2 .db3) to MCAP")]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file.
     ///
@@ -421,7 +421,7 @@ pub struct ConvertCommand {
     #[arg(long = "no-crc", default_value_t = false)]
     pub no_crc: bool,
 
-    /// Write records outside of chunks
+    /// Write records outside of chunks (ignores --chunk-size and --compression)
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
 }
@@ -463,7 +463,7 @@ pub struct MergeCommand {
     #[arg(long = "no-crc", default_value_t = false)]
     pub no_crc: bool,
 
-    /// Write records outside of chunks
+    /// Write records outside of chunks (ignores --chunk-size and --compression)
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
 
@@ -572,7 +572,7 @@ pub struct FilterCommand {
     #[arg(long = "output-compression", value_enum, hide = true)]
     pub output_compression: Option<CompressionFormat>,
 
-    /// Write records outside of chunks
+    /// Write records outside of chunks (ignores --chunk-size and --compression)
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
 
@@ -621,7 +621,7 @@ pub struct SortCommand {
     #[arg(long, value_enum, default_value = "zstd")]
     pub compression: CompressionFormat,
 
-    /// Write records outside of chunks
+    /// Write records outside of chunks (ignores --chunk-size and --compression)
     #[arg(long = "no-chunks", default_value_t = false)]
     pub no_chunks: bool,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -83,13 +83,16 @@ pub enum Command {
     Completion(CompletionCommand),
     /// Create a compressed copy of an MCAP file.
     ///
-    /// Equivalent to running `mcap filter --compression=zstd` (pick another
-    /// algorithm with `--compression`).
+    /// Equivalent to running `mcap filter --compression=zstd`.
     Compress(CompressCommand),
     /// Convert supported input files to MCAP.
-    #[command(
-        long_about = "Convert supported input files to MCAP.\n\nReads from an input path or URL and writes to an output path; does not use stdin/stdout.\n\nSupported inputs:\n  .bag  ROS 1 bag\n  .db3  ROS 2 SQLite db3"
-    )]
+    ///
+    /// Reads from an input path or URL and writes to an output path; does not use stdin/stdout.
+    ///
+    /// Supported inputs:
+    ///   .bag  ROS 1 bag
+    ///   .db3  ROS 2 SQLite db3
+    #[command(verbatim_doc_comment, about = "Convert supported input files to MCAP")]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file.
     ///
@@ -103,10 +106,9 @@ pub enum Command {
     Du(DuCommand),
     /// Copy filtered MCAP data to an output file or stdout.
     ///
-    /// The general-purpose rewrite command: copies selected records to a new
-    /// file, optionally selecting by topic and time range and changing
-    /// compression, chunking, and message order. `compress`, `decompress`, and
-    /// `sort` are presets over this command.
+    /// Copies messages (optionally filtered by topic and time range) plus metadata and
+    /// attachments, and can change compression, chunking, and message order. `compress`,
+    /// `decompress`, and `sort` are presets over this command.
     Filter(FilterCommand),
     /// Extract an attachment or metadata record from an MCAP file.
     Get(GetCommand),

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -95,7 +95,10 @@ pub enum Command {
     /// Supported inputs:
     ///   .bag  ROS 1 bag
     ///   .db3  ROS 2 SQLite db3
-    #[command(verbatim_doc_comment, about = "Convert supported files (ROS 1 .bag, ROS 2 .db3) to MCAP")]
+    #[command(
+        verbatim_doc_comment,
+        about = "Convert supported files (ROS 1 .bag, ROS 2 .db3) to MCAP"
+    )]
     Convert(ConvertCommand),
     /// Create an uncompressed copy of an MCAP file.
     ///


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

Clarified and corrected the `mcap` CLI `--help` output.

### Docs

None — the changes are inline `--help` text; no separate documentation updates are needed.

### Description

The `mcap` CLI `--help` output is the primary (and often only) reference a first-time user — including an AI agent driving the tool — has for figuring out how to use it. Reading that surface as such a user turned up descriptions that were ambiguous, inconsistent between sibling commands, or in a few cases outright inaccurate. This PR reworks the clap doc comments / `about` text in `rust/cli/src/cli.rs` to fix those. There are no behavior changes.

Highlights:

- **Corrected misleading/inaccurate text.** `get attachment` was described as "by name or offset" even though `--name` is required and `--offset` only disambiguates duplicate names; `cat --json` listed the wrong encoding identifiers; and the `add` in-place-rewrite corruption warning never actually rendered (the doc comment sat on the args struct, which clap ignores). All corrected.
- **Documented remote inputs.** Every read command accepts remote URLs (`http(s)://` and object-store), yet file arguments said "Local path" and `--allow-remote-scan` was unexplained. File args now read "Path or URL" (except `add`, which is genuinely local-only), and the flag documents its accepted schemes and scope.
- **Named the clock and clarified time filters.** Time options now say they filter on log time, state units (nanoseconds since the Unix epoch, or RFC3339), and explain the end-time sentinel (`0`/omitted = no upper bound).
- **Filled gaps and improved consistency.** Added `merge`/`recover`/`doctor` semantics and exit-code notes, topic-regex matching rules and include/exclude mutual exclusivity, chunk-size units, and de-duplicated the `--coalesce-channels` / `sort --order` rendering.
- **Hid deprecated flags from help.** `filter --start-nsecs` / `--end-nsecs` are still accepted but no longer shown, matching the other hidden deprecated flags.

Every wording change was verified against the implementation, and a separate code-grounded review pass caught and corrected several would-be inaccuracies before they landed.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

```
$ mcap get attachment --help
Get an attachment by name or offset
...
      --offset <OFFSET>    Offset of attachment to extract
  -o, --output <OUTPUT>    Location to write attachment bytes
```

</td><td>

```
$ mcap get attachment --help
Get an attachment by name
...
      --offset <OFFSET>    Byte offset of the attachment record (from
                           `mcap list attachments`), used to disambiguate
                           multiple attachments that share the same name
  -o, --output <OUTPUT>    Location to write attachment bytes. If omitted,
                           writes to stdout (refuses if stdout is a terminal)
```

</td></tr></table>

The only user-visible effect beyond wording is that the already-deprecated `--start-nsecs` / `--end-nsecs` no longer appear in `filter --help` (still accepted).

Testing:

- `cargo build -p mcap-cli`, `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`, `cargo test -p mcap-cli` (362 pass)
- Manually inspected `--help` for the top-level command and every subcommand / nested subcommand.

Larger design questions surfaced during the audit (unifying time/topic argument shapes, JSON output for inspection commands, output-overwrite policy, and `get` retrieval-by-offset / duplicate-name handling) are intentionally out of scope here and tracked separately.

Related: foxglove/mcap#1671, foxglove/mcap#1672, foxglove/mcap#1673, foxglove/mcap#1697, foxglove/mcap#1775
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a899557-8ed1-4574-9487-5103cceec830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a899557-8ed1-4574-9487-5103cceec830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>