### PR TITLE
cpp: report file write errors

### DIFF
--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -1,7 +1,9 @@
 #include "crc32.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <iostream>
+#include <system_error>
 #ifndef MCAP_COMPRESSION_NO_LZ4
 #  include <lz4frame.h>
 #  include <lz4hc.h>
@@ -55,9 +57,15 @@ Status FileWriter::open(std::string_view filename) {
 
 void FileWriter::handleWrite(const std::byte* data, uint64_t size) {
   assert(file_);
+  errno = 0;
   const size_t written = std::fwrite(data, 1, size, file_);
-  (void)written;
-  assert(written == size);
+  if (written != size) {
+    const auto error = errno == 0 ? std::make_error_code(std::errc::io_error)
+                                  : std::error_code(errno, std::generic_category());
+    const auto message =
+      internal::StrCat("failed to write ", size, " bytes (", written, " bytes written)");
+    throw std::system_error(error, message);
+  }
   size_ += size;
 }
 

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -101,6 +101,22 @@ TEST_CASE("internal::crc32", "[writer]") {
   }
 }
 
+#if defined(__linux__)
+TEST_CASE("FileWriter reports filesystem write errors", "[writer]") {
+  mcap::FileWriter writer;
+  requireOk(writer.open("/dev/full"));
+
+  // Use a payload larger than the stdio buffer so fwrite reaches the device immediately.
+  const std::vector<std::byte> data(1024 * 1024);
+  try {
+    writer.write(data.data(), data.size());
+    FAIL("Expected writing to /dev/full to fail");
+  } catch (const std::system_error& error) {
+    REQUIRE(error.code() == std::errc::no_space_on_device);
+  }
+}
+#endif
+
 TEST_CASE("internal::Parse*()", "[reader]") {
   SECTION("uint64_t") {
     const std::array<std::byte, 8> input = {std::byte(0xef), std::byte(0xcd), std::byte(0xab),


### PR DESCRIPTION
## Summary
- replace the FileWriter short-write assertion with a std::system_error
- preserve the operating system error code and report requested versus written bytes
- add a Linux regression test using /dev/full

## Why
A short fwrite can happen in production when storage fills or another filesystem error occurs. The previous assertion aborted debug builds and did not surface the failure in release builds. The new exception gives callers a recoverable, platform-appropriate error trail.

## Validation
- full macOS C++ unit suite: 489 assertions passed
- no-compression unit suite: 471 assertions passed
- targeted forced write-failure check with RLIMIT_FSIZE returned the expected system error
- clang-format and git diff checks passed

Closes #721