### PR TITLE
dependabot: reduce github-actions updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

I'm not sure why these were originally set to daily but that seems unnecessary.