### PR TITLE
python: mcap_protobuf writer supports custom profiles

### DIFF
--- a/python/mcap-protobuf-support/mcap_protobuf/writer.py
+++ b/python/mcap-protobuf-support/mcap_protobuf/writer.py
@@ -27,6 +27,7 @@ class Writer:
         chunk_size: int = 1024 * 1024,
         compression: CompressionType = CompressionType.ZSTD,
         enable_crcs: bool = True,
+        profile: str = "",
     ):
         self._writer = McapWriter(
             output,
@@ -37,7 +38,7 @@ class Writer:
         self._schemas: Dict[str, Tuple[int, str]] = {}
         self._channels: Dict[str, int] = {}
         self._finished = False
-        self._writer.start(library=_library_identifier())
+        self._writer.start(profile=profile, library=_library_identifier())
 
     def write_message(
         self,

--- a/python/mcap-protobuf-support/tests/test_writer.py
+++ b/python/mcap-protobuf-support/tests/test_writer.py
@@ -65,3 +65,14 @@ def test_write_attachment():
     assert attachments[0].name == "test_attachment"
     assert attachments[0].media_type == "text/plain"
     assert attachments[0].data == b"test_data"
+
+
+def test_write_custom_profile():
+    output = BytesIO()
+    writer = Writer(output=output, profile="custom_profile")
+    writer.write_message("timestamps", Timestamp(seconds=5, nanos=10), log_time=15)
+    writer.finish()
+
+    output.seek(0)
+    reader = make_reader(output, decoder_factories=[DecoderFactory()])
+    assert reader.get_header().profile == "custom_profile"


### PR DESCRIPTION
### Changelog
mcap-protobuf-support python writer, now supports the definition of a custom profile string (since there is no well know default protobuf profile to set)

### Docs
None

### Description

mcap-protobuf-support python writer should accept a `profile` str parameter in the wrapper constructor (setting a default empty string), since there is no _well known_ protobuf profile.
In case someone wants to specify a custom profile, the current constructor removes that possibility w.r.t. the generic mcap writer (for no reason, as far as I'm concerned), while being basically only a wrapper.

### Tests
- Added unit test
- Checked that  mcap-cli shows the custom profile string, passed to the writer, on a test mcap file.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

```python
from mcap_protobuf.writer import Writer

with open("test.mcap", "wb") as f:
    writer = Writer(f)	# no way of setting a profile 
    ...
```

</td><td>

```python
from mcap_protobuf.writer import Writer

with open("test.mcap", "wb") as f:
    writer = Writer(f, profile="custom_profile")
    ...
```

</td></tr></table>

