### PR TITLE
rust: reject oversized chunk compression strings before allocating

### DIFF
--- a/rust/mcap/src/sans_io/linear_reader.rs
+++ b/rust/mcap/src/sans_io/linear_reader.rs
@@ -571,7 +571,20 @@ impl LinearReader {
                     let min_header_buf = load!(MIN_CHUNK_HEADER_SIZE);
                     let compression_len =
                         u32::from_le_bytes(min_header_buf[28..32].try_into().unwrap());
-                    let header_len = MIN_CHUNK_HEADER_SIZE + compression_len as usize;
+                    // The compression string sits between the length prefix and compressed_size.
+                    // A corrupt file can declare a multi-gigabyte string here. Requesting that
+                    // many bytes used to allocate them in insert() before any length check ran.
+                    let header_len =
+                        (MIN_CHUNK_HEADER_SIZE as u64).saturating_add(u64::from(compression_len));
+                    if header_len > len {
+                        return Some(Err(McapError::BadChunkLength {
+                            header: header_len,
+                            available: len,
+                        }));
+                    }
+                    let header_len =
+                        check!(check_len(header_len, self.options.record_length_limit)
+                            .ok_or(McapError::ChunkTooLarge(header_len)));
                     let header_buf = consume!(header_len);
                     let header: ChunkHeader = check!(std::io::Cursor::new(header_buf).read_le());
                     // Re-use or construct a compressor
@@ -843,7 +856,9 @@ fn decompress_inner(
     }
     dest_buf.reserve_exact(additional);
     loop {
-        let need = decompressor.next_read_size();
+        let need = decompressor
+            .next_read_size()
+            .min(clamp_to_usize(*compressed_remaining));
         let have = src_buf.len();
         if need > have {
             return Ok(Some(need - have));
@@ -870,6 +885,7 @@ mod tests {
 
     use super::*;
     use crate::{parse_record, Compression};
+    use assert_matches::assert_matches;
     use std::collections::BTreeMap;
     use std::io::Read;
 
@@ -1031,6 +1047,88 @@ mod tests {
         panic!("should have errored")
     }
 
+    /// MAGIC + empty Header + a Chunk whose compression-string length disagrees with the
+    /// chunk record length. `insert()` used to allocate the declared string length.
+    fn file_with_chunk_compression_len(compression_len: u32, record_len: u64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(MAGIC);
+        // Header: empty profile and library strings.
+        buf.push(op::HEADER);
+        buf.extend_from_slice(&8u64.to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        buf.push(op::CHUNK);
+        buf.extend_from_slice(&record_len.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes()); // message_start_time
+        buf.extend_from_slice(&0u64.to_le_bytes()); // message_end_time
+        buf.extend_from_slice(&0u64.to_le_bytes()); // uncompressed_size
+        buf.extend_from_slice(&0u32.to_le_bytes()); // uncompressed_crc
+        buf.extend_from_slice(&compression_len.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes()); // compressed_size if compression_len == 0
+        buf
+    }
+
+    fn drive_linear_reader(
+        bytes: &[u8],
+        options: LinearReaderOptions,
+    ) -> (Option<McapError>, usize) {
+        let mut reader = LinearReader::new_with_options(options);
+        let mut cursor = std::io::Cursor::new(bytes);
+        let mut max_insert = 0usize;
+        let mut iter_count = 0;
+        while let Some(event) = reader.next_event() {
+            match event {
+                Ok(LinearReadEvent::ReadRequest(n)) => {
+                    assert!(
+                        n <= bytes.len().max(64),
+                        "insert requested {n} bytes for a {}-byte file",
+                        bytes.len()
+                    );
+                    max_insert = max_insert.max(n);
+                    let written = cursor
+                        .read(reader.insert(n))
+                        .expect("insert should not fail");
+                    reader.notify_read(written);
+                }
+                Ok(LinearReadEvent::Record { .. }) => {}
+                Err(err) => return (Some(err), max_insert),
+            }
+            iter_count += 1;
+            assert!(iter_count < 10000);
+        }
+        (None, max_insert)
+    }
+
+    #[test]
+    fn test_chunk_compression_len_exceeds_record() {
+        // Record body is the 40-byte minimum header; compression_len claims ~1.69 GiB.
+        const HUGE: u32 = 1_687_060_480;
+        let bytes = file_with_chunk_compression_len(HUGE, 40);
+        let (err, max_insert) = drive_linear_reader(&bytes, LinearReaderOptions::default());
+        assert!(max_insert <= 1024);
+        assert_matches!(
+            err,
+            Some(McapError::BadChunkLength {
+                header,
+                available: 40
+            }) if header == 40 + HUGE as u64
+        );
+    }
+
+    #[test]
+    fn test_chunk_compression_len_exceeds_record_length_limit() {
+        const HUGE: u32 = 1_687_060_480;
+        // Length field agrees with the huge compression string, so BadChunkLength does not
+        // fire; the record-length limit must still refuse to allocate it.
+        let bytes = file_with_chunk_compression_len(HUGE, 40 + HUGE as u64);
+        let (err, max_insert) = drive_linear_reader(
+            &bytes,
+            LinearReaderOptions::default().with_record_length_limit(1024),
+        );
+        assert!(max_insert <= 1024);
+        assert_matches!(err, Some(McapError::ChunkTooLarge(n)) if n == 40 + HUGE as u64);
+    }
+
     fn test_chunked(
         compression: Option<Compression>,
         options: LinearReaderOptions,
@@ -1077,7 +1175,6 @@ mod tests {
         );
         Ok(())
     }
-    use assert_matches::assert_matches;
     use paste::paste;
 
     macro_rules! test_chunked_parametrized {

--- a/rust/mcap/src/sans_io/summary_reader.rs
+++ b/rust/mcap/src/sans_io/summary_reader.rs
@@ -123,6 +123,23 @@ impl SummaryReaderOptions {
     }
 }
 
+/// Cap a read request to the bytes that can still exist in the file.
+///
+/// `insert(n)` allocates `n` bytes before any I/O happens. A corrupt record can ask for
+/// gigabytes; the summary section cannot be larger than the remaining file, so a larger
+/// request can never be satisfied.
+fn clamp_read_request(pos: u64, file_size: Option<u64>, n: usize) -> McapResult<usize> {
+    let Some(file_size) = file_size else {
+        return Ok(n);
+    };
+    let remaining = file_size.saturating_sub(pos);
+    if remaining == 0 {
+        return Err(McapError::UnexpectedEof);
+    }
+    let remaining = usize::try_from(remaining).unwrap_or(usize::MAX);
+    Ok(n.min(remaining))
+}
+
 /// Returns the lesser of the remaining file size, and the configured record length limit.
 fn compute_record_length_limit(
     pos: u64,
@@ -265,6 +282,7 @@ impl SummaryReader {
                         continue;
                     }
                     Some(Ok(LinearReadEvent::ReadRequest(n))) => {
+                        let n = clamp_read_request(self.pos, self.file_size, n)?;
                         return Ok(Some(SummaryReadEvent::ReadRequest(n)));
                     }
                     Some(Err(err)) => {
@@ -513,5 +531,111 @@ mod tests {
             Summary::read(file.get_ref()),
             Err(McapError::RecordTooLarge { opcode: 2, .. })
         );
+    }
+
+    /// Tiny MCAP whose summary starts with a Chunk that declares a ~1.69 GiB compression string.
+    fn mcap_with_summary_chunk_compression_len(
+        compression_len: u32,
+        chunk_record_len: u64,
+    ) -> Vec<u8> {
+        let mut file = Vec::new();
+        file.extend_from_slice(MAGIC);
+        file.push(crate::records::op::HEADER);
+        file.extend_from_slice(&8u64.to_le_bytes());
+        file.extend_from_slice(&0u32.to_le_bytes());
+        file.extend_from_slice(&0u32.to_le_bytes());
+        file.push(crate::records::op::DATA_END);
+        file.extend_from_slice(&4u64.to_le_bytes());
+        file.extend_from_slice(&0u32.to_le_bytes());
+
+        let summary_start = file.len() as u64;
+        file.push(crate::records::op::CHUNK);
+        file.extend_from_slice(&chunk_record_len.to_le_bytes());
+        file.extend_from_slice(&0u64.to_le_bytes());
+        file.extend_from_slice(&0u64.to_le_bytes());
+        file.extend_from_slice(&0u64.to_le_bytes());
+        file.extend_from_slice(&0u32.to_le_bytes());
+        file.extend_from_slice(&compression_len.to_le_bytes());
+        file.extend_from_slice(&0u64.to_le_bytes());
+
+        file.push(crate::records::op::FOOTER);
+        file.extend_from_slice(&20u64.to_le_bytes());
+        file.extend_from_slice(&summary_start.to_le_bytes());
+        file.extend_from_slice(&0u64.to_le_bytes());
+        file.extend_from_slice(&0u32.to_le_bytes());
+        file.extend_from_slice(MAGIC);
+        file
+    }
+
+    fn drive_summary_reader(
+        bytes: &[u8],
+        record_length_limit: Option<usize>,
+    ) -> (Option<McapError>, usize) {
+        let mut options = SummaryReaderOptions::default().with_file_size(bytes.len() as u64);
+        if let Some(limit) = record_length_limit {
+            options = options.with_record_length_limit(limit);
+        }
+        let mut reader = SummaryReader::new_with_options(options);
+        let mut cursor = std::io::Cursor::new(bytes);
+        let mut max_insert = 0usize;
+        while let Some(event) = reader.next_event() {
+            match event {
+                Ok(SummaryReadEvent::ReadRequest(n)) => {
+                    assert!(
+                        n <= bytes.len(),
+                        "insert requested {n} bytes for a {}-byte file",
+                        bytes.len()
+                    );
+                    max_insert = max_insert.max(n);
+                    let read = cursor.read(reader.insert(n)).expect("read");
+                    reader.notify_read(read);
+                }
+                Ok(SummaryReadEvent::SeekRequest(to)) => {
+                    let pos = cursor.seek(to).expect("seek");
+                    reader.notify_seeked(pos);
+                }
+                Err(err) => return (Some(err), max_insert),
+            }
+        }
+        (None, max_insert)
+    }
+
+    #[test]
+    fn test_summary_chunk_compression_len_does_not_overallocate() {
+        const HUGE: u32 = 1_687_060_480;
+        let bytes = mcap_with_summary_chunk_compression_len(HUGE, 40);
+        assert!(bytes.len() < 1024);
+
+        let (err, max_insert) = drive_summary_reader(&bytes, None);
+        assert!(
+            max_insert <= bytes.len(),
+            "insert requested {max_insert} bytes for a {}-byte file",
+            bytes.len()
+        );
+        assert_matches!(
+            err,
+            Some(McapError::BadChunkLength {
+                header,
+                available: 40
+            }) if header == 40 + HUGE as u64
+        );
+
+        assert!(Summary::read(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_summary_chunk_compression_len_with_record_length_limit() {
+        const HUGE: u32 = 1_687_060_480;
+        // Length field agrees with the huge compression string. record_length_limit is 64x the
+        // file, matching the report that the documented bound still did not stop the allocation.
+        let bytes = mcap_with_summary_chunk_compression_len(HUGE, 40 + HUGE as u64);
+        let limit = bytes.len().saturating_mul(64);
+        let (err, max_insert) = drive_summary_reader(&bytes, Some(limit));
+        assert!(
+            max_insert <= bytes.len(),
+            "insert requested {max_insert} bytes for a {}-byte file",
+            bytes.len()
+        );
+        assert!(err.is_some(), "expected an error, got success");
     }
 }


### PR DESCRIPTION
### Changelog
- rust: return an error instead of allocating when a chunk header declares a compression string larger than the chunk record or the configured record length limit
- rust: clamp summary-reader `ReadRequest` sizes to the remaining file length when the file size is known

### Docs
None.

### Description

`LinearReader` loads a chunk header in two steps: first the fixed prefix, then `MIN_CHUNK_HEADER_SIZE + compression_len` bytes. `compression_len` is taken from the file and was passed to `consume!` / `insert()` with no check against the chunk record length or `record_length_limit`. `insert(n)` resizes the buffer *before* any bytes are read, so a 191 KiB file that declared a ~1.69 GiB compression string drove peak RSS to about 1.69 GiB and then returned `UnexpectedEof`.

`record_length_limit` did not prevent this. The limit is applied to parsed record bodies, and the chunk path skipped that check until after the header (including the compression string) had been requested.

This PR:
1. Rejects a compression-string length that exceeds the chunk record body (`BadChunkLength`).
2. Applies `record_length_limit` to that header length (`ChunkTooLarge`).
3. Caps `SummaryReader` read requests to the remaining file bytes when `file_size` is known, so the documented sans-io loop cannot allocate more than the file can contain.
4. Caps decompressor `next_read_size()` by `compressed_remaining`.

Well-formed files are unchanged. Regression tests cover the 1.69 GiB compression-string case both with a mismatched record length and with a matching length plus a 64x file-size record limit.

Fixes #1813