### PR TITLE
cli: v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "mcap-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "binrw",

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mcap-cli"
 description = "MCAP CLI"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -106,7 +106,7 @@ Report summary statistics on an MCAP file:
 <!-- cspell: disable -->
 
     $ mcap info demo.mcap
-    library:     mcap-cli/0.2.0 mcap-rust/0.25.0
+    library:     mcap-cli/0.3.0 mcap-rust/0.25.0
     profile:     ros1
     messages:    1606
     duration:    7.780758504s
@@ -155,7 +155,7 @@ The `mcap` CLI can read files over **HTTP(S)** and from object stores: **Amazon 
 <!-- cspell: disable -->
 
     $ mcap info gs://your-remote-bucket/demo.mcap
-    library:     mcap-cli/0.2.0 mcap-rust/0.25.0
+    library:     mcap-cli/0.3.0 mcap-rust/0.25.0
     profile:     ros1
     messages:    1606
     duration:    7.780758504s


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
Release `mcap-cli` 0.3.0.

### Docs
Updated the CLI guide `mcap info` examples to show `mcap-cli/0.3.0`.

### Description
Bumps the Rust CLI crate and workspace lockfile from 0.2.0 to 0.3.0.

Release notes reviewed from `releases/mcap-cli/v0.2.0..HEAD` (diffs inspected per commit, not titles):

#### Breaking changes
- `mcap filter` is now **lossless by default**: metadata and attachments are kept unless you pass the new `--exclude-metadata` / `--exclude-attachments` flags. The old `--include-metadata` / `--include-attachments` flags are now hidden deprecated no-ops that warn on stderr. (#1756)
- `mcap filter --start` / `--end` now apply to messages only; attachments are no longer dropped when their `log_time` falls outside the window (use `--exclude-attachments` to drop them). (#1756)
- `mcap filter`, `mcap compress`, and `mcap decompress` no longer silently re-sort indexed inputs: an out-of-order indexed file was previously re-sorted to log time, but the default is now `--order preserve` (keep stored message order). Pass `--order log_time` to restore the previous behavior. (#1762)
- Rewrite commands (`filter`, `compress`, `decompress`, `sort`) now write records in a standardized physical layout (metadata after the header → messages → attachments before Data End), so byte-level output can differ from 0.2.0 even when logical content is unchanged. (#1756, #1757)

#### New features
- Shared `--order <preserve|log_time|topic>` flag on `filter`, `compress`, `decompress`, and `sort`. `preserve` keeps stored order, `log_time` sorts by ascending log time (`log-time` alias), and `topic` groups each channel's messages together (channels by topic name then channel ID), placing each channel in its own chunk(s) when chunking is enabled for contiguous single-topic reads. Note that `topic` always buffers the selected messages in memory, and `log_time` buffers them when the input has no summary. (#1762, #1754, #1757)
- `mcap filter` gains `--exclude-metadata` and `--exclude-attachments` to opt out of the new lossless default. (#1756)
- `mcap filter` gains `--no-chunks` (write records outside of chunks). (#1763)
- `mcap filter`, `compress`, and `decompress` gain `--no-crc` (disable all output CRC fields), matching `convert`/`merge`/`sort`. (#1763)
- `mcap sort` gains an overridable `--order` flag (defaults to `log_time`), and its input and output are now optional — it reads from stdin and writes to stdout when omitted. (#1757)
- Expanded and corrected `--help` text across commands (remote URL inputs and `--allow-remote-scan`, log-time semantics for time filters, corrected `cat --json` encoding names, attachment retrieval, and in-place `add` corruption warnings), and hid the deprecated `--start-nsecs` / `--end-nsecs` flags from help (they remain accepted). (#1774)

#### Bug fixes
- `mcap cat --json` now emits protobuf fields set to their proto3 default value (e.g. `0`, `""`, `false`, enum zero-variants) instead of omitting them from the output. (#1765)
- Rewrite commands no longer silently drop messages when an indexed input's `Statistics` record disagrees with its chunk message indexes (or a message index can't be parsed); the engine falls back to a linear scan. (#1771)
- `mcap compress --compression` invalid values are now rejected at parse time (exit code 2, `[possible values: zstd, lz4, none]`) instead of failing at runtime. (#1767)

#### Deprecations
These flags were renamed for consistency across the rewrite commands; the old names still work as hidden aliases that print a stderr warning, so existing invocations keep functioning.
- `mcap filter --output-compression` renamed to `--compression`, matching `sort` and the other rewrite commands (which already used `--compression`); `--compression` wins if both are set. (#1761)
- `mcap sort --output-file` renamed to `--output` (`-o` is unchanged), matching the other rewrite commands — previously only `sort` and `merge` used `--output-file`. `filter`, `compress`, and `decompress` also accept the deprecated `--output-file` as a hidden alias for uniformity. (#1757)
- `mcap merge --output-file` renamed to `--output` (`-o` is unchanged), for the same cross-command consistency. (#1771)

#### Performance
- Bounded memory for piped stdin: rewrite commands now spool non-seekable stdin to a temporary file and memory-map it instead of buffering the whole MCAP in memory. (#1759)
- Standardizing record placement adds an up-front metadata scan on the linear (summaryless or fallback) path, a modest throughput regression (~12–22% in benchmarks); well-formed indexed inputs are unaffected. (#1756)

Reviewed and excluded internal-only refactors with no user-visible effect (`#1760` extract rewrite engine, `#1757`/`#1771` shared-engine ports, and the internal portions of `#1763`), the CI/deps bumps (e.g. `#1777`, `#1770`, `#1769`, `#1766`, `#1744`, `#1740`), and non-CLI Python/docs commits (`#1739`, `#1745`, `#1747`, `#1738`, `#1741`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732efcf8-02a8-4cdd-b7cb-4de51d12fb68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732efcf8-02a8-4cdd-b7cb-4de51d12fb68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

