### PR TITLE
cpp, go: default LZ4 to fast mode, matching the other writers

### DIFF
--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -165,10 +165,12 @@ int LZ4CompressionLevel(CompressionLevel level) {
     case CompressionLevel::Fastest:
       return -1;  // "fast acceleration"
     case CompressionLevel::Fast:
-      return 0;  // "fast mode"
     case CompressionLevel::Default:
     default:
-      return LZ4HC_CLEVEL_DEFAULT;
+      // Fast mode, matching the default of the other MCAP writer implementations (Go, Rust,
+      // Python). LZ4HC remains available through Slow/Slowest for callers that prefer ratio
+      // over the speed that makes LZ4 worth choosing.
+      return 0;  // "fast mode"
     case CompressionLevel::Slow:
       return LZ4HC_CLEVEL_OPT_MIN;
     case CompressionLevel::Slowest:

--- a/go/mcap/writer.go
+++ b/go/mcap/writer.go
@@ -899,7 +899,10 @@ type WriterOptions struct {
 func encoderLevelFromLZ4(level CompressionLevel) lz4.CompressionLevel {
 	switch level {
 	case CompressionLevelDefault:
-		return lz4.Level3
+		// Fast mode, matching the default of the other MCAP writer implementations (C++,
+		// Rust, Python). The compressing levels remain available through Better/Best for
+		// callers that prefer ratio over the speed that makes LZ4 worth choosing.
+		return lz4.Fast
 	case CompressionLevelFastest:
 		return lz4.Fast
 	case CompressionLevelBetter:
@@ -907,7 +910,7 @@ func encoderLevelFromLZ4(level CompressionLevel) lz4.CompressionLevel {
 	case CompressionLevelBest:
 		return lz4.Level9
 	default:
-		return lz4.Level3
+		return lz4.Fast
 	}
 }
 


### PR DESCRIPTION
### Changelog

The C++ and Go writers' default LZ4 compression was changed from the high-compression codepaths (LZ4HC level 9 and pierrec Level3 respectively) to fast mode, matching the Rust and Python writers. Default LZ4 writes get roughly 3-5x faster and produce files roughly 15-30% larger. Callers that prefer ratio over speed can keep the old behavior through the existing slower CompressionLevel settings.

### Docs

None.

### Description

CompressionLevel::Default diverged for LZ4 across the writers: C++ mapped it to LZ4HC_CLEVEL_DEFAULT (LZ4HC level 9) and Go to pierrec lz4.Level3, while Rust and Python compress in LZ4's fast mode. (TypeScript does not ship an LZ4 writer.) High-compression LZ4 defeats the reason to pick LZ4 in the first place: both writers' own zstd defaults strictly dominate their LZ4 defaults after #1804 — on the same workload C++ zstd wrote in 710 ms producing a 71 MB file while C++ LZ4 took 2130 ms to produce 78 MB, slower and larger. Users choosing LZ4 over zstd are choosing speed.

Map CompressionLevel::Default to fast mode in both writers. On 1M 100-byte messages sharing one payload blob:

- C++: 2.23 s -> 0.46 s (~4.8x faster), 81 MB -> 103 MB
- Go:  2.19 s -> 0.77 s (~2.9x faster), 82 MB -> 93 MB
- Rust, for reference, writes the same workload in 0.67 s at its existing fast-mode default.

The high-compression levels remain reachable: C++ keeps LZ4HC through CompressionLevel::Slow (LZ4HC_CLEVEL_OPT_MIN) and Slowest (LZ4HC_CLEVEL_MAX), and Go keeps lz4.Level6/Level9 through CompressionLevelBetter/Best. Go's fallback for unknown level values also follows the default to fast mode, mirroring how its zstd mapping falls back to its own default.

As with #1804, rosbag2 is unaffected out of the box since it defaults to uncompressed writing.