### PR TITLE
ci: bump cargo-zigbuild to 0.23.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
         if: matrix.os == 'linux'
         uses: taiki-e/install-action@v2.85.10
         with:
-          tool: cargo-zigbuild@0.22.3
+          tool: cargo-zigbuild@0.23.0
           fallback: none
       - name: Build binary
         run: |


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Rust 1.98 started passing --fix-cortex-a53-843419 to the linker for aarch64 targets, and zig's cc wrapper rejects linker args it does not recognize, so the pinned cargo-zigbuild 0.22.3 now fails to link the CLI for aarch64-unknown-linux-musl with "unsupported linker arg". cargo-zigbuild 0.23.0 filters the flag in its zig wrapper (rust-cross/cargo-zigbuild#452); bump to the latest release. The zig pin itself is unaffected.