### PR TITLE
cli: avoid whole-file remote download timeouts

### DIFF
--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -33,8 +33,9 @@ const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
 // multiple metadata records selected from indexes) from becoming unexpectedly large.
 pub(crate) const MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
 // Whole-file downloads issue ranged GETs of this size. object_store's retry
-// budget (default 180s) starts when each GET is issued, so a dropped connection
-// can resume on the next part instead of restarting the whole object.
+// budget (default 180s) starts when each GET is issued, and a connection lost
+// mid-body resumes from the last byte received instead of restarting the
+// whole object.
 const REMOTE_DOWNLOAD_CHUNK_BYTES: u64 = 64 * 1024 * 1024;
 // object_store's default 30s timeout covers connect through the entire body.
 // Each download GET gets a long overall timeout so an in-progress transfer is
@@ -45,6 +46,10 @@ const REMOTE_DOWNLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(120);
 // object_store's 180s retry budget so those retries can finish. Does not apply
 // to an in-progress body (that's REMOTE_DOWNLOAD_STALL_TIMEOUT).
 const REMOTE_DOWNLOAD_RESPONSE_TIMEOUT: Duration = Duration::from_secs(240);
+// Consecutive body failures with no forward progress before a chunked download
+// gives up. Attempts that deliver any bytes reset the budget, so this only
+// bounds a connection that is persistently dead, not one that is merely flaky.
+const REMOTE_DOWNLOAD_NO_PROGRESS_ATTEMPTS: usize = 5;
 
 pub enum InputData {
     Mapped(Mmap),
@@ -785,6 +790,7 @@ impl ObjectStoreSource {
         let mut progress = DownloadProgress::new(total);
         let mut offset = 0u64;
         let mut pending = Some(first);
+        let mut attempts_without_progress = 0usize;
         while offset < total {
             let response = match pending.take() {
                 Some(response) => response,
@@ -808,14 +814,33 @@ impl ObjectStoreSource {
                     })?
                 }
             };
-            let written = self.stream_get_to_writer(response, writer, &mut progress)?;
-            if written == 0 {
-                bail!(
+            let (written, result) = self.stream_get_to_writer(response, writer, &mut progress);
+            offset = offset.saturating_add(written);
+            if written > 0 {
+                attempts_without_progress = 0;
+            }
+            let err = match result {
+                Ok(()) if written > 0 => continue,
+                // A complete zero-byte body with more bytes expected: treat it
+                // like a dropped connection and re-request the same range.
+                Ok(()) => anyhow::anyhow!(
                     "failed to read remote input {}: download made no progress",
                     self.display_url
-                );
+                ),
+                Err(StreamBodyError::Fatal(err)) => return Err(err),
+                Err(StreamBodyError::Retryable(err)) => err,
+            };
+            attempts_without_progress += 1;
+            if attempts_without_progress >= REMOTE_DOWNLOAD_NO_PROGRESS_ATTEMPTS {
+                return Err(err.context(format!(
+                    "remote download failed after {attempts_without_progress} attempts with no progress"
+                )));
             }
-            offset = offset.saturating_add(written);
+            progress.note(&format!(
+                "Warning: remote download interrupted at {} / {}, retrying: {err:#}",
+                human_bytes(offset),
+                human_bytes(total)
+            ));
         }
         Ok(())
     }
@@ -827,47 +852,77 @@ impl ObjectStoreSource {
                 concise_remote_operation_error("reading remote input from", &self.display_url, err)
             })?;
         let mut progress = DownloadProgress::new(response.meta.size);
-        self.stream_get_to_writer(response, writer, &mut progress)?;
-        Ok(())
+        // Without range support there is no way to resume mid-body, so any
+        // failure is terminal here.
+        let (_, result) = self.stream_get_to_writer(response, writer, &mut progress);
+        result.map_err(StreamBodyError::into_error)
     }
 
-    /// Stream one GET response to `writer`. Returns bytes written so the caller
-    /// can advance the download offset.
+    /// Stream one GET response to `writer`. Always reports bytes written so the
+    /// caller can advance the download offset past partial progress, alongside
+    /// how the stream ended.
     fn stream_get_to_writer(
         &self,
         response: object_store::GetResult,
         writer: &mut impl Write,
         progress: &mut DownloadProgress,
-    ) -> Result<u64> {
-        validate_identity_content_encoding(&response.attributes, &self.display_url)?;
+    ) -> (u64, std::result::Result<(), StreamBodyError>) {
+        if let Err(err) =
+            validate_identity_content_encoding(&response.attributes, &self.display_url)
+        {
+            return (0, Err(StreamBodyError::Fatal(err)));
+        }
         let mut written = 0u64;
-        self.runtime.block_on(async {
+        let result = self.runtime.block_on(async {
             let mut stream = response.into_stream();
             loop {
-                let next = tokio::time::timeout(REMOTE_DOWNLOAD_STALL_TIMEOUT, stream.try_next())
-                    .await
-                    .map_err(|_| {
-                        anyhow::anyhow!(
-                            "failed to read remote input {}: download stalled (no data for {}s)",
-                            self.display_url,
-                            REMOTE_DOWNLOAD_STALL_TIMEOUT.as_secs()
-                        )
-                    })?;
-                let Some(bytes) = next
-                    .with_context(|| format!("failed to read remote input {}", self.display_url))?
+                let Ok(next) =
+                    tokio::time::timeout(REMOTE_DOWNLOAD_STALL_TIMEOUT, stream.try_next()).await
                 else {
-                    break;
+                    return Err(StreamBodyError::Retryable(anyhow::anyhow!(
+                        "failed to read remote input {}: download stalled (no data for {}s)",
+                        self.display_url,
+                        REMOTE_DOWNLOAD_STALL_TIMEOUT.as_secs()
+                    )));
                 };
-                writer.write_all(bytes.as_ref()).with_context(|| {
-                    format!("failed to write remote input {}", self.display_url)
-                })?;
+                let bytes = match next {
+                    Ok(Some(bytes)) => bytes,
+                    Ok(None) => break,
+                    Err(err) => {
+                        return Err(StreamBodyError::Retryable(anyhow::Error::new(err).context(
+                            format!("failed to read remote input {}", self.display_url),
+                        )))
+                    }
+                };
+                if let Err(err) = writer.write_all(bytes.as_ref()) {
+                    return Err(StreamBodyError::Fatal(anyhow::Error::new(err).context(
+                        format!("failed to write remote input {}", self.display_url),
+                    )));
+                }
                 let n = bytes.len() as u64;
                 written = written.saturating_add(n);
                 progress.add(n);
             }
-            Ok::<(), anyhow::Error>(())
-        })?;
-        Ok(written)
+            Ok(())
+        });
+        (written, result)
+    }
+}
+
+// How one GET body stream ended short of success: `Retryable` failures
+// (network errors, stalls) leave the remote object re-fetchable from the
+// current offset; `Fatal` ones (local write errors, invalid content encoding)
+// would fail the same way again.
+enum StreamBodyError {
+    Retryable(anyhow::Error),
+    Fatal(anyhow::Error),
+}
+
+impl StreamBodyError {
+    fn into_error(self) -> anyhow::Error {
+        match self {
+            Self::Retryable(err) | Self::Fatal(err) => err,
+        }
     }
 }
 
@@ -895,6 +950,16 @@ impl DownloadProgress {
             self.report(false);
             self.last_report = Instant::now();
         }
+    }
+
+    // Print a standalone line, first terminating the in-place progress line so
+    // the two don't overwrite each other.
+    fn note(&self, message: &str) {
+        if self.tty && self.written > 0 {
+            eprintln!();
+        }
+        eprintln!("{message}");
+        let _ = std::io::stderr().flush();
     }
 
     fn report(&self, final_line: bool) {
@@ -1835,6 +1900,85 @@ mod tests {
         (format!("http://{addr}/demo.mcap"), request_count)
     }
 
+    // A range-supporting server that truncates the body of the first
+    // `truncated_bodies` GET responses to `truncated_len` of the promised
+    // length before closing the connection, like a connection dropped
+    // mid-transfer. Headers always promise the full range.
+    fn serve_http_truncating_bodies(
+        body: &'static [u8],
+        truncated_bodies: usize,
+        truncated_len: fn(usize) -> usize,
+    ) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let server_request_count = request_count.clone();
+        thread::spawn(move || {
+            let mut remaining_truncations = truncated_bodies;
+            for stream in listener.incoming().take(64) {
+                let mut stream = stream.expect("accept test connection");
+                server_request_count.fetch_add(1, Ordering::SeqCst);
+                let mut request = [0u8; 4096];
+                let read = stream.read(&mut request).expect("read request");
+                let request = String::from_utf8_lossy(&request[..read]);
+                let is_head = request.starts_with("HEAD ");
+                let range = request
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Range: bytes="))
+                    .or_else(|| {
+                        request
+                            .lines()
+                            .find_map(|line| line.strip_prefix("range: bytes="))
+                    })
+                    .and_then(|spec| spec.split_once('-'))
+                    .and_then(|(start, end)| {
+                        Some((
+                            start.trim().parse::<usize>().ok()?,
+                            end.trim().parse::<usize>().ok()?,
+                        ))
+                    });
+                let Some((start, end)) = range else {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write headers");
+                    if !is_head {
+                        stream.write_all(body).expect("write body");
+                    }
+                    continue;
+                };
+                let end = end.min(body.len().saturating_sub(1));
+                let start = start.min(end);
+                let content = &body[start..=end];
+                let response = format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {start}-{end}/{}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                    content.len(),
+                    body.len(),
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write headers");
+                if is_head {
+                    continue;
+                }
+                if remaining_truncations > 0 {
+                    remaining_truncations -= 1;
+                    // Closing with fewer bytes than Content-Length promised
+                    // makes the client observe a body error.
+                    stream
+                        .write_all(&content[..truncated_len(content.len())])
+                        .expect("write truncated body");
+                    continue;
+                }
+                stream.write_all(content).expect("write body");
+            }
+        });
+        (format!("http://{addr}/demo.mcap"), request_count)
+    }
+
     #[test]
     fn remote_errors_redact_query_strings() {
         let url = "http://127.0.0.1:1/demo.mcap?X-Amz-Signature=secret-token";
@@ -1897,6 +2041,76 @@ mod tests {
             requests.load(Ordering::SeqCst),
             5,
             "36-byte body at 8-byte chunks should issue five range requests"
+        );
+    }
+
+    #[test]
+    fn remote_http_download_resumes_after_mid_body_failures() {
+        let body: &'static [u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        // The first two GET bodies are cut off halfway through.
+        let (url, requests) = serve_http_truncating_bodies(body, 2, |len| len / 2);
+        let mut out = Vec::new();
+        let source = super::ObjectStoreSource::open_for_download(Path::new(&url))
+            .expect("open download source");
+        source
+            .download_to_writer(&mut out, 8)
+            .expect("download should resume past truncated bodies");
+        assert_eq!(out, body);
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            6,
+            "truncated GETs (0..8 -> 4 bytes, 4..12 -> 4 bytes) then four full chunks"
+        );
+    }
+
+    #[test]
+    fn remote_http_download_gives_up_after_no_progress_attempts() {
+        let body: &'static [u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        // Every GET body is closed before sending any bytes.
+        let (url, requests) = serve_http_truncating_bodies(body, usize::MAX, |_| 0);
+        let mut out = Vec::new();
+        let source = super::ObjectStoreSource::open_for_download(Path::new(&url))
+            .expect("open download source");
+        let err = source
+            .download_to_writer(&mut out, 8)
+            .expect_err("download with no progress should give up");
+        assert!(
+            err.to_string().contains("attempts with no progress"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            super::REMOTE_DOWNLOAD_NO_PROGRESS_ATTEMPTS,
+            "should stop after the no-progress attempt budget"
+        );
+    }
+
+    #[test]
+    fn remote_http_download_does_not_retry_local_write_errors() {
+        struct FailingWriter;
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let body: &'static [u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        let (url, requests) = serve_http_truncating_bodies(body, 0, |len| len);
+        let source = super::ObjectStoreSource::open_for_download(Path::new(&url))
+            .expect("open download source");
+        let err = source
+            .download_to_writer(&mut FailingWriter, 8)
+            .expect_err("local write errors should fail the download");
+        assert!(
+            err.to_string().contains("failed to write remote input"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            1,
+            "a local write error should not be retried"
         );
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -32,23 +32,20 @@ const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
 // Guards aggregate remote reads that should stay index-like (summary bytes, or
 // multiple metadata records selected from indexes) from becoming unexpectedly large.
 pub(crate) const MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
-// Whole-file downloads issue ranged GETs of this size. object_store's retry
-// budget (default 180s) starts when each GET is issued, and a connection lost
-// mid-body resumes from the last byte received instead of restarting the
-// whole object.
+// Ranged GET size for whole-file downloads. Each part gets a fresh
+// object_store retry budget, and a dropped connection resumes at the last
+// byte received.
 const REMOTE_DOWNLOAD_CHUNK_BYTES: u64 = 64 * 1024 * 1024;
-// object_store's default 30s timeout covers connect through the entire body.
-// Each download GET gets a long overall timeout so an in-progress transfer is
-// not killed; a stalled connection is detected by REMOTE_DOWNLOAD_STALL_TIMEOUT.
+// object_store's default 30s timeout spans the entire response body, killing
+// long transfers. Downloads get an effectively unlimited one instead; stalls
+// are caught by REMOTE_DOWNLOAD_STALL_TIMEOUT.
 const REMOTE_DOWNLOAD_REQUEST_TIMEOUT: &str = "7days";
 const REMOTE_DOWNLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(120);
-// Bounds waiting for the response head of each download GET. Sits above
-// object_store's 180s retry budget so those retries can finish. Does not apply
-// to an in-progress body (that's REMOTE_DOWNLOAD_STALL_TIMEOUT).
+// Bounds waiting for each download GET's response head; sits above
+// object_store's 180s retry budget so internal retries can finish.
 const REMOTE_DOWNLOAD_RESPONSE_TIMEOUT: Duration = Duration::from_secs(240);
-// Consecutive body failures with no forward progress before a chunked download
-// gives up. Attempts that deliver any bytes reset the budget, so this only
-// bounds a connection that is persistently dead, not one that is merely flaky.
+// Consecutive zero-progress attempts before a chunked download gives up.
+// Any delivered bytes reset the budget, so only a dead connection exhausts it.
 const REMOTE_DOWNLOAD_NO_PROGRESS_ATTEMPTS: usize = 5;
 
 pub enum InputData {
@@ -520,8 +517,7 @@ impl RemoteUrl {
     fn store_options(&self, access: RemoteAccess) -> Vec<(String, String)> {
         let mut options = self.options();
         if matches!(access, RemoteAccess::Download) {
-            // Last-wins in parse_url_opts, so this overrides any env timeout
-            // (for example AWS_TIMEOUT) on the whole-file download path.
+            // Last-wins in parse_url_opts: overrides any env timeout (e.g. AWS_TIMEOUT).
             options.push((
                 ClientConfigKey::Timeout.as_ref().to_string(),
                 REMOTE_DOWNLOAD_REQUEST_TIMEOUT.to_string(),
@@ -809,9 +805,8 @@ impl ObjectStoreSource {
                     }
                     match result {
                         Ok(()) if written > 0 => continue,
-                        // A complete zero-byte body with more bytes expected:
-                        // treat it like a dropped connection and re-request the
-                        // same range.
+                        // An empty body with more bytes expected: retry like
+                        // a dropped connection.
                         Ok(()) => anyhow::anyhow!(
                             "failed to read remote input {}: download made no progress",
                             self.display_url
@@ -839,10 +834,8 @@ impl ObjectStoreSource {
     }
 
     /// Issue the ranged GET that resumes a chunked download at `range`. Failures
-    /// are retryable — they leave the object re-fetchable from the same offset,
-    /// and the head request itself carries object_store's internal retry budget —
-    /// except a precondition failure, where the pinned ETag no longer matches and
-    /// every retry would fail the same way.
+    /// are retryable except a precondition failure: the pinned ETag no longer
+    /// matches, so every retry would fail the same way.
     fn resume_chunk_get(
         &self,
         range: std::ops::Range<u64>,
@@ -877,15 +870,13 @@ impl ObjectStoreSource {
                 concise_remote_operation_error("reading remote input from", &self.display_url, err)
             })?;
         let mut progress = DownloadProgress::new(response.meta.size);
-        // Without range support there is no way to resume mid-body, so any
-        // failure is terminal here.
+        // Without ranges there is no way to resume mid-body; any failure is terminal.
         let (_, result) = self.stream_get_to_writer(response, writer, &mut progress);
         result.map_err(DownloadError::into_error)
     }
 
-    /// Stream one GET response to `writer`. Always reports bytes written so the
-    /// caller can advance the download offset past partial progress, alongside
-    /// how the stream ended.
+    /// Stream one GET response to `writer`, reporting bytes written even on
+    /// failure so the caller can resume past partial progress.
     fn stream_get_to_writer(
         &self,
         response: object_store::GetResult,
@@ -934,11 +925,9 @@ impl ObjectStoreSource {
     }
 }
 
-// How one download GET — its head request or its body stream — failed:
-// `Retryable` failures (network errors, stalls, transient head errors) leave
-// the remote object re-fetchable from the current offset; `Fatal` ones (local
-// write errors, invalid content encoding, an ETag precondition mismatch)
-// would fail the same way again.
+// How a download GET failed: `Retryable` failures (network errors, stalls)
+// leave the object re-fetchable from the current offset; `Fatal` ones (local
+// write errors, ETag mismatch) would fail identically on retry.
 enum DownloadError {
     Retryable(anyhow::Error),
     Fatal(anyhow::Error),
@@ -978,8 +967,7 @@ impl DownloadProgress {
         }
     }
 
-    // Print a standalone line, first terminating the in-place progress line so
-    // the two don't overwrite each other.
+    // Print a standalone line without corrupting the in-place progress line.
     fn note(&self, message: &str) {
         if self.tty && self.written > 0 {
             eprintln!();
@@ -1167,9 +1155,8 @@ fn remote_range_not_supported(err: &object_store::Error) -> bool {
     matches!(err, object_store::Error::NotSupported { .. })
 }
 
-// Empty objects reject `bytes=0..N` as unsatisfiable (HTTP 416). Fall back to
-// an unranged GET. Match the parsed status, not a raw "416" substring — retry
-// error text can include request ids that happen to contain those digits.
+// Empty objects reject `bytes=0..N` with HTTP 416. Match the parsed status,
+// not a "416" substring — error text can contain request ids with those digits.
 fn remote_range_unsatisfiable(err: &object_store::Error) -> bool {
     object_store_error_status(err).is_some_and(|status| status.starts_with("416"))
 }
@@ -1926,10 +1913,9 @@ mod tests {
         (format!("http://{addr}/demo.mcap"), request_count)
     }
 
-    // A range-supporting server that truncates the body of the first
-    // `truncated_bodies` GET responses to `truncated_len` of the promised
-    // length before closing the connection, like a connection dropped
-    // mid-transfer. Headers always promise the full range.
+    // A range-supporting server that truncates the first `truncated_bodies` GET
+    // bodies to `truncated_len` of the promised length, like a connection dropped
+    // mid-transfer.
     fn serve_http_truncating_bodies(
         body: &'static [u8],
         truncated_bodies: usize,
@@ -1992,8 +1978,8 @@ mod tests {
                 }
                 if remaining_truncations > 0 {
                     remaining_truncations -= 1;
-                    // Closing with fewer bytes than Content-Length promised
-                    // makes the client observe a body error.
+                    // Fewer bytes than Content-Length promised: the client
+                    // sees a body error.
                     stream
                         .write_all(&content[..truncated_len(content.len())])
                         .expect("write truncated body");
@@ -2005,9 +1991,8 @@ mod tests {
         (format!("http://{addr}/demo.mcap"), request_count)
     }
 
-    // A range-supporting server that responds to the request at 0-based
-    // connection index `failing_index` with `status`, serving every other
-    // request normally.
+    // A range-supporting server that responds to the 0-based `failing_index`th
+    // request with `status` and serves every other request normally.
     fn serve_http_failing_request(
         body: &'static [u8],
         failing_index: usize,

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -793,42 +793,35 @@ impl ObjectStoreSource {
         let mut attempts_without_progress = 0usize;
         while offset < total {
             let response = match pending.take() {
-                Some(response) => response,
+                Some(response) => Ok(response),
                 None => {
                     let end = offset.saturating_add(chunk_bytes).min(total);
-                    self.get_opts_for_download(GetOptions {
-                        range: Some(GetRange::Bounded(offset..end)),
-                        if_match: etag.clone(),
-                        ..GetOptions::default()
-                    })?
-                    .map_err(|err| match err {
-                        object_store::Error::Precondition { .. } => anyhow::anyhow!(
-                            "failed to read {}: remote object changed while downloading",
-                            self.display_url
-                        ),
-                        err => concise_remote_operation_error(
-                            "reading remote input from",
-                            &self.display_url,
-                            err,
-                        ),
-                    })?
+                    self.resume_chunk_get(offset..end, &etag)
                 }
             };
-            let (written, result) = self.stream_get_to_writer(response, writer, &mut progress);
-            offset = offset.saturating_add(written);
-            if written > 0 {
-                attempts_without_progress = 0;
-            }
-            let err = match result {
-                Ok(()) if written > 0 => continue,
-                // A complete zero-byte body with more bytes expected: treat it
-                // like a dropped connection and re-request the same range.
-                Ok(()) => anyhow::anyhow!(
-                    "failed to read remote input {}: download made no progress",
-                    self.display_url
-                ),
-                Err(StreamBodyError::Fatal(err)) => return Err(err),
-                Err(StreamBodyError::Retryable(err)) => err,
+            let err = match response {
+                Ok(response) => {
+                    let (written, result) =
+                        self.stream_get_to_writer(response, writer, &mut progress);
+                    offset = offset.saturating_add(written);
+                    if written > 0 {
+                        attempts_without_progress = 0;
+                    }
+                    match result {
+                        Ok(()) if written > 0 => continue,
+                        // A complete zero-byte body with more bytes expected:
+                        // treat it like a dropped connection and re-request the
+                        // same range.
+                        Ok(()) => anyhow::anyhow!(
+                            "failed to read remote input {}: download made no progress",
+                            self.display_url
+                        ),
+                        Err(DownloadError::Fatal(err)) => return Err(err),
+                        Err(DownloadError::Retryable(err)) => err,
+                    }
+                }
+                Err(DownloadError::Fatal(err)) => return Err(err),
+                Err(DownloadError::Retryable(err)) => err,
             };
             attempts_without_progress += 1;
             if attempts_without_progress >= REMOTE_DOWNLOAD_NO_PROGRESS_ATTEMPTS {
@@ -845,6 +838,38 @@ impl ObjectStoreSource {
         Ok(())
     }
 
+    /// Issue the ranged GET that resumes a chunked download at `range`. Failures
+    /// are retryable — they leave the object re-fetchable from the same offset,
+    /// and the head request itself carries object_store's internal retry budget —
+    /// except a precondition failure, where the pinned ETag no longer matches and
+    /// every retry would fail the same way.
+    fn resume_chunk_get(
+        &self,
+        range: std::ops::Range<u64>,
+        etag: &Option<String>,
+    ) -> std::result::Result<object_store::GetResult, DownloadError> {
+        match self.get_opts_for_download(GetOptions {
+            range: Some(GetRange::Bounded(range)),
+            if_match: etag.clone(),
+            ..GetOptions::default()
+        }) {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(object_store::Error::Precondition { .. })) => {
+                Err(DownloadError::Fatal(anyhow::anyhow!(
+                    "failed to read {}: remote object changed while downloading",
+                    self.display_url
+                )))
+            }
+            Ok(Err(err)) => Err(DownloadError::Retryable(concise_remote_operation_error(
+                "reading remote input from",
+                &self.display_url,
+                err,
+            ))),
+            // The REMOTE_DOWNLOAD_RESPONSE_TIMEOUT wait expired.
+            Err(err) => Err(DownloadError::Retryable(err)),
+        }
+    }
+
     fn download_unranged(&self, writer: &mut impl Write) -> Result<()> {
         let response = self
             .get_opts_for_download(GetOptions::default())?
@@ -855,7 +880,7 @@ impl ObjectStoreSource {
         // Without range support there is no way to resume mid-body, so any
         // failure is terminal here.
         let (_, result) = self.stream_get_to_writer(response, writer, &mut progress);
-        result.map_err(StreamBodyError::into_error)
+        result.map_err(DownloadError::into_error)
     }
 
     /// Stream one GET response to `writer`. Always reports bytes written so the
@@ -866,11 +891,11 @@ impl ObjectStoreSource {
         response: object_store::GetResult,
         writer: &mut impl Write,
         progress: &mut DownloadProgress,
-    ) -> (u64, std::result::Result<(), StreamBodyError>) {
+    ) -> (u64, std::result::Result<(), DownloadError>) {
         if let Err(err) =
             validate_identity_content_encoding(&response.attributes, &self.display_url)
         {
-            return (0, Err(StreamBodyError::Fatal(err)));
+            return (0, Err(DownloadError::Fatal(err)));
         }
         let mut written = 0u64;
         let result = self.runtime.block_on(async {
@@ -879,7 +904,7 @@ impl ObjectStoreSource {
                 let Ok(next) =
                     tokio::time::timeout(REMOTE_DOWNLOAD_STALL_TIMEOUT, stream.try_next()).await
                 else {
-                    return Err(StreamBodyError::Retryable(anyhow::anyhow!(
+                    return Err(DownloadError::Retryable(anyhow::anyhow!(
                         "failed to read remote input {}: download stalled (no data for {}s)",
                         self.display_url,
                         REMOTE_DOWNLOAD_STALL_TIMEOUT.as_secs()
@@ -889,13 +914,13 @@ impl ObjectStoreSource {
                     Ok(Some(bytes)) => bytes,
                     Ok(None) => break,
                     Err(err) => {
-                        return Err(StreamBodyError::Retryable(anyhow::Error::new(err).context(
+                        return Err(DownloadError::Retryable(anyhow::Error::new(err).context(
                             format!("failed to read remote input {}", self.display_url),
                         )))
                     }
                 };
                 if let Err(err) = writer.write_all(bytes.as_ref()) {
-                    return Err(StreamBodyError::Fatal(anyhow::Error::new(err).context(
+                    return Err(DownloadError::Fatal(anyhow::Error::new(err).context(
                         format!("failed to write remote input {}", self.display_url),
                     )));
                 }
@@ -909,16 +934,17 @@ impl ObjectStoreSource {
     }
 }
 
-// How one GET body stream ended short of success: `Retryable` failures
-// (network errors, stalls) leave the remote object re-fetchable from the
-// current offset; `Fatal` ones (local write errors, invalid content encoding)
+// How one download GET — its head request or its body stream — failed:
+// `Retryable` failures (network errors, stalls, transient head errors) leave
+// the remote object re-fetchable from the current offset; `Fatal` ones (local
+// write errors, invalid content encoding, an ETag precondition mismatch)
 // would fail the same way again.
-enum StreamBodyError {
+enum DownloadError {
     Retryable(anyhow::Error),
     Fatal(anyhow::Error),
 }
 
-impl StreamBodyError {
+impl DownloadError {
     fn into_error(self) -> anyhow::Error {
         match self {
             Self::Retryable(err) | Self::Fatal(err) => err,
@@ -1979,6 +2005,82 @@ mod tests {
         (format!("http://{addr}/demo.mcap"), request_count)
     }
 
+    // A range-supporting server that responds to the request at 0-based
+    // connection index `failing_index` with `status`, serving every other
+    // request normally.
+    fn serve_http_failing_request(
+        body: &'static [u8],
+        failing_index: usize,
+        status: &'static str,
+    ) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let server_request_count = request_count.clone();
+        thread::spawn(move || {
+            for stream in listener.incoming().take(64) {
+                let mut stream = stream.expect("accept test connection");
+                let index = server_request_count.fetch_add(1, Ordering::SeqCst);
+                let mut request = [0u8; 4096];
+                let read = stream.read(&mut request).expect("read request");
+                let request = String::from_utf8_lossy(&request[..read]);
+                let is_head = request.starts_with("HEAD ");
+                if index == failing_index {
+                    stream
+                        .write_all(
+                            format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                                .as_bytes(),
+                        )
+                        .expect("write failure status");
+                    continue;
+                }
+                let range = request
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Range: bytes="))
+                    .or_else(|| {
+                        request
+                            .lines()
+                            .find_map(|line| line.strip_prefix("range: bytes="))
+                    })
+                    .and_then(|spec| spec.split_once('-'))
+                    .and_then(|(start, end)| {
+                        Some((
+                            start.trim().parse::<usize>().ok()?,
+                            end.trim().parse::<usize>().ok()?,
+                        ))
+                    });
+                let Some((start, end)) = range else {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write headers");
+                    if !is_head {
+                        stream.write_all(body).expect("write body");
+                    }
+                    continue;
+                };
+                let end = end.min(body.len().saturating_sub(1));
+                let start = start.min(end);
+                let content = &body[start..=end];
+                let response = format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {start}-{end}/{}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                    content.len(),
+                    body.len(),
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write headers");
+                if !is_head {
+                    stream.write_all(content).expect("write body");
+                }
+            }
+        });
+        (format!("http://{addr}/demo.mcap"), request_count)
+    }
+
     #[test]
     fn remote_errors_redact_query_strings() {
         let url = "http://127.0.0.1:1/demo.mcap?X-Amz-Signature=secret-token";
@@ -2082,6 +2184,47 @@ mod tests {
             requests.load(Ordering::SeqCst),
             super::REMOTE_DOWNLOAD_NO_PROGRESS_ATTEMPTS,
             "should stop after the no-progress attempt budget"
+        );
+    }
+
+    #[test]
+    fn remote_http_download_retries_transient_resume_head_failure() {
+        let body: &'static [u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        // The second connection is the first resume GET; fail its head request.
+        let (url, requests) = serve_http_failing_request(body, 1, "404 Not Found");
+        let mut out = Vec::new();
+        let source = super::ObjectStoreSource::open_for_download(Path::new(&url))
+            .expect("open download source");
+        source
+            .download_to_writer(&mut out, 8)
+            .expect("download should retry a transient resume head failure");
+        assert_eq!(out, body);
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            6,
+            "five range requests plus one retried head failure"
+        );
+    }
+
+    #[test]
+    fn remote_http_download_aborts_when_object_changes_mid_download() {
+        let body: &'static [u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        // A 412 on the resume GET means the pinned ETag no longer matches.
+        let (url, requests) = serve_http_failing_request(body, 1, "412 Precondition Failed");
+        let mut out = Vec::new();
+        let source = super::ObjectStoreSource::open_for_download(Path::new(&url))
+            .expect("open download source");
+        let err = source
+            .download_to_writer(&mut out, 8)
+            .expect_err("a precondition failure should abort the download");
+        assert!(
+            err.to_string().contains("remote object changed"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            2,
+            "a precondition failure should not be retried"
         );
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1,6 +1,7 @@
-use std::io::{IsTerminal as _, SeekFrom};
+use std::io::{IsTerminal as _, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use binrw::BinRead;
@@ -8,7 +9,8 @@ use futures_util::TryStreamExt;
 use mcap::records::{self, Record};
 use memmap2::Mmap;
 use object_store::{
-    path::Path as ObjectStorePath, Attribute, GetOptions, GetRange, ObjectStore, ObjectStoreExt,
+    path::Path as ObjectStorePath, Attribute, ClientConfigKey, GetOptions, GetRange, ObjectStore,
+    ObjectStoreExt,
 };
 use tempfile::NamedTempFile;
 use url::Url;
@@ -30,6 +32,19 @@ const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
 // Guards aggregate remote reads that should stay index-like (summary bytes, or
 // multiple metadata records selected from indexes) from becoming unexpectedly large.
 pub(crate) const MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
+// Whole-file downloads issue ranged GETs of this size. object_store's retry
+// budget (default 180s) starts when each GET is issued, so a dropped connection
+// can resume on the next part instead of restarting the whole object.
+const REMOTE_DOWNLOAD_CHUNK_BYTES: u64 = 64 * 1024 * 1024;
+// object_store's default 30s timeout covers connect through the entire body.
+// Each download GET gets a long overall timeout so an in-progress transfer is
+// not killed; a stalled connection is detected by REMOTE_DOWNLOAD_STALL_TIMEOUT.
+const REMOTE_DOWNLOAD_REQUEST_TIMEOUT: &str = "7days";
+const REMOTE_DOWNLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(120);
+// Bounds waiting for the response head of each download GET. Sits above
+// object_store's 180s retry budget so those retries can finish. Does not apply
+// to an in-progress body (that's REMOTE_DOWNLOAD_STALL_TIMEOUT).
+const REMOTE_DOWNLOAD_RESPONSE_TIMEOUT: Duration = Duration::from_secs(240);
 
 pub enum InputData {
     Mapped(Mmap),
@@ -497,6 +512,19 @@ impl RemoteUrl {
         self.options_from_env_vars(std::env::vars_os())
     }
 
+    fn store_options(&self, access: RemoteAccess) -> Vec<(String, String)> {
+        let mut options = self.options();
+        if matches!(access, RemoteAccess::Download) {
+            // Last-wins in parse_url_opts, so this overrides any env timeout
+            // (for example AWS_TIMEOUT) on the whole-file download path.
+            options.push((
+                ClientConfigKey::Timeout.as_ref().to_string(),
+                REMOTE_DOWNLOAD_REQUEST_TIMEOUT.to_string(),
+            ));
+        }
+        options
+    }
+
     fn options_from_env_vars(
         &self,
         vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
@@ -529,6 +557,12 @@ pub fn remote_or_local_extension(path: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteAccess {
+    Indexed,
+    Download,
+}
+
 struct ObjectStoreSource {
     runtime: Arc<tokio::runtime::Runtime>,
     store: Arc<dyn ObjectStore>,
@@ -537,20 +571,19 @@ struct ObjectStoreSource {
 }
 
 impl ObjectStoreSource {
-    fn open(path: &Path) -> Result<Self> {
-        Self::open_remote(RemoteUrl::parse(path)?)
+    fn open_for_download(path: &Path) -> Result<Self> {
+        Self::open_remote(RemoteUrl::parse(path)?, RemoteAccess::Download)
     }
 
-    fn open_remote(remote_url: RemoteUrl) -> Result<Self> {
+    fn open_remote(remote_url: RemoteUrl, access: RemoteAccess) -> Result<Self> {
         let (store, object_path) =
-            object_store::parse_url_opts(&remote_url.url, remote_url.options()).with_context(
-                || {
+            object_store::parse_url_opts(&remote_url.url, remote_url.store_options(access))
+                .with_context(|| {
                     format!(
                         "failed to configure remote store for {}",
                         remote_url.display_url
                     )
-                },
-            )?;
+                })?;
         Ok(Self {
             runtime: object_store_runtime()?,
             store: Arc::from(store),
@@ -693,6 +726,201 @@ impl ObjectStoreSource {
         let size = self.head_size()?;
         Ok(Some((size, self.bounded_tail(size, tail_bytes)?)))
     }
+
+    /// Download the object to `writer` in ranged parts of `chunk_bytes`.
+    /// Falls back to an unranged GET when the store ignores `Range` or the
+    /// object is empty (unsatisfiable `bytes=0..N`).
+    fn download_to_writer(&self, writer: &mut impl Write, chunk_bytes: u64) -> Result<()> {
+        if chunk_bytes == 0 {
+            bail!("remote download chunk size must be non-zero");
+        }
+        match self.get_opts_for_download(GetOptions {
+            range: Some(GetRange::Bounded(0..chunk_bytes)),
+            ..GetOptions::default()
+        })? {
+            Ok(response) => self.download_chunked(response, writer, chunk_bytes),
+            Err(err) if remote_range_not_supported(&err) || remote_range_unsatisfiable(&err) => {
+                self.download_unranged(writer)
+            }
+            Err(err) => Err(concise_remote_operation_error(
+                "reading remote input from",
+                &self.display_url,
+                err,
+            )),
+        }
+    }
+
+    /// Wait up to `REMOTE_DOWNLOAD_RESPONSE_TIMEOUT` for the response head.
+    /// The outer error is that wait timing out; the inner error is left intact
+    /// so callers can classify range support.
+    fn get_opts_for_download(
+        &self,
+        options: GetOptions,
+    ) -> Result<std::result::Result<object_store::GetResult, object_store::Error>> {
+        self.runtime.block_on(async {
+            match tokio::time::timeout(
+                REMOTE_DOWNLOAD_RESPONSE_TIMEOUT,
+                self.store.get_opts(&self.path, options),
+            )
+            .await
+            {
+                Ok(result) => Ok(result),
+                Err(_) => Err(anyhow::anyhow!(
+                    "failed to read remote input {}: timed out waiting for response ({}s)",
+                    self.display_url,
+                    REMOTE_DOWNLOAD_RESPONSE_TIMEOUT.as_secs()
+                )),
+            }
+        })
+    }
+
+    fn download_chunked(
+        &self,
+        first: object_store::GetResult,
+        writer: &mut impl Write,
+        chunk_bytes: u64,
+    ) -> Result<()> {
+        let total = first.meta.size;
+        let etag = first.meta.e_tag.clone();
+        let mut progress = DownloadProgress::new(total);
+        let mut offset = 0u64;
+        let mut pending = Some(first);
+        while offset < total {
+            let response = match pending.take() {
+                Some(response) => response,
+                None => {
+                    let end = offset.saturating_add(chunk_bytes).min(total);
+                    self.get_opts_for_download(GetOptions {
+                        range: Some(GetRange::Bounded(offset..end)),
+                        if_match: etag.clone(),
+                        ..GetOptions::default()
+                    })?
+                    .map_err(|err| match err {
+                        object_store::Error::Precondition { .. } => anyhow::anyhow!(
+                            "failed to read {}: remote object changed while downloading",
+                            self.display_url
+                        ),
+                        err => concise_remote_operation_error(
+                            "reading remote input from",
+                            &self.display_url,
+                            err,
+                        ),
+                    })?
+                }
+            };
+            let written = self.stream_get_to_writer(response, writer, &mut progress)?;
+            if written == 0 {
+                bail!(
+                    "failed to read remote input {}: download made no progress",
+                    self.display_url
+                );
+            }
+            offset = offset.saturating_add(written);
+        }
+        Ok(())
+    }
+
+    fn download_unranged(&self, writer: &mut impl Write) -> Result<()> {
+        let response = self
+            .get_opts_for_download(GetOptions::default())?
+            .map_err(|err| {
+                concise_remote_operation_error("reading remote input from", &self.display_url, err)
+            })?;
+        let mut progress = DownloadProgress::new(response.meta.size);
+        self.stream_get_to_writer(response, writer, &mut progress)?;
+        Ok(())
+    }
+
+    /// Stream one GET response to `writer`. Returns bytes written so the caller
+    /// can advance the download offset.
+    fn stream_get_to_writer(
+        &self,
+        response: object_store::GetResult,
+        writer: &mut impl Write,
+        progress: &mut DownloadProgress,
+    ) -> Result<u64> {
+        validate_identity_content_encoding(&response.attributes, &self.display_url)?;
+        let mut written = 0u64;
+        self.runtime.block_on(async {
+            let mut stream = response.into_stream();
+            loop {
+                let next = tokio::time::timeout(REMOTE_DOWNLOAD_STALL_TIMEOUT, stream.try_next())
+                    .await
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "failed to read remote input {}: download stalled (no data for {}s)",
+                            self.display_url,
+                            REMOTE_DOWNLOAD_STALL_TIMEOUT.as_secs()
+                        )
+                    })?;
+                let Some(bytes) = next
+                    .with_context(|| format!("failed to read remote input {}", self.display_url))?
+                else {
+                    break;
+                };
+                writer.write_all(bytes.as_ref()).with_context(|| {
+                    format!("failed to write remote input {}", self.display_url)
+                })?;
+                let n = bytes.len() as u64;
+                written = written.saturating_add(n);
+                progress.add(n);
+            }
+            Ok::<(), anyhow::Error>(())
+        })?;
+        Ok(written)
+    }
+}
+
+struct DownloadProgress {
+    tty: bool,
+    total: u64,
+    written: u64,
+    last_report: Instant,
+}
+
+impl DownloadProgress {
+    fn new(total: u64) -> Self {
+        Self {
+            tty: std::io::stderr().is_terminal(),
+            total,
+            written: 0,
+            last_report: Instant::now(),
+        }
+    }
+
+    fn add(&mut self, n: u64) {
+        let first = self.written == 0;
+        self.written = self.written.saturating_add(n);
+        if first || self.last_report.elapsed() >= Duration::from_millis(200) {
+            self.report(false);
+            self.last_report = Instant::now();
+        }
+    }
+
+    fn report(&self, final_line: bool) {
+        if !self.tty {
+            return;
+        }
+        // Pad so a shorter update erases the tail of a longer previous line.
+        let message = format!(
+            "Downloading {} / {}",
+            human_bytes(self.written),
+            human_bytes(self.total)
+        );
+        eprint!("\r{message:<48}");
+        if final_line {
+            eprintln!();
+        }
+        let _ = std::io::stderr().flush();
+    }
+}
+
+impl Drop for DownloadProgress {
+    fn drop(&mut self) {
+        if self.tty && self.written > 0 {
+            self.report(true);
+        }
+    }
 }
 
 /// The trailing bytes of a remote object fetched in a single request, used to
@@ -717,7 +945,7 @@ impl RemoteRangeReader {
     fn open(path: &Path) -> Result<Option<Self>> {
         let remote_url = RemoteUrl::parse(path)?;
         let kind = remote_url.kind;
-        let source = ObjectStoreSource::open_remote(remote_url)?;
+        let source = ObjectStoreSource::open_remote(remote_url, RemoteAccess::Indexed)?;
         let Some((size, tail)) = source.read_summary_tail(kind, REMOTE_SUMMARY_TAIL_BYTES)? else {
             return Ok(None);
         };
@@ -848,6 +1076,13 @@ fn remote_range_not_supported(err: &object_store::Error) -> bool {
     matches!(err, object_store::Error::NotSupported { .. })
 }
 
+// Empty objects reject `bytes=0..N` as unsatisfiable (HTTP 416). Fall back to
+// an unranged GET. Match the parsed status, not a raw "416" substring — retry
+// error text can include request ids that happen to contain those digits.
+fn remote_range_unsatisfiable(err: &object_store::Error) -> bool {
+    object_store_error_status(err).is_some_and(|status| status.starts_with("416"))
+}
+
 fn concise_remote_stat_error(display_url: &str, err: object_store::Error) -> anyhow::Error {
     if let Some(status) = object_store_error_status(&err) {
         return remote_status_read_error(display_url, &status);
@@ -935,28 +1170,10 @@ pub(crate) fn redacted_display(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-fn read_remote_input_to_writer(path: &Path, writer: &mut impl std::io::Write) -> Result<()> {
-    let source = ObjectStoreSource::open(path)?;
+fn read_remote_input_to_writer(path: &Path, writer: &mut impl Write) -> Result<()> {
+    let source = ObjectStoreSource::open_for_download(path)?;
     eprintln!("Warning: reading entire remote file {}", source.display_url);
-
-    source.runtime.block_on(async {
-        let response = source.store.get(&source.path).await.map_err(|err| {
-            concise_remote_operation_error("reading remote input from", &source.display_url, err)
-        })?;
-        validate_identity_content_encoding(&response.attributes, &source.display_url)?;
-        let mut stream = response.into_stream();
-        while let Some(bytes) = stream
-            .try_next()
-            .await
-            .with_context(|| format!("failed to read remote input {}", source.display_url))?
-        {
-            std::io::Write::write_all(writer, bytes.as_ref())
-                .with_context(|| format!("failed to write remote input {}", source.display_url))?;
-        }
-        Ok::<(), anyhow::Error>(())
-    })?;
-
-    Ok(())
+    source.download_to_writer(writer, REMOTE_DOWNLOAD_CHUNK_BYTES)
 }
 
 fn object_store_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
@@ -1562,6 +1779,18 @@ mod tests {
                             }
                         });
                 if let (true, Some((start, end))) = (supports_ranges, requested_range) {
+                    if start >= body.len() {
+                        stream
+                            .write_all(
+                                format!(
+                                    "HTTP/1.1 416 Range Not Satisfiable\r\nContent-Range: bytes */{}\r\nConnection: close\r\n\r\n",
+                                    body.len()
+                                )
+                                .as_bytes(),
+                            )
+                            .expect("write 416");
+                        continue;
+                    }
                     let end = end.min(body.len().saturating_sub(1));
                     let start = start.min(end);
                     let content = &body[start..=end];
@@ -1651,6 +1880,33 @@ mod tests {
         let input =
             load_path(Path::new(&url), super::SourceOptions::new(true)).expect("remote read");
         assert_eq!(input.as_slice(), b"hello remote");
+    }
+
+    #[test]
+    fn remote_http_download_uses_ranged_chunks() {
+        let body: &'static [u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        let (url, requests) = serve_http_counting(body, true);
+        let mut out = Vec::new();
+        let source = super::ObjectStoreSource::open_for_download(Path::new(&url))
+            .expect("open download source");
+        source
+            .download_to_writer(&mut out, 8)
+            .expect("chunked download");
+        assert_eq!(out, body);
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            5,
+            "36-byte body at 8-byte chunks should issue five range requests"
+        );
+    }
+
+    #[test]
+    fn remote_http_download_empty_object_falls_back_to_unranged_get() {
+        let url = serve_http(b"", true);
+        let mut out = Vec::new();
+        super::read_remote_input_to_writer(Path::new(&url), &mut out)
+            .expect("empty ranged object should fall back to an unranged GET");
+        assert!(out.is_empty());
     }
 
     #[test]
@@ -1958,9 +2214,10 @@ mod tests {
 
     #[test]
     fn object_store_source_open_uses_url_parser() {
-        let source =
-            super::ObjectStoreSource::open(Path::new("https://example.com/demo.mcap?token=secret"))
-                .expect("HTTP object store URL should parse");
+        let source = super::ObjectStoreSource::open_for_download(Path::new(
+            "https://example.com/demo.mcap?token=secret",
+        ))
+        .expect("HTTP object store URL should parse");
         assert_eq!(source.path.as_ref(), "demo.mcap");
         assert_eq!(source.display_url, "https://example.com/demo.mcap");
     }
@@ -1999,6 +2256,25 @@ mod tests {
                     "account".to_string()
                 ),
             ]
+        );
+    }
+
+    #[test]
+    fn remote_url_options_add_download_request_timeout() {
+        let url = super::RemoteUrl::parse(Path::new("https://example.com/demo.mcap")).expect("url");
+        let download = url.store_options(super::RemoteAccess::Download);
+        assert!(
+            download.iter().any(|(key, value)| key
+                == object_store::ClientConfigKey::Timeout.as_ref()
+                && value == super::REMOTE_DOWNLOAD_REQUEST_TIMEOUT),
+            "download options should set a long request timeout, got {download:?}"
+        );
+        let indexed = url.store_options(super::RemoteAccess::Indexed);
+        assert!(
+            !indexed
+                .iter()
+                .any(|(key, _)| key == object_store::ClientConfigKey::Timeout.as_ref()),
+            "indexed options should keep object_store's default timeout, got {indexed:?}"
         );
     }
 
@@ -2056,6 +2332,22 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn remote_range_unsatisfiable_matches_status_not_body_digits() {
+        let unsatisfiable = object_store::Error::Generic {
+            store: "HTTP",
+            source: "Server returned non-2xx status code: 416 Range Not Satisfiable".into(),
+        };
+        assert!(super::remote_range_unsatisfiable(&unsatisfiable));
+
+        let other = object_store::Error::Generic {
+            store: "HTTP",
+            source: "Server returned non-2xx status code: 400 Bad Request: request-id-416-xyz"
+                .into(),
+        };
+        assert!(!super::remote_range_unsatisfiable(&other));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

`mcap filter --allow-remote-scan` of a large remote file (the ~40GB S3 case in https://github.com/foxglove/mcap/issues/1803#issuecomment-5284209803) fails after about 3 minutes with nested `operation timed out` / `request or response body error`. Indexed commands (`info`, `list`, `get`) are unaffected because they only fetch a small tail.

object_store 0.13.2 applies a 30s client timeout from connect through the entire response body. Progress does not reset it. Failed attempts are retried until the 180s retry budget is exhausted, which matches the reporter's timing. v0.0.62 (Go CLI) did not have this timeout.

Local repro is transfer duration, not file size: a throttled HTTP body that takes longer than 30s hits the same error. Loopback 40GB can finish in under 30s, so throttling is the right repro, not a huge local file.

## Approach

Whole-file downloads now:

- Keep `parse_url_opts` (so GCS `allow_http` and other builder defaults stay intact).
- Set a long per-GET timeout (`7days`) on the download path only. Indexed/bounded reads still use the default 30s timeout. Connect timeout is unchanged.
- Bound waiting for each response **head** at 240s (above the 180s retry budget) so a silent endpoint cannot hang forever.
- Detect a stalled **body** (no bytes for 120s) separately, so an in-progress transfer is not killed.
- Download in 64MiB ranged GETs so each part gets a fresh object_store retry budget. Follow-up parts pin the first part's ETag (`If-Match`) so a mid-download overwrite fails instead of tearing the file.
- Fall back to an unranged GET when the store ignores `Range` or the object is empty (HTTP 416).
- Print TTY stderr progress (`Downloading X / Y`).

No new `--timeout` flag.

This does **not** make `filter` indexed. Rewrite commands still materialize the whole remote file; that remains a follow-up.

## Testing

- Unit tests for chunked range downloads, empty-object 416 fallback, download vs indexed timeout options, and 416 status matching (not a raw `"416"` substring).
- `cargo clippy -p mcap-cli --all-targets -- --no-deps -D warnings`
- `cargo test -p mcap-cli`

## Questions for review

These are product choices I made and would like input on:

1. **Part size.** 64MiB keeps a fresh 180s retry budget only above roughly 370KB/s. 16MiB would hold that guarantee down to ~90KB/s at 4× the request count.
2. **Stall at 95%.** A 120s stall currently aborts the whole download. We already track offset and could re-issue the remainder of the stalled part a bounded number of times.
3. **Head-phase 240s cap.** Pre-patch, a blackholing endpoint failed in ~3 minutes. I kept a finite head wait (240s) rather than waiting indefinitely with a frozen progress line.
4. **Mutating objects.** Follow-up parts use `If-Match`. A replaced object fails with `remote object changed while downloading`.

Related: Linear [DB-1587](https://linear.app/foxglove/issue/DB-1587/remote-reads-may-not-be-working-with-latest-cli). This PR addresses the filter timeout in #1803; it does not close that issue (credentials / `~/.aws` are separate, see #1808).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24d4d6b3-49a4-4679-a2c4-01bf8edc4d7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24d4d6b3-49a4-4679-a2c4-01bf8edc4d7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

