### PR TITLE
build(deps): clear the resolvable Dependabot alerts against yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
     "typedoc": "0.28.20",
     "typescript": "5.9.3",
     "wrangler": "4.118.0"
+  },
+  "resolutions": {
+    "serialize-javascript": "^7.0.5",
+    "undici@npm:7.28.0": "7.29.0",
+    "uuid": "^11.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15148,11 +15148,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -16983,15 +16983,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
 "range-parser@npm:1.2.0":
   version: 1.2.0
   resolution: "range-parser@npm:1.2.0"
@@ -17746,7 +17737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
@@ -17907,12 +17898,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.0, serialize-javascript@npm:^6.0.1":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+"serialize-javascript@npm:^7.0.5":
+  version: 7.1.0
+  resolution: "serialize-javascript@npm:7.1.0"
+  checksum: 10c0/8a03dd3c6d0c899b21bde218e06907ac26a19f1feaa53250e20adbfb6fef9530032d9f78005fd957fff4b68fe1ddcc6e11b93b340c1bd5301090c68cf97b54fa
   languageName: node
   linkType: hard
 
@@ -19202,10 +19191,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.28.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+"undici@npm:7.29.0":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 
@@ -19533,12 +19522,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Four packages, three mechanisms:

- nanoid 3.3.17 -> 3.3.18 (alert 271, high): plain in-range lockfile update; 3.3.18 is exactly the first patched version.
- serialize-javascript 6.0.2 -> 7.1.0 (alerts 94 high, 180): the sole consumer (copy-webpack-plugin) allows only ^6, and the fix threshold is 7.0.5, so this needs a resolutions override ("^7.0.5").
- uuid 8.3.2 -> 11.1.1 (alert 181): the advisory blankets everything below 11.1.1 and the sole consumer (sockjs, via webpack-dev-server) allows only ^8.3.2, so this also needs a resolutions override ("^11.1.1", deliberately not latest-14 to keep the jump minimal).
- undici 7.28.0 -> 7.29.0 (alerts 264-268): miniflare pins the exact version, so the override is scoped to that descriptor ("undici@npm:7.28.0") to avoid dragging node-gyp's non-vulnerable undici ^8 down to 7.x.

Not fixed here: the two image-size alerts (269, 270). No patched release exists on any line - 2.0.2 is the newest publish and the advisories cover <= 2.0.2 with no fix version - so no lockfile change can resolve them. The exposure is @docusaurus/mdx-loader sizing local repository images during website builds, not untrusted input.

All of these are development and website tooling dependencies; none ship in published packages. Verified: install is warning-neutral against main, @mcap/core tests pass, and the website builds cleanly, which exercises the copy-webpack-plugin/serialize-javascript, postcss/nanoid, and mdx-loader/image-size paths.