### PR TITLE
build(deps): bump quinn-proto to 0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Resolves Dependabot alert 252 (GHSA-4w2j-m93h-cj5j, high): remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly. quinn-proto is a transitive dependency of the CLI's remote-read stack and ships in the released mcap CLI binaries, so unlike the dev-only lockfile alerts this one is user-facing.

Minimal patch-version bump of the single crate (0.11.14 -> 0.11.15, the first patched version); no other dependencies change. The workspace builds and tests cleanly against the updated lock.