### PR TITLE
cpp: bump docker images from Ubuntu 20.04 to 22.04

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -22,7 +22,6 @@ clean:
 	docker rm -f hdoc
 	docker rmi -f mcap_cpp_dev
 	docker rmi -f mcap_cpp_ci
-	docker rmi -f mcap_cpp_ci_jammy
 	rm -rf bench/build
 	rm -rf examples/build
 	rm -rf test/build
@@ -74,11 +73,11 @@ test-examples-host:
 
 .PHONY: ci-image
 ci-image: hdoc-build
-	docker build -t mcap_cpp_ci -f ci.Dockerfile --build-arg IMAGE=ubuntu:focal .
+	docker build -t mcap_cpp_ci -f ci.Dockerfile .
 
 .PHONY: ci-clang
 ci-clang: ci-image
-	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(HOME)/.conan2/p:/root/.conan2/p -e CC=clang-13 -e CXX=clang++-13 mcap_cpp_ci ./build.sh
+	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(HOME)/.conan2/p:/root/.conan2/p -e CC=clang -e CXX=clang++ mcap_cpp_ci ./build.sh
 
 .PHONY: ci-gcc
 ci-gcc: ci-image
@@ -86,8 +85,7 @@ ci-gcc: ci-image
 
 .PHONY: ci-docs
 ci-docs: ci-image
-	docker build -t mcap_cpp_ci_jammy -f ci.Dockerfile .
-	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(CURDIR)/../__docs__/cpp:/hdoc-output -v $(HOME)/.conan2/p:/root/.conan2/p mcap_cpp_ci_jammy ./build-docs.sh
+	docker run -t --rm -v $(CURDIR):/mcap/cpp -v $(CURDIR)/../__docs__/cpp:/hdoc-output -v $(HOME)/.conan2/p:/root/.conan2/p mcap_cpp_ci ./build-docs.sh
 
 .PHONY: ci-format-check
 ci-format-check: ci-image

--- a/cpp/ci.Dockerfile
+++ b/cpp/ci.Dockerfile
@@ -21,23 +21,6 @@ RUN apt-get update && \
   clang-format \
   && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "$IMAGE" = "ubuntu:focal" ]; then \
-  echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" >> /etc/apt/sources.list && \
-  curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -  && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends --no-install-suggests \
-  clang-13 \
-  clang-format-13 \
-  && rm -rf /var/lib/apt/lists/* \
-  ; fi
-
-RUN if [ "$IMAGE" = "ubuntu:focal" ]; then \
-  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100; \
-  update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100; \
-  update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100; \
-  update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-13 100 \
-  ; fi
-
 RUN pip --no-cache-dir install "conan>=2.0,<3"
 
 WORKDIR /mcap/cpp

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 # https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai
 ENV DEBIAN_FRONTEND=noninteractive
@@ -13,21 +13,12 @@ RUN apt-get update && \
   make \
   perl \
   python3 \
-  python3-pip
+  python3-pip \
+  clang \
+  clang-format
 
-
-RUN echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" >> /etc/apt/sources.list && \
-  curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -  &&\
-  apt-get update && \
-  apt-get install -y --no-install-recommends --no-install-suggests \
-  clang-13 \
-  clang-format-13
-
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
-RUN update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-13 100
-
-ENV CC=clang-13
-ENV CXX=clang++-13
+ENV CC=clang
+ENV CXX=clang++
 
 WORKDIR /src
 


### PR DESCRIPTION
### Changelog

None.

### Docs

None.

### Description

Ubuntu 20.04 (focal) is past standard EOL and there is no longer a need to support toolchains that old. Move the dev and CI images to the jammy stock toolchain (clang-14, clang-format-14, gcc-11):

- dev.Dockerfile: base on ubuntu:jammy and drop the apt.llvm.org clang-13 install and update-alternatives plumbing in favor of the stock packages.
- ci.Dockerfile: remove the focal-only conditional blocks; the image is now always built from its ubuntu:jammy default.
- Makefile: stop passing IMAGE=ubuntu:focal to ci-image, use unversioned CC=clang/CXX=clang++ in ci-clang, and reuse mcap_cpp_ci for ci-docs since the separate jammy-tagged image is now identical.

clang-format-14 produces no formatting changes on the current tree, and the full build is warning-free under both clang-14 and gcc-11.

I originally noticed this because the LLVM Ubuntu mirrors are frequently offline; this should make CI more reliable by not depending on them anymore.