### PR TITLE
cli: AccessMode and local readahead on ByteSource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ This is a **polyglot library monorepo** for the [MCAP](https://mcap.dev) log fil
 
 **Bounded memory when reading.** Neither the language libraries nor the CLI may read (or force a consumer to read) an entire MCAP file into memory — files can be many GB. Reader memory should scale with the record or chunk being processed, not with the file length: holding one record, chunk, or attachment at a time is fine, but buffering the whole file, or all of its messages, is an out-of-memory foot-gun.
 
-- Memory-map (`mmap`) seekable local files where the language supports it, or have the API consumer supply the bytes (e.g. via their own mmap); use seek + bounded range reads for random access and streaming for sequential scans.
-- When input isn't seekable (e.g. a stdin pipe) or an operation needs random access over a stream (e.g. sorting), spool to a temporary file and mmap it rather than buffering in memory. A tmpfs temp dir keeps the spool resident, though that is typically swap-backed.
+- Prefer seek + bounded range reads (with a modest readahead buffer for sequential scans) or streaming. Do not memory-map whole files by default: under cgroup memory limits, mapped pages can count against the process budget and OOM-kill a reader that maps a multi-GB file into a small limit.
+- API consumers may still supply bytes (including their own mmap) when they control the environment. Library “slice” readers that take `&[u8]` are fine as an opt-in for that case.
+- When input isn't seekable (e.g. a stdin pipe) or an operation needs random access over a stream (e.g. sorting), spool to a temporary file and seek+read it rather than buffering the whole object in memory. A tmpfs temp dir keeps the spool resident, though that is typically swap-backed.
 
 ## General prerequisites
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -200,6 +200,8 @@ overrides:
       - mmap
       - seekable
       - tmpfs
+      - readahead
+      - cgroup
 
   - filename: "python/**/*.rst"
     words:

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -13,14 +13,14 @@ clap parses arguments, `dispatch` (in `commands.rs`) routes to a per-command han
 
 A few modules carry more than their name implies:
 
-| Module           | Responsibility                                                                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cli.rs`         | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                                    |
-| `byte_source.rs` | Random-access byte sources (`LocalFileSource`, `RemoteRangeSource`, `MemorySource`) and sans-io drivers. Local files use seek+read (no mmap); remotes prefer HTTP range requests.       |
-| `source.rs`      | Remote URL helpers, summary/index range reads, `materialize_input` (path spool for convert), and `--allow-remote-scan` gating. Command I/O prefers `byte_source` over whole-file loads. |
-| `parse.rs`       | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                                          |
-| `context.rs`     | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                                                |
-| `build.rs`       | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                                       |
+| Module           | Responsibility                                                                                                                                                                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cli.rs`         | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                                                                                                                                                          |
+| `byte_source.rs` | Random-access and sequential byte sources (`LocalFileSource`, `RemoteRangeSource`, `SequentialSource`, `MemorySource`) and sans-io drivers. Local files use seek+read (no mmap); remotes prefer HTTP range requests. Use `AccessMode::Sequential` for single-pass commands so stdin streams without spooling. |
+| `source.rs`      | Remote URL helpers, summary/index range reads, `materialize_input` (path spool for convert), and `--allow-remote-scan` gating. Command I/O prefers `byte_source` over whole-file loads.                                                                                                                       |
+| `parse.rs`       | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                                                                                                                                                                |
+| `context.rs`     | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                                                                                                                                                                      |
+| `build.rs`       | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                                                                                                                                                             |
 
 ## Conventions
 
@@ -35,7 +35,14 @@ When adding a command that can complete despite losing data, return `CommandOutc
 
 ### Remote inputs
 
-Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled via `object_store` (`source.rs` helpers + `byte_source` range reads). Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Reading remote message-chunk payloads, a full linear scan, or a whole-object download requires the global `--allow-remote-scan` flag. Gate those paths behind `SourceOptions::allow_remote_scan`, `require_remote_scan_for_linear`, or `require_remote_scan_for_chunks` accordingly. `convert` still uses `materialize_input` because ROS bag/db3 inputs need a local filesystem path for sqlite.
+Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled via `object_store` (`source.rs` helpers + `byte_source` range reads). Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would read remote message payloads (including indexed `cat` / `filter` / `merge` chunk fetches), linearly scan, or download a whole remote object requires the global `--allow-remote-scan` flag. With the flag set, indexed rewrite still uses range reads for selected chunks; linear / multi-pass remote work materializes once (via `AccessMode::Sequential` or an explicit spool) so passes do not re-transfer. Gate new whole-file or message-payload remote reads behind `SourceOptions::allow_remote_scan` / `require_remote_scan_for_linear` / `require_remote_scan_for_chunks` accordingly. `convert` still uses `materialize_input` because ROS bag/db3 inputs need a local filesystem path for sqlite.
+
+Open inputs with `byte_source::open_byte_source_with_access` and the right `AccessMode`:
+
+- `AccessMode::Sequential` — single forward `LinearReader` pass (e.g. `recover`). Stdin streams; remotes spool once.
+- `AccessMode::Random` (default via `open_byte_source`) — summary and indexed chunk fetches. Remotes keep HTTP ranges when available. Multi-pass linear rewrite opens Random for the indexed attempt, then spools a remote source before the linear passes.
+
+Sans-io event loops should fill `reader.insert(need)` via `ByteSource::read_into` rather than allocating a `Vec` per `ReadRequest`. `LocalFileSource` keeps a 256 KiB readahead window so tiny sequential requests do not each become an `lseek`+`read` syscall.
 
 ### Output and logging
 

--- a/rust/cli/benches/README.md
+++ b/rust/cli/benches/README.md
@@ -25,9 +25,6 @@ cargo bench -p mcap-cli --bench commands -- merge/indexed/100KB
 
 ## Workload controls
 
-The default workload is large enough to reduce fixed overhead noise. Override it with environment
-variables for faster local iteration or larger comparison runs:
-
 | Variable                          |                 Default | Description                                              |
 | --------------------------------- | ----------------------: | -------------------------------------------------------- |
 | `MCAP_CLI_BENCH_TOTAL_MB`         |                   `250` | Total generated payload bytes per payload-size case.     |

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -1,14 +1,15 @@
-//! Random-access byte sources for sans-io MCAP reads.
+//! Random-access and sequential byte sources for sans-io MCAP reads.
 //!
 //! Local files use seek+read (no mmap). Remote URLs prefer HTTP range requests.
-//! Stdin is spooled to a temp file when opened through [`open_byte_source`].
+//! Stdin is streamed when opened with [`AccessMode::Sequential`], or spooled to a
+//! tempfile when opened with [`AccessMode::Random`] (needed for summary / multi-pass).
 
 mod drivers;
 
 pub use drivers::{for_each_linear_record, read_header, read_summary, service_indexed_chunk};
 
 use std::fs::File;
-use std::io::{IsTerminal as _, Read as _, Seek as _, SeekFrom, Write as _};
+use std::io::{IsTerminal as _, Read, Seek as _, SeekFrom, Write as _};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -20,19 +21,39 @@ use crate::source::{
     RemoteRangeReader, SourceOptions, PLEASE_SUPPLY_FILE,
 };
 
+/// How the caller will access bytes from the source.
+///
+/// Call sites know this up front:
+/// - Summary / indexed chunk fetches need [`AccessMode::Random`] (remote: HTTP ranges).
+/// - A single forward [`LinearReader`] pass can use [`AccessMode::Sequential`]: stdin streams
+///   without a tempfile, and remotes materialize once (avoids many tiny range GETs).
+/// - Multi-pass linear rewrite still opens [`AccessMode::Random`] for the indexed attempt, then
+///   spools a remote source before the linear passes (see rewrite helpers).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AccessMode {
+    /// May seek and re-read (summary, indexes, second passes). Stdin is spooled.
+    /// Remotes keep range requests when the server supports them.
+    #[default]
+    Random,
+    /// One forward pass from offset 0. Stdin streams without a tempfile.
+    /// Remotes always spool to a local tempfile (one transfer).
+    Sequential,
+}
+
 /// Byte-oriented input with optional random access.
 pub trait ByteSource {
-    /// File size in bytes, or `None` when unknown (streaming inputs without a known length).
+    /// File size in bytes, or `None` when unknown (streaming stdin).
     fn size(&self) -> Result<Option<u64>>;
     fn is_remote(&self) -> bool;
     fn display_name(&self) -> String;
-    /// Whether random access is available.
+    /// Whether random access is available (`false` for pure stdin streams).
     fn is_seekable(&self) -> bool;
 
     /// Read up to `dest.len()` bytes at `offset` into `dest`.
     ///
-    /// Returns the number of bytes read (0 at EOF). Prefer this in sans-io event loops so
-    /// drivers can fill `reader.insert(need)` without an intermediate allocation.
+    /// Returns the number of bytes read (0 at EOF). Prefer this over [`Self::read_at`] in
+    /// sans-io event loops so the reader can fill its insert buffer without an intermediate
+    /// allocation.
     fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize>;
 
     /// Read `[offset, offset+len)` into a new buffer. `len` may be clamped to EOF.
@@ -50,16 +71,29 @@ pub trait ByteSource {
 }
 
 /// Local file opened for seek+read (not memory-mapped).
+///
+/// Small [`ByteSource::read_into`] calls are served from a readahead window so sans-io
+/// `ReadRequest`s of a few bytes do not each become an `lseek`+`read` syscall. Large reads
+/// bypass the window and go straight into the caller buffer.
 pub struct LocalFileSource {
     file: File,
     path: PathBuf,
     size: u64,
     // Keeps a spool tempfile alive for stdin / non-range remote fallbacks.
     _temp_file: Option<NamedTempFile>,
+    /// File offset of `cache[0]`.
+    cache_start: u64,
+    /// Valid readahead bytes; empty means no cached window.
+    cache: Vec<u8>,
+    /// Known OS file cursor after the last seek/read, used to skip redundant seeks.
+    file_pos: Option<u64>,
 }
 
+/// Bytes pulled from disk on a cache miss. Sized to absorb many tiny LinearReader requests.
+const LOCAL_READAHEAD: usize = 256 * 1024;
+
 impl LocalFileSource {
-    fn open_path(path: &Path) -> Result<Self> {
+    pub fn open_path(path: &Path) -> Result<Self> {
         let file =
             File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))?;
         let size = file
@@ -71,6 +105,9 @@ impl LocalFileSource {
             path: path.to_path_buf(),
             size,
             _temp_file: None,
+            cache_start: 0,
+            cache: Vec::new(),
+            file_pos: None,
         })
     }
 
@@ -91,7 +128,59 @@ impl LocalFileSource {
             path: display_path,
             size,
             _temp_file: Some(temp_file),
+            cache_start: 0,
+            cache: Vec::new(),
+            file_pos: None,
         })
+    }
+
+    fn cache_end(&self) -> u64 {
+        self.cache_start.saturating_add(self.cache.len() as u64)
+    }
+
+    fn seek_to(&mut self, offset: u64) -> Result<()> {
+        if self.file_pos == Some(offset) {
+            return Ok(());
+        }
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .context("failed to seek in local file")?;
+        self.file_pos = Some(offset);
+        Ok(())
+    }
+
+    fn fill_cache_at(&mut self, offset: u64) -> Result<()> {
+        if offset >= self.size {
+            self.cache.clear();
+            self.cache_start = offset;
+            return Ok(());
+        }
+        let available = (self.size - offset) as usize;
+        let to_read = LOCAL_READAHEAD.min(available);
+        self.seek_to(offset)?;
+        self.cache.resize(to_read, 0);
+        self.file
+            .read_exact(&mut self.cache)
+            .context("failed to read from local file")?;
+        self.cache_start = offset;
+        self.file_pos = Some(offset.saturating_add(to_read as u64));
+        Ok(())
+    }
+
+    fn read_direct_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
+        if dest.is_empty() || offset >= self.size {
+            return Ok(0);
+        }
+        let available = (self.size - offset) as usize;
+        let to_read = dest.len().min(available);
+        self.seek_to(offset)?;
+        self.file
+            .read_exact(&mut dest[..to_read])
+            .context("failed to read from local file")?;
+        self.file_pos = Some(offset.saturating_add(to_read as u64));
+        // Direct reads invalidate the window — a later random jump must not see stale bytes.
+        self.cache.clear();
+        Ok(to_read)
     }
 }
 
@@ -113,7 +202,30 @@ impl ByteSource for LocalFileSource {
     }
 
     fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
-        read_file_into(&mut self.file, self.size, offset, dest)
+        if dest.is_empty() || offset >= self.size {
+            return Ok(0);
+        }
+        let total = dest.len().min((self.size - offset) as usize);
+        // Large requests skip the readahead window (chunk payloads, summary sections).
+        if total >= LOCAL_READAHEAD {
+            return self.read_direct_into(offset, &mut dest[..total]);
+        }
+
+        let mut filled = 0usize;
+        while filled < total {
+            let at = offset.saturating_add(filled as u64);
+            if at < self.cache_start || at >= self.cache_end() {
+                self.fill_cache_at(at)?;
+                if self.cache.is_empty() {
+                    break;
+                }
+            }
+            let cache_off = (at - self.cache_start) as usize;
+            let n = (total - filled).min(self.cache.len() - cache_off);
+            dest[filled..filled + n].copy_from_slice(&self.cache[cache_off..cache_off + n]);
+            filled += n;
+        }
+        Ok(filled)
     }
 }
 
@@ -145,17 +257,82 @@ impl ByteSource for RemoteRangeSource {
         true
     }
 
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
+        // Avoid the trait-default path (zeroed Vec + copy of read_range's buffer).
+        self.inner.read_range(offset, len)
+    }
+
     fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
-        // object_store range reads return an owned buffer; copy into `dest`.
         let data = self.inner.read_range(offset, dest.len())?;
         let n = data.len();
         dest[..n].copy_from_slice(&data);
         Ok(n)
     }
+}
 
-    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
-        // Skip the trait-default zeroed Vec + second copy of read_range's buffer.
-        self.inner.read_range(offset, len)
+/// Forward-only byte source (stdin pipes, or any [`Read`] stream).
+///
+/// [`ByteSource::read_into`] accepts only `offset ==` the current cursor. Seeking backwards
+/// or skipping ahead is an error — callers that need that must open with [`AccessMode::Random`].
+pub struct SequentialSource {
+    reader: Box<dyn Read>,
+    cursor: u64,
+    name: String,
+}
+
+impl SequentialSource {
+    pub fn new(reader: impl Read + 'static, name: impl Into<String>) -> Self {
+        Self {
+            reader: Box::new(reader),
+            cursor: 0,
+            name: name.into(),
+        }
+    }
+
+    fn open_stdin() -> Result<Self> {
+        let stdin = std::io::stdin();
+        if stdin.is_terminal() {
+            bail!("{PLEASE_SUPPLY_FILE}");
+        }
+        // BufReader coalesces the many tiny LinearReader ReadRequests on a pipe.
+        Ok(Self::new(
+            std::io::BufReader::with_capacity(LOCAL_READAHEAD, stdin),
+            "<stdin>",
+        ))
+    }
+}
+
+impl ByteSource for SequentialSource {
+    fn size(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn is_remote(&self) -> bool {
+        false
+    }
+
+    fn display_name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn is_seekable(&self) -> bool {
+        false
+    }
+
+    fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
+        if offset != self.cursor {
+            bail!(
+                "{} only supports sequential reads (requested offset {offset}, cursor {})",
+                self.name,
+                self.cursor
+            );
+        }
+        let n = self
+            .reader
+            .read(dest)
+            .with_context(|| format!("failed to read from {}", self.name))?;
+        self.cursor = self.cursor.saturating_add(n as u64);
+        Ok(n)
     }
 }
 
@@ -202,28 +379,57 @@ impl ByteSource for MemorySource {
     }
 }
 
-/// Open a path, remote URL, or stdin as a [`ByteSource`].
+/// Open a path, remote URL, or stdin as a [`ByteSource`] with [`AccessMode::Random`].
 ///
-/// - `None` spools stdin to a tempfile (seek+read, no mmap).
-/// - Remote URLs use range requests when available.
-/// - Non-range remotes require `--allow-remote-scan` and fall back to a full download into a tempfile.
-/// - Local paths use seek+read (no mmap).
+/// Prefer [`open_byte_source_with_access`] when the command only needs a linear scan so stdin
+/// can stream without spooling.
 pub fn open_byte_source(
     path: Option<&Path>,
     options: SourceOptions,
 ) -> Result<Box<dyn ByteSource>> {
+    open_byte_source_with_access(path, options, AccessMode::Random)
+}
+
+/// Open a path, remote URL, or stdin with an explicit access mode.
+///
+/// - [`AccessMode::Random`] + stdin → spool to a tempfile (seek+read).
+/// - [`AccessMode::Sequential`] + stdin → stream via [`SequentialSource`] (no tempfile).
+/// - [`AccessMode::Random`] + remote → HTTP range requests when available; otherwise
+///   `--allow-remote-scan` and spool.
+/// - [`AccessMode::Sequential`] + remote → always spool (one streaming GET), requiring
+///   `--allow-remote-scan`.
+/// - Local paths always open as seekable files.
+pub fn open_byte_source_with_access(
+    path: Option<&Path>,
+    options: SourceOptions,
+    access: AccessMode,
+) -> Result<Box<dyn ByteSource>> {
     let Some(path) = path else {
-        return Ok(Box::new(spool_stdin_to_local()?));
+        return match access {
+            AccessMode::Random => Ok(Box::new(spool_stdin_to_local()?)),
+            AccessMode::Sequential => Ok(Box::new(SequentialSource::open_stdin()?)),
+        };
     };
 
     if is_remote_url(path) {
-        return open_remote_byte_source(path, options);
+        return open_remote_byte_source(path, options, access);
     }
 
     Ok(Box::new(LocalFileSource::open_path(path)?))
 }
 
-fn open_remote_byte_source(path: &Path, options: SourceOptions) -> Result<Box<dyn ByteSource>> {
+fn open_remote_byte_source(
+    path: &Path,
+    options: SourceOptions,
+    access: AccessMode,
+) -> Result<Box<dyn ByteSource>> {
+    // Sequential remote work materializes once. Range-reading a LinearReader issues one HTTP
+    // request per tiny field read; a single streaming GET into a tempfile is cheaper and matches
+    // main's remote policy for recover / non-indexed scans.
+    if matches!(access, AccessMode::Sequential) {
+        return Ok(Box::new(spool_remote_to_local(path, options)?));
+    }
+
     match open_remote_range_reader(path)? {
         Some(reader) => Ok(Box::new(RemoteRangeSource::new(reader))),
         None if !options.allow_remote_scan => {
@@ -237,21 +443,11 @@ fn open_remote_byte_source(path: &Path, options: SourceOptions) -> Result<Box<dy
     }
 }
 
-fn spool_stdin_to_local() -> Result<LocalFileSource> {
-    let stdin = std::io::stdin();
-    if stdin.is_terminal() {
-        bail!("{PLEASE_SUPPLY_FILE}");
-    }
-    let mut temp_file = tempfile::Builder::new()
-        .prefix("mcap-cli-stdin-bytesource-")
-        .tempfile()
-        .context("failed to create temporary file for stdin input")?;
-    std::io::copy(&mut stdin.lock(), temp_file.as_file_mut())
-        .context("failed to read input from stdin")?;
-    LocalFileSource::from_temp_file(temp_file, PathBuf::from("<stdin>"))
-}
-
-fn spool_remote_to_local(path: &Path, options: SourceOptions) -> Result<LocalFileSource> {
+/// Spool a remote object to a local tempfile via one streaming download.
+pub(crate) fn spool_remote_to_local(
+    path: &Path,
+    options: SourceOptions,
+) -> Result<LocalFileSource> {
     require_remote_scan_allowed(path, options)?;
     let suffix = remote_or_local_extension(path)
         .filter(|extension| !extension.is_empty())
@@ -268,17 +464,51 @@ fn spool_remote_to_local(path: &Path, options: SourceOptions) -> Result<LocalFil
     LocalFileSource::from_temp_file(temp_file, PathBuf::from(redacted_display(path)))
 }
 
-fn read_file_into(file: &mut File, size: u64, offset: u64, dest: &mut [u8]) -> Result<usize> {
-    if dest.is_empty() || offset >= size {
-        return Ok(0);
+/// Copy an already-open remote [`ByteSource`] into a local tempfile (one full read).
+///
+/// Used when a multi-pass linear path discovers it has a remote range source and must avoid
+/// re-transferring the object on each pass. Prefer [`spool_remote_to_local`] when the URL is still
+/// available so the download can be a single streaming GET.
+pub(crate) fn spool_from_byte_source(source: &mut dyn ByteSource) -> Result<LocalFileSource> {
+    let size = source
+        .size()?
+        .context("cannot spool a remote source with unknown size")?;
+    let mut temp_file = tempfile::Builder::new()
+        .prefix("mcap-cli-remote-spool-")
+        .tempfile()
+        .context("failed to create temporary file for remote spool")?;
+    let mut offset = 0u64;
+    let mut buf = vec![0u8; 1024 * 1024];
+    while offset < size {
+        let want = ((size - offset) as usize).min(buf.len());
+        let n = source.read_into(offset, &mut buf[..want])?;
+        if n == 0 {
+            bail!(
+                "remote spool hit EOF at offset {offset} before expected size {size} ({})",
+                source.display_name()
+            );
+        }
+        temp_file
+            .as_file_mut()
+            .write_all(&buf[..n])
+            .context("failed to write remote spool tempfile")?;
+        offset = offset.saturating_add(n as u64);
     }
-    let available = (size - offset) as usize;
-    let to_read = dest.len().min(available);
-    file.seek(SeekFrom::Start(offset))
-        .context("failed to seek in local file")?;
-    file.read_exact(&mut dest[..to_read])
-        .context("failed to read from local file")?;
-    Ok(to_read)
+    LocalFileSource::from_temp_file(temp_file, PathBuf::from(source.display_name()))
+}
+
+fn spool_stdin_to_local() -> Result<LocalFileSource> {
+    let stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        bail!("{PLEASE_SUPPLY_FILE}");
+    }
+    let mut temp_file = tempfile::Builder::new()
+        .prefix("mcap-cli-stdin-bytesource-")
+        .tempfile()
+        .context("failed to create temporary file for stdin input")?;
+    std::io::copy(&mut stdin.lock(), temp_file.as_file_mut())
+        .context("failed to read input from stdin")?;
+    LocalFileSource::from_temp_file(temp_file, PathBuf::from("<stdin>"))
 }
 
 #[cfg(test)]
@@ -314,13 +544,20 @@ mod tests {
     }
 
     #[test]
-    fn memory_source_read_into_clamps_to_eof() {
+    fn memory_source_read_at_clamps_to_eof() {
         let mut source = MemorySource::new(vec![1, 2, 3, 4, 5]);
-        let mut dest = [0u8; 10];
-        assert_eq!(source.read_into(3, &mut dest).expect("read"), 2);
-        assert_eq!(&dest[..2], &[4, 5]);
-        assert_eq!(source.read_into(5, &mut dest[..1]).expect("past eof"), 0);
-        assert_eq!(source.read_at(3, 10).expect("read_at"), vec![4, 5]);
+        assert_eq!(source.read_at(3, 10).expect("read"), vec![4, 5]);
+        assert!(source.read_at(5, 1).expect("past eof").is_empty());
+        assert!(source.read_at(100, 1).expect("far past eof").is_empty());
+    }
+
+    #[test]
+    fn memory_source_read_into_reuses_caller_buffer() {
+        let mut source = MemorySource::new(vec![10, 20, 30, 40]);
+        let mut buf = vec![0u8; 8];
+        let n = source.read_into(1, &mut buf).expect("read_into");
+        assert_eq!(n, 3);
+        assert_eq!(&buf[..n], &[20, 30, 40]);
     }
 
     #[test]
@@ -353,6 +590,45 @@ mod tests {
     }
 
     #[test]
+    fn local_file_readahead_serves_sequential_tiny_reads() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("seq.bin");
+        let bytes: Vec<u8> = (0..10_000u32).flat_map(|i| i.to_le_bytes()).collect();
+        std::fs::write(&path, &bytes).expect("write");
+
+        let mut local = LocalFileSource::open_path(&path).expect("open");
+        let mut offset = 0u64;
+        let mut out = Vec::new();
+        while offset < bytes.len() as u64 {
+            let mut buf = [0u8; 9];
+            let n = local.read_into(offset, &mut buf).expect("read");
+            assert!(n > 0);
+            out.extend_from_slice(&buf[..n]);
+            offset += n as u64;
+        }
+        assert_eq!(out, bytes);
+        // After a sequential scan the window should be warm near EOF.
+        assert!(!local.cache.is_empty() || local.file_pos.is_some());
+    }
+
+    #[test]
+    fn local_file_readahead_survives_random_jumps() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("rand.bin");
+        let bytes: Vec<u8> = (0..4096u16).flat_map(|i| i.to_le_bytes()).collect();
+        std::fs::write(&path, &bytes).expect("write");
+
+        let mut local = LocalFileSource::open_path(&path).expect("open");
+        for &offset in &[0u64, 100, 3000, 50, 7000, 0] {
+            let mut buf = [0u8; 16];
+            let n = local.read_into(offset, &mut buf).expect("read");
+            let start = offset as usize;
+            let end = (start + n).min(bytes.len());
+            assert_eq!(&buf[..end - start], &bytes[start..end]);
+        }
+    }
+
+    #[test]
     fn for_each_linear_record_visits_opcodes() {
         let bytes = write_summary_mcap();
         let mut source = MemorySource::new(bytes);
@@ -373,6 +649,45 @@ mod tests {
         assert!(
             opcodes.contains(&mcap::records::op::FOOTER),
             "expected footer opcode in {opcodes:?}"
+        );
+    }
+
+    #[test]
+    fn sequential_source_supports_linear_scan_without_seek() {
+        let bytes = write_summary_mcap();
+        let mut source = SequentialSource::new(Cursor::new(bytes), "<cursor>");
+        assert!(!source.is_seekable());
+        assert_eq!(source.size().expect("size"), None);
+        assert!(
+            read_summary(&mut source)
+                .expect("summary on sequential")
+                .is_none(),
+            "summary requires seek; sequential sources should skip it"
+        );
+
+        let mut source = SequentialSource::new(Cursor::new(write_summary_mcap()), "<cursor>");
+        let mut opcodes = Vec::new();
+        for_each_linear_record(
+            &mut source,
+            mcap::sans_io::LinearReaderOptions::default(),
+            |opcode, _| {
+                opcodes.push(opcode);
+                Ok(())
+            },
+        )
+        .expect("sequential linear scan");
+        assert!(opcodes.contains(&mcap::records::op::HEADER));
+    }
+
+    #[test]
+    fn sequential_source_rejects_non_monotonic_reads() {
+        let mut source = SequentialSource::new(Cursor::new(vec![1, 2, 3, 4]), "<cursor>");
+        let mut buf = [0u8; 2];
+        assert_eq!(source.read_into(0, &mut buf).expect("first"), 2);
+        let err = source.read_into(0, &mut buf).expect_err("rewind must fail");
+        assert!(
+            err.to_string().contains("sequential"),
+            "unexpected error: {err:#}"
         );
     }
 

--- a/rust/cli/src/byte_source/drivers.rs
+++ b/rust/cli/src/byte_source/drivers.rs
@@ -11,11 +11,9 @@ use mcap::sans_io::{
 use super::ByteSource;
 
 /// Read the leading [`Header`](mcap::records::Header) record, if present.
+///
+/// Works on sequential sources: reads forward from offset 0 and does not rewind.
 pub fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::records::Header>> {
-    if !source.is_seekable() {
-        bail!("reading the MCAP header requires a seekable byte source");
-    }
-
     let mut reader = LinearReader::new_with_options(LinearReaderOptions::default());
     let mut pos = 0u64;
     while let Some(event) = reader.next_event() {
@@ -39,8 +37,12 @@ pub fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::records::
 
 /// Load the MCAP summary section via [`SummaryReader`].
 ///
-/// Returns `Ok(None)` when the file has no summary section.
+/// Returns `Ok(None)` when the file has no summary section, or when the source is not
+/// seekable (summary lives at the end of the file).
 pub fn read_summary(source: &mut dyn ByteSource) -> Result<Option<mcap::Summary>> {
+    if !source.is_seekable() {
+        return Ok(None);
+    }
     let size = source.size()?;
     let options = match size {
         Some(size) => SummaryReaderOptions::default().with_file_size(size),
@@ -89,16 +91,13 @@ pub fn service_indexed_chunk(
 
 /// Walk every top-level record in file order via [`LinearReader`].
 ///
-/// Requires a seekable source. Starts at offset 0 and advances with each read.
+/// Requires only forward reads from offset 0 (seekable and sequential sources both work).
+/// Callers that already consumed bytes from a sequential source must not call this afterwards.
 pub fn for_each_linear_record(
     source: &mut dyn ByteSource,
     options: LinearReaderOptions,
     mut visit: impl FnMut(u8, &[u8]) -> Result<()>,
 ) -> Result<()> {
-    if !source.is_seekable() {
-        bail!("linear record scan requires a seekable byte source");
-    }
-
     let mut reader = LinearReader::new_with_options(options);
     let mut pos = 0u64;
 

--- a/rust/cli/src/commands/add/shared.rs
+++ b/rust/cli/src/commands/add/shared.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{Read, Seek, Write};
+use std::io::{Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -70,18 +70,34 @@ pub(crate) fn amend_mcap_file(
 
     let backup_path = make_tail_backup_path(file)?;
     let (layout, mut existing_summary) = {
-        let mut readable =
-            fs::File::open(file).with_context(|| format!("failed to open '{}'", file.display()))?;
-        let mut contents = Vec::new();
-        readable
-            .read_to_end(&mut contents)
-            .with_context(|| format!("failed to read '{}'", file.display()))?;
-        let layout = parse_existing_layout(&contents)?;
-        let tail_start = layout.old_data_end_offset as usize;
-        let tail = contents
-            .get(tail_start..)
-            .with_context(|| format!("data end offset out of range for '{}'", file.display()))?;
-        fs::write(&backup_path, tail)
+        // Seek+read only the tail (DataEnd through EOF). Do not load the whole file into a Vec —
+        // files can be far larger than the summary section this path needs.
+        let mut source = crate::byte_source::LocalFileSource::open_path(file)
+            .with_context(|| format!("failed to open '{}'", file.display()))?;
+        let size = crate::byte_source::ByteSource::size(&source)?
+            .with_context(|| format!("failed to get size of '{}'", file.display()))?;
+        let layout = parse_existing_layout_from_source(&mut source, size)?;
+        let tail_len = usize::try_from(
+            size.checked_sub(layout.old_data_end_offset)
+                .with_context(|| {
+                    format!("data end offset out of range for '{}'", file.display())
+                })?,
+        )
+        .with_context(|| format!("tail length out of range for '{}'", file.display()))?;
+        let tail = crate::byte_source::ByteSource::read_at(
+            &mut source,
+            layout.old_data_end_offset,
+            tail_len,
+        )
+        .with_context(|| format!("failed to read tail of '{}'", file.display()))?;
+        if tail.len() != tail_len {
+            bail!(
+                "short read of tail for '{}' (wanted {tail_len}, got {})",
+                file.display(),
+                tail.len()
+            );
+        }
+        fs::write(&backup_path, &tail)
             .with_context(|| format!("failed to write tail backup '{}'", backup_path.display()))?;
         let backup_file = fs::OpenOptions::new()
             .read(true)
@@ -90,7 +106,7 @@ pub(crate) fn amend_mcap_file(
         backup_file
             .sync_all()
             .with_context(|| format!("failed to sync tail backup '{}'", backup_path.display()))?;
-        let summary = collect_existing_summary(&contents)?;
+        let summary = collect_existing_summary_from_source(&mut source)?;
         (layout, summary)
     };
 
@@ -348,6 +364,7 @@ fn amend_mcap_bytes(
     Ok(output)
 }
 
+#[cfg(test)]
 fn parse_existing_layout(input: &[u8]) -> Result<ExistingLayout> {
     let footer = mcap::read::footer(input).context("failed to read footer")?;
     let footer_start = input
@@ -377,6 +394,140 @@ fn parse_existing_layout(input: &[u8]) -> Result<ExistingLayout> {
     })
 }
 
+fn parse_existing_layout_from_source(
+    source: &mut dyn crate::byte_source::ByteSource,
+    size: u64,
+) -> Result<ExistingLayout> {
+    let min_len = (mcap::MAGIC.len() as u64)
+        .checked_add(FOOTER_RECORD_LEN)
+        .and_then(|n| n.checked_add(mcap::MAGIC.len() as u64))
+        .context("footer length overflow")?;
+    if size < min_len {
+        bail!("input is too short to contain a footer");
+    }
+    let start_magic = crate::byte_source::ByteSource::read_at(source, 0, mcap::MAGIC.len())?;
+    let end_magic = crate::byte_source::ByteSource::read_at(
+        source,
+        size - mcap::MAGIC.len() as u64,
+        mcap::MAGIC.len(),
+    )?;
+    if start_magic.as_slice() != mcap::MAGIC || end_magic.as_slice() != mcap::MAGIC {
+        bail!("bad magic");
+    }
+    let footer_start = size - mcap::MAGIC.len() as u64 - FOOTER_RECORD_LEN;
+    let footer_bytes =
+        crate::byte_source::ByteSource::read_at(source, footer_start, FOOTER_RECORD_LEN as usize)?;
+    if footer_bytes.len() != FOOTER_RECORD_LEN as usize || footer_bytes[0] != op::FOOTER {
+        bail!("failed to read footer");
+    }
+    let footer_len = u64::from_le_bytes(footer_bytes[1..9].try_into().expect("len 8"));
+    if footer_len != 20 {
+        bail!("unexpected footer record length {footer_len}");
+    }
+    let summary_start = u64::from_le_bytes(footer_bytes[9..17].try_into().expect("len 8"));
+    let summary_offset_start = u64::from_le_bytes(footer_bytes[17..25].try_into().expect("len 8"));
+    let summary_crc = u32::from_le_bytes(footer_bytes[25..29].try_into().expect("len 4"));
+    let old_data_end_offset = if summary_start > 0 {
+        summary_start
+            .checked_sub(DATA_END_RECORD_LEN)
+            .context("summary start is before data end record")?
+    } else {
+        footer_start
+            .checked_sub(DATA_END_RECORD_LEN)
+            .context("footer starts before data end record")?
+    };
+    let data_end_bytes = crate::byte_source::ByteSource::read_at(
+        source,
+        old_data_end_offset,
+        DATA_END_RECORD_LEN as usize,
+    )?;
+    if data_end_bytes.len() != DATA_END_RECORD_LEN as usize || data_end_bytes[0] != op::DATA_END {
+        bail!("expected data end record at offset {old_data_end_offset}");
+    }
+    let data_section_crc = u32::from_le_bytes(data_end_bytes[9..13].try_into().expect("len 4"));
+    Ok(ExistingLayout {
+        emit_summary_offsets: summary_offset_start != 0,
+        data_crc_enabled: data_section_crc != 0,
+        summary_crc_enabled: summary_crc != 0,
+        old_data_end_crc: data_section_crc,
+        old_data_end_offset,
+    })
+}
+
+fn existing_summary_from_mcap_summary(summary: mcap::Summary) -> ExistingSummaryData {
+    let mut data = ExistingSummaryData {
+        statistics: summary.stats,
+        channels: BTreeMap::new(),
+        schemas: BTreeMap::new(),
+        chunk_indexes: summary.chunk_indexes,
+        attachment_indexes: summary.attachment_indexes,
+        metadata_indexes: summary.metadata_indexes,
+    };
+    for schema in summary.schemas.values() {
+        let schema = schema.as_ref();
+        data.schemas.insert(
+            schema.id,
+            ParsedSchema {
+                header: records::SchemaHeader {
+                    id: schema.id,
+                    name: schema.name.clone(),
+                    encoding: schema.encoding.clone(),
+                },
+                data: schema.data.clone().into_owned(),
+            },
+        );
+    }
+    for channel in summary.channels.values() {
+        let channel = channel.as_ref();
+        data.channels.insert(
+            channel.id,
+            records::Channel {
+                id: channel.id,
+                schema_id: channel.schema.as_ref().map(|schema| schema.id).unwrap_or(0),
+                topic: channel.topic.clone(),
+                message_encoding: channel.message_encoding.clone(),
+                metadata: channel.metadata.clone(),
+            },
+        );
+    }
+    data
+}
+
+fn collect_existing_summary_from_source(
+    source: &mut dyn crate::byte_source::ByteSource,
+) -> Result<ExistingSummaryData> {
+    if let Some(summary) = crate::byte_source::read_summary(source)? {
+        return Ok(existing_summary_from_mcap_summary(summary));
+    }
+    let mut data = ExistingSummaryData::default();
+    crate::byte_source::for_each_linear_record(
+        source,
+        mcap::sans_io::LinearReaderOptions::default(),
+        |opcode, body| {
+            let record = mcap::parse_record(opcode, body)?;
+            if let Record::Chunk {
+                header: chunk_header,
+                data: chunk_data,
+            } = record
+            {
+                for nested in mcap::read::ChunkReader::new(chunk_header, chunk_data.as_ref())
+                    .context("failed to parse chunk records")?
+                {
+                    collect_record(
+                        &mut data,
+                        nested.context("failed to parse nested chunk record")?,
+                    )?;
+                }
+            } else {
+                collect_record(&mut data, record)?;
+            }
+            Ok(())
+        },
+    )?;
+    Ok(data)
+}
+
+#[cfg(test)]
 fn parse_data_end(input: &[u8], offset: u64) -> Result<records::DataEnd> {
     let start = offset as usize;
     let Some(slice) = input.get(start..) else {
@@ -396,45 +547,10 @@ fn parse_data_end(input: &[u8], offset: u64) -> Result<records::DataEnd> {
     }
 }
 
+#[cfg(test)]
 fn collect_existing_summary(input: &[u8]) -> Result<ExistingSummaryData> {
     if let Some(summary) = mcap::Summary::read(input).context("failed to read summary")? {
-        let mut data = ExistingSummaryData {
-            statistics: summary.stats,
-            channels: BTreeMap::new(),
-            schemas: BTreeMap::new(),
-            chunk_indexes: summary.chunk_indexes,
-            attachment_indexes: summary.attachment_indexes,
-            metadata_indexes: summary.metadata_indexes,
-        };
-
-        for schema in summary.schemas.values() {
-            let schema = schema.as_ref();
-            data.schemas.insert(
-                schema.id,
-                ParsedSchema {
-                    header: records::SchemaHeader {
-                        id: schema.id,
-                        name: schema.name.clone(),
-                        encoding: schema.encoding.clone(),
-                    },
-                    data: schema.data.clone().into_owned(),
-                },
-            );
-        }
-        for channel in summary.channels.values() {
-            let channel = channel.as_ref();
-            data.channels.insert(
-                channel.id,
-                records::Channel {
-                    id: channel.id,
-                    schema_id: channel.schema.as_ref().map(|schema| schema.id).unwrap_or(0),
-                    topic: channel.topic.clone(),
-                    message_encoding: channel.message_encoding.clone(),
-                    metadata: channel.metadata.clone(),
-                },
-            );
-        }
-        return Ok(data);
+        return Ok(existing_summary_from_mcap_summary(summary));
     }
 
     let mut data = ExistingSummaryData::default();

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -250,19 +250,6 @@ fn cat_indexed(
         return Ok(IndexedCatResult::NeedsLinear);
     }
 
-    let has_chunks_without_message_indexes = summary
-        .chunk_indexes
-        .iter()
-        .any(|chunk| chunk.message_index_offsets.is_empty());
-    if source.is_remote() && has_chunks_without_message_indexes && !source_options.allow_remote_scan
-    {
-        bail!(
-            "{}: remote file has chunk indexes without message indexes; reading messages requires opt-in; {}",
-            source.display_name(),
-            source::remote_scan_opt_in_suffix()
-        );
-    }
-
     let needs_in_chunk_definitions = needs_in_chunk_definitions(&summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();

--- a/rust/cli/src/commands/du.rs
+++ b/rust/cli/src/commands/du.rs
@@ -35,6 +35,9 @@ struct OffsetEntry {
 pub fn run(ctx: &CommandContext, args: DuCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
     let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
+    // `du` always reads message payloads or message indexes for topic sizes — same opt-in as on
+    // main (materialize). Approximate mode still needs the flag for remote inputs.
+    source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
 
     let (usage, used_approximate) = if args.approximate {
         match collect_usage_approximate(input.as_mut())? {
@@ -43,12 +46,10 @@ pub fn run(ctx: &CommandContext, args: DuCommand) -> Result<()> {
                 eprintln!(
                     "Warning: summary/chunk indexes unavailable; falling back to exact du scan."
                 );
-                source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
                 (collect_usage_exact(input.as_mut())?, false)
             }
         }
     } else {
-        source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
         (collect_usage_exact(input.as_mut())?, false)
     };
 

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -21,11 +21,13 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     let index = select_attachment_index(&indexes, &args.name, args.offset)?;
     let length = usize::try_from(index.length)
         .context("indexed record is too large to read on this platform")?;
-    source::require_remote_indexed_read_budget(
-        index.length,
-        source_options,
-        "remote attachment record",
-    )?;
+    if input.is_remote() {
+        source::require_remote_indexed_read_budget(
+            index.length,
+            source_options,
+            "remote attachment record",
+        )?;
+    }
     let bytes = input.read_at(index.offset, length)?;
     let attachment = parse::parse_attachment_record(&bytes).with_context(|| {
         format!(

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -61,7 +61,7 @@ fn merged_metadata_for_name(
     let total_bytes = matching_indexes
         .iter()
         .fold(0u64, |total, index| total.saturating_add(index.length));
-    if matching_indexes.len() > 1 || source.is_remote() {
+    if source.is_remote() {
         source::require_remote_indexed_read_budget(
             total_bytes,
             source_options,

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -124,9 +124,13 @@ pub fn run(ctx: &CommandContext, args: RecoverCommand) -> Result<CommandOutcome>
     if let (Some(input), Some(output)) = (args.file.as_deref(), args.output.as_deref()) {
         source::ensure_distinct_local_input_output(input, output)?;
     }
-    // Path / URL / stdin all go through ByteSource. Stdin is spooled to a tempfile;
-    // remote inputs use range reads (or a full spool when ranges are unavailable).
-    let mut input = byte_source::open_byte_source(args.file.as_deref(), source_options)?;
+    // Recover is a single forward linear pass, so stdin can stream without spooling.
+    // Remote inputs still use range reads (or a full spool when ranges are unavailable).
+    let mut input = byte_source::open_byte_source_with_access(
+        args.file.as_deref(),
+        source_options,
+        byte_source::AccessMode::Sequential,
+    )?;
     source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
     let compression = resolve_compression(&args.compression)?;
 
@@ -313,8 +317,8 @@ fn recover_records<W: Write + Seek>(
         match event {
             Ok(LinearReadEvent::ReadRequest(need)) => {
                 let buf = reader.insert(need);
-                let n = match input.read_into(pos, buf) {
-                    Ok(n) => n,
+                let read = match input.read_into(pos, buf) {
+                    Ok(read) => read,
                     Err(err) if saw_any_record => {
                         warn!("{err:#} -- stopping recovery scan");
                         stats.truncated = true;
@@ -322,11 +326,11 @@ fn recover_records<W: Write + Seek>(
                     }
                     Err(err) => return Err(err).context("failed to read input"),
                 };
-                if n == 0 && !saw_any_record {
+                if read == 0 && !saw_any_record {
                     return Err(mcap::McapError::UnexpectedEof.into());
                 }
-                reader.notify_read(n);
-                pos = pos.saturating_add(n as u64);
+                reader.notify_read(read);
+                pos = pos.saturating_add(read as u64);
             }
             Ok(LinearReadEvent::Record { opcode, data }) => {
                 saw_any_record = true;

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -345,13 +345,11 @@ mod tests {
         )
         .expect_err("cloud input should fail before producing output");
         let message = err.to_string();
-        // Indexed remote rewrite may attempt a range open (network/credentials) rather than
-        // requiring --allow-remote-scan up front; either way the secret must stay redacted.
+        // Remotes require --allow-remote-scan before message-chunk reads; credential failures
+        // may also surface first. Either way the secret must stay redacted.
         assert!(!message.contains("token=secret"));
         assert!(
-            message.contains("s3://bucket/input.mcap")
-                || message.contains("--allow-remote-scan")
-                || message.contains("failed"),
+            message.contains("s3://bucket/input.mcap") || message.contains("--allow-remote-scan"),
             "unexpected error: {message}"
         );
     }

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -214,10 +214,6 @@ where
 {
     use mcap::sans_io::{LinearReadEvent, LinearReader, LinearReaderOptions};
 
-    if !source.is_seekable() {
-        bail!("linear MCAP scan requires a seekable byte source");
-    }
-
     let record_limit = source
         .size()?
         .and_then(|size| usize::try_from(size).ok())

--- a/rust/cli/src/rewrite/common.rs
+++ b/rust/cli/src/rewrite/common.rs
@@ -103,31 +103,8 @@ pub(crate) fn open_output(output: Option<&Path>) -> Result<(OutputSink, bool)> {
 /// Reads the leading [`Header`](mcap::records::Header) record, if present. Used to carry the input
 /// profile onto the output.
 pub(crate) fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::records::Header>> {
-    use mcap::sans_io::{LinearReadEvent, LinearReader, LinearReaderOptions};
-
-    if !source.is_seekable() {
-        bail!("reading the MCAP header requires a seekable byte source");
-    }
-
-    let mut reader = LinearReader::new_with_options(LinearReaderOptions::default());
-    let mut pos = 0u64;
-    while let Some(event) = reader.next_event() {
-        match event.context("linear reader error")? {
-            LinearReadEvent::ReadRequest(need) => {
-                let buf = reader.insert(need);
-                let n = source.read_into(pos, buf)?;
-                reader.notify_read(n);
-                pos = pos.saturating_add(n as u64);
-            }
-            LinearReadEvent::Record { opcode, data } => {
-                return match mcap::parse_record(opcode, data)? {
-                    mcap::records::Record::Header(header) => Ok(Some(header)),
-                    _ => Ok(None),
-                };
-            }
-        }
-    }
-    Ok(None)
+    // Shared driver fills the sans-io insert buffer via `read_into` (no intermediate Vec).
+    byte_source::read_header(source)
 }
 
 fn incomplete_indexed_summary_error() -> anyhow::Error {
@@ -136,7 +113,7 @@ fn incomplete_indexed_summary_error() -> anyhow::Error {
     )
 }
 
-fn is_unknown_schema_error(err: &anyhow::Error) -> bool {
+pub(crate) fn is_unknown_schema_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause
             .downcast_ref::<mcap::McapError>()
@@ -366,6 +343,24 @@ pub(crate) fn require_remote_scan_for_chunks(
             source::remote_scan_opt_in_suffix()
         );
     }
+    Ok(())
+}
+
+/// Replace a remote range source with a local spool so multi-pass linear work transfers once.
+pub(crate) fn materialize_remote_for_multipass(
+    source: &mut Box<dyn ByteSource>,
+    path: Option<&std::path::Path>,
+    options: SourceOptions,
+) -> Result<()> {
+    if !source.is_remote() {
+        return Ok(());
+    }
+    let local = if let Some(path) = path {
+        byte_source::spool_remote_to_local(path, options)?
+    } else {
+        byte_source::spool_from_byte_source(source.as_mut())?
+    };
+    *source = Box::new(local);
     Ok(())
 }
 

--- a/rust/cli/src/rewrite/merge.rs
+++ b/rust/cli/src/rewrite/merge.rs
@@ -54,6 +54,8 @@ struct MetadataKey {
 
 struct InputRef {
     name: String,
+    /// Local filesystem or remote URL path used to open this input; `None` in in-memory tests.
+    path: Option<std::path::PathBuf>,
 }
 
 struct IndexedInputMessageReader {
@@ -166,6 +168,7 @@ pub(crate) fn run(opts: MergeOptions, source_options: SourceOptions) -> Result<(
         let source = byte_source::open_byte_source(Some(path.as_path()), source_options)?;
         inputs.push(InputRef {
             name: source::redacted_display(path),
+            path: Some(path.clone()),
         });
         sources.push(source);
     }
@@ -210,10 +213,14 @@ fn merge_inputs<W: Write + Seek>(
 
     let summaries = sources
         .iter_mut()
-        // Treat summary lookup as best effort and fall back to linear scans when
-        // summary parsing fails.
-        .map(|source| byte_source::read_summary(source.as_mut()).unwrap_or_default())
-        .collect::<Vec<_>>();
+        .map(|source| match byte_source::read_summary(source.as_mut()) {
+            Ok(summary) => Ok(summary),
+            // A summary that references schemas only defined inside chunks can't be used for an
+            // indexed merge; fall back to the linear path.
+            Err(err) if common::is_unknown_schema_error(&err) => Ok(None),
+            Err(err) => Err(err),
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     merge_messages(
         inputs,
@@ -467,6 +474,30 @@ fn merge_messages<W: Write + Seek>(
     };
     let mut metadata_state = MetadataState::default();
 
+    // Classify each input before any multi-pass work so remotes that need a linear path spool once.
+    let mut use_indexed = vec![false; inputs.len()];
+    for (input_idx, input) in inputs.iter().enumerate() {
+        if let Some(summary) = summaries[input_idx].as_ref() {
+            if !summary.chunk_indexes.is_empty()
+                && common::summary_supports_indexed_read(summary)
+                && common::summary_indexes_all_messages(sources[input_idx].as_mut(), summary)?
+            {
+                common::require_remote_scan_for_chunks(
+                    sources[input_idx].as_ref(),
+                    source_options,
+                )?;
+                use_indexed[input_idx] = true;
+                continue;
+            }
+        }
+        common::require_remote_scan_for_linear(sources[input_idx].as_ref(), source_options)?;
+        common::materialize_remote_for_multipass(
+            &mut sources[input_idx],
+            input.path.as_deref(),
+            source_options,
+        )?;
+    }
+
     for (input_idx, input) in inputs.iter().enumerate() {
         write_metadata_records(
             writer,
@@ -481,22 +512,16 @@ fn merge_messages<W: Write + Seek>(
 
     let mut streams = Vec::<MergeMessageStream>::with_capacity(inputs.len());
     for (input_idx, input) in inputs.iter().enumerate() {
-        if let Some(summary) = summaries[input_idx].as_ref() {
-            if !summary.chunk_indexes.is_empty()
-                && common::summary_supports_indexed_read(summary)
-                && common::summary_indexes_all_messages(sources[input_idx].as_mut(), summary)?
-            {
-                common::require_remote_scan_for_chunks(
-                    sources[input_idx].as_ref(),
-                    source_options,
-                )?;
-                streams.push(MergeMessageStream::Indexed(IndexedInputMessageReader::new(
-                    input_idx,
-                    input,
-                    summary.clone(),
-                )?));
-                continue;
-            }
+        if use_indexed[input_idx] {
+            let summary = summaries[input_idx]
+                .as_ref()
+                .expect("indexed path requires a summary");
+            streams.push(MergeMessageStream::Indexed(IndexedInputMessageReader::new(
+                input_idx,
+                input,
+                summary.clone(),
+            )?));
+            continue;
         }
         // Without usable message indexes, guaranteeing log-time order requires sorting this input.
         streams.push(MergeMessageStream::Materialized(
@@ -998,6 +1023,12 @@ mod tests {
         bytes[offset..offset + 8].copy_from_slice(&(current + delta).to_le_bytes());
     }
 
+    /// Mark the footer as having no summary section so summary parse is skipped.
+    fn clear_footer_summary(bytes: &mut [u8]) {
+        let offset = record_offset(bytes, mcap::records::op::FOOTER) + 9;
+        bytes[offset..offset + 16].fill(0);
+    }
+
     fn patch_statistics_message_count(bytes: &mut [u8], message_count: u64) {
         let offset = record_offset(bytes, mcap::records::op::STATISTICS) + 9;
         bytes[offset..offset + 8].copy_from_slice(&message_count.to_le_bytes());
@@ -1022,6 +1053,7 @@ mod tests {
             .iter()
             .map(|(name, _)| InputRef {
                 name: (*name).to_string(),
+                path: None,
             })
             .collect::<Vec<_>>();
         let mut sources: Vec<Box<dyn ByteSource>> = inputs
@@ -1056,10 +1088,7 @@ mod tests {
 
     #[test]
     fn run_rejects_remote_input_without_range_support_or_scan_opt_in() {
-        // Opening a remote URL without range support requires --allow-remote-scan. A
-        // non-resolvable host fails at open time; cloud URLs that need credentials still
-        // attempt range open. Use a path that open_byte_source rejects before download when
-        // range support is unavailable — HTTP without opt-in when range open fails.
+        // Opening a remote URL without range support requires --allow-remote-scan.
         let err = run(
             merge_options(
                 vec!["http://127.0.0.1:1/a.mcap".into()],
@@ -1072,11 +1101,17 @@ mod tests {
         let message = err.to_string();
         assert!(
             message.contains("--allow-remote-scan")
-                || message.contains("failed")
                 || message.contains("Connection")
-                || message.contains("error"),
+                || message.contains("os error")
+                || message.contains("error trying to connect")
+                || message.contains("tcp connect error")
+                || message.contains("error sending request")
+                || message.contains("HTTP error"),
             "unexpected error: {message}"
         );
+        // Secrets / query tokens must never appear if present in a URL.
+        assert!(!message.contains("token="));
+        assert!(message.contains("127.0.0.1:1/a.mcap") || message.contains("a.mcap"));
     }
 
     #[test]
@@ -1333,7 +1368,7 @@ mod tests {
         let mut bytes = base;
         let data_end_offset = record_offset(&bytes, mcap::records::op::DATA_END);
         bytes.splice(data_end_offset..data_end_offset, conflict.iter().copied());
-        patch_footer_summary_start(&mut bytes, conflict.len() as u64);
+        clear_footer_summary(&mut bytes);
 
         let err = merge_bytes(&[("bad", bytes.as_slice())], CoalesceChannels::Auto, false)
             .expect_err("conflicting schema redefinition should fail");
@@ -1369,7 +1404,7 @@ mod tests {
         let mut bytes = base;
         let data_end_offset = record_offset(&bytes, mcap::records::op::DATA_END);
         bytes.splice(data_end_offset..data_end_offset, conflict.iter().copied());
-        patch_footer_summary_start(&mut bytes, conflict.len() as u64);
+        clear_footer_summary(&mut bytes);
 
         let err = merge_bytes(&[("bad", bytes.as_slice())], CoalesceChannels::Auto, false)
             .expect_err("conflicting channel redefinition should fail");
@@ -1397,7 +1432,7 @@ mod tests {
         let mut bytes = base;
         let data_end_offset = record_offset(&bytes, mcap::records::op::DATA_END);
         bytes.splice(data_end_offset..data_end_offset, invalid.iter().copied());
-        patch_footer_summary_start(&mut bytes, invalid.len() as u64);
+        clear_footer_summary(&mut bytes);
 
         let err = merge_bytes(&[("bad", bytes.as_slice())], CoalesceChannels::Auto, false)
             .expect_err("schema id 0 should fail");

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -22,17 +22,25 @@ pub(crate) fn run(args: RewriteOptions, source_options: SourceOptions) -> Result
     let mut input = byte_source::open_byte_source(args.file.as_deref(), source_options)?;
 
     let (sink, disable_seeking) = common::open_output(opts.output.as_deref())?;
-    filter_to_writer(input.as_mut(), sink, &opts, disable_seeking, source_options)
+    filter_to_writer(
+        &mut input,
+        sink,
+        &opts,
+        disable_seeking,
+        args.file.as_deref(),
+        source_options,
+    )
 }
 
 fn filter_to_writer<W: Write + Seek>(
-    input: &mut dyn ByteSource,
+    input: &mut Box<dyn ByteSource>,
     sink: W,
     opts: &ResolvedOptions,
     disable_seeking: bool,
+    input_path: Option<&std::path::Path>,
     source_options: SourceOptions,
 ) -> Result<()> {
-    let profile = common::read_header(input)?
+    let profile = common::read_header(input.as_mut())?
         .map(|header| header.profile)
         .unwrap_or_default();
     let mut writer = common::create_writer(
@@ -46,32 +54,36 @@ fn filter_to_writer<W: Write + Seek>(
         },
         disable_seeking,
     )?;
-    filter_with_writer(input, &mut writer, opts, source_options)?;
+    filter_with_writer(input, &mut writer, opts, input_path, source_options)?;
     writer.finish().context("failed to finish mcap writer")?;
     Ok(())
 }
 
 fn filter_with_writer<W: Write + Seek>(
-    input: &mut dyn ByteSource,
+    input: &mut Box<dyn ByteSource>,
     writer: &mut mcap::Writer<W>,
     opts: &ResolvedOptions,
+    input_path: Option<&std::path::Path>,
     source_options: SourceOptions,
 ) -> Result<()> {
-    if let Some(summary) = common::read_indexed_summary(input)? {
+    if let Some(summary) = common::read_indexed_summary(input.as_mut())? {
         // An index-only read skips messages that live outside the chunk indexes (loose top-level
         // messages, or chunks missing message-index records). Divert to a lossless linear scan only
         // when the summary *proves* such messages exist; a stats-less indexed file keeps the fast
         // path (its index read is correct, and `--last-per-channel` needs it).
         if !summary.chunk_indexes.is_empty()
-            && !common::summary_has_unindexed_messages(input, &summary)?
+            && !common::summary_has_unindexed_messages(input.as_mut(), &summary)?
         {
             // Message-chunk reads need the same opt-in as on main (summary-only stays unflagged).
-            common::require_remote_scan_for_chunks(input, source_options)?;
-            return filter_indexed(input, &summary, writer, opts, source_options);
+            common::require_remote_scan_for_chunks(input.as_ref(), source_options)?;
+            return filter_indexed(input.as_mut(), &summary, writer, opts, source_options);
         }
     }
-    common::require_remote_scan_for_linear(input, source_options)?;
-    filter_linear(input, writer, opts)
+    common::require_remote_scan_for_linear(input.as_ref(), source_options)?;
+    // Linear rewrite walks the input more than once (metadata, then messages/attachments). Spool a
+    // remote range source so those passes do not re-transfer the object.
+    common::materialize_remote_for_multipass(input, input_path, source_options)?;
+    filter_linear(input.as_mut(), writer, opts)
 }
 
 #[derive(Debug, Clone)]
@@ -369,7 +381,8 @@ fn filter_linear<W: Write + Seek>(
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
-    // Collected during the message pass and written last.
+    // Collected during the message pass and written last. Attachment payloads are held in memory
+    // for the duration of the linear rewrite (peak scales with the sum of selected attachment sizes).
     let mut pending_attachments = Vec::<mcap::Attachment<'static>>::new();
     // Messages buffered for the sorted path. This holds the whole selected message set in memory,
     // so the summaryless ordered path is not memory-bounded.
@@ -529,13 +542,14 @@ mod tests {
     }
 
     fn run_filter(input: &[u8], opts: &ResolvedOptions) -> Vec<u8> {
-        let mut source = MemorySource::new(input.to_vec());
+        let mut source: Box<dyn ByteSource> = Box::new(MemorySource::new(input.to_vec()));
         let mut output = Cursor::new(Vec::new());
         filter_to_writer(
             &mut source,
             &mut output,
             opts,
             false,
+            None,
             SourceOptions::default(),
         )
         .expect("filter should succeed");
@@ -543,13 +557,14 @@ mod tests {
     }
 
     fn filter_bytes(input: &[u8], opts: &ResolvedOptions) -> Result<Vec<u8>> {
-        let mut source = MemorySource::new(input.to_vec());
+        let mut source: Box<dyn ByteSource> = Box::new(MemorySource::new(input.to_vec()));
         let mut output = Cursor::new(Vec::new());
         filter_to_writer(
             &mut source,
             &mut output,
             opts,
             false,
+            None,
             SourceOptions::default(),
         )?;
         Ok(output.into_inner())
@@ -1903,25 +1918,25 @@ mod tests {
             "memory://remote-fixture.mcap".into()
         }
 
-        fn is_seekable(&self) -> bool {
-            true
-        }
-
         fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> anyhow::Result<usize> {
             let n = self.inner.read_into(offset, dest)?;
             self.bytes_read
                 .fetch_add(n, std::sync::atomic::Ordering::SeqCst);
             Ok(n)
         }
+
+        fn is_seekable(&self) -> bool {
+            true
+        }
     }
 
     #[test]
     fn remote_indexed_filter_requires_allow_remote_scan() {
         let input = write_filter_test_input(true, false);
-        let mut source = CountingRemoteSource {
+        let mut source: Box<dyn ByteSource> = Box::new(CountingRemoteSource {
             inner: MemorySource::new(input),
             bytes_read: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-        };
+        });
 
         let mut opts = include_all_options();
         opts.include_topics = vec![regex::Regex::new("^camera_a$").expect("regex")];
@@ -1934,6 +1949,7 @@ mod tests {
             &mut output,
             &opts,
             false,
+            None,
             SourceOptions::default(),
         )
         .expect_err("indexed remote filter should require --allow-remote-scan");
@@ -1947,10 +1963,10 @@ mod tests {
         let input = write_filter_test_input(true, false);
         let file_len = input.len();
         let bytes_read = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let mut source = CountingRemoteSource {
+        let mut source: Box<dyn ByteSource> = Box::new(CountingRemoteSource {
             inner: MemorySource::new(input),
             bytes_read: bytes_read.clone(),
-        };
+        });
 
         let mut opts = include_all_options();
         opts.include_topics = vec![regex::Regex::new("^camera_a$").expect("regex")];
@@ -1963,6 +1979,7 @@ mod tests {
             &mut output,
             &opts,
             false,
+            None,
             SourceOptions::new(true),
         )
         .expect("indexed remote filter with --allow-remote-scan should succeed");

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -868,6 +868,8 @@ pub(crate) fn require_remote_indexed_read_budget(
     options: SourceOptions,
     description: &str,
 ) -> Result<()> {
+    // Callers must invoke this only for remote inputs. Local indexed reads are uncapped;
+    // `--allow-remote-scan` is a remote-transfer opt-in, not a local size guard.
     if options.allow_remote_scan || total_bytes <= MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN {
         return Ok(());
     }

--- a/rust/cli/tests/cli.rs
+++ b/rust/cli/tests/cli.rs
@@ -356,6 +356,30 @@ fn stdin_pipe_cat_csv_errors_on_unknown_topic() {
 }
 
 #[test]
+fn stdin_pipe_recover() {
+    let dir = TempDir::new().unwrap();
+    let out_path = dir.path().join("recovered.mcap");
+    let output = mcap_with_stdin(
+        &[
+            "recover",
+            "-o",
+            path_str(&out_path),
+            "--compression",
+            "none",
+        ],
+        &build_mcap(3),
+    );
+    assert!(
+        output.status.success(),
+        "recover from stdin should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(looks_like_mcap(
+        &std::fs::read(&out_path).expect("recover output")
+    ));
+}
+
+#[test]
 fn stdin_pipe_filter() {
     let dir = TempDir::new().unwrap();
     let out_path = dir.path().join("filtered.mcap");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked on #1834. Adds `AccessMode` / `SequentialSource` and local readahead. Remote `--allow-remote-scan` policy for message chunks already lives in the base PR. Rebased onto the MessageStream schema/channel conflict-check tip.

## Changes

- `AccessMode::{Random, Sequential}` — stdin streams without a tempfile in sequential mode; sequential remotes spool once
- 256 KiB readahead on `LocalFileSource` for small sans-io fills
- Multi-pass linear rewrite spools remotes once via `materialize_remote_for_multipass`
- Keeps summaryless-merge conflict checks from #1834; conflict-fixture tests clear the footer summary so this branch's stricter summary-error path still reaches the linear merge
- Related docs and spellcheck updates

## Base

Depends on #1834.

## Test plan

- [x] `cargo clippy -p mcap-cli --bins -- -D warnings`
- [x] `cargo test -p mcap-cli --bins` (401 passed)
- [x] `cargo test -p mcap-cli --bin mcap -- rewrite::merge::` (22 passed, including conflict checks)
- [ ] CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e2d2a3f-13c7-4a87-a659-1d585dc289c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e2d2a3f-13c7-4a87-a659-1d585dc289c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

