### PR TITLE
cli: add --format=ndjson for cat output

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -87,6 +87,7 @@ words:
   - nanos
   - nanosec
   - ndarray
+  - ndjson
   - noenv
   - Norlab
   - nsec

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -219,7 +219,7 @@ pub struct AddCommand {
 
 /// Output format for `mcap cat`.
 ///
-/// Selected with `--format`, matching the CLI Spec (`--output` is already used for file output).
+/// Selected with `--format`, matching clispec.dev (`--output` is already used for file output).
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -280,7 +280,7 @@ impl CatCommand {
         }
     }
 
-    /// Whether to emit JSON (`--format=ndjson` or the deprecated `--json` alias).
+    /// Whether to emit JSON (`--format=ndjson`).
     pub(crate) fn json_output(&self) -> bool {
         self.json || matches!(self.format, CatFormat::Ndjson)
     }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -280,7 +280,7 @@ impl CatCommand {
         }
     }
 
-    /// Whether to emit JSON (`--format=ndjson`).
+    /// Whether to emit JSON.
     pub(crate) fn json_output(&self) -> bool {
         self.json || matches!(self.format, CatFormat::Ndjson)
     }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -73,7 +73,7 @@ pub enum Command {
     /// Concatenate the messages in one or more MCAP files to stdout.
     ///
     /// By default prints one line per message (log time, topic, schema name, and a short byte
-    /// preview). Use `--format=json` to print one JSON object per line.
+    /// preview). Use `--format=ndjson` to print one JSON object per message instead.
     Cat(CatCommand),
     /// Generate shell completion scripts.
     ///
@@ -222,11 +222,11 @@ pub struct AddCommand {
 /// Selected with `--format`, matching clispec.dev (`--output` is already used for file output).
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CatFormat {
-    /// Human-readable one-line preview.
+    /// One line per message (log time, topic, schema name, and a short byte preview).
     #[default]
     Text,
-    /// One JSON object per message.
-    Json,
+    /// One JSON object per message (supports message encodings ros1msg, protobuf, and json).
+    Ndjson,
 }
 
 #[derive(clap::Args, Debug, PartialEq, Eq)]
@@ -259,13 +259,10 @@ pub struct CatCommand {
     pub end_nsecs: u64,
 
     /// Output format.
-    ///
-    /// `json` supports schema encodings ros1msg, protobuf, and jsonschema (or schemaless channels
-    /// with json message encoding); other encodings error.
     #[arg(long = "format", value_enum, default_value_t = CatFormat::Text)]
     pub format: CatFormat,
 
-    /// Deprecated: use --format=json.
+    /// Deprecated: use --format=ndjson.
     #[arg(
         long = "json",
         action = ArgAction::SetTrue,
@@ -279,13 +276,13 @@ impl CatCommand {
     /// Warns about deprecated flags that were supplied.
     pub(crate) fn warn_deprecations(&self) {
         if self.json {
-            warn!("--json is deprecated; use --format=json instead");
+            warn!("--json is deprecated; use --format=ndjson instead");
         }
     }
 
-    /// Whether to emit JSON (`--format=json` or the deprecated `--json` alias).
+    /// Whether to emit JSON (`--format=ndjson` or the deprecated `--json` alias).
     pub(crate) fn json_output(&self) -> bool {
-        self.json || matches!(self.format, CatFormat::Json)
+        self.json || matches!(self.format, CatFormat::Ndjson)
     }
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -225,7 +225,7 @@ pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).
     #[default]
     Text,
-    /// One JSON object per message (supports message encodings ros1, protobuf, and json).
+    /// One JSON object per message (supports the ros1, protobuf, and json message encodings).
     Ndjson,
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -225,7 +225,7 @@ pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).
     #[default]
     Text,
-    /// One JSON object per message (supports message encodings ros1msg, protobuf, and json).
+    /// One JSON object per message (supports message encodings ros1, protobuf, and json).
     Ndjson,
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -222,7 +222,7 @@ pub struct AddCommand {
 /// Selected with `--format`, matching clispec.dev (`--output` is already used for file output).
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CatFormat {
-    /// One line per message (log time, topic, schema name, and a short byte preview).
+    /// Human-readable one-line preview.
     #[default]
     Text,
     /// One JSON object per message.
@@ -258,7 +258,7 @@ pub struct CatCommand {
     #[arg(long = "end-nsecs", default_value_t = 0)]
     pub end_nsecs: u64,
 
-    /// Output format: `text` (default) or `json` (one JSON object per line).
+    /// Output format.
     ///
     /// `json` supports schema encodings ros1msg, protobuf, and jsonschema (or schemaless channels
     /// with json message encoding); other encodings error.

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -225,7 +225,7 @@ pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).
     #[default]
     Text,
-    /// One JSON object per message (supports the ros1, protobuf, and json message encodings).
+    /// One JSON object per message (supports ros1, protobuf, and json message encodings).
     Ndjson,
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -265,13 +265,25 @@ pub struct CatCommand {
     #[arg(long = "format", value_enum, default_value_t = CatFormat::Text)]
     pub format: CatFormat,
 
-    /// Alias for `--format=json`.
-    #[arg(long = "json", action = ArgAction::SetTrue, conflicts_with = "format")]
+    /// Deprecated: use --format=json.
+    #[arg(
+        long = "json",
+        action = ArgAction::SetTrue,
+        conflicts_with = "format",
+        hide = true
+    )]
     pub json: bool,
 }
 
 impl CatCommand {
-    /// Whether to emit JSON (`--format=json` or the `--json` alias).
+    /// Warns about deprecated flags that were supplied.
+    pub(crate) fn warn_deprecations(&self) {
+        if self.json {
+            warn!("--json is deprecated; use --format=json instead");
+        }
+    }
+
+    /// Whether to emit JSON (`--format=json` or the deprecated `--json` alias).
     pub(crate) fn json_output(&self) -> bool {
         self.json || matches!(self.format, CatFormat::Json)
     }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -219,7 +219,7 @@ pub struct AddCommand {
 
 /// Output format for `mcap cat`.
 ///
-/// Selected with `--format`, matching clispec.dev (`--output` is already used for file output).
+/// Selected with `--format` (per clispec.dev, `--output` is already used for file output).
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -73,8 +73,7 @@ pub enum Command {
     /// Concatenate the messages in one or more MCAP files to stdout.
     ///
     /// By default prints one line per message (log time, topic, schema name, and a short byte
-    /// preview). Use `--format=json` (or the `--json` alias) to print one JSON object per message
-    /// instead.
+    /// preview). Use `--format=json` to print one JSON object per line.
     Cat(CatCommand),
     /// Generate shell completion scripts.
     ///
@@ -220,14 +219,13 @@ pub struct AddCommand {
 
 /// Output format for `mcap cat`.
 ///
-/// Selected with `--format`. (`-o`/`--output` is reserved for destination paths elsewhere in the
-/// CLI, matching the [CLI Spec](https://clispec.dev/) guidance to use `--format` in that case.)
+/// Selected with `--format`, matching the CLI Spec (`--output` is already used for file output).
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).
     #[default]
     Text,
-    /// One JSON object per message.
+    /// Newline-delimited JSON, one object per message.
     Json,
 }
 
@@ -260,10 +258,10 @@ pub struct CatCommand {
     #[arg(long = "end-nsecs", default_value_t = 0)]
     pub end_nsecs: u64,
 
-    /// Output format: `text` (default) or `json` (one JSON object per message).
+    /// Output format: `text` (default) or `json` (one JSON object per line).
     ///
-    /// JSON supports schema encodings ros1msg, protobuf, and jsonschema (or schemaless channels with
-    /// json message encoding); other encodings error.
+    /// `json` supports schema encodings ros1msg, protobuf, and jsonschema (or schemaless channels
+    /// with json message encoding); other encodings error.
     #[arg(long = "format", value_enum, default_value_t = CatFormat::Text)]
     pub format: CatFormat,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -225,7 +225,7 @@ pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).
     #[default]
     Text,
-    /// Newline-delimited JSON, one object per message.
+    /// One JSON object per message.
     Json,
 }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -73,7 +73,8 @@ pub enum Command {
     /// Concatenate the messages in one or more MCAP files to stdout.
     ///
     /// By default prints one line per message (log time, topic, schema name, and a short byte
-    /// preview). Use --json to print one JSON object per message instead.
+    /// preview). Use `--format=json` (or the `--json` alias) to print one JSON object per message
+    /// instead.
     Cat(CatCommand),
     /// Generate shell completion scripts.
     ///
@@ -217,6 +218,19 @@ pub struct AddCommand {
     pub command: AddSubcommand,
 }
 
+/// Output format for `mcap cat`.
+///
+/// Selected with `--format`. (`-o`/`--output` is reserved for destination paths elsewhere in the
+/// CLI, matching the [CLI Spec](https://clispec.dev/) guidance to use `--format` in that case.)
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CatFormat {
+    /// One line per message (log time, topic, schema name, and a short byte preview).
+    #[default]
+    Text,
+    /// One JSON object per message.
+    Json,
+}
+
 #[derive(clap::Args, Debug, PartialEq, Eq)]
 pub struct CatCommand {
     /// One or more paths or URLs to MCAP files. If omitted, reads from stdin.
@@ -246,9 +260,23 @@ pub struct CatCommand {
     #[arg(long = "end-nsecs", default_value_t = 0)]
     pub end_nsecs: u64,
 
-    /// Print messages as JSON, one object per message. Supported schema encodings: ros1msg, protobuf, and jsonschema (or schemaless channels with json message encoding); other encodings error.
-    #[arg(long = "json", default_value_t = false)]
+    /// Output format: `text` (default) or `json` (one JSON object per message).
+    ///
+    /// JSON supports schema encodings ros1msg, protobuf, and jsonschema (or schemaless channels with
+    /// json message encoding); other encodings error.
+    #[arg(long = "format", value_enum, default_value_t = CatFormat::Text)]
+    pub format: CatFormat,
+
+    /// Alias for `--format=json`.
+    #[arg(long = "json", action = ArgAction::SetTrue, conflicts_with = "format")]
     pub json: bool,
+}
+
+impl CatCommand {
+    /// Whether to emit JSON (`--format=json` or the `--json` alias).
+    pub(crate) fn json_output(&self) -> bool {
+        self.json || matches!(self.format, CatFormat::Json)
+    }
 }
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -219,7 +219,7 @@ pub struct AddCommand {
 
 /// Output format for `mcap cat`.
 ///
-/// Selected with `--format` (per clispec.dev, `--output` is already used for file output).
+/// Selected with `--format` (per clispec.dev; `--output` is already used for file output).
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CatFormat {
     /// One line per message (log time, topic, schema name, and a short byte preview).

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -785,7 +785,7 @@ impl JsonTranscoders {
                 Ok(Cow::Owned(json))
             }
             encoding => bail!(
-                "JSON output only supported for the ros1, protobuf, and json message encodings; found: {encoding}"
+                "JSON output only supported for ros1, protobuf, and json message encodings; found: {encoding}"
             ),
         }
     }

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -19,6 +19,7 @@ const PROTOBUF_SERIALIZE_OPTIONS: SerializeOptions =
     SerializeOptions::new().skip_default_fields(false);
 
 pub fn run(ctx: &CommandContext, args: CatCommand) -> Result<()> {
+    args.warn_deprecations();
     let opts = CatOptions::from_args(&args)?;
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
     let stdout = std::io::stdout();

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -2072,7 +2072,7 @@ mod tests {
     }
 
     #[test]
-    fn cat_json_wraps_jsonschema_messages() {
+    fn cat_json_passes_json_message_with_schema() {
         let message = sample_message(Some("Example"), br#"{"value":1}"#.to_vec());
         let mut out = Vec::new();
         let mut transcoders = JsonTranscoders::default();
@@ -2124,6 +2124,32 @@ mod tests {
             r#"{"topic":"/demo","sequence":1,"log_time":0.000000042,"publish_time":0.000000043,"data":{"value":1}}"#
                 .to_string()
                 + "\n"
+        );
+    }
+
+    #[test]
+    fn cat_json_transcodes_ros1_message() {
+        // Dispatch keys on the "ros1" message encoding; the ros1msg schema builds the transcoder.
+        let channel = mcap::Channel {
+            id: 1,
+            topic: "/demo".to_string(),
+            schema: Some(Arc::new(mcap::Schema {
+                id: 1,
+                name: "demo/Example".to_string(),
+                encoding: "ros1msg".to_string(),
+                data: Cow::Owned(b"int32 value\n".to_vec()),
+            })),
+            message_encoding: "ros1".to_string(),
+            metadata: BTreeMap::new(),
+        };
+        let mut transcoders = JsonTranscoders::default();
+        let data = 42i32.to_le_bytes();
+        let encoded = transcoders
+            .encode(&channel, &data)
+            .expect("ros1 message should transcode");
+        assert_eq!(
+            String::from_utf8(encoded.into_owned()).expect("valid utf8"),
+            r#"{"value":42}"#
         );
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -733,9 +733,8 @@ struct JsonTranscoders {
 
 impl JsonTranscoders {
     fn encode<'a>(&mut self, channel: &mcap::Channel<'_>, data: &'a [u8]) -> Result<Cow<'a, [u8]>> {
-        // Dispatch on the message encoding: it is how the data is framed on the wire, and (for
-        // ros1/protobuf) implies the schema encoding used to decode it. `json` messages are already
-        // JSON, whether or not they carry a jsonschema schema.
+        // Dispatch on message encoding: for ros1/protobuf it implies the schema encoding needed to
+        // decode; json messages are already JSON, with or without a jsonschema.
         match channel.message_encoding.as_str() {
             "json" => Ok(Cow::Borrowed(data)),
             "protobuf" => {

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -102,7 +102,7 @@ impl CatOptions {
             topics,
             start,
             end: (end != 0).then_some(end),
-            json: args.json,
+            json: args.json_output(),
         })
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -733,16 +733,15 @@ struct JsonTranscoders {
 
 impl JsonTranscoders {
     fn encode<'a>(&mut self, channel: &mcap::Channel<'_>, data: &'a [u8]) -> Result<Cow<'a, [u8]>> {
-        let Some(schema) = channel.schema.as_ref() else {
-            return encode_schemaless_json(&channel.message_encoding, data);
-        };
-        if schema.encoding.is_empty() {
-            return encode_schemaless_json(&channel.message_encoding, data);
-        }
-
-        match schema.encoding.as_str() {
-            "jsonschema" => Ok(Cow::Borrowed(data)),
+        // Dispatch on the message encoding: it is how the data is framed on the wire, and (for
+        // ros1/protobuf) implies the schema encoding used to decode it. `json` messages are already
+        // JSON, whether or not they carry a jsonschema schema.
+        match channel.message_encoding.as_str() {
+            "json" => Ok(Cow::Borrowed(data)),
             "protobuf" => {
+                let schema = channel.schema.as_ref().with_context(|| {
+                    format!("protobuf message on {} has no schema to decode", channel.topic)
+                })?;
                 let descriptor = match self.protobuf_descriptors.get(&schema.id) {
                     Some(descriptor) => descriptor.clone(),
                     None => {
@@ -764,7 +763,10 @@ impl JsonTranscoders {
                     .context("failed to marshal message")?;
                 Ok(Cow::Owned(serializer.into_inner()))
             }
-            "ros1msg" => {
+            "ros1" => {
+                let schema = channel.schema.as_ref().with_context(|| {
+                    format!("ros1 message on {} has no schema to decode", channel.topic)
+                })?;
                 let transcoder = match self.ros1_transcoders.get(&schema.id) {
                     Some(transcoder) => transcoder,
                     None => {
@@ -784,18 +786,9 @@ impl JsonTranscoders {
                 Ok(Cow::Owned(json))
             }
             encoding => bail!(
-                "JSON output only supported for ros1msg, protobuf, and jsonschema schemas. Found: {encoding}"
+                "JSON output only supported for the ros1, protobuf, and json message encodings; found: {encoding}"
             ),
         }
-    }
-}
-
-fn encode_schemaless_json<'a>(message_encoding: &str, data: &'a [u8]) -> Result<Cow<'a, [u8]>> {
-    match message_encoding {
-        "json" => Ok(Cow::Borrowed(data)),
-        encoding => bail!(
-            "for schema-less channels, JSON output is only supported with 'json' message encoding. found: {encoding}"
-        ),
     }
 }
 
@@ -2132,6 +2125,26 @@ mod tests {
             r#"{"topic":"/demo","sequence":1,"log_time":0.000000042,"publish_time":0.000000043,"data":{"value":1}}"#
                 .to_string()
                 + "\n"
+        );
+    }
+
+    #[test]
+    fn cat_json_rejects_unsupported_message_encoding() {
+        let channel = mcap::Channel {
+            id: 1,
+            topic: "/imu".to_string(),
+            schema: None,
+            message_encoding: "cdr".to_string(),
+            metadata: BTreeMap::new(),
+        };
+        let mut transcoders = JsonTranscoders::default();
+        let err = transcoders
+            .encode(&channel, b"\x00")
+            .expect_err("cdr message encoding should not be supported");
+        assert!(
+            err.to_string()
+                .contains("ros1, protobuf, and json message encodings"),
+            "error should name the supported message encodings: {err}"
         );
     }
 

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -41,12 +41,12 @@ mod tests {
 
     use crate::cli::{
         AddAttachmentCommand, AddCommand, AddMetadataCommand, AddSubcommand, Args, CatCommand,
-        CoalesceChannels, Command, CommonRewriteArgs, CompletionCommand, CompressCommand,
-        CompressionFormat, ConvertCommand, DecompressCommand, DoctorCommand, DuCommand,
-        FilterCommand, GetAttachmentCommand, GetCommand, GetMetadataCommand, GetSubcommand,
-        InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand, ListCommand,
-        ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand, MessageOrder,
-        RecoverCommand, SortCommand,
+        CatFormat, CoalesceChannels, Command, CommonRewriteArgs, CompletionCommand,
+        CompressCommand, CompressionFormat, ConvertCommand, DecompressCommand, DoctorCommand,
+        DuCommand, FilterCommand, GetAttachmentCommand, GetCommand, GetMetadataCommand,
+        GetSubcommand, InfoCommand, ListAttachmentsCommand, ListChannelsCommand, ListChunksCommand,
+        ListCommand, ListMetadataCommand, ListSchemasCommand, ListSubcommand, MergeCommand,
+        MessageOrder, RecoverCommand, SortCommand,
     };
 
     #[test]
@@ -73,6 +73,7 @@ mod tests {
                 start_nsecs: 0,
                 end_secs: 0,
                 end_nsecs: 0,
+                format: CatFormat::Text,
                 json: false,
             })
         );
@@ -90,6 +91,7 @@ mod tests {
                 start_nsecs: 0,
                 end_secs: 0,
                 end_nsecs: 0,
+                format: CatFormat::Text,
                 json: false,
             })
         );
@@ -119,9 +121,39 @@ mod tests {
                 start_nsecs: 0,
                 end_secs: 0,
                 end_nsecs: 20_000_000_000,
+                format: CatFormat::Text,
                 json: true,
             })
         );
+        assert!(matches!(args.command, Command::Cat(ref c) if c.json_output()));
+    }
+
+    #[test]
+    fn parses_cat_format_json() {
+        let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=json"])
+            .expect("cat --format=json should parse");
+        assert_eq!(
+            args.command,
+            Command::Cat(CatCommand {
+                files: vec!["demo.mcap".into()],
+                topics: String::new(),
+                start_secs: 0,
+                start_nsecs: 0,
+                end_secs: 0,
+                end_nsecs: 0,
+                format: CatFormat::Json,
+                json: false,
+            })
+        );
+        assert!(matches!(args.command, Command::Cat(ref c) if c.json_output()));
+    }
+
+    #[test]
+    fn cat_rejects_format_with_json_alias() {
+        let parse_err =
+            Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=json", "--json"])
+                .expect_err("--format and --json should conflict");
+        assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -109,7 +109,7 @@ mod tests {
             "10",
             "--end-nsecs",
             "20000000000",
-            "--json",
+            "--format=json",
         ])
         .expect("cat should parse");
         assert_eq!(
@@ -121,8 +121,8 @@ mod tests {
                 start_nsecs: 0,
                 end_secs: 0,
                 end_nsecs: 20_000_000_000,
-                format: CatFormat::Text,
-                json: true,
+                format: CatFormat::Json,
+                json: false,
             })
         );
         assert!(matches!(args.command, Command::Cat(ref c) if c.json_output()));
@@ -149,11 +149,49 @@ mod tests {
     }
 
     #[test]
+    fn parses_cat_deprecated_json_alias() {
+        // `--json` is retained as a hidden deprecated alias for `--format=json`.
+        let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--json"])
+            .expect("deprecated --json should still parse");
+        assert_eq!(
+            args.command,
+            Command::Cat(CatCommand {
+                files: vec!["demo.mcap".into()],
+                topics: String::new(),
+                start_secs: 0,
+                start_nsecs: 0,
+                end_secs: 0,
+                end_nsecs: 0,
+                format: CatFormat::Text,
+                json: true,
+            })
+        );
+        assert!(matches!(args.command, Command::Cat(ref c) if c.json_output()));
+    }
+
+    #[test]
     fn cat_rejects_format_with_json_alias() {
         let parse_err =
             Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=json", "--json"])
                 .expect_err("--format and --json should conflict");
         assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn cat_help_hides_deprecated_json_alias() {
+        let mut help = Vec::new();
+        let mut command = <Args as clap::CommandFactory>::command();
+        command
+            .find_subcommand_mut("cat")
+            .expect("cat subcommand")
+            .write_long_help(&mut help)
+            .expect("write help");
+        let help = String::from_utf8(help).expect("utf8 help");
+        assert!(help.contains("--format"));
+        assert!(
+            !help.contains("--json"),
+            "deprecated --json should be hidden from help:\n{help}"
+        );
     }
 
     #[test]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -109,7 +109,7 @@ mod tests {
             "10",
             "--end-nsecs",
             "20000000000",
-            "--format=json",
+            "--format=ndjson",
         ])
         .expect("cat should parse");
         assert_eq!(
@@ -121,7 +121,7 @@ mod tests {
                 start_nsecs: 0,
                 end_secs: 0,
                 end_nsecs: 20_000_000_000,
-                format: CatFormat::Json,
+                format: CatFormat::Ndjson,
                 json: false,
             })
         );
@@ -129,9 +129,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_cat_format_json() {
-        let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=json"])
-            .expect("cat --format=json should parse");
+    fn parses_cat_format_ndjson() {
+        let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=ndjson"])
+            .expect("cat --format=ndjson should parse");
         assert_eq!(
             args.command,
             Command::Cat(CatCommand {
@@ -141,7 +141,7 @@ mod tests {
                 start_nsecs: 0,
                 end_secs: 0,
                 end_nsecs: 0,
-                format: CatFormat::Json,
+                format: CatFormat::Ndjson,
                 json: false,
             })
         );
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn parses_cat_deprecated_json_alias() {
-        // `--json` is retained as a hidden deprecated alias for `--format=json`.
+        // `--json` is retained as a hidden deprecated alias for `--format=ndjson`.
         let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--json"])
             .expect("deprecated --json should still parse");
         assert_eq!(
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn cat_rejects_format_with_json_alias() {
         let parse_err =
-            Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=json", "--json"])
+            Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=ndjson", "--json"])
                 .expect_err("--format and --json should conflict");
         assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -129,26 +129,6 @@ mod tests {
     }
 
     #[test]
-    fn parses_cat_format_ndjson() {
-        let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=ndjson"])
-            .expect("cat --format=ndjson should parse");
-        assert_eq!(
-            args.command,
-            Command::Cat(CatCommand {
-                files: vec!["demo.mcap".into()],
-                topics: String::new(),
-                start_secs: 0,
-                start_nsecs: 0,
-                end_secs: 0,
-                end_nsecs: 0,
-                format: CatFormat::Ndjson,
-                json: false,
-            })
-        );
-        assert!(matches!(args.command, Command::Cat(ref c) if c.json_output()));
-    }
-
-    #[test]
     fn parses_cat_deprecated_json_alias() {
         // `--json` is retained as a hidden deprecated alias for `--format=ndjson`.
         let args = Args::try_parse_from(["mcap", "cat", "demo.mcap", "--json"])
@@ -175,23 +155,6 @@ mod tests {
             Args::try_parse_from(["mcap", "cat", "demo.mcap", "--format=ndjson", "--json"])
                 .expect_err("--format and --json should conflict");
         assert_eq!(parse_err.kind(), clap::error::ErrorKind::ArgumentConflict);
-    }
-
-    #[test]
-    fn cat_help_hides_deprecated_json_alias() {
-        let mut help = Vec::new();
-        let mut command = <Args as clap::CommandFactory>::command();
-        command
-            .find_subcommand_mut("cat")
-            .expect("cat subcommand")
-            .write_long_help(&mut help)
-            .expect("write help");
-        let help = String::from_utf8(help).expect("utf8 help");
-        assert!(help.contains("--format"));
-        assert!(
-            !help.contains("--json"),
-            "deprecated --json should be hidden from help:\n{help}"
-        );
     }
 
     #[test]

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -134,7 +134,7 @@ Report summary statistics on an MCAP file:
 
 ### Indexed reading
 
-Echo messages for a specific topic to stdout as JSON:
+Echo messages for a specific topic to stdout as newline-delimited JSON:
 
     $ mcap cat demo.mcap --topics /tf --format=json | head -n 10
     {"topic":"/tf","sequence":2,"log_time":1490149580.103843113,"publish_time":1490149580.103843113,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.117017840,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -134,7 +134,7 @@ Report summary statistics on an MCAP file:
 
 ### Indexed reading
 
-Echo messages for a specific topic to stdout as newline-delimited JSON:
+Echo messages for a specific topic to stdout as JSON (one object per line):
 
     $ mcap cat demo.mcap --topics /tf --format=json | head -n 10
     {"topic":"/tf","sequence":2,"log_time":1490149580.103843113,"publish_time":1490149580.103843113,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.117017840,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -136,7 +136,7 @@ Report summary statistics on an MCAP file:
 
 Echo messages for a specific topic to stdout as JSON:
 
-    $ mcap cat demo.mcap --topics /tf --json | head -n 10
+    $ mcap cat demo.mcap --topics /tf --format=json | head -n 10
     {"topic":"/tf","sequence":2,"log_time":1490149580.103843113,"publish_time":1490149580.103843113,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.117017840,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}
     {"topic":"/tf","sequence":3,"log_time":1490149580.113944947,"publish_time":1490149580.113944947,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.127078895,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}
     {"topic":"/tf","sequence":8,"log_time":1490149580.124028613,"publish_time":1490149580.124028613,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.137141823,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -134,9 +134,9 @@ Report summary statistics on an MCAP file:
 
 ### Indexed reading
 
-Echo messages for a specific topic to stdout as JSON (one object per line):
+Echo messages for a specific topic to stdout as newline-delimited JSON (one object per message):
 
-    $ mcap cat demo.mcap --topics /tf --format=json | head -n 10
+    $ mcap cat demo.mcap --topics /tf --format=ndjson | head -n 10
     {"topic":"/tf","sequence":2,"log_time":1490149580.103843113,"publish_time":1490149580.103843113,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.117017840,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}
     {"topic":"/tf","sequence":3,"log_time":1490149580.113944947,"publish_time":1490149580.113944947,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.127078895,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}
     {"topic":"/tf","sequence":8,"log_time":1490149580.124028613,"publish_time":1490149580.124028613,"data":{"transforms":[{"header":{"seq":0,"stamp":1490149580.137141823,"frame_id":"base_link"},"child_frame_id":"radar","transform":{"translation":{"x":3.835,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1}}}]}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

- `mcap cat` now supports `--format=text|ndjson`; use `--format=ndjson` to print one JSON object per message.
- The `--json` flag is deprecated: it still works but prints a warning — use `--format=ndjson` instead.

### Docs

Updated the CLI guide example to use `--format=ndjson`.

### Description

Prerequisite cleanup for [#1697](https://github.com/foxglove/mcap/issues/1697) and [#1778](https://github.com/foxglove/mcap/pull/1778).

Only `mcap cat` already supported `--json`. This adds a `--format` selector and names the existing newline-delimited output `ndjson`, leaving room for a future `--format=json` that emits a single JSON document/array (per the plan in #1697). `--json` is deprecated the same way as other legacy flags (`hide = true`, stderr warning, still accepted) and is now an alias for `--format=ndjson`; passing both `--format` and `--json` conflicts.

The JSON transcoder now dispatches on the channel message encoding (`ros1`, `protobuf`, `json`) rather than the schema encoding, so `--help` and the unsupported-encoding error use the same vocabulary.

[`clispec.dev`](https://clispec.dev/) recommends `--output`/`-o` for format selection, or `--format` when `-o`/`--output` is already used for destination paths — which is the case throughout this CLI — so `--format` is the right spelling here. No other commands gained structured output support.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a28d7118-3dc4-434a-9bc1-78ed3b95779a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a28d7118-3dc4-434a-9bc1-78ed3b95779a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

