### PR TITLE
cpp: McapWriter: Add scatter-gather write(Message/Attachment, ByteSpanArray)

### DIFF
--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -56,6 +56,14 @@ inline uint32_t KeyValueMapSize(const KeyValueMap& map) {
   return (uint32_t)(size);
 }
 
+inline uint64_t ByteSpanArraySize(const ByteSpanArray& payload) {
+  uint64_t size = 0;
+  for (const auto& span : payload) {
+    size += span.size;
+  }
+  return size;
+}
+
 inline const std::string CompressionString(Compression compression) {
   switch (compression) {
     case Compression::None:

--- a/cpp/mcap/include/mcap/types.hpp
+++ b/cpp/mcap/include/mcap/types.hpp
@@ -178,6 +178,16 @@ using SchemaPtr = std::shared_ptr<Schema>;
 using ChannelPtr = std::shared_ptr<Channel>;
 
 /**
+ * @brief A non-owning pointer and size describing a region of memory.
+ */
+struct MCAP_PUBLIC ByteSpan {
+  const std::byte* data;
+  std::size_t size;
+};
+
+using ByteSpanArray = std::vector<ByteSpan>;
+
+/**
  * @brief A single Message published to a Channel.
  */
 struct MCAP_PUBLIC Message {

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -410,6 +410,20 @@ public:
   Status write(const Message& message);
 
   /**
+   * @brief Write a message to the output stream, gathering its payload from a
+   * list of buffers.
+   *
+   * `message.data` and `message.dataSize` are ignored; the payload written is
+   * the concatenation of `payload`, in the given order.
+   *
+   * @param message Message to add. Only the `channelId`, `sequence`,
+   *   `logTime`, and `publishTime` fields are used.
+   * @param payload The message payload, as a list of spans.
+   * @return A non-zero error code on failure.
+   */
+  Status write(const Message& message, const ByteSpanArray& payload);
+
+  /**
    * @brief Write an attachment to the output stream.
    *
    * @param attachment Attachment to add. The `attachment.crc` will be
@@ -456,6 +470,7 @@ public:
   static uint64_t write(IWritable& output, const Channel& channel);
   static uint64_t getRecordSize(const Message& message);
   static uint64_t write(IWritable& output, const Message& message);
+  static uint64_t write(IWritable& output, const Message& message, const ByteSpanArray& payload);
   static uint64_t write(IWritable& output, const Attachment& attachment);
   static uint64_t write(IWritable& output, const Metadata& metadata);
   static uint64_t write(IWritable& output, const Chunk& chunk);

--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -433,6 +433,23 @@ public:
   Status write(Attachment& attachment);
 
   /**
+   * @brief Write an attachment to the output stream, gathering its data from
+   * a list of buffers.
+   *
+   * `attachment.data` is ignored; the data written is the concatenation of
+   * `payload`, in the given order. `attachment.dataSize` is set to the total
+   * size of `payload`.
+   *
+   * @param attachment Attachment to add. Only the `logTime`, `createTime`,
+   *   `name`, and `mediaType` fields are used. The `attachment.dataSize` will
+   *   always be set. The `attachment.crc` will be calculated and set if
+   *   configuration options allow CRC calculation.
+   * @param payload The attachment data, as a list of spans.
+   * @return A non-zero error code on failure.
+   */
+  Status write(Attachment& attachment, const ByteSpanArray& payload);
+
+  /**
    * @brief Write a metadata record to the output stream.
    *
    * @param metadata Named group of key/value string pairs to add.
@@ -472,6 +489,8 @@ public:
   static uint64_t write(IWritable& output, const Message& message);
   static uint64_t write(IWritable& output, const Message& message, const ByteSpanArray& payload);
   static uint64_t write(IWritable& output, const Attachment& attachment);
+  static uint64_t write(IWritable& output, const Attachment& attachment,
+                        const ByteSpanArray& payload);
   static uint64_t write(IWritable& output, const Metadata& metadata);
   static uint64_t write(IWritable& output, const Chunk& chunk);
   static uint64_t write(IWritable& output, const MessageIndex& index);

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -531,7 +531,7 @@ void McapWriter::addChannel(Channel& channel) {
   ++statistics_.channelCount;
 }
 
-Status McapWriter::write(const Message& message) {
+Status McapWriter::write(const Message& message, const ByteSpanArray& payload) {
   if (!output_) {
     return StatusCode::NotOpen;
   }
@@ -570,10 +570,12 @@ Status McapWriter::write(const Message& message) {
   }
 
   // Before writing a message that would overflow the current chunk, close it.
+  static const uint64_t emptyMessageRecordSize = getRecordSize(Message{});
   auto* chunkWriter = getChunkWriter();
   if (chunkWriter != nullptr && /* Chunked? */
       uncompressedSize_ != 0 && /* Current chunk is not empty/new? */
-      9 + getRecordSize(message) + uncompressedSize_ >= chunkSize_ /* Overflowing? */) {
+      9 + emptyMessageRecordSize + internal::ByteSpanArraySize(payload) + uncompressedSize_ >=
+        chunkSize_ /* Overflowing? */) {
     auto& fileOutput = *output_;
     writeChunk(fileOutput, *chunkWriter);
   }
@@ -582,7 +584,7 @@ Status McapWriter::write(const Message& message) {
   const uint64_t messageOffset = uncompressedSize_;
 
   // Write the message
-  uncompressedSize_ += write(output, message);
+  uncompressedSize_ += write(output, message, payload);
 
   // Update message statistics
   if (!options_.noSummary) {
@@ -617,6 +619,10 @@ Status McapWriter::write(const Message& message) {
   }
 
   return StatusCode::Success;
+}
+
+Status McapWriter::write(const Message& message) {
+  return write(message, {ByteSpan{message.data, message.dataSize}});
 }
 
 Status McapWriter::write(Attachment& attachment) {
@@ -913,7 +919,12 @@ uint64_t McapWriter::getRecordSize(const Message& message) {
 }
 
 uint64_t McapWriter::write(IWritable& output, const Message& message) {
-  const uint64_t recordSize = getRecordSize(message);
+  return write(output, message, {ByteSpan{message.data, message.dataSize}});
+}
+
+uint64_t McapWriter::write(IWritable& output, const Message& message, const ByteSpanArray& payload) {
+  static const uint64_t emptyMessageRecordSize = getRecordSize(Message{});
+  const uint64_t recordSize = emptyMessageRecordSize + internal::ByteSpanArraySize(payload);
 
   write(output, OpCode::Message);
   write(output, recordSize);
@@ -921,7 +932,9 @@ uint64_t McapWriter::write(IWritable& output, const Message& message) {
   write(output, message.sequence);
   write(output, message.logTime);
   write(output, message.publishTime);
-  write(output, message.data, message.dataSize);
+  for (const auto& span : payload) {
+    write(output, span.data, span.size);
+  }
 
   return 9 + recordSize;
 }

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -625,7 +625,7 @@ Status McapWriter::write(const Message& message) {
   return write(message, {ByteSpan{message.data, message.dataSize}});
 }
 
-Status McapWriter::write(Attachment& attachment) {
+Status McapWriter::write(Attachment& attachment, const ByteSpanArray& payload) {
   if (!output_) {
     return StatusCode::NotOpen;
   }
@@ -636,6 +636,8 @@ Status McapWriter::write(Attachment& attachment) {
   if (chunkWriter && !chunkWriter->empty()) {
     writeChunk(fileOutput, *chunkWriter);
   }
+
+  attachment.dataSize = internal::ByteSpanArraySize(payload);
 
   if (!options_.noAttachmentCRC) {
     // Calculate the CRC32 of the attachment
@@ -652,15 +654,16 @@ Status McapWriter::write(Attachment& attachment) {
     crc = internal::crc32Update(
       crc, reinterpret_cast<const std::byte*>(attachment.mediaType.data()), sizePrefix);
     crc = internal::crc32Update(crc, reinterpret_cast<const std::byte*>(&attachment.dataSize), 8);
-    crc = internal::crc32Update(crc, reinterpret_cast<const std::byte*>(attachment.data),
-                                attachment.dataSize);
+    for (const auto& span : payload) {
+      crc = internal::crc32Update(crc, span.data, span.size);
+    }
     attachment.crc = internal::crc32Final(crc);
   }
 
   const uint64_t fileOffset = fileOutput.size();
 
   // Write the attachment
-  write(fileOutput, attachment);
+  write(fileOutput, attachment, payload);
 
   // Update statistics and attachment index
   if (!options_.noSummary) {
@@ -671,6 +674,10 @@ Status McapWriter::write(Attachment& attachment) {
   }
 
   return StatusCode::Success;
+}
+
+Status McapWriter::write(Attachment& attachment) {
+  return write(attachment, {ByteSpan{attachment.data, attachment.dataSize}});
 }
 
 Status McapWriter::write(const Metadata& metadata) {
@@ -940,8 +947,14 @@ uint64_t McapWriter::write(IWritable& output, const Message& message, const Byte
 }
 
 uint64_t McapWriter::write(IWritable& output, const Attachment& attachment) {
+  return write(output, attachment, {ByteSpan{attachment.data, attachment.dataSize}});
+}
+
+uint64_t McapWriter::write(IWritable& output, const Attachment& attachment,
+                            const ByteSpanArray& payload) {
+  const uint64_t dataSize = internal::ByteSpanArraySize(payload);
   const uint64_t recordSize = 4 + attachment.name.size() + 8 + 8 + 4 + attachment.mediaType.size() +
-                              8 + attachment.dataSize + 4;
+                              8 + dataSize + 4;
 
   write(output, OpCode::Attachment);
   write(output, recordSize);
@@ -949,8 +962,10 @@ uint64_t McapWriter::write(IWritable& output, const Attachment& attachment) {
   write(output, attachment.createTime);
   write(output, attachment.name);
   write(output, attachment.mediaType);
-  write(output, attachment.dataSize);
-  write(output, attachment.data, attachment.dataSize);
+  write(output, dataSize);
+  for (const auto& span : payload) {
+    write(output, span.data, span.size);
+  }
   write(output, attachment.crc);
 
   return 9 + recordSize;


### PR DESCRIPTION
### Changelog

cpp: McapWriter: Add scatter-gather `write(Message, ByteSpanArray)` and `write(Attachment, ByteSpanArray)` APIs

### Docs

None

### Description

Add `McapWriter::write(const Message&, const ByteSpanArray&)` and `McapWriter::write(Attachment&, const ByteSpanArray&)` overloads that write a message's or attachment's payload from a list of spans instead of a single contiguous buffer, so callers with non-contiguous payload chunks don't need to copy them into one buffer first. The existing `write(const Message&)` and `write(Attachment&)` overloads are unchanged and now implemented as thin wrappers around the new ones.