### PR TITLE
docs: remove Stack Overflow link from website footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -158,10 +158,6 @@ const config = {
                 href: "https://foxglove.dev/chat",
               },
               {
-                label: "Stack Overflow",
-                href: "https://stackoverflow.com/questions/tagged/mcap",
-              },
-              {
                 label: "Robotics Stack Exchange",
                 href: "https://robotics.stackexchange.com/questions/tagged/mcap",
               },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the Stack Overflow link from the website footer's Community section. Stack OVerflow is dead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9ab7510-7039-408e-a2d7-7624e250eb12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9ab7510-7039-408e-a2d7-7624e250eb12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

