### PR TITLE
rust: batch CRC updates so hashing runs at SIMD speed

### DIFF
--- a/rust/mcap/src/io_utils.rs
+++ b/rust/mcap/src/io_utils.rs
@@ -2,29 +2,34 @@ use std::io::{self, prelude::*};
 
 use crc32fast::Hasher;
 
+/// Bytes are hashed in batches of at least this size (except at drain points), so the
+/// hasher's SIMD fast path gets bulk input even when the writer receives many small
+/// writes. Record serialization emits individual fields as 1-8 byte writes; hashing at
+/// that granularity keeps crc32fast on its scalar fallback, which is more than an order
+/// of magnitude slower than hashing the same bytes in bulk.
+const HASH_BATCH_SIZE: usize = 32 * 1024;
+
 pub struct CountingCrcWriter<W> {
     inner: W,
     hasher: Option<Hasher>,
+    // Bytes already written to `inner` but not yet folded into `hasher`. Hash-only
+    // batching: I/O is written through immediately, so ordering and flush semantics are
+    // unaffected. Every read of the hasher (current_checksum, finalize) accounts for
+    // these pending bytes.
+    pending: Vec<u8>,
     count: u64,
 }
 
 impl<W> CountingCrcWriter<W> {
     pub fn new(inner: W, calculate_crc: bool) -> Self {
-        Self {
-            inner,
-            hasher: if calculate_crc {
-                Some(Hasher::new())
-            } else {
-                None
-            },
-            count: 0,
-        }
+        Self::with_hasher(inner, calculate_crc.then(Hasher::new))
     }
 
     pub fn with_hasher(inner: W, hasher: Option<Hasher>) -> Self {
         Self {
             inner,
             hasher,
+            pending: Vec::new(),
             count: 0,
         }
     }
@@ -38,15 +43,31 @@ impl<W> CountingCrcWriter<W> {
     }
 
     /// Consumes the reader and returns the inner writer and the checksum
-    pub fn finalize(self) -> (W, Option<Hasher>) {
+    pub fn finalize(mut self) -> (W, Option<Hasher>) {
+        self.drain_pending();
         (self.inner, self.hasher)
     }
 
     pub fn current_checksum(&self) -> u32 {
         self.hasher
             .clone()
-            .map(|hasher| hasher.finalize())
+            .map(|mut hasher| {
+                if !self.pending.is_empty() {
+                    hasher.update(&self.pending);
+                }
+                hasher.finalize()
+            })
             .unwrap_or(0)
+    }
+
+    fn drain_pending(&mut self) {
+        if !self.pending.is_empty() {
+            self.hasher
+                .as_mut()
+                .expect("pending bytes only accumulate while hashing")
+                .update(&self.pending);
+            self.pending.clear();
+        }
     }
 }
 
@@ -54,8 +75,19 @@ impl<W: Write> Write for CountingCrcWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let res = self.inner.write(buf)?;
         self.count += res as u64;
-        if let Some(hasher) = &mut self.hasher {
-            hasher.update(&buf[..res]);
+        if self.hasher.is_some() {
+            let written = &buf[..res];
+            if written.len() >= HASH_BATCH_SIZE {
+                // Large writes are hashed directly (after any pending bytes, to keep the
+                // hashed stream in write order), skipping the extra copy.
+                self.drain_pending();
+                self.hasher.as_mut().expect("checked above").update(written);
+            } else {
+                self.pending.extend_from_slice(written);
+                if self.pending.len() >= HASH_BATCH_SIZE {
+                    self.drain_pending();
+                }
+            }
         }
         Ok(res)
     }
@@ -72,5 +104,60 @@ impl<W: Seek> Seek for CountingCrcWriter<W> {
 
     fn stream_position(&mut self) -> io::Result<u64> {
         self.inner.stream_position()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reference_crc(data: &[u8]) -> u32 {
+        let mut hasher = Hasher::new();
+        hasher.update(data);
+        hasher.finalize()
+    }
+
+    #[test]
+    fn batched_hash_matches_reference_across_write_sizes() {
+        let data: Vec<u8> = (0..1_000_000u32).map(|i| (i % 251) as u8).collect();
+        // Mix of tiny field-sized writes, payload-sized writes, and writes larger than
+        // the batch size, mirroring real record serialization patterns.
+        for sizes in [
+            &[1usize, 2, 4, 8][..],
+            &[100][..],
+            &[HASH_BATCH_SIZE - 1][..],
+            &[HASH_BATCH_SIZE][..],
+            &[HASH_BATCH_SIZE + 1][..],
+            &[3, 100, HASH_BATCH_SIZE + 7, 8, HASH_BATCH_SIZE][..],
+        ] {
+            let mut writer = CountingCrcWriter::new(Vec::new(), true);
+            let mut offset = 0;
+            let mut size_idx = 0;
+            while offset < data.len() {
+                let size = sizes[size_idx % sizes.len()].min(data.len() - offset);
+                writer.write_all(&data[offset..offset + size]).unwrap();
+                offset += size;
+                size_idx += 1;
+            }
+            assert_eq!(writer.position(), data.len() as u64);
+            // current_checksum must account for unhashed pending bytes without
+            // disturbing the stream.
+            assert_eq!(writer.current_checksum(), reference_crc(&data));
+            assert_eq!(writer.current_checksum(), reference_crc(&data));
+            let (inner, hasher) = writer.finalize();
+            assert_eq!(inner, data);
+            assert_eq!(hasher.unwrap().finalize(), reference_crc(&data));
+        }
+    }
+
+    #[test]
+    fn disabled_hasher_accumulates_nothing() {
+        let mut writer = CountingCrcWriter::new(Vec::new(), false);
+        writer.write_all(&[1, 2, 3]).unwrap();
+        assert_eq!(writer.current_checksum(), 0);
+        assert!(writer.pending.is_empty());
+        let (inner, hasher) = writer.finalize();
+        assert_eq!(inner, vec![1, 2, 3]);
+        assert!(hasher.is_none());
     }
 }


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

The Rust writer's CRC computation was made significantly cheaper by hashing in 32 KiB batches instead of per write call. Default-options writes get 15-33% faster depending on mode; written bytes and CRC values are unchanged.

CountingCrcWriter updated its crc32fast hasher on every write call. Record serialization emits individual fields as 1-8 byte writes, and crc32fast only reaches its PCLMULQDQ fast path on bulk input — tiny updates run the scalar fallback, which is more than an order of magnitude slower per byte (measured on one machine, hashing 128 MiB: 3 ms in 1 MiB updates, 30 ms in 100 B updates, 245 ms in 8 B updates). A profile of an unchunked 1M-message write showed 36% of total time inside crc32fast::baseline::update_fast_16, and the same write with CRCs disabled matched the Go and C++ writers. The Go writer avoids the problem structurally by serializing each record into a buffer and hashing it in one update.

Batch the hashing instead: writes still go to the inner writer immediately (I/O ordering, flush behavior, and position tracking are untouched), but bytes are folded into the hasher only once 32 KiB has accumulated, or directly for writes that are already at least that large. current_checksum() and finalize() account for pending bytes, so every observable CRC is identical to before.

Writing 1M 100-byte messages with default options (all CRCs on), same payload, best of 3:

- unchunked: 277 ms -> 197 ms (-29%)
- chunked:   410 ms -> 274 ms (-33%)
- zstd:      993 ms -> 954 ms (compression-dominated)
- lz4:       626 ms -> 535 ms (-15%)

This closes most of the gap to the Go and C++ writers on the uncompressed modes while keeping the Rust writer's strongest-in-the-repo integrity defaults (chunk, data section, and summary CRCs all on).