### PR TITLE
typescript: mark internals as protected

### DIFF
--- a/typescript/core/src/ChunkBuilder.ts
+++ b/typescript/core/src/ChunkBuilder.ts
@@ -1,86 +1,86 @@
 import { McapRecordBuilder } from "./McapRecordBuilder.ts";
 import type { Channel, Message, MessageIndex, Schema } from "./types.ts";
 
-type ChunkBuilderOptions = {
+export type ChunkBuilderOptions = {
   useMessageIndex?: boolean;
 };
 class ChunkBuilder {
-  #recordWriter = new McapRecordBuilder();
-  #messageIndices: Map<number, MessageIndex> | undefined;
-  #totalMessageCount = 0;
+  protected recordWriter = new McapRecordBuilder();
+  protected messageIndices: Map<number, MessageIndex> | undefined;
+  protected totalMessageCount = 0;
 
   messageStartTime = 0n;
   messageEndTime = 0n;
 
   constructor({ useMessageIndex = true }: ChunkBuilderOptions) {
     if (useMessageIndex) {
-      this.#messageIndices = new Map();
+      this.messageIndices = new Map();
     }
   }
 
   get numMessages(): number {
-    return this.#totalMessageCount;
+    return this.totalMessageCount;
   }
 
   get buffer(): Uint8Array {
-    return this.#recordWriter.buffer;
+    return this.recordWriter.buffer;
   }
 
   get byteLength(): number {
-    return this.#recordWriter.length;
+    return this.recordWriter.length;
   }
 
   get indices(): Iterable<MessageIndex> {
-    if (this.#messageIndices) {
-      return this.#messageIndices.values();
+    if (this.messageIndices) {
+      return this.messageIndices.values();
     }
     return [];
   }
 
   addSchema(schema: Schema): void {
-    this.#recordWriter.writeSchema(schema);
+    this.recordWriter.writeSchema(schema);
   }
 
   addChannel(info: Channel): void {
-    if (this.#messageIndices && !this.#messageIndices.has(info.id)) {
-      this.#messageIndices.set(info.id, {
+    if (this.messageIndices && !this.messageIndices.has(info.id)) {
+      this.messageIndices.set(info.id, {
         channelId: info.id,
         records: [],
       });
     }
-    this.#recordWriter.writeChannel(info);
+    this.recordWriter.writeChannel(info);
   }
 
   addMessage(message: Message): void {
-    if (this.#totalMessageCount === 0 || message.logTime < this.messageStartTime) {
+    if (this.totalMessageCount === 0 || message.logTime < this.messageStartTime) {
       this.messageStartTime = message.logTime;
     }
-    if (this.#totalMessageCount === 0 || message.logTime > this.messageEndTime) {
+    if (this.totalMessageCount === 0 || message.logTime > this.messageEndTime) {
       this.messageEndTime = message.logTime;
     }
 
-    if (this.#messageIndices) {
-      let messageIndex = this.#messageIndices.get(message.channelId);
+    if (this.messageIndices) {
+      let messageIndex = this.messageIndices.get(message.channelId);
       if (!messageIndex) {
         messageIndex = {
           channelId: message.channelId,
           records: [],
         };
-        this.#messageIndices.set(message.channelId, messageIndex);
+        this.messageIndices.set(message.channelId, messageIndex);
       }
-      messageIndex.records.push([message.logTime, BigInt(this.#recordWriter.length)]);
+      messageIndex.records.push([message.logTime, BigInt(this.recordWriter.length)]);
     }
 
-    this.#totalMessageCount += 1;
-    this.#recordWriter.writeMessage(message);
+    this.totalMessageCount += 1;
+    this.recordWriter.writeMessage(message);
   }
 
   reset(): void {
     this.messageStartTime = 0n;
     this.messageEndTime = 0n;
-    this.#totalMessageCount = 0;
-    this.#messageIndices?.clear();
-    this.#recordWriter.reset();
+    this.totalMessageCount = 0;
+    this.messageIndices?.clear();
+    this.recordWriter.reset();
   }
 }
 

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -4,7 +4,7 @@ import { sortedIndexBy } from "./sortedIndexBy.ts";
 import { sortedLastIndexBy } from "./sortedLastIndex.ts";
 import type { IReadable, TypedMcapRecords } from "./types.ts";
 
-type ChunkCursorParams = {
+export type ChunkCursorParams = {
   chunkIndex: TypedMcapRecords["ChunkIndex"];
   relevantChannels: Set<number> | undefined;
   startTime: bigint | undefined;
@@ -28,24 +28,24 @@ type ChunkCursorParams = {
 export class ChunkCursor {
   readonly chunkIndex: TypedMcapRecords["ChunkIndex"];
 
-  #relevantChannels?: Set<number>;
-  #startTime: bigint | undefined;
-  #endTime: bigint | undefined;
-  #reverse: boolean;
-  #readFullMessageIndexRange: boolean;
+  protected relevantChannels?: Set<number>;
+  protected startTime: bigint | undefined;
+  protected endTime: bigint | undefined;
+  protected reverse: boolean;
+  protected readFullMessageIndexRange: boolean;
 
   // List of message offsets (across all channels) sorted by logTime.
-  #orderedMessageOffsets?: [logTime: bigint, offset: bigint][];
+  protected orderedMessageOffsets?: [logTime: bigint, offset: bigint][];
   // Index for the next message offset. Gets incremented for every popMessage() call.
-  #nextMessageOffsetIndex = 0;
+  protected nextMessageOffsetIndex = 0;
 
   constructor(params: ChunkCursorParams) {
     this.chunkIndex = params.chunkIndex;
-    this.#relevantChannels = params.relevantChannels;
-    this.#startTime = params.startTime;
-    this.#endTime = params.endTime;
-    this.#reverse = params.reverse;
-    this.#readFullMessageIndexRange = params.readFullMessageIndexRange ?? false;
+    this.relevantChannels = params.relevantChannels;
+    this.startTime = params.startTime;
+    this.endTime = params.endTime;
+    this.reverse = params.reverse;
+    this.readFullMessageIndexRange = params.readFullMessageIndexRange ?? false;
 
     if (this.chunkIndex.messageIndexLength === 0n) {
       // Chunk has no message indexes.
@@ -67,18 +67,18 @@ export class ChunkCursor {
    * and re-sort the cursors.
    */
   compare(other: ChunkCursor): number {
-    if (this.#reverse !== other.#reverse) {
+    if (this.reverse !== other.reverse) {
       throw new Error("Cannot compare a reversed ChunkCursor to a non-reversed ChunkCursor");
     }
 
-    let diff = Number(this.#getSortTime() - other.#getSortTime());
+    let diff = Number(this.getSortTime() - other.getSortTime());
 
     // Break ties by chunk offset in the file
     if (diff === 0) {
       diff = Number(this.chunkIndex.chunkStartOffset - other.chunkIndex.chunkStartOffset);
     }
 
-    return this.#reverse ? -diff : diff;
+    return this.reverse ? -diff : diff;
   }
 
   /**
@@ -86,10 +86,10 @@ export class ChunkCursor {
    * loaded before using this method.
    */
   hasMoreMessages(): boolean {
-    if (this.#orderedMessageOffsets == undefined) {
+    if (this.orderedMessageOffsets == undefined) {
       throw new Error("loadMessageIndexes() must be called before hasMore()");
     }
-    return this.#nextMessageOffsetIndex < this.#orderedMessageOffsets.length;
+    return this.nextMessageOffsetIndex < this.orderedMessageOffsets.length;
   }
 
   /**
@@ -97,16 +97,16 @@ export class ChunkCursor {
    * using this method.
    */
   popMessage(): [logTime: bigint, offset: bigint] {
-    if (this.#orderedMessageOffsets == undefined) {
+    if (this.orderedMessageOffsets == undefined) {
       throw new Error("loadMessageIndexes() must be called before popMessage()");
     }
-    if (this.#nextMessageOffsetIndex >= this.#orderedMessageOffsets.length) {
+    if (this.nextMessageOffsetIndex >= this.orderedMessageOffsets.length) {
       throw new Error(
         `Unexpected popMessage() call when no more messages are available, in chunk at offset ${this.chunkIndex.chunkStartOffset}`,
       );
     }
 
-    return this.#orderedMessageOffsets[this.#nextMessageOffsetIndex++]!;
+    return this.orderedMessageOffsets[this.nextMessageOffsetIndex++]!;
   }
 
   /**
@@ -114,20 +114,20 @@ export class ChunkCursor {
    * called.
    */
   hasMessageIndexes(): boolean {
-    return this.#orderedMessageOffsets != undefined;
+    return this.orderedMessageOffsets != undefined;
   }
 
   async loadMessageIndexes(readable: IReadable): Promise<void> {
-    const reverse = this.#reverse;
+    const reverse = this.reverse;
     let messageIndexStartOffset: bigint | undefined;
     let relevantMessageIndexStartOffset: bigint | undefined;
-    const readFullRange = this.#readFullMessageIndexRange;
+    const readFullRange = this.readFullMessageIndexRange;
 
     for (const [channelId, offset] of this.chunkIndex.messageIndexOffsets) {
       if (messageIndexStartOffset == undefined || offset < messageIndexStartOffset) {
         messageIndexStartOffset = offset;
       }
-      if (readFullRange || !this.#relevantChannels || this.#relevantChannels.has(channelId)) {
+      if (readFullRange || !this.relevantChannels || this.relevantChannels.has(channelId)) {
         if (
           relevantMessageIndexStartOffset == undefined ||
           offset < relevantMessageIndexStartOffset
@@ -137,7 +137,7 @@ export class ChunkCursor {
       }
     }
     if (messageIndexStartOffset == undefined || relevantMessageIndexStartOffset == undefined) {
-      this.#orderedMessageOffsets = [];
+      this.orderedMessageOffsets = [];
       return;
     }
 
@@ -162,7 +162,7 @@ export class ChunkCursor {
       }
       if (
         record.records.length === 0 ||
-        (this.#relevantChannels && !this.#relevantChannels.has(record.channelId))
+        (this.relevantChannels && !this.relevantChannels.has(record.channelId))
       ) {
         continue;
       }
@@ -174,7 +174,7 @@ export class ChunkCursor {
       throw new Error(`${reader.bytesRemaining()} bytes remaining in message index section`);
     }
 
-    this.#orderedMessageOffsets = arrayOfMessageOffsets
+    this.orderedMessageOffsets = arrayOfMessageOffsets
       .flat()
       .sort(([logTimeA, offsetA], [logTimeB, offsetB]) => {
         let diff = Number(logTimeA - logTimeB);
@@ -191,22 +191,21 @@ export class ChunkCursor {
       // If we used `logTimeB - logTimeA` as the comparator for reverse iteration, messages with
       // the same timestamp would not be in reverse order. To avoid this problem we use reverse()
       // instead.
-      this.#orderedMessageOffsets.reverse();
+      this.orderedMessageOffsets.reverse();
     }
 
-    if (this.#orderedMessageOffsets.length === 0) {
+    if (this.orderedMessageOffsets.length === 0) {
       return;
     }
 
-    const [logTimeFirstMessage] = this.#orderedMessageOffsets[0]!;
+    const [logTimeFirstMessage] = this.orderedMessageOffsets[0]!;
     if (logTimeFirstMessage < this.chunkIndex.messageStartTime) {
       throw new Error(
         `Chunk at offset ${this.chunkIndex.chunkStartOffset} contains a message with logTime (${logTimeFirstMessage}) earlier than chunk messageStartTime (${this.chunkIndex.messageStartTime})`,
       );
     }
 
-    const [logTimeLastMessage] =
-      this.#orderedMessageOffsets[this.#orderedMessageOffsets.length - 1]!;
+    const [logTimeLastMessage] = this.orderedMessageOffsets[this.orderedMessageOffsets.length - 1]!;
     if (logTimeLastMessage > this.chunkIndex.messageEndTime) {
       throw new Error(
         `Chunk at offset ${this.chunkIndex.chunkStartOffset} contains a message with logTime (${logTimeLastMessage}) later than chunk messageEndTime (${this.chunkIndex.messageEndTime})`,
@@ -214,38 +213,38 @@ export class ChunkCursor {
     }
 
     // Determine the indexes corresponding to the start and end time.
-    const startTime = reverse ? this.#endTime : this.#startTime;
-    const endTime = reverse ? this.#startTime : this.#endTime;
+    const startTime = reverse ? this.endTime : this.startTime;
+    const endTime = reverse ? this.startTime : this.endTime;
     const iteratee = reverse ? (logTime: bigint) => -logTime : (logTime: bigint) => logTime;
     let startIndex: number | undefined;
     let endIndex: number | undefined;
 
     if (startTime != undefined) {
-      startIndex = sortedIndexBy(this.#orderedMessageOffsets, startTime, iteratee);
+      startIndex = sortedIndexBy(this.orderedMessageOffsets, startTime, iteratee);
     }
     if (endTime != undefined) {
-      endIndex = sortedLastIndexBy(this.#orderedMessageOffsets, endTime, iteratee);
+      endIndex = sortedLastIndexBy(this.orderedMessageOffsets, endTime, iteratee);
     }
 
     // Remove offsets whose log time is outside of the range [startTime, endTime] which
     // avoids having to do additional book-keep of additional array start & stop indexes.
     if (startIndex != undefined || endIndex != undefined) {
-      this.#orderedMessageOffsets = this.#orderedMessageOffsets.slice(startIndex, endIndex);
+      this.orderedMessageOffsets = this.orderedMessageOffsets.slice(startIndex, endIndex);
     }
   }
 
   // Get the next available message logTime which is being used when comparing chunkCursors (for ordering purposes).
-  #getSortTime(): bigint {
+  protected getSortTime(): bigint {
     // If message indexes have been loaded and are non-empty, we return the logTime of the next available message.
     if (
-      this.#orderedMessageOffsets != undefined &&
-      this.#orderedMessageOffsets.length > 0 &&
-      this.#nextMessageOffsetIndex < this.#orderedMessageOffsets.length
+      this.orderedMessageOffsets != undefined &&
+      this.orderedMessageOffsets.length > 0 &&
+      this.nextMessageOffsetIndex < this.orderedMessageOffsets.length
     ) {
-      return this.#orderedMessageOffsets[this.#nextMessageOffsetIndex]![0];
+      return this.orderedMessageOffsets[this.nextMessageOffsetIndex]![0];
     }
 
     // Fall back to the chunk index' start time or end time.
-    return this.#reverse ? this.chunkIndex.messageEndTime : this.chunkIndex.messageStartTime;
+    return this.reverse ? this.chunkIndex.messageEndTime : this.chunkIndex.messageStartTime;
   }
 }

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -8,7 +8,7 @@ import { MCAP_MAGIC } from "./constants.ts";
 import { parseMagic, parseRecord } from "./parse.ts";
 import type { DecompressHandlers, IReadable, TypedMcapRecords } from "./types.ts";
 
-type McapIndexedReaderArgs = {
+export type McapIndexedReaderArgs = {
   readable: IReadable;
   chunkIndexes: readonly TypedMcapRecords["ChunkIndex"][];
   attachmentIndexes: readonly TypedMcapRecords["AttachmentIndex"][];
@@ -47,22 +47,22 @@ export class McapIndexedReader {
   readonly dataEndOffset: bigint;
   readonly dataSectionCrc?: number;
 
-  #readable: IReadable;
-  #messageIndexReadable: IReadable;
-  #decompressHandlers?: DecompressHandlers;
+  protected readable: IReadable;
+  protected messageIndexReadable: IReadable;
+  protected decompressHandlers?: DecompressHandlers;
 
-  #messageStartTime: bigint | undefined;
-  #messageEndTime: bigint | undefined;
-  #attachmentStartTime: bigint | undefined;
-  #attachmentEndTime: bigint | undefined;
+  protected messageStartTime: bigint | undefined;
+  protected messageEndTime: bigint | undefined;
+  protected attachmentStartTime: bigint | undefined;
+  protected attachmentEndTime: bigint | undefined;
 
-  private constructor(args: McapIndexedReaderArgs) {
-    this.#readable = args.readable;
+  protected constructor(args: McapIndexedReaderArgs) {
+    this.readable = args.readable;
     this.chunkIndexes = args.chunkIndexes;
     this.attachmentIndexes = args.attachmentIndexes;
     this.metadataIndexes = args.metadataIndexes;
     this.statistics = args.statistics;
-    this.#decompressHandlers = args.decompressHandlers;
+    this.decompressHandlers = args.decompressHandlers;
     this.channelsById = args.channelsById;
     this.schemasById = args.schemasById;
     this.summaryOffsetsByOpcode = args.summaryOffsetsByOpcode;
@@ -72,59 +72,59 @@ export class McapIndexedReader {
     this.dataSectionCrc = args.dataSectionCrc;
 
     const messageIndexCacheSizeBytes = args.messageIndexCacheSizeBytes ?? 0;
-    this.#messageIndexReadable =
+    this.messageIndexReadable =
       messageIndexCacheSizeBytes > 0
-        ? new CachedReadable(this.#readable, messageIndexCacheSizeBytes)
-        : this.#readable;
+        ? new CachedReadable(this.readable, messageIndexCacheSizeBytes)
+        : this.readable;
 
     for (const chunk of args.chunkIndexes) {
-      if (this.#messageStartTime == undefined || chunk.messageStartTime < this.#messageStartTime) {
-        this.#messageStartTime = chunk.messageStartTime;
+      if (this.messageStartTime == undefined || chunk.messageStartTime < this.messageStartTime) {
+        this.messageStartTime = chunk.messageStartTime;
       }
-      if (this.#messageEndTime == undefined || chunk.messageEndTime > this.#messageEndTime) {
-        this.#messageEndTime = chunk.messageEndTime;
+      if (this.messageEndTime == undefined || chunk.messageEndTime > this.messageEndTime) {
+        this.messageEndTime = chunk.messageEndTime;
       }
     }
 
     for (const attachment of args.attachmentIndexes) {
-      if (
-        this.#attachmentStartTime == undefined ||
-        attachment.logTime < this.#attachmentStartTime
-      ) {
-        this.#attachmentStartTime = attachment.logTime;
+      if (this.attachmentStartTime == undefined || attachment.logTime < this.attachmentStartTime) {
+        this.attachmentStartTime = attachment.logTime;
       }
-      if (this.#attachmentEndTime == undefined || attachment.logTime > this.#attachmentEndTime) {
-        this.#attachmentEndTime = attachment.logTime;
+      if (this.attachmentEndTime == undefined || attachment.logTime > this.attachmentEndTime) {
+        this.attachmentEndTime = attachment.logTime;
       }
     }
   }
 
-  #errorWithLibrary(message: string): Error {
+  protected errorWithLibrary(message: string): Error {
     return new Error(`${message} [library=${this.header.library}]`);
   }
 
-  static async Initialize({
-    readable,
-    decompressHandlers,
-    messageIndexCacheSizeBytes,
-  }: {
-    readable: IReadable;
+  static async Initialize<T extends typeof McapIndexedReader>(
+    this: T,
+    {
+      readable,
+      decompressHandlers,
+      messageIndexCacheSizeBytes,
+    }: {
+      readable: IReadable;
 
-    /**
-     * When a compressed chunk is encountered, the entry in `decompressHandlers` corresponding to the
-     * compression will be called to decompress the chunk data.
-     */
-    decompressHandlers?: DecompressHandlers;
-    /**
-     * Maximum number of bytes of message index data to cache in memory across calls to
-     * `readMessages()`. When > 0, message indexes read on demand are cached so subsequent calls do
-     * not re-read them from the underlying readable. Defaults to 0 (no caching).
-     *
-     * When caching is enabled, each chunk's full message index region is read on first access so
-     * that later queries against different channels can be served from the cache.
-     */
-    messageIndexCacheSizeBytes?: number;
-  }): Promise<McapIndexedReader> {
+      /**
+       * When a compressed chunk is encountered, the entry in `decompressHandlers` corresponding to the
+       * compression will be called to decompress the chunk data.
+       */
+      decompressHandlers?: DecompressHandlers;
+      /**
+       * Maximum number of bytes of message index data to cache in memory across calls to
+       * `readMessages()`. When > 0, message indexes read on demand are cached so subsequent calls do
+       * not re-read them from the underlying readable. Defaults to 0 (no caching).
+       *
+       * When caching is enabled, each chunk's full message index region is read on first access so
+       * that later queries against different channels can be served from the cache.
+       */
+      messageIndexCacheSizeBytes?: number;
+    },
+  ): Promise<T["prototype"]> {
     const size = await readable.size();
 
     let header: TypedMcapRecords["Header"];
@@ -345,7 +345,7 @@ export class McapIndexedReader {
       throw errorWithLibrary(`${indexReader.bytesRemaining()} bytes remaining in index section`);
     }
 
-    return new McapIndexedReader({
+    return new this({
       readable,
       chunkIndexes,
       attachmentIndexes,
@@ -374,8 +374,8 @@ export class McapIndexedReader {
   ): AsyncGenerator<TypedMcapRecords["Message"], void, void> {
     const {
       topics,
-      startTime = this.#messageStartTime,
-      endTime = this.#messageEndTime,
+      startTime = this.messageStartTime,
+      endTime = this.messageEndTime,
       reverse = false,
       validateCrcs,
     } = args;
@@ -397,7 +397,7 @@ export class McapIndexedReader {
     const chunkCursors = new Heap<ChunkCursor>((a, b) => a.compare(b));
     let chunksOrdered = true;
     let prevChunkEndTime: bigint | undefined;
-    const readFullMessageIndexRange = this.#messageIndexReadable !== this.#readable;
+    const readFullMessageIndexRange = this.messageIndexReadable !== this.readable;
     for (const chunkIndex of this.chunkIndexes) {
       if (chunkIndex.messageStartTime <= endTime && chunkIndex.messageEndTime >= startTime) {
         chunkCursors.push(
@@ -425,7 +425,7 @@ export class McapIndexedReader {
     for (let cursor; (cursor = chunkCursors.peek()); ) {
       if (!cursor.hasMessageIndexes()) {
         // If we encounter a chunk whose message indexes have not been loaded yet, load them and re-organize the heap.
-        await cursor.loadMessageIndexes(this.#messageIndexReadable);
+        await cursor.loadMessageIndexes(this.messageIndexReadable);
         if (cursor.hasMoreMessages()) {
           chunkCursors.replace(cursor);
         } else {
@@ -436,7 +436,7 @@ export class McapIndexedReader {
 
       let chunkView = chunkViewCache.get(cursor.chunkIndex.chunkStartOffset);
       if (!chunkView) {
-        chunkView = await this.#loadChunkData(cursor.chunkIndex, {
+        chunkView = await this.loadChunkData(cursor.chunkIndex, {
           validateCrcs: validateCrcs ?? true,
         });
         chunkViewCache.set(cursor.chunkIndex.chunkStartOffset, chunkView);
@@ -444,24 +444,24 @@ export class McapIndexedReader {
 
       const [logTime, offset] = cursor.popMessage();
       if (offset >= BigInt(chunkView.byteLength)) {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Message offset beyond chunk bounds (log time ${logTime}, offset ${offset}, chunk data length ${chunkView.byteLength}) in chunk at offset ${cursor.chunkIndex.chunkStartOffset}`,
         );
       }
       chunkReader.reset(chunkView, Number(offset));
       const record = parseRecord(chunkReader, validateCrcs ?? true);
       if (!record) {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Unable to parse record at offset ${offset} in chunk at offset ${cursor.chunkIndex.chunkStartOffset}`,
         );
       }
       if (record.type !== "Message") {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Unexpected record type ${record.type} in message index (time ${logTime}, offset ${offset} in chunk at offset ${cursor.chunkIndex.chunkStartOffset})`,
         );
       }
       if (record.logTime !== logTime) {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Message log time ${record.logTime} did not match message index entry (${logTime} at offset ${offset} in chunk at offset ${cursor.chunkIndex.chunkStartOffset})`,
         );
       }
@@ -491,13 +491,13 @@ export class McapIndexedReader {
       if (name != undefined && metadataIndex.name !== name) {
         continue;
       }
-      const metadataData = await this.#readable.read(metadataIndex.offset, metadataIndex.length);
+      const metadataData = await this.readable.read(metadataIndex.offset, metadataIndex.length);
       const metadataReader = new Reader(
         new DataView(metadataData.buffer, metadataData.byteOffset, metadataData.byteLength),
       );
       const metadataRecord = parseRecord(metadataReader, false);
       if (metadataRecord?.type !== "Metadata") {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Metadata data at offset ${
             metadataIndex.offset
           } does not point to metadata record (found ${String(metadataRecord?.type)})`,
@@ -519,8 +519,8 @@ export class McapIndexedReader {
     const {
       name,
       mediaType,
-      startTime = this.#attachmentStartTime,
-      endTime = this.#attachmentEndTime,
+      startTime = this.attachmentStartTime,
+      endTime = this.attachmentEndTime,
       validateCrcs,
     } = args;
 
@@ -538,7 +538,7 @@ export class McapIndexedReader {
       if (attachmentIndex.logTime > endTime || attachmentIndex.logTime < startTime) {
         continue;
       }
-      const attachmentData = await this.#readable.read(
+      const attachmentData = await this.readable.read(
         attachmentIndex.offset,
         attachmentIndex.length,
       );
@@ -547,7 +547,7 @@ export class McapIndexedReader {
       );
       const attachmentRecord = parseRecord(attachmentReader, validateCrcs ?? true);
       if (attachmentRecord?.type !== "Attachment") {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Attachment data at offset ${
             attachmentIndex.offset
           } does not point to attachment record (found ${String(attachmentRecord?.type)})`,
@@ -557,20 +557,17 @@ export class McapIndexedReader {
     }
   }
 
-  async #loadChunkData(
+  protected async loadChunkData(
     chunkIndex: TypedMcapRecords["ChunkIndex"],
     options?: { validateCrcs: boolean },
   ): Promise<DataView> {
-    const chunkData = await this.#readable.read(
-      chunkIndex.chunkStartOffset,
-      chunkIndex.chunkLength,
-    );
+    const chunkData = await this.readable.read(chunkIndex.chunkStartOffset, chunkIndex.chunkLength);
     const chunkReader = new Reader(
       new DataView(chunkData.buffer, chunkData.byteOffset, chunkData.byteLength),
     );
     const chunkRecord = parseRecord(chunkReader, options?.validateCrcs ?? true);
     if (chunkRecord?.type !== "Chunk") {
-      throw this.#errorWithLibrary(
+      throw this.errorWithLibrary(
         `Chunk start offset ${
           chunkIndex.chunkStartOffset
         } does not point to chunk record (found ${String(chunkRecord?.type)})`,
@@ -580,16 +577,16 @@ export class McapIndexedReader {
     const chunk = chunkRecord;
     let buffer = chunk.records;
     if (chunk.compression !== "" && buffer.byteLength > 0) {
-      const decompress = this.#decompressHandlers?.[chunk.compression];
+      const decompress = this.decompressHandlers?.[chunk.compression];
       if (!decompress) {
-        throw this.#errorWithLibrary(`Unsupported compression ${chunk.compression}`);
+        throw this.errorWithLibrary(`Unsupported compression ${chunk.compression}`);
       }
       buffer = decompress(buffer, chunk.uncompressedSize);
     }
     if (chunk.uncompressedCrc !== 0 && options?.validateCrcs !== false) {
       const chunkCrc = crc32(buffer);
       if (chunkCrc !== chunk.uncompressedCrc) {
-        throw this.#errorWithLibrary(
+        throw this.errorWithLibrary(
           `Incorrect chunk CRC ${chunkCrc} (expected ${chunk.uncompressedCrc})`,
         );
       }

--- a/typescript/core/src/McapRecordBuilder.ts
+++ b/typescript/core/src/McapRecordBuilder.ts
@@ -20,7 +20,7 @@ import type {
   SummaryOffset,
 } from "./types.ts";
 
-type Options = {
+export type McapRecordBuilderOptions = {
   /** Add an unspecified number of extra padding bytes at the end of each record */
   padRecords: boolean;
 };
@@ -35,41 +35,41 @@ type Options = {
  * own higher level writing interface.
  */
 export class McapRecordBuilder {
-  #bufferBuilder = new BufferBuilder();
+  protected bufferBuilder = new BufferBuilder();
 
-  constructor(private options?: Options) {}
+  constructor(protected options?: McapRecordBuilderOptions) {}
 
   get length(): number {
-    return this.#bufferBuilder.length;
+    return this.bufferBuilder.length;
   }
 
   get buffer(): Uint8Array {
-    return this.#bufferBuilder.buffer;
+    return this.bufferBuilder.buffer;
   }
 
   reset(): void {
-    this.#bufferBuilder.reset();
+    this.bufferBuilder.reset();
   }
 
   writeMagic(): void {
-    this.#bufferBuilder.bytes(new Uint8Array(MCAP_MAGIC));
+    this.bufferBuilder.bytes(new Uint8Array(MCAP_MAGIC));
   }
 
   writeHeader(header: Header): bigint {
-    this.#bufferBuilder.uint8(Opcode.HEADER);
+    this.bufferBuilder.uint8(Opcode.HEADER);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder size
       .string(header.profile)
       .string(header.library);
 
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -78,7 +78,7 @@ export class McapRecordBuilder {
   }
 
   writeFooter(footer: Footer): bigint {
-    this.#bufferBuilder
+    this.bufferBuilder
       .uint8(Opcode.FOOTER)
       .uint64(20n) // footer is fixed length
       .uint64(footer.summaryStart)
@@ -89,10 +89,10 @@ export class McapRecordBuilder {
   }
 
   writeSchema(schema: Schema): bigint {
-    this.#bufferBuilder.uint8(Opcode.SCHEMA);
+    this.bufferBuilder.uint8(Opcode.SCHEMA);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint16(schema.id)
       .string(schema.name)
@@ -101,10 +101,10 @@ export class McapRecordBuilder {
       .bytes(schema.data);
 
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -113,25 +113,25 @@ export class McapRecordBuilder {
   }
 
   writeChannel(info: Channel): bigint {
-    this.#bufferBuilder.uint8(Opcode.CHANNEL);
+    this.bufferBuilder.uint8(Opcode.CHANNEL);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint16(info.id)
       .uint16(info.schemaId)
       .string(info.topic)
       .string(info.messageEncoding)
       .tupleArray(
-        (key) => this.#bufferBuilder.string(key),
-        (value) => this.#bufferBuilder.string(value),
+        (key) => this.bufferBuilder.string(key),
+        (value) => this.bufferBuilder.string(value),
         info.metadata,
       );
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -140,9 +140,9 @@ export class McapRecordBuilder {
   }
 
   writeMessage(message: Message): void {
-    this.#bufferBuilder.uint8(Opcode.MESSAGE);
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    this.bufferBuilder.uint8(Opcode.MESSAGE);
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint16(message.channelId)
       .uint32(message.sequence)
@@ -150,40 +150,40 @@ export class McapRecordBuilder {
       .uint64(message.publishTime)
       .bytes(message.data);
     // message record cannot be padded
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
   }
 
   writeAttachment(attachment: Attachment): bigint {
-    this.#bufferBuilder.uint8(Opcode.ATTACHMENT);
+    this.bufferBuilder.uint8(Opcode.ATTACHMENT);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder.uint64(0n); // placeholder
-    const crcStartPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder.uint64(0n); // placeholder
+    const crcStartPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(attachment.logTime)
       .uint64(attachment.createTime)
       .string(attachment.name)
       .string(attachment.mediaType)
       .uint64(BigInt(attachment.data.byteLength))
       .bytes(attachment.data);
-    this.#bufferBuilder.uint32(
+    this.bufferBuilder.uint32(
       crc32(
-        this.#bufferBuilder.bufferView(
+        this.bufferBuilder.bufferView(
           crcStartPosition,
-          this.#bufferBuilder.length - crcStartPosition,
+          this.bufferBuilder.length - crcStartPosition,
         ),
       ),
     );
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -192,10 +192,10 @@ export class McapRecordBuilder {
   }
 
   writeAttachmentIndex(attachmentIndex: AttachmentIndex): bigint {
-    this.#bufferBuilder.uint8(Opcode.ATTACHMENT_INDEX);
+    this.bufferBuilder.uint8(Opcode.ATTACHMENT_INDEX);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint64(attachmentIndex.offset)
       .uint64(attachmentIndex.length)
@@ -205,11 +205,11 @@ export class McapRecordBuilder {
       .string(attachmentIndex.name)
       .string(attachmentIndex.mediaType);
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -218,10 +218,10 @@ export class McapRecordBuilder {
   }
 
   writeChunk(chunk: Chunk): bigint {
-    this.#bufferBuilder.uint8(Opcode.CHUNK);
+    this.bufferBuilder.uint8(Opcode.CHUNK);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint64(chunk.messageStartTime)
       .uint64(chunk.messageEndTime)
@@ -231,8 +231,8 @@ export class McapRecordBuilder {
       .uint64(BigInt(chunk.records.byteLength))
       .bytes(chunk.records);
     // chunk record cannot be padded
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -241,10 +241,10 @@ export class McapRecordBuilder {
   }
 
   writeChunkIndex(chunkIndex: ChunkIndex): bigint {
-    this.#bufferBuilder.uint8(Opcode.CHUNK_INDEX);
+    this.bufferBuilder.uint8(Opcode.CHUNK_INDEX);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint64(chunkIndex.messageStartTime)
       .uint64(chunkIndex.messageEndTime)
@@ -253,20 +253,20 @@ export class McapRecordBuilder {
       .uint32(chunkIndex.messageIndexOffsets.size * 10);
 
     for (const [channelId, offset] of chunkIndex.messageIndexOffsets) {
-      this.#bufferBuilder.uint16(channelId).uint64(offset);
+      this.bufferBuilder.uint16(channelId).uint64(offset);
     }
 
-    this.#bufferBuilder
+    this.bufferBuilder
       .uint64(chunkIndex.messageIndexLength)
       .string(chunkIndex.compression)
       .uint64(chunkIndex.compressedSize)
       .uint64(chunkIndex.uncompressedSize);
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -275,26 +275,26 @@ export class McapRecordBuilder {
   }
 
   writeMessageIndex(messageIndex: MessageIndex): bigint {
-    this.#bufferBuilder.uint8(Opcode.MESSAGE_INDEX);
-    const startPosition = this.#bufferBuilder.length;
+    this.bufferBuilder.uint8(Opcode.MESSAGE_INDEX);
+    const startPosition = this.bufferBuilder.length;
 
     // each records tuple is a fixed byte length
     const messageIndexRecordsByteLength = messageIndex.records.length * 16;
 
-    this.#bufferBuilder
+    this.bufferBuilder
       .uint64(0n) // placeholder
       .uint16(messageIndex.channelId)
       .uint32(messageIndexRecordsByteLength);
 
     for (const record of messageIndex.records) {
-      this.#bufferBuilder.uint64(record[0]).uint64(record[1]);
+      this.bufferBuilder.uint64(record[0]).uint64(record[1]);
     }
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -302,23 +302,23 @@ export class McapRecordBuilder {
   }
 
   writeMetadata(metadata: Metadata): bigint {
-    this.#bufferBuilder.uint8(Opcode.METADATA);
+    this.bufferBuilder.uint8(Opcode.METADATA);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder size
       .string(metadata.name)
       .tupleArray(
-        (key) => this.#bufferBuilder.string(key),
-        (value) => this.#bufferBuilder.string(value),
+        (key) => this.bufferBuilder.string(key),
+        (value) => this.bufferBuilder.string(value),
         metadata.metadata,
       );
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -327,20 +327,20 @@ export class McapRecordBuilder {
   }
 
   writeMetadataIndex(metadataIndex: MetadataIndex): bigint {
-    this.#bufferBuilder.uint8(Opcode.METADATA_INDEX);
+    this.bufferBuilder.uint8(Opcode.METADATA_INDEX);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder size
       .uint64(metadataIndex.offset)
       .uint64(metadataIndex.length)
       .string(metadataIndex.name);
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -349,20 +349,20 @@ export class McapRecordBuilder {
   }
 
   writeSummaryOffset(summaryOffset: SummaryOffset): bigint {
-    this.#bufferBuilder.uint8(Opcode.SUMMARY_OFFSET);
+    this.bufferBuilder.uint8(Opcode.SUMMARY_OFFSET);
 
-    const startPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const startPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .uint64(0n) // placeholder size
       .uint8(summaryOffset.groupOpcode)
       .uint64(summaryOffset.groupStart)
       .uint64(summaryOffset.groupLength);
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -371,11 +371,11 @@ export class McapRecordBuilder {
   }
 
   writeStatistics(statistics: Statistics): bigint {
-    this.#bufferBuilder.uint8(Opcode.STATISTICS);
+    this.bufferBuilder.uint8(Opcode.STATISTICS);
 
-    const startPosition = this.#bufferBuilder.length;
+    const startPosition = this.bufferBuilder.length;
 
-    this.#bufferBuilder
+    this.bufferBuilder
       .uint64(0n) // placeholder size
       .uint64(statistics.messageCount)
       .uint16(statistics.schemaCount)
@@ -386,16 +386,16 @@ export class McapRecordBuilder {
       .uint64(statistics.messageStartTime)
       .uint64(statistics.messageEndTime)
       .tupleArray(
-        (key) => this.#bufferBuilder.uint16(key),
-        (value) => this.#bufferBuilder.uint64(value),
+        (key) => this.bufferBuilder.uint16(key),
+        (value) => this.bufferBuilder.uint64(value),
         statistics.channelMessageCounts,
       );
     if (this.options?.padRecords === true) {
-      this.#bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
+      this.bufferBuilder.uint8(0x01).uint8(0xff).uint8(0xff);
     }
 
-    const endPosition = this.#bufferBuilder.length;
-    this.#bufferBuilder
+    const endPosition = this.bufferBuilder.length;
+    this.bufferBuilder
       .seek(startPosition)
       .uint64(BigInt(endPosition - startPosition - 8))
       .seek(endPosition);
@@ -404,7 +404,7 @@ export class McapRecordBuilder {
   }
 
   writeDataEnd(dataEnd: DataEnd): bigint {
-    this.#bufferBuilder
+    this.bufferBuilder
       .uint8(Opcode.DATA_END)
       .uint64(4n) // data end is fixed length
       .uint32(dataEnd.dataSectionCrc);

--- a/typescript/core/src/McapStreamReader.ts
+++ b/typescript/core/src/McapStreamReader.ts
@@ -11,7 +11,7 @@ import type {
   TypedMcapRecords,
 } from "./types.ts";
 
-type McapReaderOptions = {
+export type McapReaderOptions = {
   /**
    * When set to true, Chunk records will be returned from `nextRecord()`. Chunk contents will still
    * be processed after each chunk record itself.
@@ -56,16 +56,16 @@ type McapReaderOptions = {
  * ```
  */
 export default class McapStreamReader {
-  #buffer = new ArrayBuffer(MCAP_MAGIC.length * 2);
-  #view = new DataView(this.#buffer, 0, 0);
-  #reader = new Reader(this.#view);
-  #decompressHandlers;
-  #includeChunks;
-  #validateCrcs;
-  #noMagicPrefix;
-  #doneReading = false;
-  #generator = this.#read();
-  #channelsById = new Map<number, TypedMcapRecords["Channel"]>();
+  protected buffer = new ArrayBuffer(MCAP_MAGIC.length * 2);
+  protected view = new DataView(this.buffer, 0, 0);
+  protected reader = new Reader(this.view);
+  protected decompressHandlers: DecompressHandlers;
+  protected includeChunks: boolean;
+  protected validateCrcs: boolean;
+  protected noMagicPrefix: boolean;
+  protected doneReading = false;
+  protected generator = this.read();
+  protected channelsById = new Map<number, TypedMcapRecords["Channel"]>();
 
   constructor({
     includeChunks = false,
@@ -73,20 +73,20 @@ export default class McapStreamReader {
     validateCrcs = true,
     noMagicPrefix = false,
   }: McapReaderOptions = {}) {
-    this.#includeChunks = includeChunks;
-    this.#decompressHandlers = decompressHandlers;
-    this.#validateCrcs = validateCrcs;
-    this.#noMagicPrefix = noMagicPrefix;
+    this.includeChunks = includeChunks;
+    this.decompressHandlers = decompressHandlers;
+    this.validateCrcs = validateCrcs;
+    this.noMagicPrefix = noMagicPrefix;
   }
 
   /** @returns True if a valid, complete mcap file has been parsed. */
   done(): boolean {
-    return this.#doneReading;
+    return this.doneReading;
   }
 
   /** @returns The number of bytes that have been received by `append()` but not yet parsed. */
   bytesRemaining(): number {
-    return this.#reader.bytesRemaining();
+    return this.reader.bytesRemaining();
   }
 
   /**
@@ -94,64 +94,61 @@ export default class McapStreamReader {
    * call `nextRecord()` again to parse any records that are now available.
    */
   append(data: Uint8Array): void {
-    if (this.#doneReading) {
+    if (this.doneReading) {
       throw new Error("Already done reading");
     }
-    this.#appendOrShift(data);
+    this.appendOrShift(data);
   }
 
-  #appendOrShift(data: Uint8Array): void {
+  protected appendOrShift(data: Uint8Array): void {
     /** Add data to the buffer, shifting existing data or reallocating if necessary. */
-    const consumedBytes = this.#reader.offset;
-    const unconsumedBytes = this.#view.byteLength - consumedBytes;
+    const consumedBytes = this.reader.offset;
+    const unconsumedBytes = this.view.byteLength - consumedBytes;
     const neededCapacity = unconsumedBytes + data.byteLength;
 
-    if (neededCapacity <= this.#buffer.byteLength) {
+    if (neededCapacity <= this.buffer.byteLength) {
       // Data fits in the current buffer
-      if (
-        this.#view.byteOffset + this.#view.byteLength + data.byteLength <=
-        this.#buffer.byteLength
-      ) {
+      if (this.view.byteOffset + this.view.byteLength + data.byteLength <= this.buffer.byteLength) {
         // Data fits by appending only
-        const array = new Uint8Array(this.#buffer, this.#view.byteOffset);
-        array.set(data, this.#view.byteLength);
-        this.#view = new DataView(
-          this.#buffer,
-          this.#view.byteOffset,
-          this.#view.byteLength + data.byteLength,
+        const array = new Uint8Array(this.buffer, this.view.byteOffset);
+        array.set(data, this.view.byteLength);
+        this.view = new DataView(
+          this.buffer,
+          this.view.byteOffset,
+          this.view.byteLength + data.byteLength,
         );
         // Reset the reader to use the new larger view. We keep the reader's previous offset as the
         // view's byte offset didn't change, it only got larger.
-        this.#reader.reset(this.#view, this.#reader.offset);
+        this.reader.reset(this.view, this.reader.offset);
       } else {
         // Data fits but requires moving existing data to start of buffer
         const existingData = new Uint8Array(
-          this.#buffer,
-          this.#view.byteOffset + consumedBytes,
+          this.buffer,
+          this.view.byteOffset + consumedBytes,
           unconsumedBytes,
         );
-        const array = new Uint8Array(this.#buffer);
+        const array = new Uint8Array(this.buffer);
         array.set(existingData, 0);
         array.set(data, existingData.byteLength);
-        this.#view = new DataView(this.#buffer, 0, existingData.byteLength + data.byteLength);
-        this.#reader.reset(this.#view);
+        this.view = new DataView(this.buffer, 0, existingData.byteLength + data.byteLength);
+        this.reader.reset(this.view);
       }
     } else {
       // New data doesn't fit, copy to a new buffer
 
       // Currently, the new buffer size may be smaller than the old size. For future optimizations,
       // we could consider making the buffer size increase monotonically.
-      this.#buffer = new ArrayBuffer(neededCapacity * 2);
-      const array = new Uint8Array(this.#buffer);
+      this.buffer = new ArrayBuffer(neededCapacity * 2);
+      const array = new Uint8Array(this.buffer);
       const existingData = new Uint8Array(
-        this.#view.buffer,
-        this.#view.byteOffset + consumedBytes,
+        this.view.buffer,
+        this.view.byteOffset + consumedBytes,
         unconsumedBytes,
       );
       array.set(existingData, 0);
       array.set(data, existingData.byteLength);
-      this.#view = new DataView(this.#buffer, 0, existingData.byteLength + data.byteLength);
-      this.#reader.reset(this.#view);
+      this.view = new DataView(this.buffer, 0, existingData.byteLength + data.byteLength);
+      this.reader.reset(this.view);
     }
   }
 
@@ -163,14 +160,14 @@ export default class McapStreamReader {
    * reader is in an unspecified state and should no longer be used.
    */
   nextRecord(): TypedMcapRecord | undefined {
-    if (this.#doneReading) {
+    if (this.doneReading) {
       return undefined;
     }
-    const result = this.#generator.next();
+    const result = this.generator.next();
 
     if (result.value?.type === "Channel") {
-      const existing = this.#channelsById.get(result.value.id);
-      this.#channelsById.set(result.value.id, result.value);
+      const existing = this.channelsById.get(result.value.id);
+      this.channelsById.set(result.value.id, result.value);
       if (existing && !isChannelEqual(existing, result.value)) {
         throw new Error(
           `Channel record for id ${result.value.id} (topic: ${result.value.topic}) differs from previous channel record of the same id.`,
@@ -178,22 +175,22 @@ export default class McapStreamReader {
       }
     } else if (result.value?.type === "Message") {
       const channelId = result.value.channelId;
-      const existing = this.#channelsById.get(channelId);
+      const existing = this.channelsById.get(channelId);
       if (!existing) {
         throw new Error(`Encountered message on channel ${channelId} without prior channel record`);
       }
     }
 
     if (result.done === true) {
-      this.#doneReading = true;
+      this.doneReading = true;
     }
     return result.value;
   }
 
-  *#read(): Generator<TypedMcapRecord | undefined, TypedMcapRecord | undefined, void> {
-    if (!this.#noMagicPrefix) {
+  protected *read(): Generator<TypedMcapRecord | undefined, TypedMcapRecord | undefined, void> {
+    if (!this.noMagicPrefix) {
       let magic: McapMagic | undefined;
-      while (((magic = parseMagic(this.#reader)), !magic)) {
+      while (((magic = parseMagic(this.reader)), !magic)) {
         yield;
       }
     }
@@ -206,7 +203,7 @@ export default class McapStreamReader {
 
     for (;;) {
       let record;
-      while (((record = parseRecord(this.#reader, this.#validateCrcs)), !record)) {
+      while (((record = parseRecord(this.reader, this.validateCrcs)), !record)) {
         yield;
       }
 
@@ -237,18 +234,18 @@ export default class McapStreamReader {
           break;
 
         case "Chunk": {
-          if (this.#includeChunks) {
+          if (this.includeChunks) {
             yield record;
           }
           let buffer = record.records;
           if (record.compression !== "" && buffer.byteLength > 0) {
-            const decompress = this.#decompressHandlers[record.compression];
+            const decompress = this.decompressHandlers[record.compression];
             if (!decompress) {
               throw errorWithLibrary(`Unsupported compression ${record.compression}`);
             }
             buffer = decompress(buffer, record.uncompressedSize);
           }
-          if (this.#validateCrcs && record.uncompressedCrc !== 0) {
+          if (this.validateCrcs && record.uncompressedCrc !== 0) {
             const chunkCrc = crc32(buffer);
             if (chunkCrc !== record.uncompressedCrc) {
               throw errorWithLibrary(
@@ -259,7 +256,7 @@ export default class McapStreamReader {
           const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
           const chunkReader = new Reader(view);
           let chunkRecord;
-          while ((chunkRecord = parseRecord(chunkReader, this.#validateCrcs))) {
+          while ((chunkRecord = parseRecord(chunkReader, this.validateCrcs))) {
             switch (chunkRecord.type) {
               case "Header":
               case "Footer":
@@ -290,15 +287,15 @@ export default class McapStreamReader {
         case "Footer":
           try {
             let magic;
-            while (((magic = parseMagic(this.#reader)), !magic)) {
+            while (((magic = parseMagic(this.reader)), !magic)) {
               yield;
             }
           } catch (error) {
             throw errorWithLibrary((error as Error).message);
           }
-          if (this.#reader.bytesRemaining() !== 0) {
+          if (this.reader.bytesRemaining() !== 0) {
             throw errorWithLibrary(
-              `${this.#reader.bytesRemaining()} bytes remaining after MCAP footer and trailing magic`,
+              `${this.reader.bytesRemaining()} bytes remaining after MCAP footer and trailing magic`,
             );
           }
           return record;

--- a/typescript/core/src/McapWriter.ts
+++ b/typescript/core/src/McapWriter.ts
@@ -48,36 +48,36 @@ export type McapWriterOptions = {
  * MCAP file.
  */
 export class McapWriter {
-  #nextChannelId = 0;
-  #nextSchemaId = 1;
-  #writable: IWritable;
-  #recordWriter = new McapRecordBuilder();
-  #schemas = new Map<number, Schema>();
-  #channels = new Map<number, Channel>();
-  #writtenSchemaIds = new Set<number>();
-  #writtenChannelIds = new Set<number>();
-  #chunkBuilder: ChunkBuilder | undefined;
-  #compressChunk:
+  protected nextChannelId = 0;
+  protected nextSchemaId = 1;
+  protected writable: IWritable;
+  protected recordWriter = new McapRecordBuilder();
+  protected schemas = new Map<number, Schema>();
+  protected channels = new Map<number, Channel>();
+  protected writtenSchemaIds = new Set<number>();
+  protected writtenChannelIds = new Set<number>();
+  protected chunkBuilder: ChunkBuilder | undefined;
+  protected compressChunk:
     | ((chunkData: Uint8Array) => { compression: string; compressedData: Uint8Array })
     | undefined;
-  #chunkSize: number;
+  protected chunkSize: number;
   /**
    * undefined means the CRC is not calculated, e.g. when using InitializeForAppending if the
    * original file did not have a dataSectionCrc.
    */
-  #dataSectionCrc: number | undefined;
+  protected dataSectionCrc: number | undefined;
 
   public statistics: Statistics | undefined;
-  #useSummaryOffsets: boolean;
-  #repeatSchemas: boolean;
-  #repeatChannels: boolean;
+  protected useSummaryOffsets: boolean;
+  protected repeatSchemas: boolean;
+  protected repeatChannels: boolean;
 
-  #appendMode = false;
+  protected appendMode = false;
 
   // indices
-  #chunkIndices: ChunkIndex[] | undefined;
-  #attachmentIndices: AttachmentIndex[] | undefined;
-  #metadataIndices: MetadataIndex[] | undefined;
+  protected chunkIndices: ChunkIndex[] | undefined;
+  protected attachmentIndices: AttachmentIndex[] | undefined;
+  protected metadataIndices: MetadataIndex[] | undefined;
 
   constructor(options: McapWriterOptions) {
     const {
@@ -96,8 +96,8 @@ export class McapWriter {
       compressChunk,
     } = options;
 
-    this.#writable = writable;
-    this.#useSummaryOffsets = useSummaryOffsets;
+    this.writable = writable;
+    this.useSummaryOffsets = useSummaryOffsets;
     if (useStatistics) {
       this.statistics = {
         messageCount: 0n,
@@ -112,22 +112,22 @@ export class McapWriter {
       };
     }
     if (useChunks) {
-      this.#chunkBuilder = new ChunkBuilder({ useMessageIndex });
+      this.chunkBuilder = new ChunkBuilder({ useMessageIndex });
     }
-    this.#repeatSchemas = repeatSchemas;
-    this.#repeatChannels = repeatChannels;
+    this.repeatSchemas = repeatSchemas;
+    this.repeatChannels = repeatChannels;
     if (useAttachmentIndex) {
-      this.#attachmentIndices = [];
+      this.attachmentIndices = [];
     }
     if (useMetadataIndex) {
-      this.#metadataIndices = [];
+      this.metadataIndices = [];
     }
     if (useChunkIndex) {
-      this.#chunkIndices = [];
+      this.chunkIndices = [];
     }
-    this.#nextChannelId = startChannelId;
-    this.#chunkSize = chunkSize;
-    this.#compressChunk = compressChunk;
+    this.nextChannelId = startChannelId;
+    this.chunkSize = chunkSize;
+    this.compressChunk = compressChunk;
   }
 
   /**
@@ -148,15 +148,15 @@ export class McapWriter {
     await readWrite.seek(reader.dataEndOffset);
     await readWrite.truncate();
 
-    const writer = new McapWriter({ ...options, writable: readWrite });
-    writer.#appendMode = true;
-    writer.#dataSectionCrc =
+    const writer = new this({ ...options, writable: readWrite });
+    writer.appendMode = true;
+    writer.dataSectionCrc =
       // Invert the CRC value so we can continue updating it with new data; it will be inverted
       // again in end()
       reader.dataSectionCrc != undefined ? crc32Final(reader.dataSectionCrc) : undefined;
-    writer.#chunkIndices = [...reader.chunkIndexes];
-    writer.#attachmentIndices = [...reader.attachmentIndexes];
-    writer.#metadataIndices = [...reader.metadataIndexes];
+    writer.chunkIndices = [...reader.chunkIndexes];
+    writer.attachmentIndices = [...reader.attachmentIndexes];
+    writer.metadataIndices = [...reader.metadataIndexes];
 
     if (writer.statistics) {
       if (reader.statistics) {
@@ -168,59 +168,59 @@ export class McapWriter {
       }
     }
 
-    writer.#schemas = new Map(reader.schemasById);
-    writer.#writtenSchemaIds = new Set(reader.schemasById.keys());
+    writer.schemas = new Map(reader.schemasById);
+    writer.writtenSchemaIds = new Set(reader.schemasById.keys());
     for (const schema of reader.schemasById.values()) {
-      writer.#nextSchemaId = Math.max(writer.#nextSchemaId, schema.id + 1);
+      writer.nextSchemaId = Math.max(writer.nextSchemaId, schema.id + 1);
     }
 
-    writer.#channels = new Map(reader.channelsById);
-    writer.#writtenChannelIds = new Set(reader.channelsById.keys());
+    writer.channels = new Map(reader.channelsById);
+    writer.writtenChannelIds = new Set(reader.channelsById.keys());
     for (const channel of reader.channelsById.values()) {
-      writer.#nextChannelId = Math.max(writer.#nextChannelId, channel.id + 1);
+      writer.nextChannelId = Math.max(writer.nextChannelId, channel.id + 1);
     }
 
     return writer;
   }
 
   async start(header: Header = { profile: "", library: LIBRARY_IDENTIFIER }): Promise<void> {
-    if (this.#appendMode) {
+    if (this.appendMode) {
       throw new Error(`Cannot call start() when writer is in append mode`);
     }
-    this.#dataSectionCrc = crc32Init();
-    this.#recordWriter.writeMagic();
-    this.#recordWriter.writeHeader(header);
+    this.dataSectionCrc = crc32Init();
+    this.recordWriter.writeMagic();
+    this.recordWriter.writeHeader(header);
 
-    this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    this.dataSectionCrc = crc32Update(this.dataSectionCrc, this.recordWriter.buffer);
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
   }
 
   async end(): Promise<void> {
-    await this.#finalizeChunk();
+    await this.finalizeChunk();
 
-    if (this.#dataSectionCrc != undefined) {
-      this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
+    if (this.dataSectionCrc != undefined) {
+      this.dataSectionCrc = crc32Update(this.dataSectionCrc, this.recordWriter.buffer);
     }
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
 
-    this.#recordWriter.writeDataEnd({
-      dataSectionCrc: this.#dataSectionCrc == undefined ? 0 : crc32Final(this.#dataSectionCrc),
+    this.recordWriter.writeDataEnd({
+      dataSectionCrc: this.dataSectionCrc == undefined ? 0 : crc32Final(this.dataSectionCrc),
     });
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
 
     const summaryOffsets: SummaryOffset[] = [];
 
-    const summaryStart = this.#writable.position();
+    const summaryStart = this.writable.position();
     let summaryCrc = crc32Init();
 
-    if (this.#repeatSchemas) {
-      const schemaStart = this.#writable.position();
+    if (this.repeatSchemas) {
+      const schemaStart = this.writable.position();
       let schemaLength = 0n;
-      for (const schema of this.#schemas.values()) {
-        schemaLength += this.#recordWriter.writeSchema(schema);
+      for (const schema of this.schemas.values()) {
+        schemaLength += this.recordWriter.writeSchema(schema);
       }
       summaryOffsets.push({
         groupOpcode: Opcode.SCHEMA,
@@ -229,14 +229,14 @@ export class McapWriter {
       });
     }
 
-    if (this.#repeatChannels) {
-      summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-      await this.#writable.write(this.#recordWriter.buffer);
-      this.#recordWriter.reset();
-      const channelStart = this.#writable.position();
+    if (this.repeatChannels) {
+      summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+      await this.writable.write(this.recordWriter.buffer);
+      this.recordWriter.reset();
+      const channelStart = this.writable.position();
       let channelLength = 0n;
-      for (const channel of this.#channels.values()) {
-        channelLength += this.#recordWriter.writeChannel(channel);
+      for (const channel of this.channels.values()) {
+        channelLength += this.recordWriter.writeChannel(channel);
       }
       summaryOffsets.push({
         groupOpcode: Opcode.CHANNEL,
@@ -246,11 +246,11 @@ export class McapWriter {
     }
 
     if (this.statistics) {
-      summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-      await this.#writable.write(this.#recordWriter.buffer);
-      this.#recordWriter.reset();
-      const statisticsStart = this.#writable.position();
-      const statisticsLength = this.#recordWriter.writeStatistics(this.statistics);
+      summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+      await this.writable.write(this.recordWriter.buffer);
+      this.recordWriter.reset();
+      const statisticsStart = this.writable.position();
+      const statisticsLength = this.recordWriter.writeStatistics(this.statistics);
       summaryOffsets.push({
         groupOpcode: Opcode.STATISTICS,
         groupStart: statisticsStart,
@@ -258,18 +258,18 @@ export class McapWriter {
       });
     }
 
-    summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
 
-    if (this.#metadataIndices) {
-      summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-      await this.#writable.write(this.#recordWriter.buffer);
-      this.#recordWriter.reset();
-      const metadataIndexStart = this.#writable.position();
+    if (this.metadataIndices) {
+      summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+      await this.writable.write(this.recordWriter.buffer);
+      this.recordWriter.reset();
+      const metadataIndexStart = this.writable.position();
       let metadataIndexLength = 0n;
-      for (const metadataIndex of this.#metadataIndices) {
-        metadataIndexLength += this.#recordWriter.writeMetadataIndex(metadataIndex);
+      for (const metadataIndex of this.metadataIndices) {
+        metadataIndexLength += this.recordWriter.writeMetadataIndex(metadataIndex);
       }
       summaryOffsets.push({
         groupOpcode: Opcode.METADATA_INDEX,
@@ -278,14 +278,14 @@ export class McapWriter {
       });
     }
 
-    if (this.#attachmentIndices) {
-      summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-      await this.#writable.write(this.#recordWriter.buffer);
-      this.#recordWriter.reset();
-      const attachmentIndexStart = this.#writable.position();
+    if (this.attachmentIndices) {
+      summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+      await this.writable.write(this.recordWriter.buffer);
+      this.recordWriter.reset();
+      const attachmentIndexStart = this.writable.position();
       let attachmentIndexLength = 0n;
-      for (const attachmentIndex of this.#attachmentIndices) {
-        attachmentIndexLength += this.#recordWriter.writeAttachmentIndex(attachmentIndex);
+      for (const attachmentIndex of this.attachmentIndices) {
+        attachmentIndexLength += this.recordWriter.writeAttachmentIndex(attachmentIndex);
       }
       summaryOffsets.push({
         groupOpcode: Opcode.ATTACHMENT_INDEX,
@@ -294,14 +294,14 @@ export class McapWriter {
       });
     }
 
-    if (this.#chunkIndices) {
-      summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-      await this.#writable.write(this.#recordWriter.buffer);
-      this.#recordWriter.reset();
-      const chunkIndexStart = this.#writable.position();
+    if (this.chunkIndices) {
+      summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+      await this.writable.write(this.recordWriter.buffer);
+      this.recordWriter.reset();
+      const chunkIndexStart = this.writable.position();
       let chunkIndexLength = 0n;
-      for (const chunkIndex of this.#chunkIndices) {
-        chunkIndexLength += this.#recordWriter.writeChunkIndex(chunkIndex);
+      for (const chunkIndex of this.chunkIndices) {
+        chunkIndexLength += this.recordWriter.writeChunkIndex(chunkIndex);
       }
       summaryOffsets.push({
         groupOpcode: Opcode.CHUNK_INDEX,
@@ -310,26 +310,26 @@ export class McapWriter {
       });
     }
 
-    summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
 
-    const summaryOffsetStart = this.#writable.position();
+    const summaryOffsetStart = this.writable.position();
     const summaryLength = summaryOffsetStart - summaryStart;
 
-    if (this.#useSummaryOffsets) {
+    if (this.useSummaryOffsets) {
       for (const summaryOffset of summaryOffsets) {
         if (summaryOffset.groupLength !== 0n) {
-          this.#recordWriter.writeSummaryOffset(summaryOffset);
+          this.recordWriter.writeSummaryOffset(summaryOffset);
         }
       }
     }
 
-    summaryCrc = crc32Update(summaryCrc, this.#recordWriter.buffer);
+    summaryCrc = crc32Update(summaryCrc, this.recordWriter.buffer);
 
     const footer: Footer = {
       summaryStart: summaryLength === 0n ? 0n : summaryStart,
-      summaryOffsetStart: this.#useSummaryOffsets ? summaryOffsetStart : 0n,
+      summaryOffsetStart: this.useSummaryOffsets ? summaryOffsetStart : 0n,
       summaryCrc: 0,
     };
     const tempBuffer = new DataView(new ArrayBuffer(1 + 8 + 8 + 8));
@@ -340,20 +340,20 @@ export class McapWriter {
     summaryCrc = crc32Update(summaryCrc, tempBuffer);
     footer.summaryCrc = crc32Final(summaryCrc);
 
-    this.#recordWriter.writeFooter(footer);
+    this.recordWriter.writeFooter(footer);
 
-    this.#recordWriter.writeMagic();
+    this.recordWriter.writeMagic();
 
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
   }
 
   /**
    * Add a schema and return a generated schema id. The schema id is used when adding channels.
    */
   async registerSchema(info: Omit<Schema, "id">): Promise<number> {
-    const id = this.#nextSchemaId++;
-    this.#schemas.set(id, { ...info, id });
+    const id = this.nextSchemaId++;
+    this.schemas.set(id, { ...info, id });
     if (this.statistics) {
       ++this.statistics.schemaCount;
     }
@@ -364,8 +364,8 @@ export class McapWriter {
    * Add a channel and return a generated channel id. The channel id is used when adding messages.
    */
   async registerChannel(info: Omit<Channel, "id">): Promise<number> {
-    const id = this.#nextChannelId++;
-    this.#channels.set(id, { ...info, id });
+    const id = this.nextChannelId++;
+    this.channels.set(id, { ...info, id });
     if (this.statistics) {
       ++this.statistics.channelCount;
     }
@@ -393,57 +393,57 @@ export class McapWriter {
     }
 
     // write out channel and schema if we have not yet done so
-    if (!this.#writtenChannelIds.has(message.channelId)) {
-      const channel = this.#channels.get(message.channelId);
+    if (!this.writtenChannelIds.has(message.channelId)) {
+      const channel = this.channels.get(message.channelId);
       if (!channel) {
         throw new Error(
           `McapWriter#addMessage failed: missing channel for id ${message.channelId}`,
         );
       }
 
-      if (channel.schemaId !== 0 && !this.#writtenSchemaIds.has(channel.schemaId)) {
-        const schema = this.#schemas.get(channel.schemaId);
+      if (channel.schemaId !== 0 && !this.writtenSchemaIds.has(channel.schemaId)) {
+        const schema = this.schemas.get(channel.schemaId);
         if (!schema) {
           throw new Error(
             `McapWriter#addMessage failed: missing schema for id ${channel.schemaId}`,
           );
         }
-        if (this.#chunkBuilder) {
-          this.#chunkBuilder.addSchema(schema);
+        if (this.chunkBuilder) {
+          this.chunkBuilder.addSchema(schema);
         } else {
-          this.#recordWriter.writeSchema(schema);
+          this.recordWriter.writeSchema(schema);
         }
-        this.#writtenSchemaIds.add(channel.schemaId);
+        this.writtenSchemaIds.add(channel.schemaId);
       }
 
-      if (this.#chunkBuilder) {
-        this.#chunkBuilder.addChannel(channel);
+      if (this.chunkBuilder) {
+        this.chunkBuilder.addChannel(channel);
       } else {
-        this.#recordWriter.writeChannel(channel);
+        this.recordWriter.writeChannel(channel);
       }
-      this.#writtenChannelIds.add(message.channelId);
+      this.writtenChannelIds.add(message.channelId);
     }
 
-    if (this.#chunkBuilder) {
-      this.#chunkBuilder.addMessage(message);
+    if (this.chunkBuilder) {
+      this.chunkBuilder.addMessage(message);
     } else {
-      this.#recordWriter.writeMessage(message);
+      this.recordWriter.writeMessage(message);
     }
 
-    if (this.#chunkBuilder && this.#chunkBuilder.byteLength > this.#chunkSize) {
-      await this.#finalizeChunk();
+    if (this.chunkBuilder && this.chunkBuilder.byteLength > this.chunkSize) {
+      await this.finalizeChunk();
     }
   }
 
   async addAttachment(attachment: Attachment): Promise<void> {
-    const length = this.#recordWriter.writeAttachment(attachment);
+    const length = this.recordWriter.writeAttachment(attachment);
     if (this.statistics) {
       ++this.statistics.attachmentCount;
     }
 
-    if (this.#attachmentIndices) {
-      const offset = this.#writable.position();
-      this.#attachmentIndices.push({
+    if (this.attachmentIndices) {
+      const offset = this.writable.position();
+      this.attachmentIndices.push({
         logTime: attachment.logTime,
         createTime: attachment.createTime,
         name: attachment.name,
@@ -454,82 +454,82 @@ export class McapWriter {
       });
     }
 
-    if (this.#dataSectionCrc != undefined) {
-      this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
+    if (this.dataSectionCrc != undefined) {
+      this.dataSectionCrc = crc32Update(this.dataSectionCrc, this.recordWriter.buffer);
     }
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
   }
 
   async addMetadata(metadata: Metadata): Promise<void> {
-    const recordSize = this.#recordWriter.writeMetadata(metadata);
+    const recordSize = this.recordWriter.writeMetadata(metadata);
     if (this.statistics) {
       ++this.statistics.metadataCount;
     }
 
-    if (this.#metadataIndices) {
-      const offset = this.#writable.position();
-      this.#metadataIndices.push({
+    if (this.metadataIndices) {
+      const offset = this.writable.position();
+      this.metadataIndices.push({
         name: metadata.name,
         offset,
         length: recordSize,
       });
     }
 
-    if (this.#dataSectionCrc != undefined) {
-      this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
+    if (this.dataSectionCrc != undefined) {
+      this.dataSectionCrc = crc32Update(this.dataSectionCrc, this.recordWriter.buffer);
     }
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
   }
 
-  async #finalizeChunk(): Promise<void> {
-    if (!this.#chunkBuilder || this.#chunkBuilder.numMessages === 0) {
+  protected async finalizeChunk(): Promise<void> {
+    if (!this.chunkBuilder || this.chunkBuilder.numMessages === 0) {
       return;
     }
     if (this.statistics) {
       ++this.statistics.chunkCount;
     }
 
-    const chunkData = this.#chunkBuilder.buffer;
+    const chunkData = this.chunkBuilder.buffer;
     const uncompressedSize = BigInt(chunkData.length);
     const uncompressedCrc = crc32(chunkData);
     let compression = "";
     let compressedData = chunkData;
-    if (this.#compressChunk) {
-      ({ compression, compressedData } = this.#compressChunk(chunkData));
+    if (this.compressChunk) {
+      ({ compression, compressedData } = this.compressChunk(chunkData));
     }
 
     const chunkRecord: Chunk = {
-      messageStartTime: this.#chunkBuilder.messageStartTime,
-      messageEndTime: this.#chunkBuilder.messageEndTime,
+      messageStartTime: this.chunkBuilder.messageStartTime,
+      messageEndTime: this.chunkBuilder.messageEndTime,
       uncompressedSize,
       uncompressedCrc,
       compression,
       records: compressedData,
     };
 
-    const chunkStartOffset = this.#writable.position();
+    const chunkStartOffset = this.writable.position();
 
-    const chunkLength = this.#recordWriter.writeChunk(chunkRecord);
+    const chunkLength = this.recordWriter.writeChunk(chunkRecord);
 
-    const messageIndexOffsets = this.#chunkIndices ? new Map<number, bigint>() : undefined;
+    const messageIndexOffsets = this.chunkIndices ? new Map<number, bigint>() : undefined;
 
-    if (this.#dataSectionCrc != undefined) {
-      this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
+    if (this.dataSectionCrc != undefined) {
+      this.dataSectionCrc = crc32Update(this.dataSectionCrc, this.recordWriter.buffer);
     }
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
 
-    const messageIndexStart = this.#writable.position();
+    const messageIndexStart = this.writable.position();
     let messageIndexLength = 0n;
-    for (const messageIndex of this.#chunkBuilder.indices) {
+    for (const messageIndex of this.chunkBuilder.indices) {
       messageIndexOffsets?.set(messageIndex.channelId, messageIndexStart + messageIndexLength);
-      messageIndexLength += this.#recordWriter.writeMessageIndex(messageIndex);
+      messageIndexLength += this.recordWriter.writeMessageIndex(messageIndex);
     }
 
-    if (this.#chunkIndices) {
-      this.#chunkIndices.push({
+    if (this.chunkIndices) {
+      this.chunkIndices.push({
         messageStartTime: chunkRecord.messageStartTime,
         messageEndTime: chunkRecord.messageEndTime,
         chunkStartOffset,
@@ -541,12 +541,12 @@ export class McapWriter {
         uncompressedSize: chunkRecord.uncompressedSize,
       });
     }
-    this.#chunkBuilder.reset();
+    this.chunkBuilder.reset();
 
-    if (this.#dataSectionCrc != undefined) {
-      this.#dataSectionCrc = crc32Update(this.#dataSectionCrc, this.#recordWriter.buffer);
+    if (this.dataSectionCrc != undefined) {
+      this.dataSectionCrc = crc32Update(this.dataSectionCrc, this.recordWriter.buffer);
     }
-    await this.#writable.write(this.#recordWriter.buffer);
-    this.#recordWriter.reset();
+    await this.writable.write(this.recordWriter.buffer);
+    this.recordWriter.reset();
   }
 }

--- a/typescript/core/src/index.ts
+++ b/typescript/core/src/index.ts
@@ -1,9 +1,13 @@
 export { McapIndexedReader } from "./McapIndexedReader.ts";
+export type { McapIndexedReaderArgs } from "./McapIndexedReader.ts";
 export { default as McapStreamReader } from "./McapStreamReader.ts";
+export type { McapReaderOptions } from "./McapStreamReader.ts";
 export { McapWriter } from "./McapWriter.ts";
 export type { McapWriterOptions } from "./McapWriter.ts";
 export { McapRecordBuilder } from "./McapRecordBuilder.ts";
+export type { McapRecordBuilderOptions } from "./McapRecordBuilder.ts";
 export { ChunkBuilder as McapChunkBuilder } from "./ChunkBuilder.ts";
+export type { ChunkBuilderOptions } from "./ChunkBuilder.ts";
 export type { IWritable } from "./IWritable.ts";
 export type { ISeekableWriter } from "./ISeekableWriter.ts";
 

--- a/typescript/core/src/subclassing.test.ts
+++ b/typescript/core/src/subclassing.test.ts
@@ -1,0 +1,201 @@
+import { ChunkBuilder } from "./ChunkBuilder.ts";
+import { ChunkCursor } from "./ChunkCursor.ts";
+import { McapIndexedReader } from "./McapIndexedReader.ts";
+import { McapRecordBuilder } from "./McapRecordBuilder.ts";
+import McapStreamReader from "./McapStreamReader.ts";
+import { McapWriter } from "./McapWriter.ts";
+import { TempBuffer } from "./TempBuffer.ts";
+import { collect } from "./testUtils.ts";
+import type { TypedMcapRecords } from "./types.ts";
+
+class TestChunkBuilder extends ChunkBuilder {
+  messageIndexCount(): number {
+    return this.messageIndices?.size ?? 0;
+  }
+}
+
+class TestStreamReader extends McapStreamReader {
+  channelCount(): number {
+    return this.channelsById.size;
+  }
+}
+
+class TestIndexedReader extends McapIndexedReader {
+  loadChunkDataCalls = 0;
+
+  protected override async loadChunkData(
+    chunkIndex: TypedMcapRecords["ChunkIndex"],
+    options?: { validateCrcs: boolean },
+  ): Promise<DataView> {
+    this.loadChunkDataCalls += 1;
+    return await super.loadChunkData(chunkIndex, options);
+  }
+
+  messageTimeRange(): { start?: bigint; end?: bigint } {
+    return { start: this.messageStartTime, end: this.messageEndTime };
+  }
+}
+
+class TestWriter extends McapWriter {
+  finalizeCalls = 0;
+
+  protected override async finalizeChunk(): Promise<void> {
+    this.finalizeCalls += 1;
+    await super.finalizeChunk();
+  }
+}
+
+class TestRecordBuilder extends McapRecordBuilder {
+  writtenLength(): number {
+    return this.bufferBuilder.length;
+  }
+}
+
+class TestChunkCursor extends ChunkCursor {
+  sortTime(): bigint {
+    return this.getSortTime();
+  }
+}
+
+describe("subclassing", () => {
+  it("lets ChunkBuilder subclasses use protected members", () => {
+    const builder = new TestChunkBuilder({ useMessageIndex: true });
+    builder.addChannel({
+      id: 1,
+      schemaId: 0,
+      topic: "test",
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    builder.addMessage({
+      channelId: 1,
+      sequence: 0,
+      logTime: 10n,
+      publishTime: 10n,
+      data: new Uint8Array([1]),
+    });
+
+    expect(builder.messageIndexCount()).toBe(1);
+    expect(builder.numMessages).toBe(1);
+    expect(builder.byteLength).toBeGreaterThan(0);
+  });
+
+  it("lets McapStreamReader subclasses use protected members", async () => {
+    const tempBuffer = new TempBuffer();
+    const writer = new McapWriter({ writable: tempBuffer, useChunks: false });
+
+    await writer.start({ library: "", profile: "" });
+    const channelId = await writer.registerChannel({
+      topic: "test",
+      schemaId: 0,
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+    await writer.end();
+
+    const reader = new TestStreamReader();
+    reader.append(tempBuffer.get());
+    while (reader.nextRecord()) {
+      // Parse all records so the channel map is populated.
+    }
+    expect(reader.channelCount()).toBe(1);
+    expect(reader.done()).toBe(true);
+  });
+
+  it("lets McapIndexedReader subclasses override protected methods", async () => {
+    const tempBuffer = new TempBuffer();
+    const writer = new McapWriter({ writable: tempBuffer });
+
+    await writer.start({ library: "", profile: "" });
+    const channelId = await writer.registerChannel({
+      topic: "test",
+      schemaId: 0,
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      sequence: 0,
+      logTime: 5n,
+      publishTime: 5n,
+      data: new Uint8Array([9]),
+    });
+    await writer.end();
+
+    const reader = await TestIndexedReader.Initialize({ readable: tempBuffer });
+    expect(reader).toBeInstanceOf(TestIndexedReader);
+
+    const messages = await collect(reader.readMessages());
+    expect(messages).toHaveLength(1);
+    expect(reader.loadChunkDataCalls).toBe(1);
+    expect(reader.messageTimeRange()).toEqual({ start: 5n, end: 5n });
+  });
+
+  it("lets McapWriter subclasses override protected methods", async () => {
+    const tempBuffer = new TempBuffer();
+    const writer = new TestWriter({ writable: tempBuffer, chunkSize: 0 });
+
+    await writer.start({ library: "", profile: "" });
+    const channelId = await writer.registerChannel({
+      topic: "test",
+      schemaId: 0,
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+      data: new Uint8Array(),
+    });
+    await writer.addMessage({
+      channelId,
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 1n,
+      data: new Uint8Array(),
+    });
+    await writer.end();
+
+    // chunkSize 0 finalizes after every message, plus end() finalizes any remainder.
+    expect(writer.finalizeCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("lets McapRecordBuilder subclasses use protected members", () => {
+    const builder = new TestRecordBuilder();
+    builder.writeMagic();
+    expect(builder.writtenLength()).toBeGreaterThan(0);
+    expect(builder.length).toBe(builder.writtenLength());
+  });
+
+  it("lets ChunkCursor subclasses use protected members", () => {
+    const cursor = new TestChunkCursor({
+      chunkIndex: {
+        type: "ChunkIndex",
+        messageStartTime: 0n,
+        messageEndTime: 0n,
+        chunkStartOffset: 1n,
+        chunkLength: 1n,
+        messageIndexOffsets: new Map(),
+        messageIndexLength: 0n,
+        compression: "",
+        compressedSize: 0n,
+        uncompressedSize: 0n,
+      },
+      relevantChannels: undefined,
+      startTime: undefined,
+      endTime: undefined,
+      reverse: false,
+    });
+
+    expect(cursor.sortTime()).toBe(0n);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog
TypeScript reader and writer classes now use protected members so you can subclass them and override internals.

### Docs
None

### Description
ES private fields (`#foo`) on the TypeScript reader/writer classes blocked subclassing: subclasses could not read internal state or override helper methods. `McapIndexedReader` also used a private constructor, so subclasses could not call `super()`.

This change marks those internals as `protected` on `McapIndexedReader`, `McapStreamReader`, `McapWriter`, `ChunkBuilder`, `McapRecordBuilder`, and `ChunkCursor`. `McapIndexedReader.Initialize()` and `McapWriter.InitializeForAppending()` now construct with `new this(...)` so a subclass factory returns a subclass instance. Constructor argument types are exported for subclass constructors.

Automated tests cover subclass access and method overrides. No extra human verification is needed beyond review of the visibility change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d3f0cc-7347-434f-9aa6-5c8e6272dce5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d3f0cc-7347-434f-9aa6-5c8e6272dce5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

