### PR TITLE
c++, go: Fix uncompressed chunk size panic

### DIFF
--- a/cpp/mcap/include/mcap/reader.inl
+++ b/cpp/mcap/include/mcap/reader.inl
@@ -923,6 +923,15 @@ Status McapReader::ParseChunk(const Record& record, Chunk* chunk) {
     const auto msg = internal::StrCat("invalid Chunk.records length: ", chunk->compressedSize);
     return Status{StatusCode::InvalidRecord, msg};
   }
+  // An uncompressed chunk stores its records verbatim, so the declared uncompressed size must
+  // match the compressed size. Without this check, decompressChunk() would trust uncompressedSize
+  // to bound a copy out of a buffer only compressedSize bytes long, reading out of bounds.
+  if (chunk->compression.empty() && chunk->uncompressedSize != chunk->compressedSize) {
+    const auto msg = internal::StrCat("uncompressed chunk declares uncompressed size ",
+                                      chunk->uncompressedSize, " but carries ",
+                                      chunk->compressedSize, " bytes");
+    return Status{StatusCode::DecompressionSizeMismatch, msg};
+  }
   // records
   chunk->records = record.data + offset;
 

--- a/cpp/test/unit_tests.cpp
+++ b/cpp/test/unit_tests.cpp
@@ -126,6 +126,51 @@ TEST_CASE("internal::Parse*()", "[reader]") {
   }
 }
 
+TEST_CASE("McapReader::ParseChunk()", "[reader]") {
+  // Builds the body of a Chunk record (the bytes after opcode + record length).
+  const auto makeUncompressedChunk = [](uint64_t uncompressedSize,
+                                        const std::vector<std::byte>& records) {
+    std::vector<std::byte> data;
+    const auto putU32 = [&](uint32_t v) {
+      for (int i = 0; i < 4; ++i) {
+        data.push_back(std::byte((v >> (8 * i)) & 0xff));
+      }
+    };
+    const auto putU64 = [&](uint64_t v) {
+      for (int i = 0; i < 8; ++i) {
+        data.push_back(std::byte((v >> (8 * i)) & 0xff));
+      }
+    };
+    putU64(0);                         // messageStartTime
+    putU64(0);                         // messageEndTime
+    putU64(uncompressedSize);          // uncompressedSize
+    putU32(0);                         // uncompressedCrc
+    putU32(0);                         // compression string length (empty == uncompressed)
+    putU64(uint64_t(records.size()));  // compressedSize
+    data.insert(data.end(), records.begin(), records.end());
+    return data;
+  };
+  const std::vector<std::byte> records = {std::byte(1), std::byte(2), std::byte(3)};
+
+  SECTION("rejects an uncompressed chunk whose declared sizes disagree") {
+    auto data = makeUncompressedChunk(999, records);
+    mcap::Record record{mcap::OpCode::Chunk, data.size(), data.data()};
+    mcap::Chunk chunk;
+    const auto status = mcap::McapReader::ParseChunk(record, &chunk);
+    REQUIRE(status.code == mcap::StatusCode::DecompressionSizeMismatch);
+  }
+
+  SECTION("accepts an uncompressed chunk whose declared sizes agree") {
+    auto data = makeUncompressedChunk(records.size(), records);
+    mcap::Record record{mcap::OpCode::Chunk, data.size(), data.data()};
+    mcap::Chunk chunk;
+    const auto status = mcap::McapReader::ParseChunk(record, &chunk);
+    REQUIRE(status.ok());
+    REQUIRE(chunk.uncompressedSize == records.size());
+    REQUIRE(chunk.compressedSize == records.size());
+  }
+}
+
 TEST_CASE("McapWriter::write()", "[writer]") {
   SECTION("uint8_t") {
     mcap::BufferWriter output;

--- a/go/mcap/parse.go
+++ b/go/mcap/parse.go
@@ -163,7 +163,20 @@ func ParseChunk(buf []byte) (*Chunk, error) {
 	}
 	recordsLength, offset, err := getUint64(buf, offset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read compression: %w", err)
+		return nil, fmt.Errorf("failed to read records length: %w", err)
+	}
+	// Compare in uint64 space to avoid int overflow, and to keep int(recordsLength) in range for
+	// the slice expression below.
+	if recordsLength > uint64(len(buf)-offset) {
+		return nil, fmt.Errorf("chunk records length %d exceeds remaining chunk bytes %d",
+			recordsLength, len(buf)-offset)
+	}
+	// An uncompressed chunk stores its records verbatim, so its declared uncompressed size must
+	// match the records it carries. Without this check, the indexed reader trusts UncompressedSize
+	// to size its decompression buffer and silently reads stale data past the copied records.
+	if compression == "" && uncompressedSize != recordsLength {
+		return nil, fmt.Errorf("uncompressed chunk declares uncompressed size %d but carries %d bytes",
+			uncompressedSize, recordsLength)
 	}
 	records := buf[offset : offset+int(recordsLength)]
 	return &Chunk{

--- a/go/mcap/parse_test.go
+++ b/go/mcap/parse_test.go
@@ -258,3 +258,57 @@ func TestParseSchema(t *testing.T) {
 		})
 	}
 }
+
+func TestParseChunk(t *testing.T) {
+	records := []byte{1, 2, 3}
+	makeChunk := func(uncompressedSize uint64, compression string, recordsLength uint64, records []byte) []byte {
+		return flatten(
+			encodedUint64(0),                // message start time
+			encodedUint64(0),                // message end time
+			encodedUint64(uncompressedSize), // uncompressed size
+			encodedUint32(0),                // uncompressed CRC
+			prefixedString(compression),     // compression
+			encodedUint64(recordsLength),    // records length
+			records,
+		)
+	}
+	cases := []struct {
+		assertion string
+		input     []byte
+		wantErr   bool
+	}{
+		{
+			"uncompressed chunk with matching sizes is accepted",
+			makeChunk(uint64(len(records)), "", uint64(len(records)), records),
+			false,
+		},
+		{
+			"uncompressed chunk with mismatched sizes is rejected, not crashing",
+			makeChunk(999, "", uint64(len(records)), records),
+			true,
+		},
+		{
+			"records length exceeding the buffer is rejected, not crashing",
+			makeChunk(uint64(len(records)), "", 9999, records),
+			true,
+		},
+		{
+			"records length above int range is rejected, not crashing",
+			makeChunk(uint64(len(records)), "", 1<<63, records),
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			chunk, err := ParseChunk(c.input)
+			if c.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, chunk)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, chunk)
+				assert.Equal(t, records, chunk.Records)
+			}
+		})
+	}
+}

--- a/rust/mcap/src/sans_io/indexed_reader.rs
+++ b/rust/mcap/src/sans_io/indexed_reader.rs
@@ -335,8 +335,11 @@ impl IndexedReader {
                         compressed_data.len()
                     )));
                 }
-                slot.buf.resize(uncompressed_size, 0);
-                slot.buf[..].copy_from_slice(compressed_data);
+                // The length is already known to equal uncompressed_size, so copy the data in
+                // directly rather than resize()-ing (which zero-fills the buffer first) and then
+                // overwriting every byte.
+                slot.buf.clear();
+                slot.buf.extend_from_slice(compressed_data);
             }
             #[cfg(feature = "zstd")]
             "zstd" => {


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

We recently got bug report #1814, with the follow-up fix in #1820.  That bug and fix found that in the Rust client, we weren't properly detecting an uncompressed chunk-size mismatch and panicing.

While investigating that further, I found that both C++ and Go have similar problems.  This PR does 3 things:

1.  Fixes C++ to detect and reject the uncompressed chunk-size mismatch, like Rust.
2.  Ditto for Go.
3.  Does a very small performance improvement for Rust, since we don't need to zero-fill the buffer.