### PR TITLE
cli: fall back to unsigned S3 reads without credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "object_store",
  "prost-reflect",
  "regex",
+ "reqwest",
  "rusqlite",
  "serde_json",
  "simplelog",

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -73,6 +73,7 @@ words:
   - genpy
   - gentools
   - golangci
+  - IMDS
   - infima
   - inputfile
   - intrinsics
@@ -118,6 +119,7 @@ words:
   - serde
   - sfixed
   - srgb
+  - SSO
   - staticmethod
   - stoull
   - struct

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -115,11 +115,11 @@ words:
   - rustc
   - rustup
   - Saronic
+  - SSO
   - schemaless
   - serde
   - sfixed
   - srgb
-  - SSO
   - staticmethod
   - stoull
   - struct

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -18,7 +18,7 @@ A few modules carry more than their name implies:
 | `cli.rs`     | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                   |
 | `source.rs`  | Input abstraction over local files (memory-mapped) and remote object stores. Owns summary/index range reads, remote materialization, and `--allow-remote-scan` gating. |
 | `parse.rs`   | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                         |
-| `context.rs` | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                               |
+| `context.rs` | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `no_sign_request`, `time_format`) threaded into every handler.                                               |
 | `build.rs`   | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                      |
 
 ## Conventions

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -18,7 +18,7 @@ A few modules carry more than their name implies:
 | `cli.rs`     | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                   |
 | `source.rs`  | Input abstraction over local files (memory-mapped) and remote object stores. Owns summary/index range reads, remote materialization, and `--allow-remote-scan` gating. |
 | `parse.rs`   | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                         |
-| `context.rs` | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `no_sign_request`, `time_format`) threaded into every handler.                                               |
+| `context.rs` | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `no_sign_request`, `time_format`) threaded into every handler.                            |
 | `build.rs`   | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                      |
 
 ## Conventions

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -36,6 +36,8 @@ When adding a command that can complete despite losing data, return `CommandOutc
 
 Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled in `source.rs` via `object_store`. Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would scan or download an entire remote file requires the global `--allow-remote-scan` flag; gate new whole-file remote reads behind `SourceOptions::allow_remote_scan` accordingly.
 
+For S3, requests are signed when credential environment variables are set or the EC2 instance metadata service answers a one-second probe. Otherwise the CLI falls back to an unsigned request (and `--no-sign-request` forces that). Construct new remote sources with `SourceOptions::from_context` so global flags stay wired.
+
 ### Output and logging
 
 Results go to stdout; diagnostics and warnings go to stderr. Use the `render` helpers for tabular output so column alignment and byte/time formatting stay consistent.

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -34,7 +34,7 @@ When adding a command that can complete despite losing data, return `CommandOutc
 
 ### Remote inputs
 
-Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled in `source.rs` via `object_store`. Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would scan or download an entire remote file requires the global `--allow-remote-scan` flag; gate new whole-file remote reads behind `SourceOptions::allow_remote_scan` accordingly.
+Remote inputs (HTTP(S) and object store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled in `source.rs` via `object_store`. Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would scan or download an entire remote file requires the global `--allow-remote-scan` flag; gate new whole-file remote reads behind `SourceOptions::allow_remote_scan` accordingly.
 
 For S3, requests are signed when credential environment variables are set or the EC2 instance metadata service answers a one-second probe. Otherwise the CLI falls back to an unsigned request (and `--no-sign-request` forces that). Construct new remote sources with `SourceOptions::from_context` so global flags stay wired.
 

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -30,6 +30,7 @@ prost-reflect = { version = "0.16.4", features = ["serde"] }
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 tempfile = "3.27.0"
 object_store = { version = "0.13.2", features = ["aws", "gcp", "azure", "http"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
 tokio = { version = "1.52.3", features = ["net", "rt", "time"] }
 url = "2.5.8"
 futures-util = "0.3.32"

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -53,15 +53,15 @@ pub struct Args {
 
     /// Allow whole-file scans or downloads of remote inputs.
     ///
-    /// Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small
+    /// Applies to http(s):// and object store URLs (s3://, s3a://, gs://, az://, abfs://). Small
     /// bounded indexed reads work without this flag.
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 
-    /// Do not sign object-store requests (credentials are not loaded).
+    /// Do not sign requests to S3, GCS, or Azure.
     ///
-    /// Useful for public buckets. Without this flag, S3 reads still fall back to unsigned
-    /// requests when no credentials are available.
+    /// Useful for public buckets. Credentials are not loaded. Without this flag, S3
+    /// reads still fall back to unsigned requests when no credentials are available.
     #[arg(long, default_value_t = false, global = true)]
     pub no_sign_request: bool,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -58,6 +58,13 @@ pub struct Args {
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 
+    /// Do not sign object-store requests (credentials are not loaded).
+    ///
+    /// Useful for public buckets. Without this flag, S3 reads still fall back to unsigned
+    /// requests when no credentials are available.
+    #[arg(long, default_value_t = false, global = true)]
+    pub no_sign_request: bool,
+
     /// How to render timestamps in command output
     #[arg(
         long,

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -28,7 +28,7 @@ const PROTOBUF_SERIALIZE_OPTIONS: SerializeOptions =
 pub fn run(ctx: &CommandContext, args: CatCommand) -> Result<CommandOutcome> {
     args.warn_deprecations();
     let opts = CatOptions::from_args(&args, ctx.time_format())?;
-    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let source_options = source::SourceOptions::from_context(ctx);
     let stdout = std::io::stdout();
     let stdout = stdout.lock();
     // CSV uses csv::Writer's own buffer; text/ndjson wrap stdout in a BufWriter.
@@ -1961,7 +1961,10 @@ mod tests {
                 sink,
                 Path::new(&url),
                 &CatOptions::default(),
-                crate::source::SourceOptions::new(true),
+                crate::source::SourceOptions {
+                    allow_remote_scan: true,
+                    ..crate::source::SourceOptions::default()
+                },
                 &mut CsvState::default(),
             )
         })
@@ -1982,7 +1985,10 @@ mod tests {
                 sink,
                 Path::new(&url),
                 &CatOptions::default(),
-                crate::source::SourceOptions::new(true),
+                crate::source::SourceOptions {
+                    allow_remote_scan: true,
+                    ..crate::source::SourceOptions::default()
+                },
                 &mut CsvState::default(),
             )
         })

--- a/rust/cli/src/commands/compress.rs
+++ b/rust/cli/src/commands/compress.rs
@@ -11,8 +11,5 @@ pub fn run(ctx: &CommandContext, args: CompressCommand) -> Result<()> {
     let options = RewriteOptions::from(&args.common)
         .compression(args.compression.to_compression())
         .order(args.order);
-    rewrite::run(
-        options,
-        crate::source::SourceOptions::new(ctx.allow_remote_scan()),
-    )
+    rewrite::run(options, crate::source::SourceOptions::from_context(ctx))
 }

--- a/rust/cli/src/commands/convert.rs
+++ b/rust/cli/src/commands/convert.rs
@@ -21,7 +21,7 @@ pub fn run(ctx: &CommandContext, args: ConvertCommand) -> Result<()> {
     }
     let materialized_input = crate::source::materialize_input(
         &args.input,
-        crate::source::SourceOptions::new(ctx.allow_remote_scan()),
+        crate::source::SourceOptions::from_context(ctx),
     )?;
     if !is_remote {
         crate::source::ensure_distinct_local_input_output(materialized_input.path(), &args.output)?;

--- a/rust/cli/src/commands/decompress.rs
+++ b/rust/cli/src/commands/decompress.rs
@@ -11,8 +11,5 @@ pub fn run(ctx: &CommandContext, args: DecompressCommand) -> Result<()> {
     let options = RewriteOptions::from(&args.common)
         .compression(None)
         .order(args.order);
-    rewrite::run(
-        options,
-        crate::source::SourceOptions::new(ctx.allow_remote_scan()),
-    )
+    rewrite::run(options, crate::source::SourceOptions::from_context(ctx))
 }

--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -8,10 +8,7 @@ use crate::context::CommandContext;
 use crate::source;
 
 pub fn run(ctx: &CommandContext, args: DoctorCommand) -> Result<()> {
-    let mcap = source::load_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let mcap = source::load_path(&args.file, source::SourceOptions::from_context(ctx))?;
 
     let diagnosis = diagnose_mcap(&mcap, args.strict_message_order);
     for warning in &diagnosis.warnings {

--- a/rust/cli/src/commands/du.rs
+++ b/rust/cli/src/commands/du.rs
@@ -32,10 +32,7 @@ struct OffsetEntry {
 }
 
 pub fn run(ctx: &CommandContext, args: DuCommand) -> Result<()> {
-    let mcap = source::load_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let mcap = source::load_path(&args.file, source::SourceOptions::from_context(ctx))?;
 
     let (usage, used_approximate) = if args.approximate {
         match collect_usage_approximate(&mcap)? {

--- a/rust/cli/src/commands/filter.rs
+++ b/rust/cli/src/commands/filter.rs
@@ -22,6 +22,6 @@ pub fn run(ctx: &CommandContext, args: FilterCommand) -> Result<()> {
     }
     rewrite::run(
         RewriteOptions::from(&args),
-        source::SourceOptions::new(ctx.allow_remote_scan()),
+        source::SourceOptions::from_context(ctx),
     )
 }

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -11,7 +11,7 @@ const PLEASE_REDIRECT: &str =
     "Binary output can screw up your terminal. Supply -o or redirect to a file or pipe";
 
 pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
-    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let source_options = source::SourceOptions::from_context(ctx);
     if let Some(output) = args.output.as_deref() {
         source::ensure_distinct_local_input_output(&args.file, output)?;
     }

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -7,7 +7,7 @@ use crate::context::CommandContext;
 use crate::{parse, source};
 
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
-    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let source_options = source::SourceOptions::from_context(ctx);
     let metadata = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
         merged_remote_metadata_for_name(&remote, &args.name, source_options)?
     } else {

--- a/rust/cli/src/commands/info.rs
+++ b/rust/cli/src/commands/info.rs
@@ -10,7 +10,7 @@ use crate::{parse, render, source};
 pub fn run(ctx: &CommandContext, args: InfoCommand) -> Result<()> {
     let parsed = source::parse_mcap_from_path(
         &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()).scan_data_without_statistics(true),
+        source::SourceOptions::from_context(ctx).scan_data_without_statistics(true),
     )?;
     print!("{}", render_info(&parsed, ctx.time_format()));
     Ok(())

--- a/rust/cli/src/commands/list/attachments.rs
+++ b/rust/cli/src/commands/list/attachments.rs
@@ -5,7 +5,7 @@ use crate::context::CommandContext;
 use crate::{parse, render, source};
 
 pub fn run(ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
-    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let source_options = source::SourceOptions::from_context(ctx);
     let mut indexes =
         if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
             remote.summary().attachment_indexes.clone()

--- a/rust/cli/src/commands/list/channels.rs
+++ b/rust/cli/src/commands/list/channels.rs
@@ -5,10 +5,8 @@ use crate::context::CommandContext;
 use crate::{render, source};
 
 pub fn run(ctx: &CommandContext, args: ListChannelsCommand) -> Result<()> {
-    let parsed = source::parse_mcap_from_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let parsed =
+        source::parse_mcap_from_path(&args.file, source::SourceOptions::from_context(ctx))?;
     render::print_table(&render_channel_rows(&parsed.channels)?);
     Ok(())
 }

--- a/rust/cli/src/commands/list/chunks.rs
+++ b/rust/cli/src/commands/list/chunks.rs
@@ -5,10 +5,8 @@ use crate::context::CommandContext;
 use crate::{render, source};
 
 pub fn run(ctx: &CommandContext, args: ListChunksCommand) -> Result<()> {
-    let parsed = source::parse_mcap_from_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let parsed =
+        source::parse_mcap_from_path(&args.file, source::SourceOptions::from_context(ctx))?;
     render::print_table(&render_chunk_rows(&parsed.chunk_indexes, ctx.time_format()));
     Ok(())
 }

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -5,7 +5,7 @@ use crate::context::CommandContext;
 use crate::{parse, render, source};
 
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
-    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let source_options = source::SourceOptions::from_context(ctx);
     let records = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
         collect_remote_metadata_records(&remote, source_options)?
     } else {

--- a/rust/cli/src/commands/list/schemas.rs
+++ b/rust/cli/src/commands/list/schemas.rs
@@ -4,10 +4,8 @@ use crate::{render, source};
 use anyhow::Result;
 
 pub fn run(ctx: &CommandContext, args: ListSchemasCommand) -> Result<()> {
-    let parsed = source::parse_mcap_from_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let parsed =
+        source::parse_mcap_from_path(&args.file, source::SourceOptions::from_context(ctx))?;
     render::print_table(&render_schema_rows(&parsed.schemas));
     Ok(())
 }

--- a/rust/cli/src/commands/merge.rs
+++ b/rust/cli/src/commands/merge.rs
@@ -15,10 +15,7 @@ pub fn run(ctx: &CommandContext, args: MergeCommand) -> Result<()> {
     if args.output_file.is_some() {
         warn!("--output-file is deprecated; use --output instead");
     }
-    rewrite::run_merge(
-        build_merge_options(args),
-        SourceOptions::new(ctx.allow_remote_scan()),
-    )
+    rewrite::run_merge(build_merge_options(args), SourceOptions::from_context(ctx))
 }
 
 /// Maps the parsed `merge` CLI arguments onto the engine-facing [`MergeOptions`]. The output path

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -119,7 +119,7 @@ impl RecoverStats {
 /// - 2: command-line parsing error (owned by clap)
 /// - 3: successful recovery with warning-level data loss (`CommandOutcome::Warnings`)
 pub fn run(ctx: &CommandContext, args: RecoverCommand) -> Result<CommandOutcome> {
-    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let source_options = source::SourceOptions::from_context(ctx);
     if let (Some(input), Some(output)) = (args.file.as_deref(), args.output.as_deref()) {
         source::ensure_distinct_local_input_output(input, output)?;
     }

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -16,7 +16,7 @@ pub fn run(ctx: &CommandContext, args: SortCommand) -> Result<()> {
     args.common.warn_deprecations();
     rewrite::run(
         RewriteOptions::from(&args),
-        source::SourceOptions::new(ctx.allow_remote_scan()),
+        source::SourceOptions::from_context(ctx),
     )
 }
 

--- a/rust/cli/src/context.rs
+++ b/rust/cli/src/context.rs
@@ -3,14 +3,15 @@ use crate::logsetup::Color;
 
 /// Global CLI execution context shared across command handlers.
 ///
-/// Holds the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into
-/// every handler.
+/// Holds the global options (verbosity, color, `allow_remote_scan`, `no_sign_request`,
+/// `time_format`) threaded into every handler.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CommandContext {
     verbose: u8,
     color: Color,
     allow_remote_scan: bool,
+    no_sign_request: bool,
     time_format: TimeFormat,
 }
 
@@ -20,6 +21,7 @@ impl Default for CommandContext {
             verbose: 0,
             color: Color::Auto,
             allow_remote_scan: false,
+            no_sign_request: false,
             time_format: TimeFormat::Auto,
         }
     }
@@ -31,12 +33,14 @@ impl CommandContext {
         verbose: u8,
         color: Color,
         allow_remote_scan: bool,
+        no_sign_request: bool,
         time_format: TimeFormat,
     ) -> Self {
         Self {
             verbose,
             color,
             allow_remote_scan,
+            no_sign_request,
             time_format,
         }
     }
@@ -51,6 +55,10 @@ impl CommandContext {
 
     pub fn allow_remote_scan(&self) -> bool {
         self.allow_remote_scan
+    }
+
+    pub fn no_sign_request(&self) -> bool {
+        self.no_sign_request
     }
 
     pub fn time_format(&self) -> TimeFormat {

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -21,6 +21,7 @@ fn run() -> Result<CommandOutcome> {
         args.verbose,
         args.color,
         args.allow_remote_scan,
+        args.no_sign_request,
         args.time_format,
     );
 
@@ -265,6 +266,17 @@ mod tests {
         let args = Args::try_parse_from(["mcap", "info", "--allow-remote-scan", "demo.mcap"])
             .expect("allow remote scan should parse after subcommand");
         assert!(args.allow_remote_scan);
+    }
+
+    #[test]
+    fn parses_global_no_sign_request_flag() {
+        let args = Args::try_parse_from(["mcap", "--no-sign-request", "info", "demo.mcap"])
+            .expect("no-sign-request should parse before subcommand");
+        assert!(args.no_sign_request);
+
+        let args = Args::try_parse_from(["mcap", "info", "--no-sign-request", "demo.mcap"])
+            .expect("no-sign-request should parse after subcommand");
+        assert!(args.no_sign_request);
     }
 
     #[test]

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -73,12 +73,14 @@ impl InputData {
 pub struct SourceOptions {
     pub allow_remote_scan: bool,
     pub scan_data_without_statistics: bool,
+    pub no_sign_request: bool,
 }
 
 impl SourceOptions {
-    pub fn new(allow_remote_scan: bool) -> Self {
+    pub fn from_context(ctx: &crate::context::CommandContext) -> Self {
         Self {
-            allow_remote_scan,
+            allow_remote_scan: ctx.allow_remote_scan(),
+            no_sign_request: ctx.no_sign_request(),
             ..Self::default()
         }
     }
@@ -237,7 +239,7 @@ pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
 
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
     if is_remote_url(path) {
-        match open_remote_range_reader(path)? {
+        match open_remote_range_reader(path, options)? {
             Some(mut reader) => {
                 if let Some(summary_bytes) = read_summary_bytes_from_remote(&mut reader, options)
                     .map_err(|err| remote_read_error(path, err))?
@@ -378,7 +380,7 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
     let mut temp_file = builder
         .tempfile()
         .context("failed to create temporary remote input file")?;
-    read_remote_input_to_writer(path, temp_file.as_file_mut())?;
+    read_remote_input_to_writer(path, temp_file.as_file_mut(), options)?;
     std::io::Write::flush(temp_file.as_file_mut())
         .context("failed to flush temporary remote input file")?;
     Ok(MaterializedInput {
@@ -391,7 +393,7 @@ pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Optio
     if !is_remote_url(path) {
         return Ok(None);
     }
-    let Some(mut reader) = open_remote_range_reader(path)? else {
+    let Some(mut reader) = open_remote_range_reader(path, options)? else {
         if !options.allow_remote_scan {
             bail!(
                 "{}: remote server does not support range requests; {}",
@@ -493,15 +495,24 @@ impl RemoteUrl {
         })
     }
 
-    fn options(&self) -> Vec<(String, String)> {
-        self.options_from_env_vars(std::env::vars_os())
+    fn is_s3(&self) -> bool {
+        matches!(
+            self.url.scheme().to_ascii_lowercase().as_str(),
+            "s3" | "s3a"
+        )
+    }
+
+    fn options(&self, source_options: SourceOptions) -> (Vec<(String, String)>, bool) {
+        self.options_from_env_vars(std::env::vars_os(), source_options, aws_imds_available)
     }
 
     fn options_from_env_vars(
         &self,
         vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
-    ) -> Vec<(String, String)> {
-        match self.kind {
+        source_options: SourceOptions,
+        imds_available: impl FnOnce() -> bool,
+    ) -> (Vec<(String, String)>, bool) {
+        let mut options = match self.kind {
             RemoteUrlKind::Http if self.url.scheme() == "http" => {
                 vec![("allow_http".to_string(), "true".to_string())]
             }
@@ -509,7 +520,19 @@ impl RemoteUrl {
             RemoteUrlKind::CloudSuffix | RemoteUrlKind::CloudNoSuffix => {
                 object_store_options_from_env_vars(vars)
             }
+        };
+
+        let unsigned = should_skip_signature(
+            &options,
+            self.is_s3(),
+            source_options.no_sign_request,
+            imds_available,
+        );
+        if unsigned && !options_request_skip_signature(&options) {
+            // object_store accepts the unprefixed alias for S3, GCS, and Azure.
+            options.push(("skip_signature".to_string(), "true".to_string()));
         }
+        (options, unsigned)
     }
 
     fn extension(&self) -> Option<String> {
@@ -534,35 +557,36 @@ struct ObjectStoreSource {
     store: Arc<dyn ObjectStore>,
     path: ObjectStorePath,
     display_url: String,
+    unsigned: bool,
 }
 
 impl ObjectStoreSource {
-    fn open(path: &Path) -> Result<Self> {
-        Self::open_remote(RemoteUrl::parse(path)?)
+    fn open(path: &Path, options: SourceOptions) -> Result<Self> {
+        Self::open_remote(RemoteUrl::parse(path)?, options)
     }
 
-    fn open_remote(remote_url: RemoteUrl) -> Result<Self> {
-        let (store, object_path) =
-            object_store::parse_url_opts(&remote_url.url, remote_url.options()).with_context(
-                || {
-                    format!(
-                        "failed to configure remote store for {}",
-                        remote_url.display_url
-                    )
-                },
-            )?;
+    fn open_remote(remote_url: RemoteUrl, options: SourceOptions) -> Result<Self> {
+        let (store_options, unsigned) = remote_url.options(options);
+        let (store, object_path) = object_store::parse_url_opts(&remote_url.url, store_options)
+            .with_context(|| {
+                format!(
+                    "failed to configure remote store for {}",
+                    remote_url.display_url
+                )
+            })?;
         Ok(Self {
             runtime: object_store_runtime()?,
             store: Arc::from(store),
             path: object_path,
             display_url: remote_url.display_url,
+            unsigned,
         })
     }
 
     fn stat(&self) -> Result<object_store::ObjectMeta> {
         self.runtime
             .block_on(self.store.head(&self.path))
-            .map_err(|err| concise_remote_stat_error(&self.display_url, err))
+            .map_err(|err| concise_remote_stat_error(&self.display_url, self.unsigned, err))
     }
 
     fn head_size(&self) -> Result<u64> {
@@ -582,7 +606,12 @@ impl ObjectStoreSource {
                 },
             ))
             .map_err(|err| {
-                concise_remote_operation_error("fetching range from", &self.display_url, err)
+                concise_remote_operation_error(
+                    "fetching range from",
+                    &self.display_url,
+                    self.unsigned,
+                    err,
+                )
             })?;
         validate_identity_content_encoding(&response.attributes, &self.display_url)?;
         let bytes = self
@@ -615,6 +644,7 @@ impl ObjectStoreSource {
             Err(err) => Err(concise_remote_operation_error(
                 "fetching range from",
                 &self.display_url,
+                self.unsigned,
                 err,
             )),
         }
@@ -682,6 +712,7 @@ impl ObjectStoreSource {
                     return Err(concise_remote_operation_error(
                         "fetching range from",
                         &self.display_url,
+                        self.unsigned,
                         err,
                     ));
                 }
@@ -714,10 +745,10 @@ pub struct RemoteRangeReader {
 }
 
 impl RemoteRangeReader {
-    fn open(path: &Path) -> Result<Option<Self>> {
+    fn open(path: &Path, options: SourceOptions) -> Result<Option<Self>> {
         let remote_url = RemoteUrl::parse(path)?;
         let kind = remote_url.kind;
-        let source = ObjectStoreSource::open_remote(remote_url)?;
+        let source = ObjectStoreSource::open_remote(remote_url, options)?;
         let Some((size, tail)) = source.read_summary_tail(kind, REMOTE_SUMMARY_TAIL_BYTES)? else {
             return Ok(None);
         };
@@ -738,6 +769,7 @@ impl RemoteRangeReader {
                 store,
                 path,
                 display_url: "memory:///test".to_string(),
+                unsigned: false,
             },
             kind: RemoteUrlKind::CloudSuffix,
             size,
@@ -766,6 +798,7 @@ impl RemoteRangeReader {
                 store,
                 path,
                 display_url: "memory:///test".to_string(),
+                unsigned: false,
             },
             kind: RemoteUrlKind::CloudSuffix,
             size,
@@ -831,14 +864,136 @@ const OBJECT_STORE_ENV_PREFIXES: [&str; 3] = ["AWS_", "GOOGLE_", "AZURE_"];
 fn object_store_options_from_env_vars(
     vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
 ) -> Vec<(String, String)> {
-    vars.into_iter()
+    let mut options: Vec<(String, String)> = vars
+        .into_iter()
         .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
         .filter(|(key, _)| {
             OBJECT_STORE_ENV_PREFIXES
                 .iter()
                 .any(|prefix| key.starts_with(prefix))
         })
-        .collect()
+        .collect();
+
+    // object_store recognizes AWS_METADATA_ENDPOINT, not the AWS SDK name
+    // AWS_EC2_METADATA_SERVICE_ENDPOINT. Mirror the latter onto the former so the
+    // IMDS probe and credential fetch agree on the endpoint.
+    let has_metadata_endpoint = env_option(&options, &["AWS_METADATA_ENDPOINT"]).is_some();
+    if !has_metadata_endpoint {
+        if let Some(endpoint) = env_option(&options, &["AWS_EC2_METADATA_SERVICE_ENDPOINT"]) {
+            options.push(("AWS_METADATA_ENDPOINT".to_string(), endpoint.to_string()));
+        }
+    }
+
+    options
+}
+
+fn env_option<'a>(options: &'a [(String, String)], names: &[&str]) -> Option<&'a str> {
+    options.iter().find_map(|(key, value)| {
+        names
+            .iter()
+            .any(|name| key.eq_ignore_ascii_case(name))
+            .then_some(value.as_str())
+    })
+}
+
+fn is_env_truthy(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "1" | "true" | "t" | "yes" | "y" | "on"
+    )
+}
+
+fn options_request_skip_signature(options: &[(String, String)]) -> bool {
+    env_option(
+        options,
+        &[
+            "skip_signature",
+            "aws_skip_signature",
+            "google_skip_signature",
+            "azure_skip_signature",
+        ],
+    )
+    .is_some_and(is_env_truthy)
+}
+
+// Mirrors the credential branches AmazonS3Builder::build takes before its IMDS
+// fallback, so auto-unsigned only kicks in when object_store would otherwise
+// probe the instance metadata service.
+fn aws_env_credentials_present(options: &[(String, String)]) -> bool {
+    let has = |name: &str| env_option(options, &[name]).is_some();
+    if has("AWS_ACCESS_KEY_ID") || has("AWS_SECRET_ACCESS_KEY") {
+        return true;
+    }
+    if has("AWS_WEB_IDENTITY_TOKEN_FILE") && has("AWS_ROLE_ARN") {
+        return true;
+    }
+    if has("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
+        return true;
+    }
+    has("AWS_CONTAINER_CREDENTIALS_FULL_URI") && has("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
+}
+
+fn should_skip_signature(
+    options: &[(String, String)],
+    is_s3: bool,
+    no_sign_request: bool,
+    imds_available: impl FnOnce() -> bool,
+) -> bool {
+    if options_request_skip_signature(options) || no_sign_request {
+        return true;
+    }
+    // Auto-unsigned is S3-only: GCS and Azure have their own credential fallbacks.
+    is_s3 && !aws_env_credentials_present(options) && !imds_available()
+}
+
+fn aws_ec2_metadata_disabled() -> bool {
+    // AWS SDKs treat only the string "true" (case-insensitive) as disabled.
+    std::env::var("AWS_EC2_METADATA_DISABLED")
+        .ok()
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+}
+
+fn aws_imds_endpoint() -> String {
+    std::env::var("AWS_EC2_METADATA_SERVICE_ENDPOINT")
+        .or_else(|_| std::env::var("AWS_METADATA_ENDPOINT"))
+        .unwrap_or_else(|_| "http://169.254.169.254".to_string())
+}
+
+// One attempt, one-second timeout — matching AWS SDK defaults for
+// metadata_service_timeout / metadata_service_num_attempts. Cached so a process
+// that opens several S3 URLs does not repeat the probe.
+fn aws_imds_available() -> bool {
+    static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        if aws_ec2_metadata_disabled() {
+            return false;
+        }
+        probe_aws_imds_at(&aws_imds_endpoint())
+    })
+}
+
+fn probe_aws_imds_at(endpoint: &str) -> bool {
+    let endpoint = endpoint.trim_end_matches('/');
+    let token_url = format!("{endpoint}/latest/api/token");
+    let Ok(runtime) = object_store_runtime() else {
+        return false;
+    };
+    runtime.block_on(async {
+        let Ok(client) = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(1))
+            .connect_timeout(std::time::Duration::from_secs(1))
+            .build()
+        else {
+            return false;
+        };
+        client
+            .put(token_url)
+            .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
+            .send()
+            .await
+            .map(|response| response.status().is_success())
+            .unwrap_or(false)
+    })
 }
 
 // object_store maps a `200 OK` response to a ranged request onto `NotSupported`,
@@ -848,9 +1003,13 @@ fn remote_range_not_supported(err: &object_store::Error) -> bool {
     matches!(err, object_store::Error::NotSupported { .. })
 }
 
-fn concise_remote_stat_error(display_url: &str, err: object_store::Error) -> anyhow::Error {
+fn concise_remote_stat_error(
+    display_url: &str,
+    unsigned: bool,
+    err: object_store::Error,
+) -> anyhow::Error {
     if let Some(status) = object_store_error_status(&err) {
-        return remote_status_read_error(display_url, &status);
+        return remote_status_read_error(display_url, &status, unsigned);
     }
     anyhow::anyhow!("failed to read {display_url}\nFailed to stat remote input: {err}")
 }
@@ -858,16 +1017,26 @@ fn concise_remote_stat_error(display_url: &str, err: object_store::Error) -> any
 fn concise_remote_operation_error(
     operation: &str,
     display_url: &str,
+    unsigned: bool,
     err: object_store::Error,
 ) -> anyhow::Error {
     if let Some(status) = object_store_error_status(&err) {
-        return remote_status_read_error(display_url, &status);
+        return remote_status_read_error(display_url, &status, unsigned);
     }
     anyhow::anyhow!("failed to read {display_url}\nFailed while {operation}: {err}")
 }
 
-fn remote_status_read_error(display_url: &str, status: &str) -> anyhow::Error {
-    anyhow::anyhow!("failed to read {display_url}\nRemote server returned {status}")
+fn remote_status_read_error(display_url: &str, status: &str, unsigned: bool) -> anyhow::Error {
+    let mut message = format!("failed to read {display_url}\nRemote server returned {status}");
+    if unsigned && status.starts_with("403") {
+        let scheme = display_url.split_once("://").map(|(scheme, _)| scheme);
+        if matches!(scheme, Some("s3" | "s3a")) {
+            message.push_str(
+                "\nNo AWS credentials were found. The CLI reads credentials from environment variables only (not ~/.aws/credentials or SSO profiles). If this bucket is private, export credentials (for example via `aws configure export-credentials`); if it is public, check AWS_REGION.",
+            );
+        }
+    }
+    anyhow::anyhow!("{message}")
 }
 
 fn remote_read_error(path: &Path, err: anyhow::Error) -> anyhow::Error {
@@ -922,9 +1091,12 @@ fn status_from_object_store_message(message: &str) -> Option<String> {
     (!status.is_empty()).then(|| status.to_string())
 }
 
-fn open_remote_range_reader(path: &Path) -> Result<Option<RemoteRangeReader>> {
+fn open_remote_range_reader(
+    path: &Path,
+    options: SourceOptions,
+) -> Result<Option<RemoteRangeReader>> {
     if is_remote_url(path) {
-        return RemoteRangeReader::open(path);
+        return RemoteRangeReader::open(path, options);
     }
     Ok(None)
 }
@@ -935,13 +1107,22 @@ pub(crate) fn redacted_display(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-fn read_remote_input_to_writer(path: &Path, writer: &mut impl std::io::Write) -> Result<()> {
-    let source = ObjectStoreSource::open(path)?;
+fn read_remote_input_to_writer(
+    path: &Path,
+    writer: &mut impl std::io::Write,
+    options: SourceOptions,
+) -> Result<()> {
+    let source = ObjectStoreSource::open(path, options)?;
     eprintln!("Warning: reading entire remote file {}", source.display_url);
 
     source.runtime.block_on(async {
         let response = source.store.get(&source.path).await.map_err(|err| {
-            concise_remote_operation_error("reading remote input from", &source.display_url, err)
+            concise_remote_operation_error(
+                "reading remote input from",
+                &source.display_url,
+                source.unsigned,
+                err,
+            )
         })?;
         validate_identity_content_encoding(&response.attributes, &source.display_url)?;
         let mut stream = response.into_stream();
@@ -1648,16 +1829,28 @@ mod tests {
     #[test]
     fn remote_http_input_reads_entire_file() {
         let url = serve_http(b"hello remote", true);
-        let input =
-            load_path(Path::new(&url), super::SourceOptions::new(true)).expect("remote read");
+        let input = load_path(
+            Path::new(&url),
+            super::SourceOptions {
+                allow_remote_scan: true,
+                ..super::SourceOptions::default()
+            },
+        )
+        .expect("remote read");
         assert_eq!(input.as_slice(), b"hello remote");
     }
 
     #[test]
     fn remote_http_input_rejects_gzip_content_encoding() {
         let url = serve_http_with_headers(b"hello remote", false, &[("Content-Encoding", "gzip")]);
-        let err = load_path(Path::new(&url), super::SourceOptions::new(true))
-            .expect_err("gzip-encoded remote read should fail");
+        let err = load_path(
+            Path::new(&url),
+            super::SourceOptions {
+                allow_remote_scan: true,
+                ..super::SourceOptions::default()
+            },
+        )
+        .expect_err("gzip-encoded remote read should fail");
         let message = format!("{err:#}");
         assert!(message.contains("MCAP remote reads require identity encoding"));
     }
@@ -1917,9 +2110,10 @@ mod tests {
     #[test]
     fn http_range_reader_uses_object_store_and_allows_seek_past_end() {
         let url = serve_http(b"hello remote", true);
-        let mut reader = super::RemoteRangeReader::open(Path::new(&url))
-            .expect("HTTP range reader should open through object_store")
-            .expect("HTTP range reader should support ranges");
+        let mut reader =
+            super::RemoteRangeReader::open(Path::new(&url), super::SourceOptions::default())
+                .expect("HTTP range reader should open through object_store")
+                .expect("HTTP range reader should support ranges");
 
         assert_eq!(reader.read_range(0, 5).expect("range"), b"hello");
         assert_eq!(
@@ -1958,9 +2152,11 @@ mod tests {
 
     #[test]
     fn object_store_source_open_uses_url_parser() {
-        let source =
-            super::ObjectStoreSource::open(Path::new("https://example.com/demo.mcap?token=secret"))
-                .expect("HTTP object store URL should parse");
+        let source = super::ObjectStoreSource::open(
+            Path::new("https://example.com/demo.mcap?token=secret"),
+            super::SourceOptions::default(),
+        )
+        .expect("HTTP object store URL should parse");
         assert_eq!(source.path.as_ref(), "demo.mcap");
         assert_eq!(source.display_url, "https://example.com/demo.mcap");
     }
@@ -1979,18 +2175,25 @@ mod tests {
         ];
         let http =
             super::RemoteUrl::parse(Path::new("http://example.com/demo.mcap")).expect("http URL");
+        let (http_options, http_unsigned) =
+            http.options_from_env_vars(vars.clone(), super::SourceOptions::default(), || false);
         assert_eq!(
-            http.options_from_env_vars(vars.clone()),
+            http_options,
             vec![("allow_http".to_string(), "true".to_string())]
         );
+        assert!(!http_unsigned);
 
         let https =
             super::RemoteUrl::parse(Path::new("https://example.com/demo.mcap")).expect("https URL");
-        assert!(https.options_from_env_vars(vars.clone()).is_empty());
+        let (https_options, _) =
+            https.options_from_env_vars(vars.clone(), super::SourceOptions::default(), || false);
+        assert!(https_options.is_empty());
 
         let s3 = super::RemoteUrl::parse(Path::new("s3://bucket/demo.mcap")).expect("s3 URL");
+        let (s3_options, s3_unsigned) =
+            s3.options_from_env_vars(vars, super::SourceOptions::default(), || false);
         assert_eq!(
-            s3.options_from_env_vars(vars),
+            s3_options,
             vec![
                 ("AWS_ACCESS_KEY_ID".to_string(), "akid".to_string()),
                 ("GOOGLE_BUCKET".to_string(), "bucket".to_string()),
@@ -1999,6 +2202,153 @@ mod tests {
                     "account".to_string()
                 ),
             ]
+        );
+        assert!(!s3_unsigned);
+    }
+
+    #[test]
+    fn s3_skips_signature_when_no_credentials_and_imds_unavailable() {
+        use std::ffi::OsString;
+
+        let s3 = super::RemoteUrl::parse(Path::new("s3://bucket/demo.mcap")).expect("s3 URL");
+        let (options, unsigned) = s3.options_from_env_vars(
+            None::<(OsString, OsString)>,
+            super::SourceOptions::default(),
+            || false,
+        );
+        assert!(unsigned);
+        assert!(options
+            .iter()
+            .any(|(key, value)| { key.eq_ignore_ascii_case("skip_signature") && value == "true" }));
+    }
+
+    #[test]
+    fn s3_keeps_signature_when_imds_available() {
+        use std::ffi::OsString;
+
+        let s3 = super::RemoteUrl::parse(Path::new("s3://bucket/demo.mcap")).expect("s3 URL");
+        let (options, unsigned) = s3.options_from_env_vars(
+            None::<(OsString, OsString)>,
+            super::SourceOptions::default(),
+            || true,
+        );
+        assert!(!unsigned);
+        assert!(!options
+            .iter()
+            .any(|(key, _)| key.eq_ignore_ascii_case("skip_signature")));
+    }
+
+    #[test]
+    fn s3_keeps_signature_when_env_credentials_present() {
+        use std::ffi::OsString;
+
+        let s3 = super::RemoteUrl::parse(Path::new("s3://bucket/demo.mcap")).expect("s3 URL");
+        let (options, unsigned) = s3.options_from_env_vars(
+            [
+                (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
+                (
+                    OsString::from("AWS_SECRET_ACCESS_KEY"),
+                    OsString::from("secret"),
+                ),
+            ],
+            super::SourceOptions::default(),
+            || false,
+        );
+        assert!(!unsigned);
+        assert!(!options
+            .iter()
+            .any(|(key, _)| key.eq_ignore_ascii_case("skip_signature")));
+    }
+
+    #[test]
+    fn no_sign_request_forces_unsigned_even_with_credentials() {
+        use std::ffi::OsString;
+
+        let s3 = super::RemoteUrl::parse(Path::new("s3://bucket/demo.mcap")).expect("s3 URL");
+        let source_options = super::SourceOptions {
+            no_sign_request: true,
+            ..super::SourceOptions::default()
+        };
+        let (options, unsigned) = s3.options_from_env_vars(
+            [
+                (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
+                (
+                    OsString::from("AWS_SECRET_ACCESS_KEY"),
+                    OsString::from("secret"),
+                ),
+            ],
+            source_options,
+            || true,
+        );
+        assert!(unsigned);
+        assert!(options
+            .iter()
+            .any(|(key, value)| { key.eq_ignore_ascii_case("skip_signature") && value == "true" }));
+    }
+
+    #[test]
+    fn gs_does_not_auto_skip_signature_without_credentials() {
+        use std::ffi::OsString;
+
+        let gs = super::RemoteUrl::parse(Path::new("gs://bucket/demo.mcap")).expect("gs URL");
+        let (options, unsigned) = gs.options_from_env_vars(
+            None::<(OsString, OsString)>,
+            super::SourceOptions::default(),
+            || false,
+        );
+        assert!(!unsigned);
+        assert!(!options
+            .iter()
+            .any(|(key, _)| key.eq_ignore_ascii_case("skip_signature")));
+    }
+
+    #[test]
+    fn aws_skip_signature_env_is_left_alone() {
+        use std::ffi::OsString;
+
+        let s3 = super::RemoteUrl::parse(Path::new("s3://bucket/demo.mcap")).expect("s3 URL");
+        let (options, unsigned) = s3.options_from_env_vars(
+            [(OsString::from("AWS_SKIP_SIGNATURE"), OsString::from("true"))],
+            super::SourceOptions::default(),
+            || true,
+        );
+        assert!(unsigned);
+        assert_eq!(
+            options
+                .iter()
+                .filter(|(key, _)| key.eq_ignore_ascii_case("skip_signature")
+                    || key.eq_ignore_ascii_case("aws_skip_signature"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn imds_probe_succeeds_against_token_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut request = [0u8; 1024];
+                let _ = stream.read(&mut request);
+                let _ = stream.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\ntokentok",
+                );
+            }
+        });
+        assert!(super::probe_aws_imds_at(&format!("http://{addr}")));
+    }
+
+    #[test]
+    fn imds_probe_fails_fast_against_closed_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        drop(listener);
+        let started = std::time::Instant::now();
+        assert!(!super::probe_aws_imds_at(&format!("http://{addr}")));
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(3),
+            "IMDS probe should fail within the one-second timeout budget"
         );
     }
 
@@ -2056,6 +2406,40 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn object_store_env_options_mirror_sdk_imds_endpoint() {
+        use std::ffi::OsString;
+
+        let options = super::object_store_options_from_env_vars([(
+            OsString::from("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+            OsString::from("http://127.0.0.1:9"),
+        )]);
+        assert!(options.iter().any(|(key, value)| {
+            key == "AWS_METADATA_ENDPOINT" && value == "http://127.0.0.1:9"
+        }));
+
+        let options = super::object_store_options_from_env_vars([
+            (
+                OsString::from("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+                OsString::from("http://127.0.0.1:9"),
+            ),
+            (
+                OsString::from("AWS_METADATA_ENDPOINT"),
+                OsString::from("http://127.0.0.1:8"),
+            ),
+        ]);
+        assert_eq!(
+            options
+                .iter()
+                .filter(|(key, _)| key == "AWS_METADATA_ENDPOINT")
+                .count(),
+            1
+        );
+        assert!(options.iter().any(|(key, value)| {
+            key == "AWS_METADATA_ENDPOINT" && value == "http://127.0.0.1:8"
+        }));
     }
 
     #[test]
@@ -2172,8 +2556,14 @@ mod tests {
         let (buffer, channel_id) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let url = serve_http(body, false);
-        let parsed = super::parse_mcap_from_path(Path::new(&url), super::SourceOptions::new(true))
-            .expect("non-range HTTP input should materialize with scan opt-in");
+        let parsed = super::parse_mcap_from_path(
+            Path::new(&url),
+            super::SourceOptions {
+                allow_remote_scan: true,
+                ..super::SourceOptions::default()
+            },
+        )
+        .expect("non-range HTTP input should materialize with scan opt-in");
 
         assert!(parsed.channels.contains_key(&channel_id));
     }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -917,8 +917,9 @@ fn options_request_skip_signature(options: &[(String, String)]) -> bool {
 }
 
 // Mirrors the credential branches AmazonS3Builder::build takes before its IMDS
-// fallback, so auto-unsigned only kicks in when object_store would otherwise
-// probe the instance metadata service.
+// fallback (object_store 0.13.2), so auto-unsigned only kicks in when
+// object_store would otherwise probe the instance metadata service. Re-check
+// this list when bumping object_store.
 fn aws_env_credentials_present(options: &[(String, String)]) -> bool {
     let has = |name: &str| env_option(options, &[name]).is_some();
     if has("AWS_ACCESS_KEY_ID") || has("AWS_SECRET_ACCESS_KEY") {
@@ -1032,7 +1033,7 @@ fn remote_status_read_error(display_url: &str, status: &str, unsigned: bool) -> 
         let scheme = display_url.split_once("://").map(|(scheme, _)| scheme);
         if matches!(scheme, Some("s3" | "s3a")) {
             message.push_str(
-                "\nNo AWS credentials were found. The CLI reads credentials from environment variables only (not ~/.aws/credentials or SSO profiles). If this bucket is private, export credentials (for example via `aws configure export-credentials`); if it is public, check AWS_REGION.",
+                "\nThe request was sent unsigned. The CLI reads AWS credentials from environment variables only (not ~/.aws/credentials or SSO profiles). If this bucket is private, export credentials (for example via `aws configure export-credentials`); if it is public, check AWS_REGION.",
             );
         }
     }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -72,8 +72,8 @@ impl InputData {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SourceOptions {
     pub allow_remote_scan: bool,
-    pub scan_data_without_statistics: bool,
     pub no_sign_request: bool,
+    pub scan_data_without_statistics: bool,
 }
 
 impl SourceOptions {
@@ -861,6 +861,22 @@ impl std::io::Seek for RemoteRangeReader {
 // object_store builders themselves read in their `from_env` constructors.
 const OBJECT_STORE_ENV_PREFIXES: [&str; 3] = ["AWS_", "GOOGLE_", "AZURE_"];
 
+fn env_option<'a>(options: &'a [(String, String)], names: &[&str]) -> Option<&'a str> {
+    options.iter().find_map(|(key, value)| {
+        names
+            .iter()
+            .any(|name| key.eq_ignore_ascii_case(name))
+            .then_some(value.as_str())
+    })
+}
+
+fn is_env_truthy(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "1" | "true" | "t" | "yes" | "y" | "on"
+    )
+}
+
 fn object_store_options_from_env_vars(
     vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
 ) -> Vec<(String, String)> {
@@ -885,22 +901,6 @@ fn object_store_options_from_env_vars(
     }
 
     options
-}
-
-fn env_option<'a>(options: &'a [(String, String)], names: &[&str]) -> Option<&'a str> {
-    options.iter().find_map(|(key, value)| {
-        names
-            .iter()
-            .any(|name| key.eq_ignore_ascii_case(name))
-            .then_some(value.as_str())
-    })
-}
-
-fn is_env_truthy(value: &str) -> bool {
-    matches!(
-        value.to_ascii_lowercase().as_str(),
-        "1" | "true" | "t" | "yes" | "y" | "on"
-    )
 }
 
 fn options_request_skip_signature(options: &[(String, String)]) -> bool {
@@ -934,19 +934,6 @@ fn aws_env_credentials_present(options: &[(String, String)]) -> bool {
     has("AWS_CONTAINER_CREDENTIALS_FULL_URI") && has("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
 }
 
-fn should_skip_signature(
-    options: &[(String, String)],
-    is_s3: bool,
-    no_sign_request: bool,
-    imds_available: impl FnOnce() -> bool,
-) -> bool {
-    if options_request_skip_signature(options) || no_sign_request {
-        return true;
-    }
-    // Auto-unsigned is S3-only: GCS and Azure have their own credential fallbacks.
-    is_s3 && !aws_env_credentials_present(options) && !imds_available()
-}
-
 fn aws_ec2_metadata_disabled() -> bool {
     // AWS SDKs treat only the string "true" (case-insensitive) as disabled.
     std::env::var("AWS_EC2_METADATA_DISABLED")
@@ -958,19 +945,6 @@ fn aws_imds_endpoint() -> String {
     std::env::var("AWS_EC2_METADATA_SERVICE_ENDPOINT")
         .or_else(|_| std::env::var("AWS_METADATA_ENDPOINT"))
         .unwrap_or_else(|_| "http://169.254.169.254".to_string())
-}
-
-// One attempt, one-second timeout — matching AWS SDK defaults for
-// metadata_service_timeout / metadata_service_num_attempts. Cached so a process
-// that opens several S3 URLs does not repeat the probe.
-fn aws_imds_available() -> bool {
-    static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *AVAILABLE.get_or_init(|| {
-        if aws_ec2_metadata_disabled() {
-            return false;
-        }
-        probe_aws_imds_at(&aws_imds_endpoint())
-    })
 }
 
 fn probe_aws_imds_at(endpoint: &str) -> bool {
@@ -995,6 +969,32 @@ fn probe_aws_imds_at(endpoint: &str) -> bool {
             .map(|response| response.status().is_success())
             .unwrap_or(false)
     })
+}
+
+// One attempt, one-second timeout — matching AWS SDK defaults for
+// metadata_service_timeout / metadata_service_num_attempts. Cached so a process
+// that opens several S3 URLs does not repeat the probe.
+fn aws_imds_available() -> bool {
+    static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        if aws_ec2_metadata_disabled() {
+            return false;
+        }
+        probe_aws_imds_at(&aws_imds_endpoint())
+    })
+}
+
+fn should_skip_signature(
+    options: &[(String, String)],
+    is_s3: bool,
+    no_sign_request: bool,
+    imds_available: impl FnOnce() -> bool,
+) -> bool {
+    if options_request_skip_signature(options) || no_sign_request {
+        return true;
+    }
+    // Auto-unsigned is S3-only: GCS and Azure have their own credential fallbacks.
+    is_s3 && !aws_env_credentials_present(options) && !imds_available()
 }
 
 // object_store maps a `200 OK` response to a ranged request onto `NotSupported`,
@@ -2162,6 +2162,96 @@ mod tests {
         assert_eq!(source.display_url, "https://example.com/demo.mcap");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn object_store_env_options_ignore_non_utf8_values() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let options = super::object_store_options_from_env_vars([
+            (OsString::from("AWS_REGION"), OsString::from("us-east-1")),
+            (
+                OsString::from_vec(vec![0xFF, b'B', b'A', b'D']),
+                OsString::from("ignored-key"),
+            ),
+            (
+                OsString::from("IGNORED_VALUE"),
+                OsString::from_vec(vec![0xFF, b'v']),
+            ),
+        ]);
+        assert_eq!(
+            options,
+            vec![("AWS_REGION".to_string(), "us-east-1".to_string())]
+        );
+    }
+
+    #[test]
+    fn object_store_env_options_only_forward_recognized_prefixes() {
+        use std::ffi::OsString;
+
+        let options = super::object_store_options_from_env_vars([
+            (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
+            (OsString::from("GOOGLE_BUCKET"), OsString::from("bucket")),
+            (
+                OsString::from("AZURE_STORAGE_ACCOUNT_NAME"),
+                OsString::from("account"),
+            ),
+            // Unprefixed aliases like `endpoint`/`region`/`token` would otherwise
+            // be applied by object_store; they must not be forwarded.
+            (
+                OsString::from("ENDPOINT"),
+                OsString::from("http://attacker"),
+            ),
+            (OsString::from("REGION"), OsString::from("elsewhere")),
+            (OsString::from("TOKEN"), OsString::from("unrelated")),
+        ]);
+        assert_eq!(
+            options,
+            vec![
+                ("AWS_ACCESS_KEY_ID".to_string(), "akid".to_string()),
+                ("GOOGLE_BUCKET".to_string(), "bucket".to_string()),
+                (
+                    "AZURE_STORAGE_ACCOUNT_NAME".to_string(),
+                    "account".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn object_store_env_options_mirror_sdk_imds_endpoint() {
+        use std::ffi::OsString;
+
+        let options = super::object_store_options_from_env_vars([(
+            OsString::from("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+            OsString::from("http://127.0.0.1:9"),
+        )]);
+        assert!(options.iter().any(|(key, value)| {
+            key == "AWS_METADATA_ENDPOINT" && value == "http://127.0.0.1:9"
+        }));
+
+        let options = super::object_store_options_from_env_vars([
+            (
+                OsString::from("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+                OsString::from("http://127.0.0.1:9"),
+            ),
+            (
+                OsString::from("AWS_METADATA_ENDPOINT"),
+                OsString::from("http://127.0.0.1:8"),
+            ),
+        ]);
+        assert_eq!(
+            options
+                .iter()
+                .filter(|(key, _)| key == "AWS_METADATA_ENDPOINT")
+                .count(),
+            1
+        );
+        assert!(options.iter().any(|(key, value)| {
+            key == "AWS_METADATA_ENDPOINT" && value == "http://127.0.0.1:8"
+        }));
+    }
+
     #[test]
     fn remote_url_options_keep_http_and_cloud_config_separate() {
         use std::ffi::OsString;
@@ -2351,96 +2441,6 @@ mod tests {
             started.elapsed() < std::time::Duration::from_secs(3),
             "IMDS probe should fail within the one-second timeout budget"
         );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn object_store_env_options_ignore_non_utf8_values() {
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-
-        let options = super::object_store_options_from_env_vars([
-            (OsString::from("AWS_REGION"), OsString::from("us-east-1")),
-            (
-                OsString::from_vec(vec![0xFF, b'B', b'A', b'D']),
-                OsString::from("ignored-key"),
-            ),
-            (
-                OsString::from("IGNORED_VALUE"),
-                OsString::from_vec(vec![0xFF, b'v']),
-            ),
-        ]);
-        assert_eq!(
-            options,
-            vec![("AWS_REGION".to_string(), "us-east-1".to_string())]
-        );
-    }
-
-    #[test]
-    fn object_store_env_options_only_forward_recognized_prefixes() {
-        use std::ffi::OsString;
-
-        let options = super::object_store_options_from_env_vars([
-            (OsString::from("AWS_ACCESS_KEY_ID"), OsString::from("akid")),
-            (OsString::from("GOOGLE_BUCKET"), OsString::from("bucket")),
-            (
-                OsString::from("AZURE_STORAGE_ACCOUNT_NAME"),
-                OsString::from("account"),
-            ),
-            // Unprefixed aliases like `endpoint`/`region`/`token` would otherwise
-            // be applied by object_store; they must not be forwarded.
-            (
-                OsString::from("ENDPOINT"),
-                OsString::from("http://attacker"),
-            ),
-            (OsString::from("REGION"), OsString::from("elsewhere")),
-            (OsString::from("TOKEN"), OsString::from("unrelated")),
-        ]);
-        assert_eq!(
-            options,
-            vec![
-                ("AWS_ACCESS_KEY_ID".to_string(), "akid".to_string()),
-                ("GOOGLE_BUCKET".to_string(), "bucket".to_string()),
-                (
-                    "AZURE_STORAGE_ACCOUNT_NAME".to_string(),
-                    "account".to_string()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn object_store_env_options_mirror_sdk_imds_endpoint() {
-        use std::ffi::OsString;
-
-        let options = super::object_store_options_from_env_vars([(
-            OsString::from("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
-            OsString::from("http://127.0.0.1:9"),
-        )]);
-        assert!(options.iter().any(|(key, value)| {
-            key == "AWS_METADATA_ENDPOINT" && value == "http://127.0.0.1:9"
-        }));
-
-        let options = super::object_store_options_from_env_vars([
-            (
-                OsString::from("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
-                OsString::from("http://127.0.0.1:9"),
-            ),
-            (
-                OsString::from("AWS_METADATA_ENDPOINT"),
-                OsString::from("http://127.0.0.1:8"),
-            ),
-        ]);
-        assert_eq!(
-            options
-                .iter()
-                .filter(|(key, _)| key == "AWS_METADATA_ENDPOINT")
-                .count(),
-            1
-        );
-        assert!(options.iter().any(|(key, value)| {
-            key == "AWS_METADATA_ENDPOINT" && value == "http://127.0.0.1:8"
-        }));
     }
 
     #[test]

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -74,6 +74,11 @@ Options:
 
           Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads work without this flag.
 
+      --no-sign-request
+          Do not sign object-store requests (credentials are not loaded).
+
+          Useful for public buckets. Without this flag, S3 reads still fall back to unsigned requests when no credentials are available.
+
       --time-format <TIME_FORMAT>
           How to render timestamps in command output
 
@@ -301,11 +306,16 @@ mcap filter --allow-remote-scan gs://your-remote-bucket/demo.mcap -o filtered.mc
 
 #### Credentials
 
-Credentials are read from the standard environment variables for each backend (`AWS_*` for S3, `GOOGLE_*` for GCS, and `AZURE_*` for Azure Blob Storage). When reading from S3 you must also specify the region of the bucket:
+Credentials are read from the standard environment variables for each backend (`AWS_*` for S3, `GOOGLE_*` for GCS, and `AZURE_*` for Azure Blob Storage). The CLI does not read `~/.aws/credentials` or SSO profiles; export credentials into the environment when needed (for example with `aws configure export-credentials`).
+
+When reading from S3, set the bucket region. Public buckets work without credentials: if none are available, the CLI sends an unsigned request. Force that with `--no-sign-request`:
 
 ```
 AWS_REGION=eu-north-1 mcap info s3://my-public-bucket/demo.mcap
+AWS_REGION=eu-north-1 mcap --no-sign-request info s3://my-public-bucket/demo.mcap
 ```
+
+Set `AWS_EC2_METADATA_DISABLED=true` to skip the EC2 instance metadata probe when no credential environment variables are set.
 
 ### File Diagnostics
 

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -312,7 +312,7 @@ When reading from S3, set the bucket region. Public buckets work without credent
 
 ```
 AWS_REGION=eu-north-1 mcap info s3://my-public-bucket/demo.mcap
-AWS_REGION=eu-north-1 mcap --no-sign-request info s3://my-public-bucket/demo.mcap
+AWS_REGION=eu-north-1 mcap info --no-sign-request s3://my-public-bucket/demo.mcap
 ```
 
 Set `AWS_EC2_METADATA_DISABLED=true` to skip the EC2 instance metadata probe when no credential environment variables are set.

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -72,12 +72,12 @@ Options:
       --allow-remote-scan
           Allow whole-file scans or downloads of remote inputs.
 
-          Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads work without this flag.
+          Applies to http(s):// and object store URLs (s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads work without this flag.
 
       --no-sign-request
-          Do not sign object-store requests (credentials are not loaded).
+          Do not sign requests to S3, GCS, or Azure.
 
-          Useful for public buckets. Without this flag, S3 reads still fall back to unsigned requests when no credentials are available.
+          Useful for public buckets. Credentials are not loaded. Without this flag, S3 reads still fall back to unsigned requests when no credentials are available.
 
       --time-format <TIME_FORMAT>
           How to render timestamps in command output


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

S3 reads without AWS credentials no longer hang on the EC2 metadata service; the CLI falls back to unsigned requests, and `--no-sign-request` forces unsigned requests to S3, GCS, or Azure.

### Docs

Updated `website/docs/guides/cli.md` (global help text and the Credentials section).

### Description

Without AWS credential environment variables, `object_store` fell through to the EC2 instance metadata service and applied its data-plane retry budget. On a machine that is not using IMDS credentials that produced a multi-second hang and an opaque error naming `169.254.169.254`.

This change:

- Adds global `--no-sign-request` (same spelling as the AWS CLI and s5cmd) to force unsigned requests to S3, GCS, or Azure. The flag is global and parses after the subcommand, e.g. `mcap info --no-sign-request s3://...`.
- For S3 only, when no credential env vars are present, probes IMDS once with a one-second timeout. If the probe fails, the request is sent unsigned so public buckets work with no configuration. GCS and Azure keep their own credential fallbacks unless the flag is set.
- Honors `AWS_EC2_METADATA_DISABLED=true` and maps `AWS_EC2_METADATA_SERVICE_ENDPOINT` onto `AWS_METADATA_ENDPOINT` so the probe and credential fetch agree.
- On unsigned S3 403s, explains that credentials come from environment variables only (not `~/.aws/credentials` or SSO).

This does not fully address https://github.com/foxglove/mcap/issues/1803. The reporter's bucket is authenticated and their keys live in `~/.aws/credentials` (the Go CLI 0.0.62 read that file; `object_store` does not). Exporting keys with `aws configure export-credentials` unblocks them today. A follow-up should read the shared AWS credentials file; that is out of scope here.

Region is not required (`object_store` defaults to `us-east-1`); set `AWS_REGION` when the bucket is elsewhere.

Credential detection for the auto-unsigned path mirrors `AmazonS3Builder::build` in object_store 0.13.2. Re-check that list when bumping object_store; a missed branch would force unsigned on a source that should sign.

### Testing

- [x] Public bucket, no `AWS_*` credentials: `mcap info` finishes in well under a few seconds with no IMDS hang (verified against local MinIO).
- [x] Private bucket, no credentials: returns quickly with `403 Forbidden` and "The request was sent unsigned..." (verified against local MinIO).
- [x] Private bucket with `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` set: `mcap info` succeeds (verified against local MinIO).
- [x] `mcap info --no-sign-request` with credentials still set: unsigned 403 guidance; flag wins over keys (verified against local MinIO).

Related: https://github.com/foxglove/mcap/issues/1803
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d1bfc4-d7f3-4b2e-afb2-4576cc27e63f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d1bfc4-d7f3-4b2e-afb2-4576cc27e63f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

