### PR TITLE
docs: refine website Foxglove attribution

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -167,15 +167,6 @@ const config = {
               },
             ],
           },
-          {
-            title: "Enterprise",
-            items: [
-              {
-                label: "Foxglove",
-                href: "https://foxglove.dev/",
-              },
-            ],
-          },
         ],
         copyright: `Copyright &copy; <a href="https://foxglove.dev" style="color: inherit">Foxglove</a>`,
       },

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -93,6 +93,21 @@
   color: var(--button-color-highlight);
 }
 
+.heroAttribution {
+  margin: 1.5rem auto 0;
+  font-size: 1rem;
+}
+
+.heroAttribution a {
+  color: inherit;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+.heroAttribution a:hover {
+  text-decoration: none;
+}
+
 .section {
   padding: 4rem 0;
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -101,11 +101,11 @@
 .heroAttribution a {
   color: inherit;
   font-weight: bold;
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 .heroAttribution a:hover {
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .section {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -118,6 +118,9 @@ export default function Home(): JSX.Element {
               API Reference
             </Link>
           </div>
+          <p className={styles.heroAttribution}>
+            A <Link href="https://foxglove.dev/home">Foxglove</Link> project
+          </p>
         </div>
       </header>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changelog

Refines how the MCAP website attributes Foxglove:

- Removes the "Enterprise" footer column, which only linked to Foxglove and framed it as an enterprise vendor. Foxglove created and maintains MCAP rather than selling it, so that framing was misleading.
- Adds an "A Foxglove project" line to the homepage masthead, directly under the "Get Started" / "API Reference" buttons, with "Foxglove" linking to https://foxglove.dev/home. The link is not underlined by default and underlines on hover.

## Docs

None.

## Description

- `website/docusaurus.config.js`: deleted the `Enterprise` footer link group.
- `website/src/pages/index.tsx`: added the attribution paragraph below the hero buttons.
- `website/src/pages/index.module.css`: added `.heroAttribution` styling (no underline by default, underline on hover).

Verified locally with the Docusaurus dev server.

Footer now shows only "Docs" and "Community":

[MCAP website footer showing only Docs and Community columns](https://cursor.com/agents/bc-db85c591-1e82-4503-8b7c-b464ecc24e6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter_after_no_enterprise.webp)

Masthead attribution below the action buttons, with "Foxglove" not underlined by default:

[MCAP homepage masthead showing ](https://cursor.com/agents/bc-db85c591-1e82-4503-8b7c-b464ecc24e6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmasthead_foxglove_no_underline.webp)

"Foxglove" link points to https://foxglove.dev/home:

[Hovering the Foxglove link shows https://foxglove.dev/home in the status bar](https://cursor.com/agents/bc-db85c591-1e82-4503-8b7c-b464ecc24e6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmasthead_foxglove_link_hover.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db85c591-1e82-4503-8b7c-b464ecc24e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db85c591-1e82-4503-8b7c-b464ecc24e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

