### PR TITLE
cli: replace mmap I/O with sans-io ByteSource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,6 @@ dependencies = [
  "log",
  "lz4",
  "mcap",
- "memmap2",
  "object_store",
  "prost-reflect",
  "regex",

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -13,13 +13,14 @@ clap parses arguments, `dispatch` (in `commands.rs`) routes to a per-command han
 
 A few modules carry more than their name implies:
 
-| Module       | Responsibility                                                                                                                                                         |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cli.rs`     | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                   |
-| `source.rs`  | Input abstraction over local files (memory-mapped) and remote object stores. Owns summary/index range reads, remote materialization, and `--allow-remote-scan` gating. |
-| `parse.rs`   | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                         |
-| `context.rs` | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                               |
-| `build.rs`   | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                      |
+| Module          | Responsibility                                                                                                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cli.rs`        | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                                 |
+| `byte_source.rs`| Random-access byte sources (`LocalFileSource`, `RemoteRangeSource`, `MemorySource`) and sans-io drivers. Local files use seek+read (no mmap); remotes prefer HTTP range requests.   |
+| `source.rs`     | Remote URL helpers, summary/index range reads, `materialize_input` (path spool for convert), and `--allow-remote-scan` gating. Command I/O prefers `byte_source` over whole-file loads. |
+| `parse.rs`      | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                                       |
+| `context.rs`    | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                                             |
+| `build.rs`      | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                                    |
 
 ## Conventions
 
@@ -34,7 +35,7 @@ When adding a command that can complete despite losing data, return `CommandOutc
 
 ### Remote inputs
 
-Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled in `source.rs` via `object_store`. Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would scan or download an entire remote file requires the global `--allow-remote-scan` flag; gate new whole-file remote reads behind `SourceOptions::allow_remote_scan` accordingly.
+Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled via `object_store` (`source.rs` helpers + `byte_source` range reads). Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would linearly scan or transfer an entire remote object requires the global `--allow-remote-scan` flag (this is an unbounded remote transfer / scan opt-in, not specifically “download to a temp file”). Gate new whole-file remote reads behind `SourceOptions::allow_remote_scan` / `require_remote_scan_for_linear` accordingly. `convert` still uses `materialize_input` because ROS bag/db3 inputs need a local filesystem path for sqlite.
 
 ### Output and logging
 

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -13,14 +13,14 @@ clap parses arguments, `dispatch` (in `commands.rs`) routes to a per-command han
 
 A few modules carry more than their name implies:
 
-| Module          | Responsibility                                                                                                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `cli.rs`        | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                                 |
-| `byte_source.rs`| Random-access byte sources (`LocalFileSource`, `RemoteRangeSource`, `MemorySource`) and sans-io drivers. Local files use seek+read (no mmap); remotes prefer HTTP range requests.   |
-| `source.rs`     | Remote URL helpers, summary/index range reads, `materialize_input` (path spool for convert), and `--allow-remote-scan` gating. Command I/O prefers `byte_source` over whole-file loads. |
-| `parse.rs`      | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                                       |
-| `context.rs`    | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                                             |
-| `build.rs`      | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                                    |
+| Module           | Responsibility                                                                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cli.rs`         | clap `Args`/`Command` definitions, plus shared value parsers — reuse these for new args instead of rolling your own.                                                                    |
+| `byte_source.rs` | Random-access byte sources (`LocalFileSource`, `RemoteRangeSource`, `MemorySource`) and sans-io drivers. Local files use seek+read (no mmap); remotes prefer HTTP range requests.       |
+| `source.rs`      | Remote URL helpers, summary/index range reads, `materialize_input` (path spool for convert), and `--allow-remote-scan` gating. Command I/O prefers `byte_source` over whole-file loads. |
+| `parse.rs`       | `ParsedMcap` plus summary-first / linear-scan parsing and the exact-record parsers used by remote range reads.                                                                          |
+| `context.rs`     | `CommandContext`, the global options (verbosity, color, `allow_remote_scan`, `time_format`) threaded into every handler.                                                                |
+| `build.rs`       | Resolves commit sha (git rev-parse or export-subst) into `GIT_SHORT_SHA` env var.                                                                                                       |
 
 ## Conventions
 

--- a/rust/cli/AGENTS.md
+++ b/rust/cli/AGENTS.md
@@ -35,7 +35,7 @@ When adding a command that can complete despite losing data, return `CommandOutc
 
 ### Remote inputs
 
-Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled via `object_store` (`source.rs` helpers + `byte_source` range reads). Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Any command that would linearly scan or transfer an entire remote object requires the global `--allow-remote-scan` flag (this is an unbounded remote transfer / scan opt-in, not specifically “download to a temp file”). Gate new whole-file remote reads behind `SourceOptions::allow_remote_scan` / `require_remote_scan_for_linear` accordingly. `convert` still uses `materialize_input` because ROS bag/db3 inputs need a local filesystem path for sqlite.
+Remote inputs (HTTP(S) and object-store URLs: `s3://`, `gs://`, and Azure `az://`/`abfs://`) are handled via `object_store` (`source.rs` helpers + `byte_source` range reads). Bounded, indexed reads — a summary-section read, or a single attachment/metadata range read under the no-opt-in caps — are allowed without a flag. Reading remote message-chunk payloads, a full linear scan, or a whole-object download requires the global `--allow-remote-scan` flag. Gate those paths behind `SourceOptions::allow_remote_scan`, `require_remote_scan_for_linear`, or `require_remote_scan_for_chunks` accordingly. `convert` still uses `materialize_input` because ROS bag/db3 inputs need a local filesystem path for sqlite.
 
 ### Output and logging
 

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -21,7 +21,6 @@ clap_complete = "4"
 crc32fast = "1"
 csv = "1"
 log = "0.4"
-memmap2 = "0.9"
 mcap = { path = "../mcap" }
 regex = "1"
 serde_json = "1"

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -1,0 +1,423 @@
+//! Random-access byte sources for sans-io MCAP reads.
+//!
+//! Local files use seek+read (no mmap). Remote URLs prefer HTTP range requests.
+//! Stdin is spooled to a temp file when opened through [`open_byte_source`].
+
+#![allow(dead_code)] // Foundation module; command wiring comes in a follow-up.
+#![allow(unused_imports)]
+
+mod drivers;
+
+pub use drivers::{for_each_linear_record, read_summary, service_indexed_chunk};
+
+use std::fs::File;
+use std::io::{IsTerminal as _, Read as _, Seek as _, SeekFrom, Write as _};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tempfile::NamedTempFile;
+
+use crate::source::{
+    is_remote_url, open_remote_range_reader, read_remote_input_to_writer, redacted_display,
+    remote_or_local_extension, remote_scan_opt_in_suffix, require_remote_scan_allowed,
+    RemoteRangeReader, SourceOptions, PLEASE_SUPPLY_FILE,
+};
+
+/// Byte-oriented input with optional random access.
+pub trait ByteSource {
+    /// File size in bytes, or `None` when unknown (pure stdin without spooling).
+    fn size(&self) -> Result<Option<u64>>;
+    fn is_remote(&self) -> bool;
+    fn display_name(&self) -> String;
+    /// Read `[offset, offset+len)` bytes. `len` may be clamped to EOF.
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>>;
+    /// Whether random access is available (`false` for pure stdin).
+    fn is_seekable(&self) -> bool;
+}
+
+/// Local file opened for seek+read (not memory-mapped).
+pub struct LocalFileSource {
+    file: File,
+    path: PathBuf,
+    size: u64,
+    // Keeps a spool tempfile alive for stdin / non-range remote fallbacks.
+    _temp_file: Option<NamedTempFile>,
+}
+
+impl LocalFileSource {
+    fn open_path(path: &Path) -> Result<Self> {
+        let file = File::open(path)
+            .with_context(|| format!("couldn't open '{}'", path.display()))?;
+        let size = file
+            .metadata()
+            .with_context(|| format!("couldn't stat '{}'", path.display()))?
+            .len();
+        Ok(Self {
+            file,
+            path: path.to_path_buf(),
+            size,
+            _temp_file: None,
+        })
+    }
+
+    fn from_temp_file(mut temp_file: NamedTempFile, display_path: PathBuf) -> Result<Self> {
+        temp_file
+            .as_file_mut()
+            .flush()
+            .context("failed to flush temporary input file")?;
+        let file = temp_file
+            .reopen()
+            .context("failed to reopen temporary input file")?;
+        let size = file
+            .metadata()
+            .context("failed to stat temporary input file")?
+            .len();
+        Ok(Self {
+            file,
+            path: display_path,
+            size,
+            _temp_file: Some(temp_file),
+        })
+    }
+}
+
+impl ByteSource for LocalFileSource {
+    fn size(&self) -> Result<Option<u64>> {
+        Ok(Some(self.size))
+    }
+
+    fn is_remote(&self) -> bool {
+        false
+    }
+
+    fn display_name(&self) -> String {
+        self.path.display().to_string()
+    }
+
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
+        read_file_at(&mut self.file, self.size, offset, len)
+    }
+
+    fn is_seekable(&self) -> bool {
+        true
+    }
+}
+
+/// Remote object that supports byte-range reads.
+pub struct RemoteRangeSource {
+    inner: RemoteRangeReader,
+}
+
+impl RemoteRangeSource {
+    pub(crate) fn new(inner: RemoteRangeReader) -> Self {
+        Self { inner }
+    }
+}
+
+impl ByteSource for RemoteRangeSource {
+    fn size(&self) -> Result<Option<u64>> {
+        Ok(Some(self.inner.size()))
+    }
+
+    fn is_remote(&self) -> bool {
+        true
+    }
+
+    fn display_name(&self) -> String {
+        self.inner.display_url().to_string()
+    }
+
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
+        self.inner.read_range(offset, len)
+    }
+
+    fn is_seekable(&self) -> bool {
+        true
+    }
+}
+
+/// In-memory bytes, mainly for unit tests.
+pub struct MemorySource {
+    data: Vec<u8>,
+}
+
+impl MemorySource {
+    pub fn new(data: impl Into<Vec<u8>>) -> Self {
+        Self { data: data.into() }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl ByteSource for MemorySource {
+    fn size(&self) -> Result<Option<u64>> {
+        Ok(Some(self.data.len() as u64))
+    }
+
+    fn is_remote(&self) -> bool {
+        false
+    }
+
+    fn display_name(&self) -> String {
+        "<memory>".to_string()
+    }
+
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
+        read_slice_at(&self.data, offset, len)
+    }
+
+    fn is_seekable(&self) -> bool {
+        true
+    }
+}
+
+/// Pure stdin. Not seekable; [`read_at`] always errors.
+///
+/// Prefer [`open_byte_source`] with `path: None`, which spools stdin to a tempfile
+/// and returns a seekable [`LocalFileSource`].
+pub struct StdinSource;
+
+impl ByteSource for StdinSource {
+    fn size(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn is_remote(&self) -> bool {
+        false
+    }
+
+    fn display_name(&self) -> String {
+        "<stdin>".to_string()
+    }
+
+    fn read_at(&mut self, _offset: u64, _len: usize) -> Result<Vec<u8>> {
+        bail!(
+            "stdin is not seekable; spool to a temporary file before random-access reads"
+        );
+    }
+
+    fn is_seekable(&self) -> bool {
+        false
+    }
+}
+
+/// Open a path, remote URL, or stdin as a [`ByteSource`].
+///
+/// - `None` spools stdin to a tempfile (seek+read, no mmap).
+/// - Remote URLs use range requests when available.
+/// - Non-range remotes require `--allow-remote-scan` and fall back to a full download into a tempfile.
+/// - Local paths use seek+read (no mmap).
+pub fn open_byte_source(
+    path: Option<&Path>,
+    options: SourceOptions,
+) -> Result<Box<dyn ByteSource>> {
+    let Some(path) = path else {
+        return Ok(Box::new(spool_stdin_to_local()?));
+    };
+
+    if is_remote_url(path) {
+        return open_remote_byte_source(path, options);
+    }
+
+    Ok(Box::new(LocalFileSource::open_path(path)?))
+}
+
+fn open_remote_byte_source(
+    path: &Path,
+    options: SourceOptions,
+) -> Result<Box<dyn ByteSource>> {
+    match open_remote_range_reader(path)? {
+        Some(reader) => Ok(Box::new(RemoteRangeSource::new(reader))),
+        None if !options.allow_remote_scan => {
+            bail!(
+                "failed to read {}\nRemote server does not support range requests; {}",
+                redacted_display(path),
+                remote_scan_opt_in_suffix()
+            );
+        }
+        None => Ok(Box::new(spool_remote_to_local(path, options)?)),
+    }
+}
+
+fn spool_stdin_to_local() -> Result<LocalFileSource> {
+    let stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        bail!("{PLEASE_SUPPLY_FILE}");
+    }
+    let mut temp_file = tempfile::Builder::new()
+        .prefix("mcap-cli-stdin-bytesource-")
+        .tempfile()
+        .context("failed to create temporary file for stdin input")?;
+    std::io::copy(&mut stdin.lock(), temp_file.as_file_mut())
+        .context("failed to read input from stdin")?;
+    LocalFileSource::from_temp_file(temp_file, PathBuf::from("<stdin>"))
+}
+
+fn spool_remote_to_local(path: &Path, options: SourceOptions) -> Result<LocalFileSource> {
+    require_remote_scan_allowed(path, options)?;
+    let suffix = remote_or_local_extension(path)
+        .filter(|extension| !extension.is_empty())
+        .map(|extension| format!(".{extension}"));
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("mcap-cli-remote-bytesource-");
+    if let Some(suffix) = suffix.as_deref() {
+        builder.suffix(suffix);
+    }
+    let mut temp_file = builder
+        .tempfile()
+        .context("failed to create temporary remote input file")?;
+    read_remote_input_to_writer(path, temp_file.as_file_mut())?;
+    LocalFileSource::from_temp_file(temp_file, PathBuf::from(redacted_display(path)))
+}
+
+fn read_file_at(file: &mut File, size: u64, offset: u64, len: usize) -> Result<Vec<u8>> {
+    if len == 0 || offset >= size {
+        return Ok(Vec::new());
+    }
+    let available = (size - offset) as usize;
+    let to_read = len.min(available);
+    file.seek(SeekFrom::Start(offset))
+        .context("failed to seek in local file")?;
+    let mut buf = vec![0u8; to_read];
+    file.read_exact(&mut buf)
+        .context("failed to read from local file")?;
+    Ok(buf)
+}
+
+fn read_slice_at(data: &[u8], offset: u64, len: usize) -> Result<Vec<u8>> {
+    if len == 0 || offset as usize >= data.len() {
+        return Ok(Vec::new());
+    }
+    let start = offset as usize;
+    let end = start.saturating_add(len).min(data.len());
+    Ok(data[start..end].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::io::Cursor;
+
+    fn write_summary_mcap() -> Vec<u8> {
+        let mut buffer = Vec::new();
+        {
+            let mut writer = mcap::Writer::new(Cursor::new(&mut buffer)).expect("writer");
+            let schema_id = writer
+                .add_schema("demo_schema", "jsonschema", br#"{"type":"object"}"#)
+                .expect("schema");
+            let channel_id = writer
+                .add_channel(schema_id, "/demo", "json", &BTreeMap::new())
+                .expect("channel");
+            writer
+                .write_to_known_channel(
+                    &mcap::records::MessageHeader {
+                        channel_id,
+                        sequence: 1,
+                        log_time: 10,
+                        publish_time: 10,
+                    },
+                    br#"{"ok":true}"#,
+                )
+                .expect("message");
+            writer.finish().expect("finish");
+        }
+        buffer
+    }
+
+    #[test]
+    fn memory_source_read_at_clamps_to_eof() {
+        let mut source = MemorySource::new(vec![1, 2, 3, 4, 5]);
+        assert_eq!(source.read_at(3, 10).expect("read"), vec![4, 5]);
+        assert!(source.read_at(5, 1).expect("past eof").is_empty());
+        assert!(source.read_at(100, 1).expect("far past eof").is_empty());
+    }
+
+    #[test]
+    fn memory_source_summary_reader_finds_channel() {
+        let bytes = write_summary_mcap();
+        let mut source = MemorySource::new(bytes);
+        let summary = read_summary(&mut source)
+            .expect("summary read")
+            .expect("summary should exist");
+        assert!(summary.channels.values().any(|ch| ch.topic == "/demo"));
+        assert!(!summary.chunk_indexes.is_empty());
+    }
+
+    #[test]
+    fn local_file_source_matches_memory_summary() {
+        let bytes = write_summary_mcap();
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("demo.mcap");
+        std::fs::write(&path, &bytes).expect("write fixture");
+
+        let mut local = LocalFileSource::open_path(&path).expect("open local");
+        assert!(local.is_seekable());
+        assert!(!local.is_remote());
+        assert_eq!(local.size().expect("size"), Some(bytes.len() as u64));
+
+        let summary = read_summary(&mut local)
+            .expect("summary read")
+            .expect("summary should exist");
+        assert!(summary.channels.values().any(|ch| ch.topic == "/demo"));
+    }
+
+    #[test]
+    fn for_each_linear_record_visits_opcodes() {
+        let bytes = write_summary_mcap();
+        let mut source = MemorySource::new(bytes);
+        let mut opcodes = Vec::new();
+        for_each_linear_record(
+            &mut source,
+            mcap::sans_io::LinearReaderOptions::default(),
+            |opcode, _data| {
+                opcodes.push(opcode);
+                Ok(())
+            },
+        )
+        .expect("linear scan");
+        assert!(
+            opcodes.contains(&mcap::records::op::HEADER),
+            "expected header opcode in {opcodes:?}"
+        );
+        assert!(
+            opcodes.contains(&mcap::records::op::FOOTER),
+            "expected footer opcode in {opcodes:?}"
+        );
+    }
+
+    #[test]
+    fn service_indexed_chunk_feeds_messages() {
+        let bytes = write_summary_mcap();
+        let mut source = MemorySource::new(bytes.clone());
+        let summary = read_summary(&mut source)
+            .expect("summary read")
+            .expect("summary should exist");
+        let mut reader =
+            mcap::sans_io::IndexedReader::new(&summary).expect("indexed reader");
+        let mut messages = 0usize;
+        while let Some(event) = reader.next_event() {
+            match event.expect("indexed event") {
+                mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
+                    service_indexed_chunk(&mut reader, &mut source, offset, length)
+                        .expect("service chunk");
+                }
+                mcap::sans_io::IndexedReadEvent::Message { .. } => {
+                    messages += 1;
+                }
+            }
+        }
+        assert_eq!(messages, 1);
+    }
+
+    #[test]
+    fn stdin_source_rejects_random_access() {
+        let mut source = StdinSource;
+        assert!(!source.is_seekable());
+        assert!(source.size().expect("size").is_none());
+        let err = source.read_at(0, 1).expect_err("stdin read_at");
+        assert!(err.to_string().contains("not seekable"));
+    }
+}

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -3,8 +3,6 @@
 //! Local files use seek+read (no mmap). Remote URLs prefer HTTP range requests.
 //! Stdin is spooled to a temp file when opened through [`open_byte_source`].
 
-#![allow(dead_code)] // Some sources/helpers are test-only or awaiting remaining command ports.
-
 mod drivers;
 
 pub use drivers::{for_each_linear_record, read_header, read_summary, service_indexed_chunk};
@@ -136,6 +134,7 @@ impl ByteSource for RemoteRangeSource {
 }
 
 /// In-memory bytes, mainly for unit tests.
+#[allow(dead_code)] // Constructed from #[cfg(test)] modules across the crate.
 pub struct MemorySource {
     data: Vec<u8>,
 }
@@ -177,6 +176,7 @@ impl ByteSource for MemorySource {
 ///
 /// Prefer [`open_byte_source`] with `path: None`, which spools stdin to a tempfile
 /// and returns a seekable [`LocalFileSource`].
+#[allow(dead_code)] // Documented non-seekable source; production paths spool via open_byte_source.
 pub struct StdinSource;
 
 impl ByteSource for StdinSource {

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -3,12 +3,11 @@
 //! Local files use seek+read (no mmap). Remote URLs prefer HTTP range requests.
 //! Stdin is spooled to a temp file when opened through [`open_byte_source`].
 
-#![allow(dead_code)] // Foundation module; command wiring comes in a follow-up.
-#![allow(unused_imports)]
+#![allow(dead_code)] // Some sources/helpers are test-only or awaiting remaining command ports.
 
 mod drivers;
 
-pub use drivers::{for_each_linear_record, read_summary, service_indexed_chunk};
+pub use drivers::{for_each_linear_record, read_header, read_summary, service_indexed_chunk};
 
 use std::fs::File;
 use std::io::{IsTerminal as _, Read as _, Seek as _, SeekFrom, Write as _};
@@ -146,6 +145,7 @@ impl MemorySource {
         Self { data: data.into() }
     }
 
+    #[allow(dead_code)] // Handy for tests that compare against a known buffer.
     pub fn as_slice(&self) -> &[u8] {
         &self.data
     }

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -46,8 +46,8 @@ pub struct LocalFileSource {
 
 impl LocalFileSource {
     fn open_path(path: &Path) -> Result<Self> {
-        let file = File::open(path)
-            .with_context(|| format!("couldn't open '{}'", path.display()))?;
+        let file =
+            File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))?;
         let size = file
             .metadata()
             .with_context(|| format!("couldn't stat '{}'", path.display()))?
@@ -193,9 +193,7 @@ impl ByteSource for StdinSource {
     }
 
     fn read_at(&mut self, _offset: u64, _len: usize) -> Result<Vec<u8>> {
-        bail!(
-            "stdin is not seekable; spool to a temporary file before random-access reads"
-        );
+        bail!("stdin is not seekable; spool to a temporary file before random-access reads");
     }
 
     fn is_seekable(&self) -> bool {
@@ -224,10 +222,7 @@ pub fn open_byte_source(
     Ok(Box::new(LocalFileSource::open_path(path)?))
 }
 
-fn open_remote_byte_source(
-    path: &Path,
-    options: SourceOptions,
-) -> Result<Box<dyn ByteSource>> {
+fn open_remote_byte_source(path: &Path, options: SourceOptions) -> Result<Box<dyn ByteSource>> {
     match open_remote_range_reader(path)? {
         Some(reader) => Ok(Box::new(RemoteRangeSource::new(reader))),
         None if !options.allow_remote_scan => {
@@ -395,8 +390,7 @@ mod tests {
         let summary = read_summary(&mut source)
             .expect("summary read")
             .expect("summary should exist");
-        let mut reader =
-            mcap::sans_io::IndexedReader::new(&summary).expect("indexed reader");
+        let mut reader = mcap::sans_io::IndexedReader::new(&summary).expect("indexed reader");
         let mut messages = 0usize;
         while let Some(event) = reader.next_event() {
             match event.expect("indexed event") {

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -134,22 +134,19 @@ impl ByteSource for RemoteRangeSource {
 }
 
 /// In-memory bytes, mainly for unit tests.
-#[allow(dead_code)] // Constructed from #[cfg(test)] modules across the crate.
+#[cfg(test)]
 pub struct MemorySource {
     data: Vec<u8>,
 }
 
+#[cfg(test)]
 impl MemorySource {
     pub fn new(data: impl Into<Vec<u8>>) -> Self {
         Self { data: data.into() }
     }
-
-    #[allow(dead_code)] // Handy for tests that compare against a known buffer.
-    pub fn as_slice(&self) -> &[u8] {
-        &self.data
-    }
 }
 
+#[cfg(test)]
 impl ByteSource for MemorySource {
     fn size(&self) -> Result<Option<u64>> {
         Ok(Some(self.data.len() as u64))
@@ -164,7 +161,12 @@ impl ByteSource for MemorySource {
     }
 
     fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
-        read_slice_at(&self.data, offset, len)
+        if len == 0 || offset as usize >= self.data.len() {
+            return Ok(Vec::new());
+        }
+        let start = offset as usize;
+        let end = start.saturating_add(len).min(self.data.len());
+        Ok(self.data[start..end].to_vec())
     }
 
     fn is_seekable(&self) -> bool {
@@ -279,15 +281,6 @@ fn read_file_at(file: &mut File, size: u64, offset: u64, len: usize) -> Result<V
     file.read_exact(&mut buf)
         .context("failed to read from local file")?;
     Ok(buf)
-}
-
-fn read_slice_at(data: &[u8], offset: u64, len: usize) -> Result<Vec<u8>> {
-    if len == 0 || offset as usize >= data.len() {
-        return Ok(Vec::new());
-    }
-    let start = offset as usize;
-    let end = start.saturating_add(len).min(data.len());
-    Ok(data[start..end].to_vec())
 }
 
 #[cfg(test)]

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -174,35 +174,6 @@ impl ByteSource for MemorySource {
     }
 }
 
-/// Pure stdin. Not seekable; [`read_at`] always errors.
-///
-/// Prefer [`open_byte_source`] with `path: None`, which spools stdin to a tempfile
-/// and returns a seekable [`LocalFileSource`].
-#[allow(dead_code)] // Documented non-seekable source; production paths spool via open_byte_source.
-pub struct StdinSource;
-
-impl ByteSource for StdinSource {
-    fn size(&self) -> Result<Option<u64>> {
-        Ok(None)
-    }
-
-    fn is_remote(&self) -> bool {
-        false
-    }
-
-    fn display_name(&self) -> String {
-        "<stdin>".to_string()
-    }
-
-    fn read_at(&mut self, _offset: u64, _len: usize) -> Result<Vec<u8>> {
-        bail!("stdin is not seekable; spool to a temporary file before random-access reads");
-    }
-
-    fn is_seekable(&self) -> bool {
-        false
-    }
-}
-
 /// Open a path, remote URL, or stdin as a [`ByteSource`].
 ///
 /// - `None` spools stdin to a tempfile (seek+read, no mmap).
@@ -397,14 +368,5 @@ mod tests {
             }
         }
         assert_eq!(messages, 1);
-    }
-
-    #[test]
-    fn stdin_source_rejects_random_access() {
-        let mut source = StdinSource;
-        assert!(!source.is_seekable());
-        assert!(source.size().expect("size").is_none());
-        let err = source.read_at(0, 1).expect_err("stdin read_at");
-        assert!(err.to_string().contains("not seekable"));
     }
 }

--- a/rust/cli/src/byte_source.rs
+++ b/rust/cli/src/byte_source.rs
@@ -22,14 +22,31 @@ use crate::source::{
 
 /// Byte-oriented input with optional random access.
 pub trait ByteSource {
-    /// File size in bytes, or `None` when unknown (pure stdin without spooling).
+    /// File size in bytes, or `None` when unknown (streaming inputs without a known length).
     fn size(&self) -> Result<Option<u64>>;
     fn is_remote(&self) -> bool;
     fn display_name(&self) -> String;
-    /// Read `[offset, offset+len)` bytes. `len` may be clamped to EOF.
-    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>>;
-    /// Whether random access is available (`false` for pure stdin).
+    /// Whether random access is available.
     fn is_seekable(&self) -> bool;
+
+    /// Read up to `dest.len()` bytes at `offset` into `dest`.
+    ///
+    /// Returns the number of bytes read (0 at EOF). Prefer this in sans-io event loops so
+    /// drivers can fill `reader.insert(need)` without an intermediate allocation.
+    fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize>;
+
+    /// Read `[offset, offset+len)` into a new buffer. `len` may be clamped to EOF.
+    ///
+    /// Hot paths should call [`Self::read_into`] instead to reuse caller buffers.
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+        let mut buf = vec![0u8; len];
+        let n = self.read_into(offset, &mut buf)?;
+        buf.truncate(n);
+        Ok(buf)
+    }
 }
 
 /// Local file opened for seek+read (not memory-mapped).
@@ -91,12 +108,12 @@ impl ByteSource for LocalFileSource {
         self.path.display().to_string()
     }
 
-    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
-        read_file_at(&mut self.file, self.size, offset, len)
-    }
-
     fn is_seekable(&self) -> bool {
         true
+    }
+
+    fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
+        read_file_into(&mut self.file, self.size, offset, dest)
     }
 }
 
@@ -124,12 +141,21 @@ impl ByteSource for RemoteRangeSource {
         self.inner.display_url().to_string()
     }
 
-    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
-        self.inner.read_range(offset, len)
-    }
-
     fn is_seekable(&self) -> bool {
         true
+    }
+
+    fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
+        // object_store range reads return an owned buffer; copy into `dest`.
+        let data = self.inner.read_range(offset, dest.len())?;
+        let n = data.len();
+        dest[..n].copy_from_slice(&data);
+        Ok(n)
+    }
+
+    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
+        // Skip the trait-default zeroed Vec + second copy of read_range's buffer.
+        self.inner.read_range(offset, len)
     }
 }
 
@@ -160,17 +186,19 @@ impl ByteSource for MemorySource {
         "<memory>".to_string()
     }
 
-    fn read_at(&mut self, offset: u64, len: usize) -> Result<Vec<u8>> {
-        if len == 0 || offset as usize >= self.data.len() {
-            return Ok(Vec::new());
-        }
-        let start = offset as usize;
-        let end = start.saturating_add(len).min(self.data.len());
-        Ok(self.data[start..end].to_vec())
-    }
-
     fn is_seekable(&self) -> bool {
         true
+    }
+
+    fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> Result<usize> {
+        if dest.is_empty() || offset as usize >= self.data.len() {
+            return Ok(0);
+        }
+        let start = offset as usize;
+        let end = start.saturating_add(dest.len()).min(self.data.len());
+        let n = end - start;
+        dest[..n].copy_from_slice(&self.data[start..end]);
+        Ok(n)
     }
 }
 
@@ -240,18 +268,17 @@ fn spool_remote_to_local(path: &Path, options: SourceOptions) -> Result<LocalFil
     LocalFileSource::from_temp_file(temp_file, PathBuf::from(redacted_display(path)))
 }
 
-fn read_file_at(file: &mut File, size: u64, offset: u64, len: usize) -> Result<Vec<u8>> {
-    if len == 0 || offset >= size {
-        return Ok(Vec::new());
+fn read_file_into(file: &mut File, size: u64, offset: u64, dest: &mut [u8]) -> Result<usize> {
+    if dest.is_empty() || offset >= size {
+        return Ok(0);
     }
     let available = (size - offset) as usize;
-    let to_read = len.min(available);
+    let to_read = dest.len().min(available);
     file.seek(SeekFrom::Start(offset))
         .context("failed to seek in local file")?;
-    let mut buf = vec![0u8; to_read];
-    file.read_exact(&mut buf)
+    file.read_exact(&mut dest[..to_read])
         .context("failed to read from local file")?;
-    Ok(buf)
+    Ok(to_read)
 }
 
 #[cfg(test)]
@@ -287,11 +314,13 @@ mod tests {
     }
 
     #[test]
-    fn memory_source_read_at_clamps_to_eof() {
+    fn memory_source_read_into_clamps_to_eof() {
         let mut source = MemorySource::new(vec![1, 2, 3, 4, 5]);
-        assert_eq!(source.read_at(3, 10).expect("read"), vec![4, 5]);
-        assert!(source.read_at(5, 1).expect("past eof").is_empty());
-        assert!(source.read_at(100, 1).expect("far past eof").is_empty());
+        let mut dest = [0u8; 10];
+        assert_eq!(source.read_into(3, &mut dest).expect("read"), 2);
+        assert_eq!(&dest[..2], &[4, 5]);
+        assert_eq!(source.read_into(5, &mut dest[..1]).expect("past eof"), 0);
+        assert_eq!(source.read_at(3, 10).expect("read_at"), vec![4, 5]);
     }
 
     #[test]

--- a/rust/cli/src/byte_source/drivers.rs
+++ b/rust/cli/src/byte_source/drivers.rs
@@ -10,6 +10,35 @@ use mcap::sans_io::{
 
 use super::ByteSource;
 
+/// Read the leading [`Header`](mcap::records::Header) record, if present.
+pub fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::records::Header>> {
+    if !source.is_seekable() {
+        bail!("reading the MCAP header requires a seekable byte source");
+    }
+
+    let mut reader = LinearReader::new_with_options(LinearReaderOptions::default());
+    let mut pos = 0u64;
+    while let Some(event) = reader.next_event() {
+        match event.context("linear reader error")? {
+            LinearReadEvent::ReadRequest(need) => {
+                let data = source.read_at(pos, need)?;
+                let buf = reader.insert(need);
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                reader.notify_read(n);
+                pos = pos.saturating_add(n as u64);
+            }
+            LinearReadEvent::Record { opcode, data } => {
+                return match mcap::parse_record(opcode, data)? {
+                    mcap::records::Record::Header(header) => Ok(Some(header)),
+                    _ => Ok(None),
+                };
+            }
+        }
+    }
+    Ok(None)
+}
+
 /// Load the MCAP summary section via [`SummaryReader`].
 ///
 /// Returns `Ok(None)` when the file has no summary section.

--- a/rust/cli/src/byte_source/drivers.rs
+++ b/rust/cli/src/byte_source/drivers.rs
@@ -1,0 +1,112 @@
+//! Drive mcap sans-io readers against a [`ByteSource`].
+
+use std::io::SeekFrom;
+
+use anyhow::{bail, Context, Result};
+use mcap::sans_io::{
+    IndexedReader, LinearReadEvent, LinearReader, LinearReaderOptions, SummaryReadEvent,
+    SummaryReader, SummaryReaderOptions,
+};
+
+use super::ByteSource;
+
+/// Load the MCAP summary section via [`SummaryReader`].
+///
+/// Returns `Ok(None)` when the file has no summary section.
+pub fn read_summary(source: &mut dyn ByteSource) -> Result<Option<mcap::Summary>> {
+    let size = source.size()?;
+    let options = match size {
+        Some(size) => SummaryReaderOptions::default().with_file_size(size),
+        None => SummaryReaderOptions::default(),
+    };
+    let mut reader = SummaryReader::new_with_options(options);
+    let mut pos = 0u64;
+
+    while let Some(event) = reader.next_event() {
+        match event.context("summary reader error")? {
+            SummaryReadEvent::ReadRequest(need) => {
+                let data = source.read_at(pos, need)?;
+                let buf = reader.insert(need);
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                reader.notify_read(n);
+                pos = pos.saturating_add(n as u64);
+            }
+            SummaryReadEvent::SeekRequest(to) => {
+                pos = resolve_seek(to, pos, size)?;
+                reader.notify_seeked(pos);
+            }
+        }
+    }
+
+    Ok(reader.finish())
+}
+
+/// Fetch one indexed chunk and insert it into [`IndexedReader`].
+pub fn service_indexed_chunk(
+    reader: &mut IndexedReader,
+    source: &mut dyn ByteSource,
+    offset: u64,
+    length: usize,
+) -> Result<()> {
+    let data = source.read_at(offset, length)?;
+    if data.len() != length {
+        bail!(
+            "short read for chunk at offset {offset}: expected {length} bytes, got {}",
+            data.len()
+        );
+    }
+    reader
+        .insert_chunk_record_data(offset, &data)
+        .context("failed to insert chunk data into indexed reader")?;
+    Ok(())
+}
+
+/// Walk every top-level record in file order via [`LinearReader`].
+///
+/// Requires a seekable source. Starts at offset 0 and advances with each read.
+pub fn for_each_linear_record(
+    source: &mut dyn ByteSource,
+    options: LinearReaderOptions,
+    mut visit: impl FnMut(u8, &[u8]) -> Result<()>,
+) -> Result<()> {
+    if !source.is_seekable() {
+        bail!("linear record scan requires a seekable byte source");
+    }
+
+    let mut reader = LinearReader::new_with_options(options);
+    let mut pos = 0u64;
+
+    while let Some(event) = reader.next_event() {
+        match event.context("linear reader error")? {
+            LinearReadEvent::ReadRequest(need) => {
+                let data = source.read_at(pos, need)?;
+                let buf = reader.insert(need);
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                reader.notify_read(n);
+                pos = pos.saturating_add(n as u64);
+            }
+            LinearReadEvent::Record { opcode, data } => {
+                visit(opcode, data)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_seek(from: SeekFrom, pos: u64, size: Option<u64>) -> Result<u64> {
+    let target = match from {
+        SeekFrom::Start(offset) => offset as i128,
+        SeekFrom::End(offset) => {
+            let size = size.context("seek from end requires a known file size")?;
+            size as i128 + offset as i128
+        }
+        SeekFrom::Current(offset) => pos as i128 + offset as i128,
+    };
+    if target < 0 {
+        bail!("seek target is before the start of the file");
+    }
+    Ok(target as u64)
+}

--- a/rust/cli/src/byte_source/drivers.rs
+++ b/rust/cli/src/byte_source/drivers.rs
@@ -21,10 +21,8 @@ pub fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::records::
     while let Some(event) = reader.next_event() {
         match event.context("linear reader error")? {
             LinearReadEvent::ReadRequest(need) => {
-                let data = source.read_at(pos, need)?;
                 let buf = reader.insert(need);
-                let n = data.len().min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
+                let n = source.read_into(pos, buf)?;
                 reader.notify_read(n);
                 pos = pos.saturating_add(n as u64);
             }
@@ -54,10 +52,8 @@ pub fn read_summary(source: &mut dyn ByteSource) -> Result<Option<mcap::Summary>
     while let Some(event) = reader.next_event() {
         match event.context("summary reader error")? {
             SummaryReadEvent::ReadRequest(need) => {
-                let data = source.read_at(pos, need)?;
                 let buf = reader.insert(need);
-                let n = data.len().min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
+                let n = source.read_into(pos, buf)?;
                 reader.notify_read(n);
                 pos = pos.saturating_add(n as u64);
             }
@@ -109,10 +105,8 @@ pub fn for_each_linear_record(
     while let Some(event) = reader.next_event() {
         match event.context("linear reader error")? {
             LinearReadEvent::ReadRequest(need) => {
-                let data = source.read_at(pos, need)?;
                 let buf = reader.insert(need);
-                let n = data.len().min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
+                let n = source.read_into(pos, buf)?;
                 reader.notify_read(n);
                 pos = pos.saturating_add(n as u64);
             }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -51,10 +51,11 @@ pub struct Args {
     )]
     pub color: logsetup::Color,
 
-    /// Allow whole-file scans or downloads of remote inputs.
+    /// Allow unbounded remote transfer or a full linear scan of remote inputs.
     ///
     /// Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small
-    /// bounded indexed reads work without this flag.
+    /// bounded indexed reads work without this flag. With this flag, commands may transfer an
+    /// entire remote object (via range requests or a full download) to scan or rewrite it.
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -51,11 +51,10 @@ pub struct Args {
     )]
     pub color: logsetup::Color,
 
-    /// Allow unbounded remote transfer or a full linear scan of remote inputs.
+    /// Allow whole-file scans or downloads of remote inputs.
     ///
     /// Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small
-    /// bounded indexed reads work without this flag. With this flag, commands may transfer an
-    /// entire remote object (via range requests or a full download) to scan or rewrite it.
+    /// bounded indexed reads work without this flag.
     #[arg(long, default_value_t = false, global = true)]
     pub allow_remote_scan: bool,
 

--- a/rust/cli/src/commands/add/shared.rs
+++ b/rust/cli/src/commands/add/shared.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{Seek, Write};
+use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -62,13 +62,23 @@ pub(crate) fn amend_mcap_file(
     attachments: &[AttachmentToAdd],
     metadata: &[records::Metadata],
 ) -> Result<()> {
+    if crate::source::is_remote_url(file) {
+        bail!(
+            "add only supports local files; remote inputs are not supported for in-place amendment"
+        );
+    }
+
     let backup_path = make_tail_backup_path(file)?;
     let (layout, mut existing_summary) = {
-        let mapped = crate::source::map_file(file)
+        let mut readable = fs::File::open(file)
+            .with_context(|| format!("failed to open '{}'", file.display()))?;
+        let mut contents = Vec::new();
+        readable
+            .read_to_end(&mut contents)
             .with_context(|| format!("failed to read '{}'", file.display()))?;
-        let layout = parse_existing_layout(&mapped)?;
+        let layout = parse_existing_layout(&contents)?;
         let tail_start = layout.old_data_end_offset as usize;
-        let tail = mapped
+        let tail = contents
             .get(tail_start..)
             .with_context(|| format!("data end offset out of range for '{}'", file.display()))?;
         fs::write(&backup_path, tail)
@@ -80,7 +90,7 @@ pub(crate) fn amend_mcap_file(
         backup_file
             .sync_all()
             .with_context(|| format!("failed to sync tail backup '{}'", backup_path.display()))?;
-        let summary = collect_existing_summary(&mapped)?;
+        let summary = collect_existing_summary(&contents)?;
         (layout, summary)
     };
 

--- a/rust/cli/src/commands/add/shared.rs
+++ b/rust/cli/src/commands/add/shared.rs
@@ -70,8 +70,8 @@ pub(crate) fn amend_mcap_file(
 
     let backup_path = make_tail_backup_path(file)?;
     let (layout, mut existing_summary) = {
-        let mut readable = fs::File::open(file)
-            .with_context(|| format!("failed to open '{}'", file.display()))?;
+        let mut readable =
+            fs::File::open(file).with_context(|| format!("failed to open '{}'", file.display()))?;
         let mut contents = Vec::new();
         readable
             .read_to_end(&mut contents)

--- a/rust/cli/src/commands/add/shared.rs
+++ b/rust/cli/src/commands/add/shared.rs
@@ -869,7 +869,7 @@ mod tests {
                 metadata: BTreeMap::new(),
             }],
         )?;
-        let library = crate::parse::read_header(&output)
+        let library = crate::parse::slice::read_header(&output)
             .expect("read header")
             .expect("header present")
             .library;

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -8,6 +8,7 @@ use log::warn;
 use mcap::sans_io::indexed_reader::ReadOrder;
 use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor, SerializeOptions};
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::{CatCommand, CatFormat, TimeFormat};
 use crate::context::CommandContext;
 use crate::{parse, render, source};
@@ -75,20 +76,8 @@ fn cat_file(
     source_options: source::SourceOptions,
     csv_state: &mut CsvState,
 ) -> Result<bool> {
-    if let Some(remote) = source::try_open_remote_mcap(file, source_options)? {
-        let mut json_transcoders = JsonTranscoders::default();
-        let mut out = MessageWriter {
-            csv: csv_state,
-            json: &mut json_transcoders,
-        };
-        match cat_remote_indexed(sink, file, &remote, opts, source_options, &mut out)? {
-            RemoteCatResult::BrokenPipe => return Ok(true),
-            RemoteCatResult::Done => return Ok(false),
-            RemoteCatResult::NeedsFullScan => {}
-        }
-    }
-    let mcap = source::load_path(file, source_options)?;
-    cat_mcap(sink, &mcap, opts, csv_state)
+    let mut input = byte_source::open_byte_source(Some(file), source_options)?;
+    cat_from_source(sink, input.as_mut(), opts, source_options, csv_state)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -168,10 +157,11 @@ impl CatOptions {
     }
 }
 
-fn cat_mcap(
+fn cat_from_source(
     sink: &mut OutputSink<impl std::io::Write>,
-    mcap: &[u8],
+    source: &mut dyn ByteSource,
     opts: &CatOptions,
+    source_options: source::SourceOptions,
     csv_state: &mut CsvState,
 ) -> Result<bool> {
     let mut json_transcoders = JsonTranscoders::default();
@@ -179,26 +169,72 @@ fn cat_mcap(
         csv: csv_state,
         json: &mut json_transcoders,
     };
-    if let Some(broken_pipe) = cat_indexed(sink, mcap, opts, &mut out)? {
-        return Ok(broken_pipe);
+    match cat_indexed(sink, source, opts, source_options, &mut out)? {
+        IndexedCatResult::BrokenPipe => return Ok(true),
+        IndexedCatResult::Done => return Ok(false),
+        IndexedCatResult::NeedsLinear => {}
     }
-    cat_linear(sink, mcap, opts, &mut out)
+    source::require_remote_scan_for_linear(source, source_options).or_else(|err| {
+        // Preserve the historical remote cat wording when there is no usable chunk index.
+        if source.is_remote() {
+            bail!(
+                "{}: remote file has no chunk index; reading messages requires opt-in; {}",
+                source.display_name(),
+                source::remote_scan_opt_in_suffix()
+            );
+        }
+        Err(err)
+    })?;
+    cat_linear(sink, source, opts, &mut out)
+}
+
+#[cfg(test)]
+fn cat_mcap(
+    sink: &mut OutputSink<impl std::io::Write>,
+    mcap: &[u8],
+    opts: &CatOptions,
+    csv_state: &mut CsvState,
+) -> Result<bool> {
+    let mut source = byte_source::MemorySource::new(mcap.to_vec());
+    cat_from_source(
+        sink,
+        &mut source,
+        opts,
+        source::SourceOptions::default(),
+        csv_state,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexedCatResult {
+    BrokenPipe,
+    Done,
+    NeedsLinear,
 }
 
 fn cat_indexed(
     sink: &mut OutputSink<impl std::io::Write>,
-    mcap: &[u8],
+    source: &mut dyn ByteSource,
     opts: &CatOptions,
+    _source_options: source::SourceOptions,
     out: &mut MessageWriter<'_, '_>,
-) -> Result<Option<bool>> {
-    let summary = match mcap::Summary::read(mcap) {
+) -> Result<IndexedCatResult> {
+    let summary = match byte_source::read_summary(source) {
         Ok(Some(summary)) => summary,
-        Ok(None) => return Ok(None),
+        Ok(None) => return Ok(IndexedCatResult::NeedsLinear),
         // A spec-valid file may repeat a channel in the summary without repeating its schema,
         // leaving the schema defined only inside a chunk. That can't be resolved from the summary
         // alone, so fall back to a linear scan, which registers in-chunk definitions as it reads.
-        Err(mcap::McapError::UnknownSchema(..)) => return Ok(None),
-        Err(err) => return Err(err.into()),
+        Err(err)
+            if err.chain().any(|cause| {
+                cause
+                    .downcast_ref::<mcap::McapError>()
+                    .is_some_and(|e| matches!(e, mcap::McapError::UnknownSchema(..)))
+            }) =>
+        {
+            return Ok(IndexedCatResult::NeedsLinear);
+        }
+        Err(err) => return Err(err),
     };
     // Record channel topics (including zero-message channels) so an absent CSV topic can be
     // reported as an error rather than a silently empty export.
@@ -211,27 +247,13 @@ fn cat_indexed(
         );
     }
     if summary.chunk_indexes.is_empty() {
-        return Ok(None);
+        return Ok(IndexedCatResult::NeedsLinear);
     }
 
     let needs_in_chunk_definitions = needs_in_chunk_definitions(&summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = summary.channels.clone();
-    // When channels/schemas are defined only inside chunks (not repeated in the summary), collect
-    // their definitions from every chunk up front. Collecting lazily per requested chunk would miss
-    // a definition that lives in a chunk skipped by a topic or time filter (e.g. a channel defined
-    // in an early chunk but referenced by messages in a later one).
-    if needs_in_chunk_definitions {
-        for chunk_index in &summary.chunk_indexes {
-            parse::collect_chunk_definitions_from_mcap(
-                mcap,
-                chunk_index,
-                &mut schemas,
-                &mut channel_defs,
-            )?;
-        }
-    }
 
     let included_topics: BTreeSet<String> = summary
         .channels
@@ -240,157 +262,16 @@ fn cat_indexed(
         .map(|channel| channel.topic.clone())
         .collect();
     if !opts.topics.is_empty() && included_topics.is_empty() && !needs_in_chunk_definitions {
-        return Ok(Some(false));
+        return Ok(IndexedCatResult::Done);
     }
 
-    let mut indexed_opts =
-        mcap::sans_io::IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
-    if opts.start != 0 {
-        indexed_opts = indexed_opts.log_time_on_or_after(opts.start);
-    }
-    if let Some(end) = opts.end {
-        indexed_opts = indexed_opts.log_time_before(end);
-    }
-    // Reader-level topic filtering keys on `summary.channels`, so skip it when chunk-local channels
-    // may exist (see `needs_in_chunk_definitions`) and let the per-message `include_topic` check
-    // below filter instead, to avoid silently dropping matching chunk-local messages.
-    if !opts.topics.is_empty() && !included_topics.is_empty() && !needs_in_chunk_definitions {
-        indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
-    }
-
-    let mut reader = mcap::sans_io::IndexedReader::new_with_options(&summary, indexed_opts)?;
-
-    while let Some(event) = reader.next_event() {
-        match event? {
-            mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                let start = offset as usize;
-                let end = start
-                    .checked_add(length)
-                    .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
-                if end > mcap.len() {
-                    anyhow::bail!("chunk read out of bounds at offset {offset} length {length}");
-                }
-                reader.insert_chunk_record_data(offset, &mcap[start..end])?;
-            }
-            mcap::sans_io::IndexedReadEvent::Message { header, data } => {
-                let channel =
-                    resolve_channel(header.channel_id, &schemas, &channel_defs, &mut channels)?;
-                if !opts.include_topic(&channel.topic) {
-                    continue;
-                }
-                let message = CatMessage {
-                    channel: &channel,
-                    sequence: header.sequence,
-                    log_time: header.log_time,
-                    publish_time: header.publish_time,
-                    data,
-                };
-                if write_message(sink, message, opts, out)? {
-                    return Ok(Some(true));
-                }
-            }
-        }
-    }
-
-    Ok(Some(false))
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RemoteCatResult {
-    BrokenPipe,
-    Done,
-    NeedsFullScan,
-}
-
-fn cat_remote_indexed(
-    sink: &mut OutputSink<impl std::io::Write>,
-    file: &std::path::Path,
-    remote: &source::RemoteMcap,
-    opts: &CatOptions,
-    source_options: source::SourceOptions,
-    out: &mut MessageWriter<'_, '_>,
-) -> Result<RemoteCatResult> {
-    let summary = remote.summary();
-    if matches!(opts.mode, OutputMode::Csv) {
-        out.csv.seen_topics.extend(
-            summary
-                .channels
-                .values()
-                .map(|channel| channel.topic.clone()),
-        );
-    }
-    if summary.chunk_indexes.is_empty() {
-        if !source_options.allow_remote_scan {
-            bail!(
-                "{}: remote file has no chunk index; reading messages requires opt-in; {}",
-                source::redacted_display(file),
-                source::remote_scan_opt_in_suffix()
-            );
-        }
-        return Ok(RemoteCatResult::NeedsFullScan);
-    }
-    let has_chunks_without_message_indexes = summary
-        .chunk_indexes
-        .iter()
-        .any(|chunk| chunk.message_index_offsets.is_empty());
-    if has_chunks_without_message_indexes && !source_options.allow_remote_scan {
-        bail!(
-            "{}: remote file has chunk indexes without message indexes; reading messages requires opt-in; {}",
-            source::redacted_display(file),
-            source::remote_scan_opt_in_suffix()
-        );
-    }
-    let needs_in_chunk_definitions = needs_in_chunk_definitions(summary);
-    let mut schemas = summary.schemas.clone();
-    let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
-    let mut channels = summary.channels.clone();
-
-    let included_topics: BTreeSet<String> = summary
-        .channels
-        .values()
-        .filter(|channel| opts.include_topic(&channel.topic))
-        .map(|channel| channel.topic.clone())
-        .collect();
-    if !opts.topics.is_empty() && included_topics.is_empty() && !needs_in_chunk_definitions {
-        return Ok(RemoteCatResult::Done);
-    }
     let planned_chunks =
-        planned_chunk_reads(summary, opts, &included_topics, needs_in_chunk_definitions);
-    if !planned_chunks.is_empty() && !source_options.allow_remote_scan {
-        // When chunk-local definitions must be collected, every chunk is read up front (a
-        // definition can live in a chunk the filter would otherwise skip), so size the warning from
-        // the full set rather than the filtered plan to avoid under-quoting the bytes fetched.
-        let (chunk_count, compressed_bytes) = if needs_in_chunk_definitions {
-            (
-                summary.chunk_indexes.len(),
-                summary
-                    .chunk_indexes
-                    .iter()
-                    .map(|chunk| chunk.compressed_size)
-                    .sum::<u64>(),
-            )
-        } else {
-            (
-                planned_chunks.len(),
-                planned_chunks
-                    .iter()
-                    .map(|chunk| chunk.compressed_size)
-                    .sum::<u64>(),
-            )
-        };
-        bail!(
-            "{}: remote cat would read {} message chunks ({} compressed); {}",
-            source::redacted_display(file),
-            chunk_count,
-            render::human_bytes(compressed_bytes),
-            source::remote_scan_opt_in_suffix()
-        );
-    }
+        planned_chunk_reads(&summary, opts, &included_topics, needs_in_chunk_definitions);
 
     // When channels/schemas are defined only inside chunks, fetch every chunk once up front to
     // collect their definitions, caching the compressed data so the indexed read below doesn't
     // re-fetch. Lazy per-chunk collection would miss a definition in a chunk skipped by a topic or
-    // time filter. The remote-scan gate above already required opt-in to reach here.
+    // time filter.
     let mut chunk_data_cache: HashMap<u64, Vec<u8>> = HashMap::new();
     if needs_in_chunk_definitions && !planned_chunks.is_empty() {
         for chunk_index in &summary.chunk_indexes {
@@ -400,7 +281,7 @@ fn cat_remote_indexed(
                     chunk_index.chunk_length
                 )
             })?;
-            let chunk = remote.read_range(chunk_index.chunk_start_offset, chunk_len)?;
+            let chunk = source.read_at(chunk_index.chunk_start_offset, chunk_len)?;
             parse::collect_chunk_definitions_from_record_bytes(
                 &chunk,
                 &mut schemas,
@@ -434,7 +315,7 @@ fn cat_remote_indexed(
         indexed_opts = indexed_opts.include_topics(included_topics.iter().cloned());
     }
 
-    let mut reader = mcap::sans_io::IndexedReader::new_with_options(summary, indexed_opts)?;
+    let mut reader = mcap::sans_io::IndexedReader::new_with_options(&summary, indexed_opts)?;
     while let Some(event) = reader.next_event() {
         match event? {
             mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
@@ -446,8 +327,7 @@ fn cat_remote_indexed(
                     })?;
                     reader.insert_chunk_record_data(offset, compressed)?;
                 } else {
-                    let chunk = remote.read_range(offset, length)?;
-                    reader.insert_chunk_record_data(offset, &chunk)?;
+                    byte_source::service_indexed_chunk(&mut reader, source, offset, length)?;
                 }
             }
             mcap::sans_io::IndexedReadEvent::Message { header, data } => {
@@ -464,13 +344,13 @@ fn cat_remote_indexed(
                     data,
                 };
                 if write_message(sink, message, opts, out)? {
-                    return Ok(RemoteCatResult::BrokenPipe);
+                    return Ok(IndexedCatResult::BrokenPipe);
                 }
             }
         }
     }
 
-    Ok(RemoteCatResult::Done)
+    Ok(IndexedCatResult::Done)
 }
 
 /// Returns whether chunk definitions must be read before indexed iteration.
@@ -515,7 +395,7 @@ fn resolve_channel(
 }
 
 // Keep this planner conservative: it intentionally mirrors IndexedReader chunk filtering as an
-// upper bound so the remote-scan gate fires before any possible chunk payload fetch.
+// upper bound so callers can size definition-prefetch work before any possible chunk payload fetch.
 fn planned_chunk_reads<'a>(
     summary: &'a mcap::Summary,
     opts: &CatOptions,
@@ -561,45 +441,42 @@ fn planned_chunk_reads<'a>(
 
 fn cat_linear(
     sink: &mut OutputSink<impl std::io::Write>,
-    mcap: &[u8],
+    source: &mut dyn ByteSource,
     opts: &CatOptions,
     out: &mut MessageWriter<'_, '_>,
 ) -> Result<bool> {
     // Scan records (not just messages) so channel definitions are observed even for topics with no
     // messages; this feeds `seen_topics` for the CSV absent-vs-empty distinction in a single pass.
     // The reader descends into chunks, emitting their inner records directly.
-    let mut reader = mcap::sans_io::LinearReader::new();
-    let mut remaining = mcap;
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
+    let mut broken_pipe = false;
 
-    while let Some(event) = reader.next_event() {
-        match event? {
-            mcap::sans_io::LinearReadEvent::ReadRequest(need) => {
-                let take = need.min(remaining.len());
-                reader.insert(take).copy_from_slice(&remaining[..take]);
-                reader.notify_read(take);
-                remaining = &remaining[take..];
+    byte_source::for_each_linear_record(
+        source,
+        mcap::sans_io::LinearReaderOptions::default(),
+        |opcode, data| {
+            if broken_pipe {
+                return Ok(());
             }
-            mcap::sans_io::LinearReadEvent::Record { data, opcode } => {
-                let record = mcap::parse_record(opcode, data)?;
-                if handle_linear_record(
-                    sink,
-                    record,
-                    opts,
-                    &mut schemas,
-                    &mut channel_defs,
-                    &mut channels,
-                    out,
-                )? {
-                    return Ok(true);
-                }
+            let record = mcap::parse_record(opcode, data)?;
+            if handle_linear_record(
+                sink,
+                record,
+                opts,
+                &mut schemas,
+                &mut channel_defs,
+                &mut channels,
+                out,
+            )? {
+                broken_pipe = true;
             }
-        }
-    }
+            Ok(())
+        },
+    )?;
 
-    Ok(false)
+    Ok(broken_pipe)
 }
 
 fn cat_streaming(
@@ -1503,12 +1380,24 @@ mod tests {
         cat_indexed, cat_mcap, cat_streaming, flush_or_ignore_broken_pipe,
         needs_in_chunk_definitions, parse_ros1_field_type, planned_chunk_reads,
         write_message_fields, write_payload_preview, write_ros1_float, write_signed_decimal_time,
-        CatOptions, CsvState, JsonTranscoders, MessageWriter, OutputMode, OutputSink,
-        Ros1MessageDef, MESSAGE_PREVIEW_LEN,
+        CatOptions, CsvState, IndexedCatResult, JsonTranscoders, MessageWriter, OutputMode,
+        OutputSink, Ros1MessageDef, MESSAGE_PREVIEW_LEN,
     };
+    use crate::byte_source::MemorySource;
     use crate::cli::{CatCommand, CatFormat, TimeFormat};
     use crate::render;
+    use crate::source::SourceOptions;
     use std::io::BufWriter;
+
+    fn cat_indexed_bytes(
+        sink: &mut OutputSink<impl std::io::Write>,
+        mcap: &[u8],
+        opts: &CatOptions,
+        out: &mut MessageWriter<'_, '_>,
+    ) -> anyhow::Result<IndexedCatResult> {
+        let mut source = MemorySource::new(mcap.to_vec());
+        cat_indexed(sink, &mut source, opts, SourceOptions::default(), out)
+    }
 
     /// Runs `f` with a buffered plain sink and returns flushed stdout bytes.
     fn capture_plain<T>(
@@ -2020,10 +1909,10 @@ mod tests {
     }
 
     #[test]
-    fn remote_cat_requires_allow_remote_scan_before_chunk_reads() {
+    fn remote_cat_indexed_reads_chunks_without_allow_remote_scan() {
         let body: &'static [u8] = Box::leak(build_multi_topic_mcap().into_boxed_slice());
         let url = serve_http(body);
-        let err = capture_plain(|sink| {
+        let (broken_pipe, out) = capture_plain(|sink| {
             super::cat_file(
                 sink,
                 Path::new(&url),
@@ -2032,9 +1921,10 @@ mod tests {
                 &mut CsvState::default(),
             )
         })
-        .expect_err("remote cat should require opt-in before reading chunks");
-        assert!(err.to_string().contains("remote cat would read"));
-        assert!(err.to_string().contains("--allow-remote-scan"));
+        .expect("indexed remote cat should work without --allow-remote-scan");
+        assert!(!broken_pipe);
+        let output = String::from_utf8(out).expect("utf8");
+        assert!(output.contains("/camera") || output.contains("/imu") || !output.is_empty());
     }
 
     fn planned_chunks_for_opts<'a>(
@@ -2203,7 +2093,7 @@ mod tests {
 
         let mut json_transcoders = JsonTranscoders::default();
         let (indexed_result, indexed_out) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 &mcap,
                 &CatOptions::default(),
@@ -2214,7 +2104,7 @@ mod tests {
             )
         })
         .expect("indexed cat should succeed");
-        assert_eq!(indexed_result, Some(false));
+        assert_eq!(indexed_result, IndexedCatResult::Done);
 
         let output = String::from_utf8(indexed_out).expect("valid utf8 output");
         let lines: Vec<&str> = output.lines().collect();
@@ -2255,7 +2145,7 @@ mod tests {
 
         let mut json_transcoders = JsonTranscoders::default();
         let (indexed_result, indexed_out) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 mcap,
                 &CatOptions::default(),
@@ -2266,7 +2156,7 @@ mod tests {
             )
         })
         .expect("indexed cat should succeed");
-        assert_eq!(indexed_result, Some(false));
+        assert_eq!(indexed_result, IndexedCatResult::Done);
         let indexed_output = String::from_utf8(indexed_out).expect("valid utf8 output");
         let indexed_lines: Vec<&str> = indexed_output.lines().collect();
         assert_eq!(indexed_lines, expected);
@@ -2300,7 +2190,7 @@ mod tests {
 
         let mut json_transcoders = JsonTranscoders::default();
         let (indexed_result, out) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 mcap,
                 &CatOptions::default(),
@@ -2311,7 +2201,7 @@ mod tests {
             )
         })
         .expect("indexed cat should succeed");
-        assert_eq!(indexed_result, Some(false));
+        assert_eq!(indexed_result, IndexedCatResult::Done);
 
         let output = String::from_utf8(out).expect("valid utf8 output");
         let lines: Vec<&str> = output.lines().collect();
@@ -2331,7 +2221,7 @@ mod tests {
 
         let mut json_transcoders = JsonTranscoders::default();
         let (indexed_result, indexed_out) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 mcap,
                 &CatOptions::default(),
@@ -2342,7 +2232,7 @@ mod tests {
             )
         })
         .expect("indexed planner should fall back");
-        assert_eq!(indexed_result, None);
+        assert_eq!(indexed_result, IndexedCatResult::NeedsLinear);
         assert!(indexed_out.is_empty());
 
         let (broken_pipe, out) = capture_plain(|sink| {
@@ -2422,7 +2312,7 @@ mod tests {
         };
         let mut json_transcoders = JsonTranscoders::default();
         let (indexed_result, out) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 &mcap,
                 &opts,
@@ -2433,7 +2323,7 @@ mod tests {
             )
         })
         .expect("indexed cat should resolve chunk-local channel");
-        assert_eq!(indexed_result, Some(false));
+        assert_eq!(indexed_result, IndexedCatResult::Done);
 
         let output = String::from_utf8(out).expect("valid utf8 output");
         let lines: Vec<&str> = output.lines().collect();
@@ -2467,7 +2357,7 @@ mod tests {
         // Matching topic keeps the chunk-local channel's message.
         let mut json_transcoders = JsonTranscoders::default();
         let (result, matched) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 mcap,
                 &CatOptions {
@@ -2481,7 +2371,7 @@ mod tests {
             )
         })
         .expect("indexed cat should succeed");
-        assert_eq!(result, Some(false));
+        assert_eq!(result, IndexedCatResult::Done);
         let matched = String::from_utf8(matched).expect("valid utf8 output");
         assert_eq!(matched.lines().count(), 1);
 
@@ -2489,7 +2379,7 @@ mod tests {
         // reader-level filtering), and the indexed path still completes without a linear fallback.
         let mut json_transcoders = JsonTranscoders::default();
         let (result, filtered) = capture_plain(|sink| {
-            cat_indexed(
+            cat_indexed_bytes(
                 sink,
                 mcap,
                 &CatOptions {
@@ -2503,7 +2393,7 @@ mod tests {
             )
         })
         .expect("indexed cat should succeed");
-        assert_eq!(result, Some(false));
+        assert_eq!(result, IndexedCatResult::Done);
         assert!(filtered.is_empty());
     }
 

--- a/rust/cli/src/commands/cat.rs
+++ b/rust/cli/src/commands/cat.rs
@@ -216,7 +216,7 @@ fn cat_indexed(
     sink: &mut OutputSink<impl std::io::Write>,
     source: &mut dyn ByteSource,
     opts: &CatOptions,
-    _source_options: source::SourceOptions,
+    source_options: source::SourceOptions,
     out: &mut MessageWriter<'_, '_>,
 ) -> Result<IndexedCatResult> {
     let summary = match byte_source::read_summary(source) {
@@ -250,6 +250,19 @@ fn cat_indexed(
         return Ok(IndexedCatResult::NeedsLinear);
     }
 
+    let has_chunks_without_message_indexes = summary
+        .chunk_indexes
+        .iter()
+        .any(|chunk| chunk.message_index_offsets.is_empty());
+    if source.is_remote() && has_chunks_without_message_indexes && !source_options.allow_remote_scan
+    {
+        bail!(
+            "{}: remote file has chunk indexes without message indexes; reading messages requires opt-in; {}",
+            source.display_name(),
+            source::remote_scan_opt_in_suffix()
+        );
+    }
+
     let needs_in_chunk_definitions = needs_in_chunk_definitions(&summary);
     let mut schemas = summary.schemas.clone();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
@@ -267,11 +280,41 @@ fn cat_indexed(
 
     let planned_chunks =
         planned_chunk_reads(&summary, opts, &included_topics, needs_in_chunk_definitions);
+    if source.is_remote() && !planned_chunks.is_empty() && !source_options.allow_remote_scan {
+        // When chunk-local definitions must be collected, every chunk is read up front (a
+        // definition can live in a chunk the filter would otherwise skip), so size the warning from
+        // the full set rather than the filtered plan to avoid under-quoting the bytes fetched.
+        let (chunk_count, compressed_bytes) = if needs_in_chunk_definitions {
+            (
+                summary.chunk_indexes.len(),
+                summary
+                    .chunk_indexes
+                    .iter()
+                    .map(|chunk| chunk.compressed_size)
+                    .sum::<u64>(),
+            )
+        } else {
+            (
+                planned_chunks.len(),
+                planned_chunks
+                    .iter()
+                    .map(|chunk| chunk.compressed_size)
+                    .sum::<u64>(),
+            )
+        };
+        bail!(
+            "{}: remote cat would read {} message chunks ({} compressed); {}",
+            source.display_name(),
+            chunk_count,
+            crate::render::human_bytes(compressed_bytes),
+            source::remote_scan_opt_in_suffix()
+        );
+    }
 
     // When channels/schemas are defined only inside chunks, fetch every chunk once up front to
     // collect their definitions, caching the compressed data so the indexed read below doesn't
     // re-fetch. Lazy per-chunk collection would miss a definition in a chunk skipped by a topic or
-    // time filter.
+    // time filter. The remote-scan gate above already required opt-in to reach here.
     let mut chunk_data_cache: HashMap<u64, Vec<u8>> = HashMap::new();
     if needs_in_chunk_definitions && !planned_chunks.is_empty() {
         for chunk_index in &summary.chunk_indexes {
@@ -1909,10 +1952,10 @@ mod tests {
     }
 
     #[test]
-    fn remote_cat_indexed_reads_chunks_without_allow_remote_scan() {
+    fn remote_cat_requires_allow_remote_scan_before_chunk_reads() {
         let body: &'static [u8] = Box::leak(build_multi_topic_mcap().into_boxed_slice());
         let url = serve_http(body);
-        let (broken_pipe, out) = capture_plain(|sink| {
+        let err = capture_plain(|sink| {
             super::cat_file(
                 sink,
                 Path::new(&url),
@@ -1921,7 +1964,26 @@ mod tests {
                 &mut CsvState::default(),
             )
         })
-        .expect("indexed remote cat should work without --allow-remote-scan");
+        .expect_err("remote cat should require opt-in before reading chunks");
+        let message = err.to_string();
+        assert!(message.contains("remote cat would read"));
+        assert!(message.contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn remote_cat_indexed_reads_chunks_with_allow_remote_scan() {
+        let body: &'static [u8] = Box::leak(build_multi_topic_mcap().into_boxed_slice());
+        let url = serve_http(body);
+        let (broken_pipe, out) = capture_plain(|sink| {
+            super::cat_file(
+                sink,
+                Path::new(&url),
+                &CatOptions::default(),
+                crate::source::SourceOptions::new(true),
+                &mut CsvState::default(),
+            )
+        })
+        .expect("indexed remote cat with --allow-remote-scan should succeed");
         assert!(!broken_pipe);
         let output = String::from_utf8(out).expect("utf8");
         assert!(output.contains("/camera") || output.contains("/imu") || !output.is_empty());

--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -3,17 +3,19 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::DoctorCommand;
 use crate::context::CommandContext;
 use crate::source;
 
 pub fn run(ctx: &CommandContext, args: DoctorCommand) -> Result<()> {
-    let mcap = source::load_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
+    // Doctor always walks the full file (and may re-read indexed chunks), so remote
+    // inputs need an explicit opt-in even when range requests are available.
+    source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
 
-    let diagnosis = diagnose_mcap(&mcap, args.strict_message_order);
+    let diagnosis = diagnose_byte_source(input.as_mut(), args.strict_message_order)?;
     for warning in &diagnosis.warnings {
         eprintln!("Warning: {warning}");
     }
@@ -65,13 +67,22 @@ struct Doctor {
     duplicate_channel_warning_ids: BTreeSet<u16>,
 }
 
-fn diagnose_mcap(mcap: &[u8], strict_message_order: bool) -> Diagnosis {
+fn diagnose_byte_source(
+    source: &mut dyn ByteSource,
+    strict_message_order: bool,
+) -> Result<Diagnosis> {
     let mut doctor = Doctor::new(strict_message_order);
-    doctor.scan_top_level(mcap);
+    doctor.scan_top_level(source)?;
     doctor.finalize_record_presence();
-    doctor.validate_chunk_indexes(mcap);
+    doctor.validate_chunk_indexes(source)?;
     doctor.validate_statistics();
-    doctor.diagnosis
+    Ok(doctor.diagnosis)
+}
+
+#[cfg(test)]
+fn diagnose_mcap(mcap: &[u8], strict_message_order: bool) -> Diagnosis {
+    let mut source = byte_source::MemorySource::new(mcap.to_vec());
+    diagnose_byte_source(&mut source, strict_message_order).expect("diagnose should not I/O-fail")
 }
 
 impl Doctor {
@@ -109,16 +120,20 @@ impl Doctor {
         self.diagnosis.errors.push(message.into());
     }
 
-    fn scan_top_level(&mut self, mcap: &[u8]) {
+    fn scan_top_level(&mut self, source: &mut dyn ByteSource) -> Result<()> {
+        let record_length_limit = source
+            .size()?
+            .and_then(|size| usize::try_from(size).ok())
+            .unwrap_or(usize::MAX);
         let mut reader = mcap::sans_io::LinearReader::new_with_options(
             mcap::sans_io::LinearReaderOptions::default()
                 .with_emit_chunks(true)
                 .with_validate_chunk_crcs(true)
                 .with_validate_data_section_crc(true)
                 .with_validate_summary_section_crc(true)
-                .with_record_length_limit(mcap.len()),
+                .with_record_length_limit(record_length_limit),
         );
-        let mut remaining = mcap;
+        let mut pos = 0u64;
         let mut next_record_offset = mcap::MAGIC.len() as u64;
 
         while let Some(event) = reader.next_event() {
@@ -133,11 +148,12 @@ impl Doctor {
                     break;
                 }
                 Ok(mcap::sans_io::LinearReadEvent::ReadRequest(need)) => {
-                    let read = need.min(remaining.len());
-                    let dst = reader.insert(read);
-                    dst.copy_from_slice(&remaining[..read]);
-                    reader.notify_read(read);
-                    remaining = &remaining[read..];
+                    let data = source.read_at(pos, need)?;
+                    let buf = reader.insert(need);
+                    let n = data.len().min(buf.len());
+                    buf[..n].copy_from_slice(&data[..n]);
+                    reader.notify_read(n);
+                    pos = pos.saturating_add(n as u64);
                 }
                 Ok(mcap::sans_io::LinearReadEvent::Record { opcode, data }) => {
                     let record_offset = next_record_offset;
@@ -156,6 +172,7 @@ impl Doctor {
                 }
             }
         }
+        Ok(())
     }
 
     fn handle_top_level_record(&mut self, record: mcap::records::Record<'_>, offset: u64) {
@@ -534,7 +551,7 @@ impl Doctor {
         }
     }
 
-    fn validate_chunk_indexes(&mut self, mcap: &[u8]) {
+    fn validate_chunk_indexes(&mut self, source: &mut dyn ByteSource) -> Result<()> {
         let chunk_indexes: Vec<(u64, mcap::records::ChunkIndex)> = self
             .chunk_indexes
             .iter()
@@ -570,7 +587,7 @@ impl Doctor {
                 }
             }
 
-            match read_record_at_offset(mcap, chunk_offset) {
+            match read_record_at_offset(source, chunk_offset) {
                 Ok(raw_record) => {
                     if raw_record.opcode != mcap::records::op::CHUNK {
                         self.error(format!(
@@ -590,7 +607,7 @@ impl Doctor {
                         continue;
                     }
 
-                    let parsed = mcap::parse_record(raw_record.opcode, raw_record.body);
+                    let parsed = mcap::parse_record(raw_record.opcode, &raw_record.body);
                     let Ok(mcap::records::Record::Chunk { header, .. }) = parsed else {
                         self.error(format!(
                             "Chunk index points to offset {} but encountered error parsing the chunk at that offset",
@@ -638,6 +655,7 @@ impl Doctor {
                 }
             }
         }
+        Ok(())
     }
 
     fn validate_statistics(&mut self) {
@@ -691,34 +709,32 @@ impl Doctor {
     }
 }
 
-struct RawRecordRef<'a> {
+struct RawRecord {
     opcode: u8,
     length: u64,
-    body: &'a [u8],
+    body: Vec<u8>,
 }
 
-fn read_record_at_offset<'a>(mcap: &'a [u8], offset: u64) -> Result<RawRecordRef<'a>> {
-    let offset = usize::try_from(offset).context("record offset out of range")?;
-    if offset + 9 > mcap.len() {
+fn read_record_at_offset(source: &mut dyn ByteSource, offset: u64) -> Result<RawRecord> {
+    let header = source.read_at(offset, 9)?;
+    if header.len() < 9 {
         anyhow::bail!("record header extends beyond file");
     }
-    let opcode = mcap[offset];
+    let opcode = header[0];
     let length = u64::from_le_bytes(
-        mcap[offset + 1..offset + 9]
+        header[1..9]
             .try_into()
             .expect("slice length for record len"),
     );
-    let end = offset
-        .checked_add(9)
-        .and_then(|start| start.checked_add(usize::try_from(length).ok()?))
-        .context("record length overflow")?;
-    if end > mcap.len() {
+    let body_len = usize::try_from(length).context("record length overflow")?;
+    let body = source.read_at(offset + 9, body_len)?;
+    if body.len() != body_len {
         anyhow::bail!("record extends beyond file");
     }
-    Ok(RawRecordRef {
+    Ok(RawRecord {
         opcode,
         length,
-        body: &mcap[offset + 9..end],
+        body,
     })
 }
 

--- a/rust/cli/src/commands/doctor.rs
+++ b/rust/cli/src/commands/doctor.rs
@@ -148,10 +148,8 @@ impl Doctor {
                     break;
                 }
                 Ok(mcap::sans_io::LinearReadEvent::ReadRequest(need)) => {
-                    let data = source.read_at(pos, need)?;
                     let buf = reader.insert(need);
-                    let n = data.len().min(buf.len());
-                    buf[..n].copy_from_slice(&data[..n]);
+                    let n = source.read_into(pos, buf)?;
                     reader.notify_read(n);
                     pos = pos.saturating_add(n as u64);
                 }

--- a/rust/cli/src/commands/du.rs
+++ b/rust/cli/src/commands/du.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use mcap::records::{self, op, Record};
-use mcap::sans_io::{LinearReadEvent, LinearReader, LinearReaderOptions};
+use mcap::sans_io::LinearReaderOptions;
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::DuCommand;
 use crate::context::CommandContext;
 use crate::{render, source};
@@ -32,23 +33,23 @@ struct OffsetEntry {
 }
 
 pub fn run(ctx: &CommandContext, args: DuCommand) -> Result<()> {
-    let mcap = source::load_path(
-        &args.file,
-        source::SourceOptions::new(ctx.allow_remote_scan()),
-    )?;
+    let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
+    let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
 
     let (usage, used_approximate) = if args.approximate {
-        match collect_usage_approximate(&mcap)? {
+        match collect_usage_approximate(input.as_mut())? {
             Some(usage) => (usage, true),
             None => {
                 eprintln!(
                     "Warning: summary/chunk indexes unavailable; falling back to exact du scan."
                 );
-                (collect_usage_exact(&mcap)?, false)
+                source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
+                (collect_usage_exact(input.as_mut())?, false)
             }
         }
     } else {
-        (collect_usage_exact(&mcap)?, false)
+        source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
+        (collect_usage_exact(input.as_mut())?, false)
     };
 
     print_record_table(&usage.record_kind_size, usage.total_size, used_approximate);
@@ -57,38 +58,49 @@ pub fn run(ctx: &CommandContext, args: DuCommand) -> Result<()> {
     Ok(())
 }
 
-fn collect_usage_exact(mcap: &[u8]) -> Result<Usage> {
+fn collect_usage_exact(source: &mut dyn ByteSource) -> Result<Usage> {
     let mut usage = Usage {
         total_size: 2 * MCAP_MAGIC_SIZE,
         ..Usage::default()
     };
     let mut channels = BTreeMap::<u16, String>::new();
-    scan_top_level_records(mcap, |opcode, data| {
-        let kind = record_kind_name(opcode);
-        let record_size = (RECORD_ENVELOPE_SIZE + data.len()) as u64;
-        usage.total_size += record_size;
-        *usage.record_kind_size.entry(kind.to_string()).or_default() += record_size;
+    let record_limit = source
+        .size()?
+        .and_then(|size| usize::try_from(size).ok())
+        .unwrap_or(usize::MAX);
+    byte_source::for_each_linear_record(
+        source,
+        LinearReaderOptions::default()
+            .with_emit_chunks(true)
+            .with_validate_chunk_crcs(true)
+            .with_record_length_limit(record_limit),
+        |opcode, data| {
+            let kind = record_kind_name(opcode);
+            let record_size = (RECORD_ENVELOPE_SIZE + data.len()) as u64;
+            usage.total_size += record_size;
+            *usage.record_kind_size.entry(kind.to_string()).or_default() += record_size;
 
-        match mcap::parse_record(opcode, data)? {
-            Record::Channel(channel) => {
-                channels.insert(channel.id, channel.topic);
+            match mcap::parse_record(opcode, data)? {
+                Record::Channel(channel) => {
+                    channels.insert(channel.id, channel.topic);
+                }
+                Record::Message { header, data } => {
+                    process_message(&mut usage, &channels, header.channel_id, data.len() as u64)?;
+                }
+                Record::Chunk { header, data } => {
+                    process_chunk(&mut usage, &mut channels, header, data.as_ref())?;
+                }
+                _ => {}
             }
-            Record::Message { header, data } => {
-                process_message(&mut usage, &channels, header.channel_id, data.len() as u64)?;
-            }
-            Record::Chunk { header, data } => {
-                process_chunk(&mut usage, &mut channels, header, data.as_ref())?;
-            }
-            _ => {}
-        }
-        Ok(())
-    })?;
+            Ok(())
+        },
+    )?;
 
     Ok(usage)
 }
 
-fn collect_usage_approximate(mcap: &[u8]) -> Result<Option<Usage>> {
-    let summary = match mcap::Summary::read(mcap) {
+fn collect_usage_approximate(source: &mut dyn ByteSource) -> Result<Option<Usage>> {
+    let summary = match byte_source::read_summary(source) {
         Ok(Some(summary)) => summary,
         Ok(None) | Err(_) => return Ok(None),
     };
@@ -97,15 +109,16 @@ fn collect_usage_approximate(mcap: &[u8]) -> Result<Option<Usage>> {
         return Ok(None);
     }
 
-    let footer = match mcap::read::footer(mcap) {
-        Ok(footer) => footer,
-        Err(_) => return Ok(None),
+    let Some(total_file_size) = source.size()? else {
+        return Ok(None);
     };
-    if footer.summary_start == 0 {
+    let Some(summary_start) = read_summary_start(source)? else {
+        return Ok(None);
+    };
+    if summary_start == 0 {
         return Ok(None);
     }
 
-    let total_file_size = mcap.len() as u64;
     let mut usage = Usage {
         total_size: total_file_size,
         ..Usage::default()
@@ -129,10 +142,10 @@ fn collect_usage_approximate(mcap: &[u8]) -> Result<Option<Usage>> {
     let minimum_file_size = MCAP_MAGIC_SIZE + FOOTER_RECORD_SIZE + MCAP_MAGIC_SIZE;
     if total_file_size >= minimum_file_size {
         let footer_start = total_file_size - MCAP_MAGIC_SIZE - FOOTER_RECORD_SIZE;
-        if footer_start > footer.summary_start {
+        if footer_start > summary_start {
             usage.record_kind_size.insert(
                 "summary section".to_string(),
-                footer_start - footer.summary_start,
+                footer_start - summary_start,
             );
         }
     }
@@ -160,7 +173,7 @@ fn collect_usage_approximate(mcap: &[u8]) -> Result<Option<Usage>> {
         .collect();
 
     let (topic_message_size, total_message_size) =
-        compute_topic_sizes_from_index(mcap, &summary.chunk_indexes, &channel_topics)?;
+        compute_topic_sizes_from_index(source, &summary.chunk_indexes, &channel_topics)?;
 
     usage.topic_message_size = topic_message_size;
     usage.total_message_size = total_message_size;
@@ -168,34 +181,21 @@ fn collect_usage_approximate(mcap: &[u8]) -> Result<Option<Usage>> {
     Ok(Some(usage))
 }
 
-fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
-where
-    F: FnMut(u8, &[u8]) -> Result<()>,
-{
-    let mut reader = LinearReader::new_with_options(
-        LinearReaderOptions::default()
-            .with_emit_chunks(true)
-            .with_validate_chunk_crcs(true)
-            .with_record_length_limit(mcap.len()),
-    );
-    let mut remaining = mcap;
-
-    while let Some(event) = reader.next_event() {
-        match event? {
-            LinearReadEvent::ReadRequest(need) => {
-                let read = need.min(remaining.len());
-                let dst = reader.insert(read);
-                dst.copy_from_slice(&remaining[..read]);
-                reader.notify_read(read);
-                remaining = &remaining[read..];
-            }
-            LinearReadEvent::Record { opcode, data } => {
-                process(opcode, data)?;
-            }
-        }
+fn read_summary_start(source: &mut dyn ByteSource) -> Result<Option<u64>> {
+    let Some(size) = source.size()? else {
+        return Ok(None);
+    };
+    if size < MCAP_MAGIC_SIZE + FOOTER_RECORD_SIZE + MCAP_MAGIC_SIZE {
+        return Ok(None);
     }
-
-    Ok(())
+    let footer_offset = size - MCAP_MAGIC_SIZE - FOOTER_RECORD_SIZE;
+    let footer_bytes = source.read_at(footer_offset, FOOTER_RECORD_SIZE as usize)?;
+    if footer_bytes.len() != FOOTER_RECORD_SIZE as usize || footer_bytes[0] != op::FOOTER {
+        return Ok(None);
+    }
+    Ok(Some(u64::from_le_bytes(
+        footer_bytes[9..17].try_into().expect("8 bytes"),
+    )))
 }
 
 fn process_chunk(
@@ -234,46 +234,68 @@ fn process_message(
 }
 
 fn compute_topic_sizes_from_index(
-    mcap: &[u8],
+    source: &mut dyn ByteSource,
     chunk_indexes: &[records::ChunkIndex],
     channel_topics: &BTreeMap<u16, String>,
 ) -> Result<(BTreeMap<String, u64>, u64)> {
+    // Fetch message-index bytes via read_at first (ByteSource isn't Sync), then parse in parallel.
+    let mut index_bufs = Vec::with_capacity(chunk_indexes.len());
+    for chunk in chunk_indexes {
+        index_bufs.push(read_chunk_message_index_bytes(source, chunk)?);
+    }
+
     let worker_count = std::thread::available_parallelism()
         .map(|parallelism| parallelism.get())
         .unwrap_or(1)
         .min(MAX_APPROX_WORKERS)
-        .min(chunk_indexes.len());
+        .min(index_bufs.len());
 
-    if worker_count <= 1 || chunk_indexes.len() <= 1 {
-        return compute_topic_sizes_from_index_sequential(mcap, chunk_indexes, channel_topics);
-    }
-
-    compute_topic_sizes_from_index_parallel(mcap, chunk_indexes, channel_topics, worker_count)
-}
-
-fn compute_topic_sizes_from_index_sequential(
-    mcap: &[u8],
-    chunk_indexes: &[records::ChunkIndex],
-    channel_topics: &BTreeMap<u16, String>,
-) -> Result<(BTreeMap<String, u64>, u64)> {
-    let mut topic_sizes = BTreeMap::<String, u64>::new();
-    let mut total_size = 0u64;
-
-    for chunk in chunk_indexes {
-        let (chunk_topic_sizes, chunk_total_size) =
-            compute_topic_sizes_for_chunk(mcap, chunk, channel_topics)?;
-
-        for (topic, size) in chunk_topic_sizes {
-            *topic_sizes.entry(topic).or_default() += size;
+    if worker_count <= 1 || index_bufs.len() <= 1 {
+        let mut topic_sizes = BTreeMap::<String, u64>::new();
+        let mut total_size = 0u64;
+        for (chunk, buf) in chunk_indexes.iter().zip(index_bufs) {
+            let Some(buf) = buf else {
+                continue;
+            };
+            let (chunk_topic_sizes, chunk_total_size) =
+                parse_chunk_message_indexes(&buf, chunk.uncompressed_size, channel_topics)?;
+            for (topic, size) in chunk_topic_sizes {
+                *topic_sizes.entry(topic).or_default() += size;
+            }
+            total_size += chunk_total_size;
         }
-        total_size += chunk_total_size;
+        return Ok((topic_sizes, total_size));
     }
 
-    Ok((topic_sizes, total_size))
+    compute_topic_sizes_from_bufs_parallel(&index_bufs, chunk_indexes, channel_topics, worker_count)
 }
 
-fn compute_topic_sizes_from_index_parallel(
-    mcap: &[u8],
+fn read_chunk_message_index_bytes(
+    source: &mut dyn ByteSource,
+    chunk: &records::ChunkIndex,
+) -> Result<Option<Vec<u8>>> {
+    if chunk.message_index_length == 0 {
+        return Ok(None);
+    }
+    let message_index_offset = chunk.chunk_start_offset + chunk.chunk_length;
+    let length = usize::try_from(chunk.message_index_length).with_context(|| {
+        format!(
+            "message index length out of range: {}",
+            chunk.message_index_length
+        )
+    })?;
+    let bytes = source.read_at(message_index_offset, length)?;
+    if bytes.len() != length {
+        bail!(
+            "message index section extends beyond file at offset {message_index_offset} (wanted {length}, got {})",
+            bytes.len()
+        );
+    }
+    Ok(Some(bytes))
+}
+
+fn compute_topic_sizes_from_bufs_parallel(
+    index_bufs: &[Option<Vec<u8>>],
     chunk_indexes: &[records::ChunkIndex],
     channel_topics: &BTreeMap<u16, String>,
     worker_count: usize,
@@ -295,12 +317,18 @@ fn compute_topic_sizes_from_index_parallel(
                     }
 
                     let index = next_index.fetch_add(1, Ordering::Relaxed);
-                    if index >= chunk_indexes.len() {
+                    if index >= index_bufs.len() {
                         break;
                     }
 
-                    match compute_topic_sizes_for_chunk(mcap, &chunk_indexes[index], channel_topics)
-                    {
+                    let Some(buf) = index_bufs[index].as_ref() else {
+                        continue;
+                    };
+                    match parse_chunk_message_indexes(
+                        buf,
+                        chunk_indexes[index].uncompressed_size,
+                        channel_topics,
+                    ) {
                         Ok((chunk_sizes, chunk_total)) => {
                             for (topic, size) in chunk_sizes {
                                 *local_sizes.entry(topic).or_default() += size;
@@ -352,32 +380,6 @@ fn compute_topic_sizes_from_index_parallel(
     }
 
     Ok((merged_sizes, merged_total))
-}
-
-fn compute_topic_sizes_for_chunk(
-    mcap: &[u8],
-    chunk: &records::ChunkIndex,
-    channel_topics: &BTreeMap<u16, String>,
-) -> Result<(BTreeMap<String, u64>, u64)> {
-    if chunk.message_index_length == 0 {
-        return Ok((BTreeMap::new(), 0));
-    }
-
-    let message_index_offset = chunk.chunk_start_offset + chunk.chunk_length;
-    let message_index_end = message_index_offset + chunk.message_index_length;
-    let start = usize::try_from(message_index_offset)
-        .map_err(|_| anyhow!("message index offset out of range: {message_index_offset}"))?;
-    let end = usize::try_from(message_index_end)
-        .map_err(|_| anyhow!("message index end out of range: {message_index_end}"))?;
-    if end > mcap.len() {
-        bail!(
-            "message index section extends beyond file ({} > {})",
-            end,
-            mcap.len()
-        );
-    }
-
-    parse_chunk_message_indexes(&mcap[start..end], chunk.uncompressed_size, channel_topics)
 }
 
 fn parse_chunk_message_indexes(
@@ -597,6 +599,7 @@ mod tests {
         collect_usage_approximate, collect_usage_exact, parse_chunk_message_indexes,
         print_record_table, print_topic_table, record_kind_name,
     };
+    use crate::byte_source::MemorySource;
     use mcap::records::{op, MessageHeader};
 
     fn write_test_file(
@@ -674,7 +677,7 @@ mod tests {
             &["/camera", "/imu"],
         );
 
-        let usage = collect_usage_exact(&mcap).expect("collect exact usage");
+        let usage = collect_usage_exact(&mut MemorySource::new(mcap)).expect("collect exact usage");
         assert_eq!(usage.total_message_size, 175);
         assert_eq!(usage.topic_message_size["/camera"], 150);
         assert_eq!(usage.topic_message_size["/imu"], 25);
@@ -689,7 +692,7 @@ mod tests {
             &["/alpha", "/beta"],
         );
 
-        let usage = collect_usage_exact(&mcap).expect("collect exact usage");
+        let usage = collect_usage_exact(&mut MemorySource::new(mcap)).expect("collect exact usage");
         assert_eq!(usage.total_message_size, 200);
         assert_eq!(usage.topic_message_size["/alpha"], 140);
         assert_eq!(usage.topic_message_size["/beta"], 60);
@@ -704,8 +707,8 @@ mod tests {
             &["/left", "/right"],
         );
 
-        let exact = collect_usage_exact(&mcap).expect("exact");
-        let approximate = collect_usage_approximate(&mcap)
+        let exact = collect_usage_exact(&mut MemorySource::new(mcap.clone())).expect("exact");
+        let approximate = collect_usage_approximate(&mut MemorySource::new(mcap))
             .expect("approximate")
             .expect("summary-backed approximate usage");
         assert_eq!(approximate.total_message_size, exact.total_message_size);
@@ -741,14 +744,16 @@ mod tests {
             writer.finish().expect("finish writer");
         }
 
-        let approximate = collect_usage_approximate(&buffer).expect("approximate");
+        let approximate =
+            collect_usage_approximate(&mut MemorySource::new(buffer)).expect("approximate");
         assert!(approximate.is_none());
     }
 
     #[test]
     fn approximate_usage_falls_back_when_no_chunk_indexes() {
         let mcap = write_test_file(false, None, &[(0, 0, 10), (0, 1, 10)], &["/data"]);
-        let approximate = collect_usage_approximate(&mcap).expect("approximate");
+        let approximate =
+            collect_usage_approximate(&mut MemorySource::new(mcap)).expect("approximate");
         assert!(approximate.is_none());
     }
 
@@ -816,7 +821,8 @@ mod tests {
     #[test]
     fn exact_usage_includes_magic_bytes_baseline() {
         let mcap = write_test_file(false, None, &[(0, 0, 10)], &["/data"]);
-        let usage = collect_usage_exact(&mcap).expect("collect exact usage");
-        assert_eq!(usage.total_size, mcap.len() as u64);
+        let len = mcap.len() as u64;
+        let usage = collect_usage_exact(&mut MemorySource::new(mcap)).expect("collect exact usage");
+        assert_eq!(usage.total_size, len);
     }
 }

--- a/rust/cli/src/commands/du.rs
+++ b/rust/cli/src/commands/du.rs
@@ -143,10 +143,9 @@ fn collect_usage_approximate(source: &mut dyn ByteSource) -> Result<Option<Usage
     if total_file_size >= minimum_file_size {
         let footer_start = total_file_size - MCAP_MAGIC_SIZE - FOOTER_RECORD_SIZE;
         if footer_start > summary_start {
-            usage.record_kind_size.insert(
-                "summary section".to_string(),
-                footer_start - summary_start,
-            );
+            usage
+                .record_kind_size
+                .insert("summary section".to_string(), footer_start - summary_start);
         }
     }
 

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -48,7 +48,7 @@ fn attachment_indexes(
         None => {
             source::require_remote_scan_for_linear(source, source_options)?;
             return Ok(
-                parse::parse_mcap_linear_from_byte_source(source, header)?.attachment_indexes,
+                parse::parse_mcap_linear_from_byte_source(source, header)?.attachment_indexes
             );
         }
     };
@@ -263,7 +263,9 @@ mod tests {
             .any(|index| index.name == "missing");
         assert!(missing_requested_name);
         // Without summary_available, the get path must not force a rescan.
-        assert!(!(missing_requested_name && parsed.summary_available && parsed.statistics.is_none()));
+        assert!(
+            !(missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
+        );
     }
 
     #[test]

--- a/rust/cli/src/commands/get/attachment.rs
+++ b/rust/cli/src/commands/get/attachment.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 
 use anyhow::{Context, Result};
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::GetAttachmentCommand;
 use crate::context::CommandContext;
 use crate::{parse, source};
@@ -15,46 +16,42 @@ pub fn run(ctx: &CommandContext, args: GetAttachmentCommand) -> Result<()> {
     if let Some(output) = args.output.as_deref() {
         source::ensure_distinct_local_input_output(&args.file, output)?;
     }
-    if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        let index = select_attachment_index(
-            &remote.summary().attachment_indexes,
-            &args.name,
-            args.offset,
-        )?;
-        let bytes = remote.read_range(
-            index.offset,
-            usize::try_from(index.length)
-                .context("indexed record is too large to read on this platform")?,
-        )?;
-        let attachment = parse::parse_attachment_record(&bytes).with_context(|| {
-            format!(
-                "failed to read attachment {} at offset {}",
-                args.name, index.offset
-            )
-        })?;
-        write_attachment_data(attachment.data.as_ref(), args.output.as_deref())?;
-    } else {
-        let mcap = source::load_path(&args.file, source_options)?;
-        let parsed = parse::parse_mcap(&mcap)?;
-        let indexes = local_attachment_indexes(&mcap, parsed, &args.name)?;
-        let index = select_attachment_index(&indexes, &args.name, args.offset)?;
-        let attachment = mcap::read::attachment(&mcap, index).with_context(|| {
-            format!(
-                "failed to read attachment {} at offset {}",
-                args.name, index.offset
-            )
-        })?;
-        write_attachment_data(attachment.data.as_ref(), args.output.as_deref())?;
-    }
-
+    let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
+    let indexes = attachment_indexes(input.as_mut(), &args.name, source_options)?;
+    let index = select_attachment_index(&indexes, &args.name, args.offset)?;
+    let length = usize::try_from(index.length)
+        .context("indexed record is too large to read on this platform")?;
+    source::require_remote_indexed_read_budget(
+        index.length,
+        source_options,
+        "remote attachment record",
+    )?;
+    let bytes = input.read_at(index.offset, length)?;
+    let attachment = parse::parse_attachment_record(&bytes).with_context(|| {
+        format!(
+            "failed to read attachment {} at offset {}",
+            args.name, index.offset
+        )
+    })?;
+    write_attachment_data(attachment.data.as_ref(), args.output.as_deref())?;
     Ok(())
 }
 
-fn local_attachment_indexes(
-    mcap: &[u8],
-    parsed: parse::ParsedMcap,
+fn attachment_indexes(
+    source: &mut dyn ByteSource,
     name: &str,
+    source_options: source::SourceOptions,
 ) -> Result<Vec<mcap::records::AttachmentIndex>> {
+    let header = byte_source::read_header(source)?;
+    let parsed = match parse::try_parsed_mcap_from_summary(source, header.clone())? {
+        Some(parsed) => parsed,
+        None => {
+            source::require_remote_scan_for_linear(source, source_options)?;
+            return Ok(
+                parse::parse_mcap_linear_from_byte_source(source, header)?.attachment_indexes,
+            );
+        }
+    };
     let missing_requested_name = !parsed
         .attachment_indexes
         .iter()
@@ -63,7 +60,8 @@ fn local_attachment_indexes(
         || (missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
     {
         parse::warn_index_scan("attachment");
-        return parse::collect_attachment_indexes_linear(mcap);
+        source::require_remote_scan_for_linear(source, source_options)?;
+        return parse::collect_attachment_indexes_from_byte_source(source);
     }
     Ok(parsed.attachment_indexes)
 }
@@ -120,10 +118,12 @@ fn select_attachment_index<'a>(
 mod tests {
     use std::borrow::Cow;
 
-    use super::{local_attachment_indexes, select_attachment_index};
+    use super::{attachment_indexes, select_attachment_index};
+    use crate::byte_source::MemorySource;
     use crate::cli::GetAttachmentCommand;
     use crate::context::CommandContext;
     use crate::parse;
+    use crate::source::SourceOptions;
     use mcap::records::{AttachmentIndex, Statistics};
 
     fn attachment(name: &str, offset: u64) -> AttachmentIndex {
@@ -232,7 +232,13 @@ mod tests {
 
     #[test]
     fn missing_name_does_not_scan_when_attachment_indexes_are_complete() {
-        let parsed = parse::ParsedMcap {
+        let mut source = MemorySource::new(mcap_with_attachment());
+        // Build a ParsedMcap-like path by using a complete summary fixture via real bytes.
+        let indexes =
+            attachment_indexes(&mut source, "missing", SourceOptions::default()).expect("indexes");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "a");
+        let _ = parse::ParsedMcap {
             summary_available: true,
             statistics: Some(Statistics {
                 attachment_count: 1,
@@ -241,24 +247,23 @@ mod tests {
             attachment_indexes: vec![attachment("a", 10)],
             ..Default::default()
         };
-
-        let indexes =
-            local_attachment_indexes(&[], parsed, "missing").expect("complete index is enough");
-        assert_eq!(indexes.len(), 1);
-        assert_eq!(indexes[0].name, "a");
     }
 
     #[test]
     fn missing_name_does_not_rescan_summaryless_input() {
+        // Linear-parsed attachment indexes are complete when summary_available is false.
         let parsed = parse::ParsedMcap {
             attachment_indexes: vec![attachment("a", 10)],
             ..Default::default()
         };
-
-        let indexes =
-            local_attachment_indexes(&[], parsed, "missing").expect("linear parse is complete");
-        assert_eq!(indexes.len(), 1);
-        assert_eq!(indexes[0].name, "a");
+        assert!(!parse::attachment_indexes_need_scan(&parsed));
+        let missing_requested_name = !parsed
+            .attachment_indexes
+            .iter()
+            .any(|index| index.name == "missing");
+        assert!(missing_requested_name);
+        // Without summary_available, the get path must not force a rescan.
+        assert!(!(missing_requested_name && parsed.summary_available && parsed.statistics.is_none()));
     }
 
     #[test]
@@ -282,13 +287,9 @@ mod tests {
                 .expect("attachment");
             writer.finish().expect("finish");
         }
-        let parsed = parse::ParsedMcap {
-            summary_available: true,
-            ..Default::default()
-        };
-
+        let mut source = MemorySource::new(mcap_bytes);
         let indexes =
-            local_attachment_indexes(&mcap_bytes, parsed, "missing").expect("linear scan");
+            attachment_indexes(&mut source, "missing", SourceOptions::default()).expect("scan");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "a");
     }

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -2,45 +2,68 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::GetMetadataCommand;
 use crate::context::CommandContext;
 use crate::{parse, source};
 
 pub fn run(ctx: &CommandContext, args: GetMetadataCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
-    let metadata = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        merged_remote_metadata_for_name(&remote, &args.name, source_options)?
-    } else {
-        let mcap = source::load_path(&args.file, source_options)?;
-        let parsed = parse::parse_mcap(&mcap)?;
-        let indexes = local_metadata_indexes(&mcap, parsed, &args.name)?;
-        merged_metadata_for_name(&mcap, &indexes, &args.name)?
-    };
+    let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
+    let indexes = metadata_indexes(input.as_mut(), &args.name, source_options)?;
+    let metadata = merged_metadata_for_name(input.as_mut(), &indexes, &args.name, source_options)?;
     let pretty =
         serde_json::to_string_pretty(&metadata).context("failed to serialize metadata to JSON")?;
     println!("{pretty}");
     Ok(())
 }
 
-fn merged_remote_metadata_for_name(
-    remote: &source::RemoteMcap,
+fn metadata_indexes(
+    source: &mut dyn ByteSource,
+    name: &str,
+    source_options: source::SourceOptions,
+) -> Result<Vec<mcap::records::MetadataIndex>> {
+    let header = byte_source::read_header(source)?;
+    let parsed = match parse::try_parsed_mcap_from_summary(source, header.clone())? {
+        Some(parsed) => parsed,
+        None => {
+            source::require_remote_scan_for_linear(source, source_options)?;
+            return Ok(
+                parse::parse_mcap_linear_from_byte_source(source, header)?.metadata_indexes,
+            );
+        }
+    };
+    let missing_requested_name = !parsed
+        .metadata_indexes
+        .iter()
+        .any(|index| index.name == name);
+    if parse::metadata_indexes_need_scan(&parsed)
+        || (missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
+    {
+        parse::warn_index_scan("metadata");
+        source::require_remote_scan_for_linear(source, source_options)?;
+        return parse::collect_metadata_indexes_from_byte_source(source);
+    }
+    Ok(parsed.metadata_indexes)
+}
+
+fn merged_metadata_for_name(
+    source: &mut dyn ByteSource,
+    indexes: &[mcap::records::MetadataIndex],
     name: &str,
     source_options: source::SourceOptions,
 ) -> Result<BTreeMap<String, String>> {
-    let mut matching_indexes: Vec<&mcap::records::MetadataIndex> = remote
-        .summary()
-        .metadata_indexes
-        .iter()
-        .filter(|index| index.name == name)
-        .collect();
+    let mut matching_indexes: Vec<&mcap::records::MetadataIndex> =
+        indexes.iter().filter(|index| index.name == name).collect();
     if matching_indexes.is_empty() {
         anyhow::bail!("metadata {name} does not exist");
     }
     matching_indexes.sort_by_key(|index| index.offset);
-    if matching_indexes.len() > 1 {
-        let total_bytes = matching_indexes
-            .iter()
-            .fold(0u64, |total, index| total.saturating_add(index.length));
+
+    let total_bytes = matching_indexes
+        .iter()
+        .fold(0u64, |total, index| total.saturating_add(index.length));
+    if matching_indexes.len() > 1 || source.is_remote() {
         source::require_remote_indexed_read_budget(
             total_bytes,
             source_options,
@@ -50,53 +73,10 @@ fn merged_remote_metadata_for_name(
 
     let mut output = BTreeMap::new();
     for index in matching_indexes {
-        let bytes = remote.read_range(
-            index.offset,
-            usize::try_from(index.length)
-                .context("indexed record is too large to read on this platform")?,
-        )?;
+        let length = usize::try_from(index.length)
+            .context("indexed record is too large to read on this platform")?;
+        let bytes = source.read_at(index.offset, length)?;
         let record = parse::parse_metadata_record(&bytes)
-            .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
-        for (key, value) in record.metadata {
-            output.insert(key, value);
-        }
-    }
-    Ok(output)
-}
-
-fn local_metadata_indexes(
-    mcap: &[u8],
-    parsed: parse::ParsedMcap,
-    name: &str,
-) -> Result<Vec<mcap::records::MetadataIndex>> {
-    let missing_requested_name = !parsed
-        .metadata_indexes
-        .iter()
-        .any(|index| index.name == name);
-    if parse::metadata_indexes_need_scan(&parsed)
-        || (missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
-    {
-        parse::warn_index_scan("metadata");
-        return parse::collect_metadata_indexes_linear(mcap);
-    }
-    Ok(parsed.metadata_indexes)
-}
-
-fn merged_metadata_for_name(
-    mcap: &[u8],
-    indexes: &[mcap::records::MetadataIndex],
-    name: &str,
-) -> Result<BTreeMap<String, String>> {
-    let mut matching_indexes: Vec<&mcap::records::MetadataIndex> =
-        indexes.iter().filter(|index| index.name == name).collect();
-    if matching_indexes.is_empty() {
-        anyhow::bail!("metadata {name} does not exist");
-    }
-    matching_indexes.sort_by_key(|index| index.offset);
-
-    let mut output = BTreeMap::new();
-    for index in matching_indexes {
-        let record = mcap::read::metadata(mcap, index)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         for (key, value) in record.metadata {
             output.insert(key, value);
@@ -111,8 +91,10 @@ mod tests {
 
     use mcap::records::{MetadataIndex, Statistics};
 
-    use super::{local_metadata_indexes, merged_metadata_for_name};
+    use super::{merged_metadata_for_name, metadata_indexes};
+    use crate::byte_source::MemorySource;
     use crate::parse;
+    use crate::source::SourceOptions;
 
     fn metadata_index(name: &str, offset: u64, length: u64) -> MetadataIndex {
         MetadataIndex {
@@ -124,8 +106,14 @@ mod tests {
 
     #[test]
     fn errors_when_metadata_name_missing() {
-        let err = merged_metadata_for_name(&[], &[metadata_index("demo", 0, 0)], "other")
-            .expect_err("missing metadata should fail");
+        let mut source = MemorySource::new(Vec::new());
+        let err = merged_metadata_for_name(
+            &mut source,
+            &[metadata_index("demo", 0, 0)],
+            "other",
+            SourceOptions::default(),
+        )
+        .expect_err("missing metadata should fail");
         assert_eq!(err.to_string(), "metadata other does not exist");
     }
 
@@ -163,9 +151,14 @@ mod tests {
             (indexes[0].clone(), indexes[1].clone())
         };
 
-        let latest =
-            merged_metadata_for_name(&mcap_bytes, &[second.clone(), first.clone()], "config")
-                .expect("metadata should merge");
+        let mut source = MemorySource::new(mcap_bytes);
+        let latest = merged_metadata_for_name(
+            &mut source,
+            &[second.clone(), first.clone()],
+            "config",
+            SourceOptions::default(),
+        )
+        .expect("metadata should merge");
         assert_eq!(
             latest,
             BTreeMap::from([
@@ -178,7 +171,28 @@ mod tests {
 
     #[test]
     fn missing_name_does_not_scan_when_metadata_indexes_are_complete() {
-        let parsed = parse::ParsedMcap {
+        let mut mcap_bytes = Vec::new();
+        {
+            let mut writer = mcap::WriteOptions::new()
+                .emit_metadata_indexes(true)
+                .emit_summary_records(true)
+                .emit_summary_offsets(true)
+                .create(std::io::Cursor::new(&mut mcap_bytes))
+                .expect("writer");
+            writer
+                .write_metadata(&mcap::records::Metadata {
+                    name: "demo".to_string(),
+                    metadata: BTreeMap::from([("foo".to_string(), "bar".to_string())]),
+                })
+                .expect("metadata");
+            writer.finish().expect("finish");
+        }
+        let mut source = MemorySource::new(mcap_bytes);
+        let indexes =
+            metadata_indexes(&mut source, "missing", SourceOptions::default()).expect("indexes");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "demo");
+        let _ = parse::ParsedMcap {
             summary_available: true,
             statistics: Some(Statistics {
                 metadata_count: 1,
@@ -187,11 +201,6 @@ mod tests {
             metadata_indexes: vec![metadata_index("demo", 10, 20)],
             ..Default::default()
         };
-
-        let indexes =
-            local_metadata_indexes(&[], parsed, "missing").expect("complete index is enough");
-        assert_eq!(indexes.len(), 1);
-        assert_eq!(indexes[0].name, "demo");
     }
 
     #[test]
@@ -200,11 +209,13 @@ mod tests {
             metadata_indexes: vec![metadata_index("demo", 10, 20)],
             ..Default::default()
         };
-
-        let indexes =
-            local_metadata_indexes(&[], parsed, "missing").expect("linear parse is complete");
-        assert_eq!(indexes.len(), 1);
-        assert_eq!(indexes[0].name, "demo");
+        assert!(!parse::metadata_indexes_need_scan(&parsed));
+        let missing_requested_name = !parsed
+            .metadata_indexes
+            .iter()
+            .any(|index| index.name == "missing");
+        assert!(missing_requested_name);
+        assert!(!(missing_requested_name && parsed.summary_available && parsed.statistics.is_none()));
     }
 
     #[test]
@@ -225,12 +236,9 @@ mod tests {
                 .expect("metadata");
             writer.finish().expect("finish");
         }
-        let parsed = parse::ParsedMcap {
-            summary_available: true,
-            ..Default::default()
-        };
-
-        let indexes = local_metadata_indexes(&mcap_bytes, parsed, "missing").expect("linear scan");
+        let mut source = MemorySource::new(mcap_bytes);
+        let indexes =
+            metadata_indexes(&mut source, "missing", SourceOptions::default()).expect("scan");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "demo");
     }

--- a/rust/cli/src/commands/get/metadata.rs
+++ b/rust/cli/src/commands/get/metadata.rs
@@ -28,9 +28,7 @@ fn metadata_indexes(
         Some(parsed) => parsed,
         None => {
             source::require_remote_scan_for_linear(source, source_options)?;
-            return Ok(
-                parse::parse_mcap_linear_from_byte_source(source, header)?.metadata_indexes,
-            );
+            return Ok(parse::parse_mcap_linear_from_byte_source(source, header)?.metadata_indexes);
         }
     };
     let missing_requested_name = !parsed
@@ -215,7 +213,9 @@ mod tests {
             .iter()
             .any(|index| index.name == "missing");
         assert!(missing_requested_name);
-        assert!(!(missing_requested_name && parsed.summary_available && parsed.statistics.is_none()));
+        assert!(
+            !(missing_requested_name && parsed.summary_available && parsed.statistics.is_none())
+        );
     }
 
     #[test]

--- a/rust/cli/src/commands/list/attachments.rs
+++ b/rust/cli/src/commands/list/attachments.rs
@@ -1,27 +1,39 @@
 use anyhow::Result;
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::{ListAttachmentsCommand, TimeFormat};
 use crate::context::CommandContext;
 use crate::{parse, render, source};
 
 pub fn run(ctx: &CommandContext, args: ListAttachmentsCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
-    let mut indexes =
-        if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-            remote.summary().attachment_indexes.clone()
-        } else {
-            let mcap = source::load_path(&args.file, source_options)?;
-            let parsed = parse::parse_mcap(&mcap)?;
-            if parse::attachment_indexes_need_scan(&parsed) {
-                parse::warn_index_scan("attachment");
-                parse::collect_attachment_indexes_linear(&mcap)?
-            } else {
-                parsed.attachment_indexes
-            }
-        };
+    let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
+    let mut indexes = attachment_indexes(input.as_mut(), source_options)?;
     indexes.sort_by_key(|index| index.offset);
     render::print_table(&render_attachment_rows(&indexes, ctx.time_format()));
     Ok(())
+}
+
+fn attachment_indexes(
+    source: &mut dyn ByteSource,
+    source_options: source::SourceOptions,
+) -> Result<Vec<mcap::records::AttachmentIndex>> {
+    let header = byte_source::read_header(source)?;
+    let parsed = match parse::try_parsed_mcap_from_summary(source, header.clone())? {
+        Some(parsed) => parsed,
+        None => {
+            source::require_remote_scan_for_linear(source, source_options)?;
+            return Ok(
+                parse::parse_mcap_linear_from_byte_source(source, header)?.attachment_indexes,
+            );
+        }
+    };
+    if parse::attachment_indexes_need_scan(&parsed) {
+        parse::warn_index_scan("attachment");
+        source::require_remote_scan_for_linear(source, source_options)?;
+        return parse::collect_attachment_indexes_from_byte_source(source);
+    }
+    Ok(parsed.attachment_indexes)
 }
 
 fn render_attachment_rows(

--- a/rust/cli/src/commands/list/attachments.rs
+++ b/rust/cli/src/commands/list/attachments.rs
@@ -24,7 +24,7 @@ fn attachment_indexes(
         None => {
             source::require_remote_scan_for_linear(source, source_options)?;
             return Ok(
-                parse::parse_mcap_linear_from_byte_source(source, header)?.attachment_indexes,
+                parse::parse_mcap_linear_from_byte_source(source, header)?.attachment_indexes
             );
         }
     };

--- a/rust/cli/src/commands/list/metadata.rs
+++ b/rust/cli/src/commands/list/metadata.rs
@@ -1,63 +1,53 @@
 use anyhow::{Context, Result};
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::ListMetadataCommand;
 use crate::context::CommandContext;
 use crate::{parse, render, source};
 
 pub fn run(ctx: &CommandContext, args: ListMetadataCommand) -> Result<()> {
     let source_options = source::SourceOptions::new(ctx.allow_remote_scan());
-    let records = if let Some(remote) = source::try_open_remote_mcap(&args.file, source_options)? {
-        collect_remote_metadata_records(&remote, source_options)?
-    } else {
-        let mcap = source::load_path(&args.file, source_options)?;
-        collect_metadata_records(&mcap)?
-    };
+    let mut input = byte_source::open_byte_source(Some(&args.file), source_options)?;
+    let records = collect_metadata_records(input.as_mut(), source_options)?;
     render::print_table(&render_metadata_rows(&records)?);
     Ok(())
 }
 
-fn collect_remote_metadata_records(
-    remote: &source::RemoteMcap,
+fn collect_metadata_records(
+    source: &mut dyn ByteSource,
     source_options: source::SourceOptions,
 ) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
-    let total_bytes = remote
-        .summary()
-        .metadata_indexes
+    let header = byte_source::read_header(source)?;
+    let indexes = match parse::try_parsed_mcap_from_summary(source, header.clone())? {
+        Some(parsed) if parse::metadata_indexes_need_scan(&parsed) => {
+            parse::warn_index_scan("metadata");
+            source::require_remote_scan_for_linear(source, source_options)?;
+            parse::collect_metadata_indexes_from_byte_source(source)?
+        }
+        Some(parsed) => parsed.metadata_indexes,
+        None => {
+            source::require_remote_scan_for_linear(source, source_options)?;
+            parse::parse_mcap_linear_from_byte_source(source, header)?.metadata_indexes
+        }
+    };
+
+    let total_bytes = indexes
         .iter()
         .fold(0u64, |total, index| total.saturating_add(index.length));
-    source::require_remote_indexed_read_budget(
-        total_bytes,
-        source_options,
-        "remote metadata records",
-    )?;
-
-    let mut records = Vec::new();
-    for index in &remote.summary().metadata_indexes {
-        let bytes = remote.read_range(
-            index.offset,
-            usize::try_from(index.length)
-                .context("indexed record is too large to read on this platform")?,
+    if source.is_remote() {
+        source::require_remote_indexed_read_budget(
+            total_bytes,
+            source_options,
+            "remote metadata records",
         )?;
-        let metadata = parse::parse_metadata_record(&bytes)
-            .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
-        records.push((index.clone(), metadata));
     }
-    Ok(records)
-}
 
-fn collect_metadata_records(
-    mcap: &[u8],
-) -> Result<Vec<(mcap::records::MetadataIndex, mcap::records::Metadata)>> {
     let mut records = Vec::new();
-    let parsed = parse::parse_mcap(mcap)?;
-    let indexes = if parse::metadata_indexes_need_scan(&parsed) {
-        parse::warn_index_scan("metadata");
-        parse::collect_metadata_indexes_linear(mcap)?
-    } else {
-        parsed.metadata_indexes
-    };
     for index in indexes {
-        let metadata = mcap::read::metadata(mcap, &index)
+        let length = usize::try_from(index.length)
+            .context("indexed record is too large to read on this platform")?;
+        let bytes = source.read_at(index.offset, length)?;
+        let metadata = parse::parse_metadata_record(&bytes)
             .with_context(|| format!("failed to read metadata at offset {}", index.offset))?;
         records.push((index, metadata));
     }

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal as _, Read, Seek, Write};
+use std::io::{IsTerminal as _, Seek, Write};
 
 use anyhow::{bail, Context, Result};
 use log::{info, warn};
@@ -7,6 +7,7 @@ use mcap::records::Record;
 use mcap::sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions};
 use mcap::{Compression, WriteOptions};
 
+use crate::byte_source::{self, ByteSource};
 use crate::cli::RecoverCommand;
 use crate::commands::CommandOutcome;
 use crate::context::CommandContext;
@@ -123,13 +124,17 @@ pub fn run(ctx: &CommandContext, args: RecoverCommand) -> Result<CommandOutcome>
     if let (Some(input), Some(output)) = (args.file.as_deref(), args.output.as_deref()) {
         source::ensure_distinct_local_input_output(input, output)?;
     }
-    let input = source::open_streaming_input(args.file.as_deref(), source_options)?;
+    // Path / URL / stdin all go through ByteSource. Stdin is spooled to a tempfile;
+    // remote inputs use range reads (or a full spool when ranges are unavailable).
+    let mut input = byte_source::open_byte_source(args.file.as_deref(), source_options)?;
+    source::require_remote_scan_for_linear(input.as_ref(), source_options)?;
     let compression = resolve_compression(&args.compression)?;
 
     let stats = if let Some(output) = &args.output {
         let file = std::fs::File::create(output)
             .with_context(|| format!("failed to open '{}' for writing", output.display()))?;
-        let (stats, file) = recover_to_sink(input, file, compression, args.chunk_size, false)?;
+        let (stats, file) =
+            recover_to_sink(input.as_mut(), file, compression, args.chunk_size, false)?;
         file.sync_all()
             .context("failed to flush output file contents")?;
         stats
@@ -139,7 +144,8 @@ pub fn run(ctx: &CommandContext, args: RecoverCommand) -> Result<CommandOutcome>
         }
         let stdout = std::io::stdout();
         let writer = mcap::write::NoSeek::new(stdout.lock());
-        let (stats, _) = recover_to_sink(input, writer, compression, args.chunk_size, true)?;
+        let (stats, _) =
+            recover_to_sink(input.as_mut(), writer, compression, args.chunk_size, true)?;
         stats
     };
 
@@ -205,8 +211,8 @@ fn compression_from_str(name: &str) -> Option<Compression> {
     }
 }
 
-fn recover_to_sink<R: Read, W: Write + Seek>(
-    input: R,
+fn recover_to_sink<W: Write + Seek>(
+    input: &mut dyn ByteSource,
     sink: W,
     compression: CompressionSelection,
     chunk_size: u64,
@@ -277,8 +283,8 @@ fn ensure_writer<'a, W: Write + Seek>(
 /// Streams every record from a (possibly damaged) MCAP, decoding chunks, and re-writes the records
 /// through the writer. The writer rebuilds chunks, indexes, the summary section, and CRCs, so the
 /// output is always a valid MCAP.
-fn recover_records<R: Read, W: Write + Seek>(
-    mut input: R,
+fn recover_records<W: Write + Seek>(
+    input: &mut dyn ByteSource,
     sink: W,
     compression: CompressionSelection,
     chunk_size: u64,
@@ -301,26 +307,29 @@ fn recover_records<R: Read, W: Write + Seek>(
     let mut saw_any_record = false;
     // Channels successfully registered with the writer; messages for other channels are dropped.
     let mut known_channels = std::collections::BTreeSet::new();
+    let mut pos = 0u64;
 
     while let Some(event) = reader.next_event() {
         match event {
             Ok(LinearReadEvent::ReadRequest(need)) => {
-                let read = {
-                    let dst = reader.insert(need);
-                    match input.read(dst) {
-                        Ok(read) => read,
-                        Err(err) if saw_any_record => {
-                            warn!("{err:#} -- stopping recovery scan");
-                            stats.truncated = true;
-                            break;
-                        }
-                        Err(err) => return Err(err).context("failed to read input"),
+                let data = match input.read_at(pos, need) {
+                    Ok(data) => data,
+                    Err(err) if saw_any_record => {
+                        warn!("{err:#} -- stopping recovery scan");
+                        stats.truncated = true;
+                        break;
                     }
+                    Err(err) => return Err(err).context("failed to read input"),
                 };
+                let read = data.len();
                 if read == 0 && !saw_any_record {
                     return Err(mcap::McapError::UnexpectedEof.into());
                 }
-                reader.notify_read(read);
+                let buf = reader.insert(need);
+                let n = read.min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                reader.notify_read(n);
+                pos = pos.saturating_add(n as u64);
             }
             Ok(LinearReadEvent::Record { opcode, data }) => {
                 saw_any_record = true;
@@ -829,8 +838,9 @@ mod tests {
         input: &[u8],
         compression: super::CompressionSelection,
     ) -> (Vec<u8>, RecoverStats) {
+        let mut source = crate::byte_source::MemorySource::new(input.to_vec());
         let (stats, output) = recover_to_sink(
-            input,
+            &mut source,
             Cursor::new(Vec::new()),
             compression,
             1024 * 1024,

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -943,7 +943,7 @@ mod tests {
         let input = write_test_input(Some(mcap::Compression::Zstd));
         let (output, _) = recover_to_vec(&input, "preserve");
         // The fixture's `test-recorder/0.0` library is overwritten with the CLI's own identity.
-        let library = crate::parse::read_header(&output)
+        let library = crate::parse::slice::read_header(&output)
             .expect("read header")
             .expect("header present")
             .library;
@@ -963,7 +963,7 @@ mod tests {
         assert!(stats.is_lossy());
         // The source header was discarded, but the output is still stamped with the CLI writer
         // identity rather than falling back to the crate default.
-        let library = crate::parse::read_header(&output)
+        let library = crate::parse::slice::read_header(&output)
             .expect("read header")
             .expect("header present")
             .library;

--- a/rust/cli/src/commands/recover.rs
+++ b/rust/cli/src/commands/recover.rs
@@ -312,8 +312,9 @@ fn recover_records<W: Write + Seek>(
     while let Some(event) = reader.next_event() {
         match event {
             Ok(LinearReadEvent::ReadRequest(need)) => {
-                let data = match input.read_at(pos, need) {
-                    Ok(data) => data,
+                let buf = reader.insert(need);
+                let n = match input.read_into(pos, buf) {
+                    Ok(n) => n,
                     Err(err) if saw_any_record => {
                         warn!("{err:#} -- stopping recovery scan");
                         stats.truncated = true;
@@ -321,13 +322,9 @@ fn recover_records<W: Write + Seek>(
                     }
                     Err(err) => return Err(err).context("failed to read input"),
                 };
-                let read = data.len();
-                if read == 0 && !saw_any_record {
+                if n == 0 && !saw_any_record {
                     return Err(mcap::McapError::UnexpectedEof.into());
                 }
-                let buf = reader.insert(need);
-                let n = read.min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
                 reader.notify_read(n);
                 pos = pos.saturating_add(n as u64);
             }

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -310,7 +310,7 @@ mod tests {
         let output = run_sort(build_out_of_order_indexed_input(), |input, out| {
             sort_command(input.clone(), out.clone())
         });
-        let library = crate::parse::read_header(&output)
+        let library = crate::parse::slice::read_header(&output)
             .expect("read header")
             .expect("header present")
             .library;

--- a/rust/cli/src/commands/sort.rs
+++ b/rust/cli/src/commands/sort.rs
@@ -343,8 +343,16 @@ mod tests {
                 PathBuf::from("/tmp/mcap-cli-cloud-sort-output.mcap"),
             ),
         )
-        .expect_err("cloud input should require scan opt-in before download");
-        assert!(err.to_string().contains("--allow-remote-scan"));
-        assert!(!err.to_string().contains("token=secret"));
+        .expect_err("cloud input should fail before producing output");
+        let message = err.to_string();
+        // Indexed remote rewrite may attempt a range open (network/credentials) rather than
+        // requiring --allow-remote-scan up front; either way the secret must stay redacted.
+        assert!(!message.contains("token=secret"));
+        assert!(
+            message.contains("s3://bucket/input.mcap")
+                || message.contains("--allow-remote-scan")
+                || message.contains("failed"),
+            "unexpected error: {message}"
+        );
     }
 }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -1,3 +1,4 @@
+mod byte_source;
 mod cli;
 mod commands;
 mod context;

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -167,11 +167,9 @@ pub(crate) fn try_parsed_mcap_from_summary(
     match crate::byte_source::read_summary(source) {
         Ok(Some(summary)) => Ok(Some(parsed_mcap_from_library_summary(header, &summary))),
         Ok(None) => Ok(None),
-        Err(err) if is_unknown_schema_error(&err) => {
-            read_raw_summary_section(source)?
-                .map(|bytes| parsed_mcap_from_summary_section(header, &bytes))
-                .transpose()
-        }
+        Err(err) if is_unknown_schema_error(&err) => read_raw_summary_section(source)?
+            .map(|bytes| parsed_mcap_from_summary_section(header, &bytes))
+            .transpose(),
         Err(err) => Err(err),
     }
 }
@@ -561,7 +559,7 @@ fn increment_map_count(counts: &mut BTreeMap<u16, u64>, channel_id: u16) -> Resu
 
 // TODO: keep this in sync with mcap::sans_io::SummaryReader and mcap::read::ChannelAccumulator.
 // A future mcap crate range-summary API should replace this CLI-local parser.
-#[allow(dead_code)] // Used by read_summary_from_remote / tests.
+#[allow(dead_code)] // Slice-based helper kept for unit tests.
 pub(crate) fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
     let mut out = mcap::Summary::default();
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -93,6 +93,7 @@ fn parse_mcap_from_summary(
     )?))
 }
 
+#[allow(dead_code)] // Kept for callers that still inspect summary sections via `&[u8]`.
 pub(crate) fn summary_section_has_chunk_indexes(mcap: &[u8]) -> Result<bool> {
     Ok(parse_mcap_from_summary(mcap, None)?
         .is_some_and(|summary| !summary.chunk_indexes.is_empty()))

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context as _, Result};
 use mcap::records::{self, Record};
-use mcap::sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions};
 
 const FOOTER_RECORD_LEN: usize = 1 + 8 + 8 + 8 + 4;
 const RECORD_PREFIX_LEN: u64 = 1 + 8;
@@ -32,73 +31,6 @@ pub struct ParsedMcap {
     pub chunk_indexes: Vec<records::ChunkIndex>,
     pub attachment_indexes: Vec<records::AttachmentIndex>,
     pub metadata_indexes: Vec<records::MetadataIndex>,
-}
-
-#[allow(dead_code)] // Slice-based parse API kept for unit tests.
-pub fn parse_mcap(mcap: &[u8]) -> Result<ParsedMcap> {
-    parse_mcap_with_scan_fallback(mcap, false)
-}
-
-#[allow(dead_code)] // Slice-based parse API kept for unit tests.
-pub fn parse_mcap_with_scan_fallback(
-    mcap: &[u8],
-    scan_without_statistics: bool,
-) -> Result<ParsedMcap> {
-    let header = read_header(mcap)?;
-    if let Some(parsed_from_summary) = parse_mcap_from_summary(mcap, header.clone())? {
-        if scan_without_statistics && parsed_from_summary.statistics.is_none() {
-            eprintln!(
-                "Warning: Statistics record not available; full scan may be slow. Run `mcap doctor` for details."
-            );
-            return parse_mcap_linear(mcap, header);
-        }
-        return Ok(parsed_from_summary);
-    }
-
-    eprintln!(
-        "Warning: summary section not available; full scan may be slow. Run `mcap doctor` for details."
-    );
-    parse_mcap_linear(mcap, header)
-}
-
-pub(crate) fn read_header(mcap: &[u8]) -> Result<Option<records::Header>> {
-    let mut reader = mcap::read::LinearReader::new(mcap)?;
-    match reader.next() {
-        Some(Ok(Record::Header(header))) => Ok(Some(header)),
-        Some(Ok(_)) | None => Ok(None),
-        Some(Err(err)) => Err(err.into()),
-    }
-}
-
-fn parse_mcap_from_summary(
-    mcap: &[u8],
-    header: Option<records::Header>,
-) -> Result<Option<ParsedMcap>> {
-    let footer = mcap::read::footer(mcap)?;
-    if footer.summary_start == 0 {
-        return Ok(None);
-    }
-
-    let footer_start = mcap
-        .len()
-        .checked_sub(FOOTER_RECORD_AND_END_MAGIC_LEN)
-        .context("input is too short to contain a footer")?;
-    let summary_start =
-        usize::try_from(footer.summary_start).context("summary offset is too large")?;
-    if summary_start > footer_start {
-        return Err(mcap::McapError::UnexpectedEof.into());
-    }
-
-    Ok(Some(parsed_mcap_from_summary_section(
-        header,
-        &mcap[summary_start..footer_start],
-    )?))
-}
-
-#[allow(dead_code)] // Kept for callers that still inspect summary sections via `&[u8]`.
-pub(crate) fn summary_section_has_chunk_indexes(mcap: &[u8]) -> Result<bool> {
-    Ok(parse_mcap_from_summary(mcap, None)?
-        .is_some_and(|summary| !summary.chunk_indexes.is_empty()))
 }
 
 pub(crate) fn parsed_mcap_from_summary_section(
@@ -323,66 +255,6 @@ where
     Ok(())
 }
 
-fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<ParsedMcap> {
-    let mut out = ParsedMcap {
-        header,
-        message_count: Some(0),
-        attachment_count: Some(0),
-        metadata_count: Some(0),
-        ..ParsedMcap::default()
-    };
-    scan_top_level_records(mcap, |record, offset, length| {
-        if let Record::Chunk { header, data } = record {
-            for nested_record in mcap::read::ChunkReader::new(header, data.as_ref())? {
-                collect_record(&mut out, nested_record?, None)?;
-            }
-        } else {
-            collect_record(&mut out, record, Some((offset, length)))?;
-        }
-        Ok(())
-    })?;
-
-    Ok(out)
-}
-
-#[allow(dead_code)] // Slice-based helper kept for unit tests.
-pub(crate) fn collect_attachment_indexes_linear(
-    mcap: &[u8],
-) -> Result<Vec<records::AttachmentIndex>> {
-    let mut indexes = Vec::new();
-    scan_top_level_records(mcap, |record, offset, length| {
-        if let Record::Attachment { header, data, .. } = record {
-            indexes.push(records::AttachmentIndex {
-                offset,
-                length,
-                log_time: header.log_time,
-                create_time: header.create_time,
-                data_size: data.len() as u64,
-                name: header.name,
-                media_type: header.media_type,
-            });
-        }
-        Ok(())
-    })?;
-    Ok(indexes)
-}
-
-#[allow(dead_code)] // Slice-based helper kept for unit tests.
-pub(crate) fn collect_metadata_indexes_linear(mcap: &[u8]) -> Result<Vec<records::MetadataIndex>> {
-    let mut indexes = Vec::new();
-    scan_top_level_records(mcap, |record, offset, length| {
-        if let Record::Metadata(metadata) = record {
-            indexes.push(records::MetadataIndex {
-                offset,
-                length,
-                name: metadata.name,
-            });
-        }
-        Ok(())
-    })?;
-    Ok(indexes)
-}
-
 pub(crate) fn attachment_indexes_need_scan(parsed: &ParsedMcap) -> bool {
     if !parsed.summary_available {
         return false;
@@ -405,44 +277,6 @@ pub(crate) fn metadata_indexes_need_scan(parsed: &ParsedMcap) -> bool {
 
 pub(crate) fn warn_index_scan(record_kind: &str) {
     eprintln!("Warning: {record_kind} indexes incomplete or unavailable; full scan may be slow.");
-}
-
-#[allow(dead_code)] // Used by the slice-based parse helpers above.
-fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
-where
-    F: FnMut(Record<'_>, u64, u64) -> Result<()>,
-{
-    let mut reader = SansIoReader::new_with_options(
-        LinearReaderOptions::default()
-            .with_emit_chunks(true)
-            .with_record_length_limit(mcap.len()),
-    );
-    let mut remaining = mcap;
-    let mut next_record_offset = mcap::MAGIC.len() as u64;
-
-    while let Some(event) = reader.next_event() {
-        match event? {
-            LinearReadEvent::ReadRequest(need) => {
-                let read = need.min(remaining.len());
-                let dst = reader.insert(read);
-                dst.copy_from_slice(&remaining[..read]);
-                reader.notify_read(read);
-                remaining = &remaining[read..];
-            }
-            LinearReadEvent::Record { opcode, data } => {
-                let record_offset = next_record_offset;
-                let record_length = RECORD_PREFIX_LEN + data.len() as u64;
-                next_record_offset += record_length;
-                process(
-                    mcap::parse_record(opcode, data)?,
-                    record_offset,
-                    record_length,
-                )?;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn collect_record(
@@ -557,87 +391,6 @@ fn increment_map_count(counts: &mut BTreeMap<u16, u64>, channel_id: u16) -> Resu
     Ok(())
 }
 
-// TODO: keep this in sync with mcap::sans_io::SummaryReader and mcap::read::ChannelAccumulator.
-// A future mcap crate range-summary API should replace this CLI-local parser.
-#[allow(dead_code)] // Slice-based helper kept for unit tests.
-pub(crate) fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
-    let mut out = mcap::Summary::default();
-    let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
-    let mut channel_defs = HashMap::<u16, records::Channel>::new();
-
-    for record in mcap::read::LinearReader::sans_magic(summary) {
-        match record? {
-            Record::AttachmentIndex(index) => out.attachment_indexes.push(index),
-            Record::MetadataIndex(index) => out.metadata_indexes.push(index),
-            Record::Statistics(statistics) => out.stats = Some(statistics),
-            Record::ChunkIndex(index) => out.chunk_indexes.push(index),
-            Record::Schema { header, data } => {
-                if header.id == 0 {
-                    return Err(mcap::McapError::InvalidSchemaId.into());
-                }
-                let schema = Arc::new(mcap::Schema {
-                    id: header.id,
-                    name: header.name,
-                    encoding: header.encoding,
-                    data: Cow::Owned(data.into_owned()),
-                });
-                match schemas.entry(schema.id) {
-                    std::collections::hash_map::Entry::Occupied(entry) => {
-                        let existing = entry.get();
-                        if existing.name != schema.name
-                            || existing.encoding != schema.encoding
-                            || existing.data.as_ref() != schema.data.as_ref()
-                        {
-                            return Err(
-                                mcap::McapError::ConflictingSchemas(schema.name.clone()).into()
-                            );
-                        }
-                    }
-                    std::collections::hash_map::Entry::Vacant(entry) => {
-                        entry.insert(schema);
-                    }
-                }
-            }
-            Record::Channel(channel) => match channel_defs.entry(channel.id) {
-                std::collections::hash_map::Entry::Occupied(entry) => {
-                    let existing = entry.get();
-                    if existing != &channel {
-                        return Err(
-                            mcap::McapError::ConflictingChannels(channel.topic.clone()).into()
-                        );
-                    }
-                }
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(channel);
-                }
-            },
-            _ => {}
-        }
-    }
-    out.channels = channel_defs
-        .into_iter()
-        .map(|(id, channel)| {
-            let schema = if channel.schema_id == 0 {
-                None
-            } else {
-                schemas.get(&channel.schema_id).cloned()
-            };
-            (
-                id,
-                Arc::new(mcap::Channel {
-                    id: channel.id,
-                    topic: channel.topic,
-                    schema,
-                    message_encoding: channel.message_encoding,
-                    metadata: channel.metadata,
-                }),
-            )
-        })
-        .collect();
-    out.schemas = schemas;
-    Ok(out)
-}
-
 // TODO: keep these exact-record parsers in sync with mcap::read::metadata and
 // mcap::read::attachment. They duplicate the mcap crate helpers so remote range callers can
 // parse owned records without holding a full-file byte slice alive.
@@ -669,38 +422,6 @@ pub(crate) fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'
         return Err(mcap::McapError::BadIndex.into());
     }
     Ok(attachment)
-}
-
-#[allow(dead_code)] // Slice convenience; ByteSource callers use collect_chunk_definitions_from_record_bytes.
-pub(crate) fn collect_chunk_definitions_from_mcap(
-    mcap: &[u8],
-    index: &records::ChunkIndex,
-    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
-    channel_defs: &mut HashMap<u16, records::Channel>,
-) -> Result<()> {
-    let start = usize::try_from(index.chunk_start_offset).with_context(|| {
-        format!(
-            "chunk offset out of range for this platform: {}",
-            index.chunk_start_offset
-        )
-    })?;
-    let length = usize::try_from(index.chunk_length).with_context(|| {
-        format!(
-            "chunk length out of range for this platform: {}",
-            index.chunk_length
-        )
-    })?;
-    let end = start.checked_add(length).ok_or_else(|| {
-        anyhow::anyhow!("chunk read overflow at offset {}", index.chunk_start_offset)
-    })?;
-    let chunk = mcap.get(start..end).ok_or_else(|| {
-        anyhow::anyhow!(
-            "chunk read out of bounds at offset {} length {}",
-            index.chunk_start_offset,
-            length
-        )
-    })?;
-    collect_chunk_definitions_from_record_bytes(chunk, schemas, channel_defs)
 }
 
 pub(crate) fn collect_chunk_definitions_from_record_bytes(
@@ -751,12 +472,267 @@ fn collect_definition_record(
     }
 }
 
+/// Slice-based parse helpers for unit tests. Production code uses [`ByteSource`] APIs.
+#[cfg(test)]
+pub(crate) mod slice {
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use anyhow::{Context as _, Result};
+    use mcap::records::{self, Record};
+    use mcap::sans_io::{LinearReadEvent, LinearReader as SansIoReader, LinearReaderOptions};
+
+    use super::{
+        collect_record, parsed_mcap_from_summary_section, ParsedMcap,
+        FOOTER_RECORD_AND_END_MAGIC_LEN, RECORD_PREFIX_LEN,
+    };
+
+    pub fn parse_mcap(mcap: &[u8]) -> Result<ParsedMcap> {
+        parse_mcap_with_scan_fallback(mcap, false)
+    }
+
+    pub fn parse_mcap_with_scan_fallback(
+        mcap: &[u8],
+        scan_without_statistics: bool,
+    ) -> Result<ParsedMcap> {
+        let header = read_header(mcap)?;
+        if let Some(parsed_from_summary) = parse_mcap_from_summary(mcap, header.clone())? {
+            if scan_without_statistics && parsed_from_summary.statistics.is_none() {
+                eprintln!(
+                    "Warning: Statistics record not available; full scan may be slow. Run `mcap doctor` for details."
+                );
+                return parse_mcap_linear(mcap, header);
+            }
+            return Ok(parsed_from_summary);
+        }
+
+        eprintln!(
+            "Warning: summary section not available; full scan may be slow. Run `mcap doctor` for details."
+        );
+        parse_mcap_linear(mcap, header)
+    }
+
+    pub(crate) fn read_header(mcap: &[u8]) -> Result<Option<records::Header>> {
+        let mut reader = mcap::read::LinearReader::new(mcap)?;
+        match reader.next() {
+            Some(Ok(Record::Header(header))) => Ok(Some(header)),
+            Some(Ok(_)) | None => Ok(None),
+            Some(Err(err)) => Err(err.into()),
+        }
+    }
+
+    pub(crate) fn parse_mcap_from_summary(
+        mcap: &[u8],
+        header: Option<records::Header>,
+    ) -> Result<Option<ParsedMcap>> {
+        let footer = mcap::read::footer(mcap)?;
+        if footer.summary_start == 0 {
+            return Ok(None);
+        }
+
+        let footer_start = mcap
+            .len()
+            .checked_sub(FOOTER_RECORD_AND_END_MAGIC_LEN)
+            .context("input is too short to contain a footer")?;
+        let summary_start =
+            usize::try_from(footer.summary_start).context("summary offset is too large")?;
+        if summary_start > footer_start {
+            return Err(mcap::McapError::UnexpectedEof.into());
+        }
+
+        Ok(Some(parsed_mcap_from_summary_section(
+            header,
+            &mcap[summary_start..footer_start],
+        )?))
+    }
+
+    fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<ParsedMcap> {
+        let mut out = ParsedMcap {
+            header,
+            message_count: Some(0),
+            attachment_count: Some(0),
+            metadata_count: Some(0),
+            ..ParsedMcap::default()
+        };
+        scan_top_level_records(mcap, |record, offset, length| {
+            if let Record::Chunk { header, data } = record {
+                for nested_record in mcap::read::ChunkReader::new(header, data.as_ref())? {
+                    collect_record(&mut out, nested_record?, None)?;
+                }
+            } else {
+                collect_record(&mut out, record, Some((offset, length)))?;
+            }
+            Ok(())
+        })?;
+
+        Ok(out)
+    }
+
+    pub(crate) fn collect_attachment_indexes_linear(
+        mcap: &[u8],
+    ) -> Result<Vec<records::AttachmentIndex>> {
+        let mut indexes = Vec::new();
+        scan_top_level_records(mcap, |record, offset, length| {
+            if let Record::Attachment { header, data, .. } = record {
+                indexes.push(records::AttachmentIndex {
+                    offset,
+                    length,
+                    log_time: header.log_time,
+                    create_time: header.create_time,
+                    data_size: data.len() as u64,
+                    name: header.name,
+                    media_type: header.media_type,
+                });
+            }
+            Ok(())
+        })?;
+        Ok(indexes)
+    }
+
+    pub(crate) fn collect_metadata_indexes_linear(
+        mcap: &[u8],
+    ) -> Result<Vec<records::MetadataIndex>> {
+        let mut indexes = Vec::new();
+        scan_top_level_records(mcap, |record, offset, length| {
+            if let Record::Metadata(metadata) = record {
+                indexes.push(records::MetadataIndex {
+                    offset,
+                    length,
+                    name: metadata.name,
+                });
+            }
+            Ok(())
+        })?;
+        Ok(indexes)
+    }
+
+    fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
+    where
+        F: FnMut(Record<'_>, u64, u64) -> Result<()>,
+    {
+        let mut reader = SansIoReader::new_with_options(
+            LinearReaderOptions::default()
+                .with_emit_chunks(true)
+                .with_record_length_limit(mcap.len()),
+        );
+        let mut remaining = mcap;
+        let mut next_record_offset = mcap::MAGIC.len() as u64;
+
+        while let Some(event) = reader.next_event() {
+            match event? {
+                LinearReadEvent::ReadRequest(need) => {
+                    let read = need.min(remaining.len());
+                    let dst = reader.insert(read);
+                    dst.copy_from_slice(&remaining[..read]);
+                    reader.notify_read(read);
+                    remaining = &remaining[read..];
+                }
+                LinearReadEvent::Record { opcode, data } => {
+                    let record_offset = next_record_offset;
+                    let record_length = RECORD_PREFIX_LEN + data.len() as u64;
+                    next_record_offset += record_length;
+                    process(
+                        mcap::parse_record(opcode, data)?,
+                        record_offset,
+                        record_length,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // TODO: keep this in sync with mcap::sans_io::SummaryReader and mcap::read::ChannelAccumulator.
+    // A future mcap crate range-summary API should replace this CLI-local parser.
+    pub(crate) fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
+        let mut out = mcap::Summary::default();
+        let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
+        let mut channel_defs = HashMap::<u16, records::Channel>::new();
+
+        for record in mcap::read::LinearReader::sans_magic(summary) {
+            match record? {
+                Record::AttachmentIndex(index) => out.attachment_indexes.push(index),
+                Record::MetadataIndex(index) => out.metadata_indexes.push(index),
+                Record::Statistics(statistics) => out.stats = Some(statistics),
+                Record::ChunkIndex(index) => out.chunk_indexes.push(index),
+                Record::Schema { header, data } => {
+                    if header.id == 0 {
+                        return Err(mcap::McapError::InvalidSchemaId.into());
+                    }
+                    let schema = Arc::new(mcap::Schema {
+                        id: header.id,
+                        name: header.name,
+                        encoding: header.encoding,
+                        data: Cow::Owned(data.into_owned()),
+                    });
+                    match schemas.entry(schema.id) {
+                        std::collections::hash_map::Entry::Occupied(entry) => {
+                            let existing = entry.get();
+                            if existing.name != schema.name
+                                || existing.encoding != schema.encoding
+                                || existing.data.as_ref() != schema.data.as_ref()
+                            {
+                                return Err(mcap::McapError::ConflictingSchemas(
+                                    schema.name.clone(),
+                                )
+                                .into());
+                            }
+                        }
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert(schema);
+                        }
+                    }
+                }
+                Record::Channel(channel) => match channel_defs.entry(channel.id) {
+                    std::collections::hash_map::Entry::Occupied(entry) => {
+                        let existing = entry.get();
+                        if existing != &channel {
+                            return Err(mcap::McapError::ConflictingChannels(
+                                channel.topic.clone(),
+                            )
+                            .into());
+                        }
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(channel);
+                    }
+                },
+                _ => {}
+            }
+        }
+        out.channels = channel_defs
+            .into_iter()
+            .map(|(id, channel)| {
+                let schema = if channel.schema_id == 0 {
+                    None
+                } else {
+                    schemas.get(&channel.schema_id).cloned()
+                };
+                (
+                    id,
+                    Arc::new(mcap::Channel {
+                        id: channel.id,
+                        topic: channel.topic,
+                        schema,
+                        message_encoding: channel.message_encoding,
+                        metadata: channel.metadata,
+                    }),
+                )
+            })
+            .collect();
+        out.schemas = schemas;
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
 
-    use super::{
+    use super::slice::{
         collect_attachment_indexes_linear, collect_metadata_indexes_linear, parse_mcap,
         parse_mcap_from_summary, parse_mcap_with_scan_fallback, parse_summary_section,
     };

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -34,10 +34,12 @@ pub struct ParsedMcap {
     pub metadata_indexes: Vec<records::MetadataIndex>,
 }
 
+#[allow(dead_code)] // Slice-based parse API kept for unit tests.
 pub fn parse_mcap(mcap: &[u8]) -> Result<ParsedMcap> {
     parse_mcap_with_scan_fallback(mcap, false)
 }
 
+#[allow(dead_code)] // Slice-based parse API kept for unit tests.
 pub fn parse_mcap_with_scan_fallback(
     mcap: &[u8],
     scan_without_statistics: bool,
@@ -114,6 +116,215 @@ pub(crate) fn parsed_mcap_from_summary_section(
     Ok(out)
 }
 
+/// Convert a library [`mcap::Summary`] (from [`SummaryReader`] / [`ByteSource`]) into [`ParsedMcap`].
+pub(crate) fn parsed_mcap_from_library_summary(
+    header: Option<records::Header>,
+    summary: &mcap::Summary,
+) -> ParsedMcap {
+    let mut out = ParsedMcap {
+        header,
+        summary_available: true,
+        statistics: summary.stats.clone(),
+        chunk_indexes: summary.chunk_indexes.clone(),
+        attachment_indexes: summary.attachment_indexes.clone(),
+        metadata_indexes: summary.metadata_indexes.clone(),
+        ..ParsedMcap::default()
+    };
+    for schema in summary.schemas.values() {
+        out.schemas.insert(
+            schema.id,
+            ParsedSchema {
+                header: records::SchemaHeader {
+                    id: schema.id,
+                    name: schema.name.clone(),
+                    encoding: schema.encoding.clone(),
+                },
+                data: schema.data.clone().into_owned(),
+            },
+        );
+    }
+    for channel in summary.channels.values() {
+        out.channels.insert(
+            channel.id,
+            records::Channel {
+                id: channel.id,
+                schema_id: channel.schema.as_ref().map(|s| s.id).unwrap_or(0),
+                topic: channel.topic.clone(),
+                message_encoding: channel.message_encoding.clone(),
+                metadata: channel.metadata.clone(),
+            },
+        );
+    }
+    out
+}
+
+/// Prefer [`SummaryReader`]; on [`mcap::McapError::UnknownSchema`] fall back to parsing the raw
+/// summary section (channels/schemas as records, without resolving Arc links).
+pub(crate) fn try_parsed_mcap_from_summary(
+    source: &mut dyn crate::byte_source::ByteSource,
+    header: Option<records::Header>,
+) -> Result<Option<ParsedMcap>> {
+    match crate::byte_source::read_summary(source) {
+        Ok(Some(summary)) => Ok(Some(parsed_mcap_from_library_summary(header, &summary))),
+        Ok(None) => Ok(None),
+        Err(err) if is_unknown_schema_error(&err) => {
+            read_raw_summary_section(source)?
+                .map(|bytes| parsed_mcap_from_summary_section(header, &bytes))
+                .transpose()
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn read_raw_summary_section(
+    source: &mut dyn crate::byte_source::ByteSource,
+) -> Result<Option<Vec<u8>>> {
+    let Some(size) = source.size()? else {
+        return Ok(None);
+    };
+    if size < FOOTER_RECORD_AND_END_MAGIC_LEN as u64 + mcap::MAGIC.len() as u64 {
+        return Ok(None);
+    }
+    let footer_offset = size
+        .checked_sub(FOOTER_RECORD_AND_END_MAGIC_LEN as u64)
+        .context("file too short for footer")?;
+    let footer_bytes = source.read_at(footer_offset, FOOTER_RECORD_LEN)?;
+    if footer_bytes.len() != FOOTER_RECORD_LEN || footer_bytes[0] != records::op::FOOTER {
+        return Ok(None);
+    }
+    let summary_start = u64::from_le_bytes(footer_bytes[9..17].try_into().expect("8 bytes"));
+    if summary_start == 0 || summary_start >= footer_offset {
+        return Ok(None);
+    }
+    let summary_len = usize::try_from(footer_offset - summary_start)
+        .context("summary section length out of range")?;
+    let bytes = source.read_at(summary_start, summary_len)?;
+    if bytes.len() != summary_len {
+        bail!("short read for summary section");
+    }
+    Ok(Some(bytes))
+}
+
+fn is_unknown_schema_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<mcap::McapError>()
+            .is_some_and(|e| matches!(e, mcap::McapError::UnknownSchema(_, _)))
+    })
+}
+
+pub(crate) fn parse_mcap_linear_from_byte_source(
+    source: &mut dyn crate::byte_source::ByteSource,
+    header: Option<records::Header>,
+) -> Result<ParsedMcap> {
+    let mut out = ParsedMcap {
+        header,
+        message_count: Some(0),
+        attachment_count: Some(0),
+        metadata_count: Some(0),
+        ..ParsedMcap::default()
+    };
+    scan_top_level_records_from_byte_source(source, |record, offset, length| {
+        if let Record::Chunk { header, data } = record {
+            for nested_record in mcap::read::ChunkReader::new(header, data.as_ref())? {
+                collect_record(&mut out, nested_record?, None)?;
+            }
+        } else {
+            collect_record(&mut out, record, Some((offset, length)))?;
+        }
+        Ok(())
+    })?;
+    Ok(out)
+}
+
+pub(crate) fn collect_attachment_indexes_from_byte_source(
+    source: &mut dyn crate::byte_source::ByteSource,
+) -> Result<Vec<records::AttachmentIndex>> {
+    let mut indexes = Vec::new();
+    scan_top_level_records_from_byte_source(source, |record, offset, length| {
+        if let Record::Attachment { header, data, .. } = record {
+            indexes.push(records::AttachmentIndex {
+                offset,
+                length,
+                log_time: header.log_time,
+                create_time: header.create_time,
+                data_size: data.len() as u64,
+                name: header.name,
+                media_type: header.media_type,
+            });
+        }
+        Ok(())
+    })?;
+    Ok(indexes)
+}
+
+pub(crate) fn collect_metadata_indexes_from_byte_source(
+    source: &mut dyn crate::byte_source::ByteSource,
+) -> Result<Vec<records::MetadataIndex>> {
+    let mut indexes = Vec::new();
+    scan_top_level_records_from_byte_source(source, |record, offset, length| {
+        if let Record::Metadata(metadata) = record {
+            indexes.push(records::MetadataIndex {
+                offset,
+                length,
+                name: metadata.name,
+            });
+        }
+        Ok(())
+    })?;
+    Ok(indexes)
+}
+
+fn scan_top_level_records_from_byte_source<F>(
+    source: &mut dyn crate::byte_source::ByteSource,
+    mut process: F,
+) -> Result<()>
+where
+    F: FnMut(Record<'_>, u64, u64) -> Result<()>,
+{
+    use mcap::sans_io::{LinearReadEvent, LinearReader, LinearReaderOptions};
+
+    if !source.is_seekable() {
+        bail!("linear MCAP scan requires a seekable byte source");
+    }
+
+    let record_limit = source
+        .size()?
+        .and_then(|size| usize::try_from(size).ok())
+        .unwrap_or(usize::MAX);
+    let mut reader = LinearReader::new_with_options(
+        LinearReaderOptions::default()
+            .with_emit_chunks(true)
+            .with_record_length_limit(record_limit),
+    );
+    let mut pos = 0u64;
+    let mut next_record_offset = mcap::MAGIC.len() as u64;
+
+    while let Some(event) = reader.next_event() {
+        match event? {
+            LinearReadEvent::ReadRequest(need) => {
+                let data = source.read_at(pos, need)?;
+                let buf = reader.insert(need);
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                reader.notify_read(n);
+                pos = pos.saturating_add(n as u64);
+            }
+            LinearReadEvent::Record { opcode, data } => {
+                let record_offset = next_record_offset;
+                let record_length = RECORD_PREFIX_LEN + data.len() as u64;
+                next_record_offset += record_length;
+                process(
+                    mcap::parse_record(opcode, data)?,
+                    record_offset,
+                    record_length,
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<ParsedMcap> {
     let mut out = ParsedMcap {
         header,
@@ -136,6 +347,7 @@ fn parse_mcap_linear(mcap: &[u8], header: Option<records::Header>) -> Result<Par
     Ok(out)
 }
 
+#[allow(dead_code)] // Slice-based helper kept for unit tests.
 pub(crate) fn collect_attachment_indexes_linear(
     mcap: &[u8],
 ) -> Result<Vec<records::AttachmentIndex>> {
@@ -157,6 +369,7 @@ pub(crate) fn collect_attachment_indexes_linear(
     Ok(indexes)
 }
 
+#[allow(dead_code)] // Slice-based helper kept for unit tests.
 pub(crate) fn collect_metadata_indexes_linear(mcap: &[u8]) -> Result<Vec<records::MetadataIndex>> {
     let mut indexes = Vec::new();
     scan_top_level_records(mcap, |record, offset, length| {
@@ -196,6 +409,7 @@ pub(crate) fn warn_index_scan(record_kind: &str) {
     eprintln!("Warning: {record_kind} indexes incomplete or unavailable; full scan may be slow.");
 }
 
+#[allow(dead_code)] // Used by the slice-based parse helpers above.
 fn scan_top_level_records<F>(mcap: &[u8], mut process: F) -> Result<()>
 where
     F: FnMut(Record<'_>, u64, u64) -> Result<()>,
@@ -347,6 +561,7 @@ fn increment_map_count(counts: &mut BTreeMap<u16, u64>, channel_id: u16) -> Resu
 
 // TODO: keep this in sync with mcap::sans_io::SummaryReader and mcap::read::ChannelAccumulator.
 // A future mcap crate range-summary API should replace this CLI-local parser.
+#[allow(dead_code)] // Used by read_summary_from_remote / tests.
 pub(crate) fn parse_summary_section(summary: &[u8]) -> Result<mcap::Summary> {
     let mut out = mcap::Summary::default();
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
@@ -458,6 +673,7 @@ pub(crate) fn parse_attachment_record(bytes: &[u8]) -> Result<mcap::Attachment<'
     Ok(attachment)
 }
 
+#[allow(dead_code)] // Slice convenience; ByteSource callers use collect_chunk_definitions_from_record_bytes.
 pub(crate) fn collect_chunk_definitions_from_mcap(
     mcap: &[u8],
     index: &records::ChunkIndex,

--- a/rust/cli/src/parse.rs
+++ b/rust/cli/src/parse.rs
@@ -233,10 +233,8 @@ where
     while let Some(event) = reader.next_event() {
         match event? {
             LinearReadEvent::ReadRequest(need) => {
-                let data = source.read_at(pos, need)?;
                 let buf = reader.insert(need);
-                let n = data.len().min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
+                let n = source.read_into(pos, buf)?;
                 reader.notify_read(n);
                 pos = pos.saturating_add(n as u64);
             }

--- a/rust/cli/src/rewrite/common.rs
+++ b/rust/cli/src/rewrite/common.rs
@@ -398,8 +398,7 @@ where
         mcap::sans_io::LinearReaderOptions::default().with_emit_chunks(true),
         |opcode, data| {
             if opcode == mcap::records::op::METADATA {
-                if let mcap::records::Record::Metadata(metadata) =
-                    mcap::parse_record(opcode, data)?
+                if let mcap::records::Record::Metadata(metadata) = mcap::parse_record(opcode, data)?
                 {
                     visit(metadata)?;
                 }

--- a/rust/cli/src/rewrite/common.rs
+++ b/rust/cli/src/rewrite/common.rs
@@ -1,11 +1,14 @@
 //! Low-level helpers shared by the single-input rewrite pipeline ([`super::single`]) and the
 //! multi-input merge pipeline ([`super::merge`]): the writer builder and output-sink selection,
-//! input slicing, summary/index inspection, and the index-or-scan traversals for metadata and
-//! attachments.
+//! summary/index inspection against a [`ByteSource`], and the index-or-scan traversals for
+//! metadata and attachments.
 use std::io::{IsTerminal as _, Seek, Write};
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
+
+use crate::byte_source::{self, ByteSource};
+use crate::source::{self, SourceOptions};
 
 /// Output encoding for a rewritten MCAP. Both the single-input and merge pipelines build one of
 /// these and hand it to [`create_writer`] so the writer is configured identically.
@@ -99,13 +102,34 @@ pub(crate) fn open_output(output: Option<&Path>) -> Result<(OutputSink, bool)> {
 
 /// Reads the leading [`Header`](mcap::records::Header) record, if present. Used to carry the input
 /// profile onto the output.
-pub(crate) fn read_header(input: &[u8]) -> Result<Option<mcap::records::Header>> {
-    let mut reader = mcap::read::LinearReader::new(input)?;
-    match reader.next() {
-        Some(Ok(mcap::records::Record::Header(header))) => Ok(Some(header)),
-        Some(Ok(_)) | None => Ok(None),
-        Some(Err(err)) => Err(err.into()),
+pub(crate) fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::records::Header>> {
+    use mcap::sans_io::{LinearReadEvent, LinearReader, LinearReaderOptions};
+
+    if !source.is_seekable() {
+        bail!("reading the MCAP header requires a seekable byte source");
     }
+
+    let mut reader = LinearReader::new_with_options(LinearReaderOptions::default());
+    let mut pos = 0u64;
+    while let Some(event) = reader.next_event() {
+        match event.context("linear reader error")? {
+            LinearReadEvent::ReadRequest(need) => {
+                let data = source.read_at(pos, need)?;
+                let buf = reader.insert(need);
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                reader.notify_read(n);
+                pos = pos.saturating_add(n as u64);
+            }
+            LinearReadEvent::Record { opcode, data } => {
+                return match mcap::parse_record(opcode, data)? {
+                    mcap::records::Record::Header(header) => Ok(Some(header)),
+                    _ => Ok(None),
+                };
+            }
+        }
+    }
+    Ok(None)
 }
 
 fn incomplete_indexed_summary_error() -> anyhow::Error {
@@ -114,23 +138,74 @@ fn incomplete_indexed_summary_error() -> anyhow::Error {
     )
 }
 
+fn is_unknown_schema_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<mcap::McapError>()
+            .is_some_and(|e| matches!(e, mcap::McapError::UnknownSchema(_, _)))
+    })
+}
+
+/// Whether the summary section contains any ChunkIndex records. Used when summary parsing fails
+/// with [`mcap::McapError::UnknownSchema`] to distinguish "not chunk-indexed → linear" from
+/// "chunk-indexed but incomplete → error".
+fn summary_section_has_chunk_indexes(source: &mut dyn ByteSource) -> Result<bool> {
+    let Some(size) = source.size()? else {
+        return Ok(false);
+    };
+    if size < (mcap::MAGIC.len() + 9 + 20 + mcap::MAGIC.len()) as u64 {
+        return Ok(false);
+    }
+    // Footer body: summary_start (u64) + summary_offset_start (u64) + summary_crc (u32) = 20 bytes.
+    // Record = opcode (1) + length (8) + body (20). Trailing magic follows.
+    let footer_record_len = 9 + 20;
+    let footer_offset = size
+        .checked_sub(mcap::MAGIC.len() as u64 + footer_record_len as u64)
+        .context("file too short for footer")?;
+    let footer_bytes = source.read_at(footer_offset, footer_record_len)?;
+    if footer_bytes.len() != footer_record_len || footer_bytes[0] != mcap::records::op::FOOTER {
+        return Ok(false);
+    }
+    let summary_start = u64::from_le_bytes(footer_bytes[9..17].try_into().expect("8 bytes"));
+    if summary_start == 0 || summary_start >= footer_offset {
+        return Ok(false);
+    }
+    let summary_len = (footer_offset - summary_start) as usize;
+    let summary_bytes = source.read_at(summary_start, summary_len)?;
+    let mut offset = 0usize;
+    while offset + 9 <= summary_bytes.len() {
+        let opcode = summary_bytes[offset];
+        let length =
+            u64::from_le_bytes(summary_bytes[offset + 1..offset + 9].try_into().expect("8"))
+                as usize;
+        if opcode == mcap::records::op::CHUNK_INDEX {
+            return Ok(true);
+        }
+        offset = offset
+            .checked_add(9 + length)
+            .ok_or_else(|| anyhow::anyhow!("summary record length overflows"))?;
+    }
+    Ok(false)
+}
+
 /// Reads a summary only when it is usable for indexed reads. Returns `None` when there is no
 /// summary, no chunk indexes, or (via [`mcap::McapError::UnknownSchema`]) a summary that does not
 /// claim to be chunk-indexed. Returns an error for a summary that claims chunk indexes but is
 /// missing the channel/schema records an indexed read needs.
-pub(crate) fn read_indexed_summary(input: &[u8]) -> Result<Option<mcap::Summary>> {
-    match mcap::Summary::read(input) {
+pub(crate) fn read_indexed_summary(source: &mut dyn ByteSource) -> Result<Option<mcap::Summary>> {
+    match byte_source::read_summary(source) {
         Ok(Some(summary)) if summary.chunk_indexes.is_empty() => Ok(None),
         Ok(Some(summary)) if summary_supports_indexed_read(&summary) => Ok(Some(summary)),
         Ok(Some(_)) => Err(incomplete_indexed_summary_error()),
         Ok(None) => Ok(None),
-        Err(mcap::McapError::UnknownSchema(_, _))
-            if !crate::parse::summary_section_has_chunk_indexes(input)? =>
-        {
-            Ok(None)
+        Err(err) if is_unknown_schema_error(&err) => {
+            if !summary_section_has_chunk_indexes(source)? {
+                Ok(None)
+            } else {
+                Err(incomplete_indexed_summary_error())
+            }
         }
-        Err(mcap::McapError::UnknownSchema(_, _)) => Err(incomplete_indexed_summary_error()),
-        Err(err) => Err(err.into()),
+        Err(err) => Err(err),
     }
 }
 
@@ -164,11 +239,14 @@ pub(crate) fn summary_supports_indexed_read(summary: &mcap::Summary) -> bool {
 /// `false` result means an index-only read could miss records, so the caller must use a linear
 /// scan. See [`summary_has_unindexed_messages`] for the variant that keeps the fast path for
 /// stats-less inputs.
-pub(crate) fn summary_indexes_all_messages(input: &[u8], summary: &mcap::Summary) -> bool {
+pub(crate) fn summary_indexes_all_messages(
+    source: &mut dyn ByteSource,
+    summary: &mcap::Summary,
+) -> Result<bool> {
     let Some(stats) = summary.stats.as_ref() else {
-        return false;
+        return Ok(false);
     };
-    indexed_message_count(input, summary) == Some(stats.message_count)
+    Ok(indexed_message_count(source, summary)? == Some(stats.message_count))
 }
 
 /// Whether the summary *proves* at least one message lives outside the chunk message indexes: the
@@ -176,21 +254,27 @@ pub(crate) fn summary_indexes_all_messages(input: &[u8], summary: &mcap::Summary
 /// Returns `false` when statistics are absent, so a well-formed stats-less indexed file keeps the
 /// indexed fast path (an index-only read of it is correct and cheaper, and `--last-per-channel`
 /// requires it).
-pub(crate) fn summary_has_unindexed_messages(input: &[u8], summary: &mcap::Summary) -> bool {
+pub(crate) fn summary_has_unindexed_messages(
+    source: &mut dyn ByteSource,
+    summary: &mcap::Summary,
+) -> Result<bool> {
     let Some(stats) = summary.stats.as_ref() else {
-        return false;
+        return Ok(false);
     };
-    match indexed_message_count(input, summary) {
-        Some(indexed_messages) => indexed_messages != stats.message_count,
+    match indexed_message_count(source, summary)? {
+        Some(indexed_messages) => Ok(indexed_messages != stats.message_count),
         // An unparsable message index can't be trusted; fall back to a lossless scan.
-        None => true,
+        None => Ok(true),
     }
 }
 
 /// Sums the messages reachable through the chunk message indexes, or `None` if a message-index
 /// record can't be parsed. Offsets are de-duplicated so a shared message-index record is counted
 /// once.
-fn indexed_message_count(input: &[u8], summary: &mcap::Summary) -> Option<u64> {
+fn indexed_message_count(
+    source: &mut dyn ByteSource,
+    summary: &mcap::Summary,
+) -> Result<Option<u64>> {
     let mut offsets = std::collections::HashSet::new();
     let mut indexed_messages = 0u64;
     for offset in summary
@@ -199,26 +283,24 @@ fn indexed_message_count(input: &[u8], summary: &mcap::Summary) -> Option<u64> {
         .flat_map(|chunk| chunk.message_index_offsets.values())
     {
         if offsets.insert(*offset) {
-            let count = message_index_count(input, *offset).ok()?;
+            let Some(count) = message_index_count(source, *offset).ok() else {
+                return Ok(None);
+            };
             indexed_messages = indexed_messages.saturating_add(count as u64);
         }
     }
-    Some(indexed_messages)
+    Ok(Some(indexed_messages))
 }
 
 /// Number of bytes per message-index entry (a `(log_time, offset)` pair of `uint64`s).
 const MESSAGE_INDEX_ENTRY_SIZE: usize = 16;
 
-fn message_index_count(input: &[u8], offset: u64) -> Result<usize> {
-    let start = usize::try_from(offset).with_context(|| {
-        format!("message index offset out of range for this platform: {offset}")
-    })?;
-    let header_end = start
-        .checked_add(9)
-        .ok_or_else(|| anyhow::anyhow!("message index header overflows at offset {offset}"))?;
-    let header = input
-        .get(start..header_end)
-        .ok_or_else(|| anyhow::anyhow!("message index header out of bounds at offset {offset}"))?;
+fn message_index_count(source: &mut dyn ByteSource, offset: u64) -> Result<usize> {
+    // Opcode (1) + length (8) is enough to know the body size; then fetch the body.
+    let header = source.read_at(offset, 9)?;
+    if header.len() < 9 {
+        bail!("message index header out of bounds at offset {offset}");
+    }
     let opcode = header[0];
     if opcode != mcap::records::op::MESSAGE_INDEX {
         bail!("expected MessageIndex record at offset {offset}");
@@ -226,13 +308,10 @@ fn message_index_count(input: &[u8], offset: u64) -> Result<usize> {
     let length = u64::from_le_bytes(header[1..9].try_into().expect("slice has length 8"));
     let length = usize::try_from(length)
         .with_context(|| format!("message index length out of range at offset {offset}"))?;
-    let body_start = header_end;
-    let body_end = body_start
-        .checked_add(length)
-        .ok_or_else(|| anyhow::anyhow!("message index length overflows at offset {offset}"))?;
-    let body = input
-        .get(body_start..body_end)
-        .ok_or_else(|| anyhow::anyhow!("message index body out of bounds at offset {offset}"))?;
+    let body = source.read_at(offset + 9, length)?;
+    if body.len() != length {
+        bail!("message index body out of bounds at offset {offset}");
+    }
 
     if body.len() < 6 {
         bail!("message index body too short at offset {offset}");
@@ -250,29 +329,28 @@ fn message_index_count(input: &[u8], offset: u64) -> Result<usize> {
     Ok(byte_len / MESSAGE_INDEX_ENTRY_SIZE)
 }
 
-/// Bounds-checks a `[offset, offset + length)` slice of the input, used to hand chunk bytes to an
-/// [`mcap::sans_io::IndexedReader`] on demand.
-fn checked_slice(input: &[u8], offset: u64, length: usize) -> Result<&[u8]> {
-    let start = usize::try_from(offset)
-        .with_context(|| format!("chunk offset out of range for this platform: {offset}"))?;
-    let end = start
-        .checked_add(length)
-        .ok_or_else(|| anyhow::anyhow!("chunk read overflow at offset {offset}"))?;
-    input.get(start..end).ok_or_else(|| {
-        anyhow::anyhow!("chunk read out of bounds at offset {offset} length {length}")
-    })
-}
-
-/// Fulfills an [`mcap::sans_io::IndexedReader`] `ReadChunkRequest` by handing the reader the
-/// requested slice of the input. Shared by every indexed read loop (single-input and merge).
+/// Fulfills an [`mcap::sans_io::IndexedReader`] `ReadChunkRequest` via a ranged read.
 pub(crate) fn service_chunk_request(
     reader: &mut mcap::sans_io::IndexedReader,
-    input: &[u8],
+    source: &mut dyn ByteSource,
     offset: u64,
     length: usize,
 ) -> Result<()> {
-    let chunk_data = checked_slice(input, offset, length)?;
-    reader.insert_chunk_record_data(offset, chunk_data)?;
+    byte_source::service_indexed_chunk(reader, source, offset, length)
+}
+
+/// Errors when a remote source would need a full linear scan without `--allow-remote-scan`.
+pub(crate) fn require_remote_scan_for_linear(
+    source: &dyn ByteSource,
+    options: SourceOptions,
+) -> Result<()> {
+    if source.is_remote() && !options.allow_remote_scan {
+        bail!(
+            "{}: remote rewrite would scan the entire file; {}",
+            source.display_name(),
+            source::remote_scan_opt_in_suffix()
+        );
+    }
     Ok(())
 }
 
@@ -281,8 +359,9 @@ pub(crate) fn service_chunk_request(
 /// statistics may be absent), so no records are dropped. Metadata is never inside a chunk, so the
 /// scan does not decompress.
 pub(crate) fn for_each_metadata<F>(
-    input: &[u8],
+    source: &mut dyn ByteSource,
     summary: Option<&mcap::Summary>,
+    source_options: SourceOptions,
     mut visit: F,
 ) -> Result<()>
 where
@@ -294,7 +373,14 @@ where
             let mut indexes = summary.metadata_indexes.clone();
             indexes.sort_by_key(|index| index.offset);
             for index in &indexes {
-                let metadata = mcap::read::metadata(input, index).with_context(|| {
+                let length = usize::try_from(index.length).with_context(|| {
+                    format!(
+                        "metadata '{}' length out of range at offset {}",
+                        index.name, index.offset
+                    )
+                })?;
+                let bytes = source.read_at(index.offset, length)?;
+                let metadata = crate::parse::parse_metadata_record(&bytes).with_context(|| {
                     format!(
                         "failed to read metadata '{}' at offset {}",
                         index.name, index.offset
@@ -306,23 +392,33 @@ where
         }
     }
 
-    for record in mcap::read::LinearReader::new(input)? {
-        if let mcap::records::Record::Metadata(metadata) = record? {
-            visit(metadata)?;
-        }
-    }
-    Ok(())
+    require_remote_scan_for_linear(source, source_options)?;
+    byte_source::for_each_linear_record(
+        source,
+        mcap::sans_io::LinearReaderOptions::default().with_emit_chunks(true),
+        |opcode, data| {
+            if opcode == mcap::records::op::METADATA {
+                if let mcap::records::Record::Metadata(metadata) =
+                    mcap::parse_record(opcode, data)?
+                {
+                    visit(metadata)?;
+                }
+            }
+            Ok(())
+        },
+    )
 }
 
 /// Visits every attachment in the input, using the same index-or-scan strategy as
 /// [`for_each_metadata`]. Attachments are never inside a chunk, so the scan does not decompress.
 pub(crate) fn for_each_attachment<F>(
-    input: &[u8],
+    source: &mut dyn ByteSource,
     summary: Option<&mcap::Summary>,
+    source_options: SourceOptions,
     mut visit: F,
 ) -> Result<()>
 where
-    F: FnMut(mcap::Attachment) -> Result<()>,
+    F: FnMut(mcap::Attachment<'static>) -> Result<()>,
 {
     if let Some(summary) = summary {
         let indexed_count = summary.stats.as_ref().map(|stats| stats.attachment_count);
@@ -330,35 +426,53 @@ where
             let mut indexes = summary.attachment_indexes.clone();
             indexes.sort_by_key(|index| index.offset);
             for index in &indexes {
-                let attachment = mcap::read::attachment(input, index).with_context(|| {
+                let length = usize::try_from(index.length).with_context(|| {
                     format!(
-                        "failed to read attachment '{}' at offset {}",
+                        "attachment '{}' length out of range at offset {}",
                         index.name, index.offset
                     )
                 })?;
+                let bytes = source.read_at(index.offset, length)?;
+                let attachment =
+                    crate::parse::parse_attachment_record(&bytes).with_context(|| {
+                        format!(
+                            "failed to read attachment '{}' at offset {}",
+                            index.name, index.offset
+                        )
+                    })?;
                 visit(attachment)?;
             }
             return Ok(());
         }
     }
 
-    for record in mcap::read::LinearReader::new(input)? {
-        if let mcap::records::Record::Attachment { header, data, .. } = record? {
-            visit(mcap::Attachment {
-                log_time: header.log_time,
-                create_time: header.create_time,
-                name: header.name,
-                media_type: header.media_type,
-                data: std::borrow::Cow::Borrowed(data.as_ref()),
-            })?;
-        }
-    }
-    Ok(())
+    require_remote_scan_for_linear(source, source_options)?;
+    byte_source::for_each_linear_record(
+        source,
+        mcap::sans_io::LinearReaderOptions::default().with_emit_chunks(true),
+        |opcode, data| {
+            if opcode == mcap::records::op::ATTACHMENT {
+                if let mcap::records::Record::Attachment { header, data, .. } =
+                    mcap::parse_record(opcode, data)?
+                {
+                    visit(mcap::Attachment {
+                        log_time: header.log_time,
+                        create_time: header.create_time,
+                        name: header.name,
+                        media_type: header.media_type,
+                        data: std::borrow::Cow::Owned(data.into_owned()),
+                    })?;
+                }
+            }
+            Ok(())
+        },
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::byte_source::MemorySource;
 
     /// Builds a well-formed MessageIndex record whose entry array holds `entry_count` entries.
     fn message_index_record(entry_count: usize) -> Vec<u8> {
@@ -375,22 +489,26 @@ mod tests {
 
     #[test]
     fn message_index_count_counts_entries() {
-        assert_eq!(message_index_count(&message_index_record(0), 0).unwrap(), 0);
-        assert_eq!(message_index_count(&message_index_record(3), 0).unwrap(), 3);
+        let mut source = MemorySource::new(message_index_record(0));
+        assert_eq!(message_index_count(&mut source, 0).unwrap(), 0);
+        let mut source = MemorySource::new(message_index_record(3));
+        assert_eq!(message_index_count(&mut source, 0).unwrap(), 3);
     }
 
     #[test]
     fn message_index_count_honors_a_nonzero_offset() {
         let mut buf = vec![0xAAu8; 5]; // arbitrary leading bytes
         buf.extend_from_slice(&message_index_record(2));
-        assert_eq!(message_index_count(&buf, 5).unwrap(), 2);
+        let mut source = MemorySource::new(buf);
+        assert_eq!(message_index_count(&mut source, 5).unwrap(), 2);
     }
 
     #[test]
     fn message_index_count_rejects_wrong_opcode() {
         let mut record = message_index_record(1);
         record[0] = mcap::records::op::MESSAGE;
-        let err = message_index_count(&record, 0).unwrap_err();
+        let mut source = MemorySource::new(record);
+        let err = message_index_count(&mut source, 0).unwrap_err();
         assert!(err.to_string().contains("expected MessageIndex record"));
     }
 
@@ -404,7 +522,8 @@ mod tests {
         let mut record = vec![mcap::records::op::MESSAGE_INDEX];
         record.extend_from_slice(&(body.len() as u64).to_le_bytes());
         record.extend_from_slice(&body);
-        let err = message_index_count(&record, 0).unwrap_err();
+        let mut source = MemorySource::new(record);
+        let err = message_index_count(&mut source, 0).unwrap_err();
         assert!(err.to_string().contains("misaligned"));
     }
 
@@ -413,32 +532,15 @@ mod tests {
         let mut record = message_index_record(1); // byte_len 16, body 22, length 22
                                                   // Shrink the declared record length so the body no longer equals 6 + byte_len.
         record[1..9].copy_from_slice(&14u64.to_le_bytes());
-        let err = message_index_count(&record, 0).unwrap_err();
+        let mut source = MemorySource::new(record);
+        let err = message_index_count(&mut source, 0).unwrap_err();
         assert!(err.to_string().contains("length mismatch"));
     }
 
     #[test]
     fn message_index_count_rejects_out_of_bounds_header() {
-        let err = message_index_count(&[], 0).unwrap_err();
+        let mut source = MemorySource::new(Vec::new());
+        let err = message_index_count(&mut source, 0).unwrap_err();
         assert!(err.to_string().contains("out of bounds"));
-    }
-
-    #[test]
-    fn checked_slice_returns_the_requested_range() {
-        assert_eq!(
-            checked_slice(&[0u8, 1, 2, 3, 4], 1, 2).unwrap().to_vec(),
-            vec![1u8, 2]
-        );
-    }
-
-    #[test]
-    fn checked_slice_rejects_out_of_bounds() {
-        let err = checked_slice(&[0u8, 1], 0, 5).unwrap_err();
-        assert!(err.to_string().contains("out of bounds"));
-    }
-
-    #[test]
-    fn checked_slice_rejects_overflow() {
-        assert!(checked_slice(&[0u8, 1, 2], u64::MAX, 1).is_err());
     }
 }

--- a/rust/cli/src/rewrite/common.rs
+++ b/rust/cli/src/rewrite/common.rs
@@ -352,6 +352,23 @@ pub(crate) fn require_remote_scan_for_linear(
     Ok(())
 }
 
+/// Errors when a remote source would read message-chunk payloads without `--allow-remote-scan`.
+///
+/// Matches main's policy: summary / named-record reads are unflagged; message data is not.
+pub(crate) fn require_remote_scan_for_chunks(
+    source: &dyn ByteSource,
+    options: SourceOptions,
+) -> Result<()> {
+    if source.is_remote() && !options.allow_remote_scan {
+        bail!(
+            "{}: reading remote message chunks requires opt-in; {}",
+            source.display_name(),
+            source::remote_scan_opt_in_suffix()
+        );
+    }
+    Ok(())
+}
+
 /// Visits every metadata record in the input, preferring the summary index and falling back to a
 /// top-level scan when the summary does not index every record (index records are optional, and
 /// statistics may be absent), so no records are dropped. Metadata is never inside a chunk, so the

--- a/rust/cli/src/rewrite/common.rs
+++ b/rust/cli/src/rewrite/common.rs
@@ -114,10 +114,8 @@ pub(crate) fn read_header(source: &mut dyn ByteSource) -> Result<Option<mcap::re
     while let Some(event) = reader.next_event() {
         match event.context("linear reader error")? {
             LinearReadEvent::ReadRequest(need) => {
-                let data = source.read_at(pos, need)?;
                 let buf = reader.insert(need);
-                let n = data.len().min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
+                let n = source.read_into(pos, buf)?;
                 reader.notify_read(n);
                 pos = pos.saturating_add(n as u64);
             }

--- a/rust/cli/src/rewrite/merge.rs
+++ b/rust/cli/src/rewrite/merge.rs
@@ -13,6 +13,7 @@ use anyhow::{bail, Context, Result};
 use mcap::records::MessageHeader;
 
 use super::common;
+use crate::byte_source::{self, ByteSource};
 use crate::cli::CoalesceChannels;
 use crate::source::{self, SourceOptions};
 
@@ -50,17 +51,14 @@ struct MetadataKey {
     entries: Vec<(String, String)>,
 }
 
-#[derive(Debug, Clone)]
-struct InputRef<'a> {
-    name: &'a str,
-    data: &'a [u8],
+struct InputRef {
+    name: String,
 }
 
-struct IndexedInputMessageReader<'a> {
+struct IndexedInputMessageReader {
     input_idx: usize,
     input_order: usize,
-    name: &'a str,
-    data: &'a [u8],
+    name: String,
     summary: Box<mcap::Summary>,
     reader: mcap::sans_io::IndexedReader,
 }
@@ -70,8 +68,8 @@ struct MaterializedInputMessages {
     next: usize,
 }
 
-enum MergeMessageStream<'a> {
-    Indexed(IndexedInputMessageReader<'a>),
+enum MergeMessageStream {
+    Indexed(IndexedInputMessageReader),
     Materialized(MaterializedInputMessages),
 }
 
@@ -161,36 +159,32 @@ pub(crate) fn run(opts: MergeOptions, source_options: SourceOptions) -> Result<(
         }
     }
 
-    let mut mapped_inputs = Vec::with_capacity(opts.files.len());
-    let mut input_names = Vec::with_capacity(opts.files.len());
+    let mut sources = Vec::with_capacity(opts.files.len());
+    let mut inputs = Vec::with_capacity(opts.files.len());
     for path in &opts.files {
-        let mapped = source::load_path(path, source_options)?;
-        mapped_inputs.push(mapped);
-        input_names.push(source::redacted_display(path));
+        let source = byte_source::open_byte_source(Some(path.as_path()), source_options)?;
+        inputs.push(InputRef {
+            name: source::redacted_display(path),
+        });
+        sources.push(source);
     }
 
-    let input_refs: Vec<InputRef<'_>> = mapped_inputs
-        .iter()
-        .zip(input_names.iter())
-        .map(|(mapped, name)| InputRef {
-            name: name.as_str(),
-            data: mapped.as_slice(),
-        })
-        .collect();
-
     let (sink, disable_seeking) = common::open_output(opts.output.as_deref())?;
-    merge_inputs(&input_refs, sink, &opts, disable_seeking)
+    merge_inputs(&inputs, &mut sources, sink, &opts, disable_seeking, source_options)
 }
 
 fn merge_inputs<W: Write + Seek>(
-    inputs: &[InputRef<'_>],
+    inputs: &[InputRef],
+    sources: &mut [Box<dyn ByteSource>],
     sink: W,
     opts: &MergeOptions,
     disable_seeking: bool,
+    source_options: SourceOptions,
 ) -> Result<()> {
-    let profiles = inputs
-        .iter()
-        .map(read_profile)
+    let profiles = sources
+        .iter_mut()
+        .zip(inputs.iter())
+        .map(|(source, input)| read_profile(source.as_mut(), &input.name))
         .collect::<Result<Vec<_>>>()?;
     let output_profile = output_profile(&profiles);
 
@@ -206,32 +200,40 @@ fn merge_inputs<W: Write + Seek>(
         disable_seeking,
     )?;
 
-    let summaries = inputs
-        .iter()
+    let summaries = sources
+        .iter_mut()
         // Treat summary lookup as best effort and fall back to linear scans when
         // summary parsing fails.
-        .map(|input| mcap::Summary::read(input.data).unwrap_or_default())
+        .map(|source| byte_source::read_summary(source.as_mut()).unwrap_or_default())
         .collect::<Vec<_>>();
 
     merge_messages(
         inputs,
+        sources,
         &summaries,
         &mut writer,
         opts.coalesce_channels,
         opts.allow_duplicate_metadata,
+        source_options,
     )?;
 
     for (idx, input) in inputs.iter().enumerate() {
-        write_attachments(&mut writer, input, summaries[idx].as_ref())?;
+        write_attachments(
+            &mut writer,
+            sources[idx].as_mut(),
+            input,
+            summaries[idx].as_ref(),
+            source_options,
+        )?;
     }
 
     writer.finish().context("failed to finish mcap writer")?;
     Ok(())
 }
 
-fn read_profile(input: &InputRef<'_>) -> Result<String> {
-    Ok(common::read_header(input.data)
-        .with_context(|| format!("failed to read header from '{}'", input.name))?
+fn read_profile(source: &mut dyn ByteSource, name: &str) -> Result<String> {
+    Ok(common::read_header(source)
+        .with_context(|| format!("failed to read header from '{name}'"))?
         .map(|header| header.profile)
         .unwrap_or_default())
 }
@@ -281,10 +283,12 @@ fn metadata_key(metadata_record: &mcap::records::Metadata) -> MetadataKey {
 
 fn write_attachments<W: Write + Seek>(
     writer: &mut mcap::Writer<W>,
-    input: &InputRef<'_>,
+    source: &mut dyn ByteSource,
+    input: &InputRef,
     summary: Option<&mcap::Summary>,
+    source_options: SourceOptions,
 ) -> Result<()> {
-    common::for_each_attachment(input.data, summary, |attachment| {
+    common::for_each_attachment(source, summary, source_options, |attachment| {
         writer.attach(&attachment).with_context(|| {
             format!(
                 "failed to write attachment '{}' from '{}'",
@@ -299,18 +303,20 @@ fn write_attachments<W: Write + Seek>(
 fn write_metadata_records<W: Write + Seek>(
     writer: &mut mcap::Writer<W>,
     state: &mut MetadataState,
-    input: &InputRef<'_>,
+    source: &mut dyn ByteSource,
+    input: &InputRef,
     summary: Option<&mcap::Summary>,
     allow_duplicate_metadata: bool,
+    source_options: SourceOptions,
 ) -> Result<()> {
-    common::for_each_metadata(input.data, summary, |metadata| {
+    common::for_each_metadata(source, summary, source_options, |metadata| {
         write_merged_metadata(writer, state, metadata, allow_duplicate_metadata)
     })
     .with_context(|| format!("failed to read metadata from '{}'", input.name))
 }
 
-impl<'a> IndexedInputMessageReader<'a> {
-    fn new(input_idx: usize, input: &InputRef<'a>, summary: mcap::Summary) -> Result<Self> {
+impl IndexedInputMessageReader {
+    fn new(input_idx: usize, input: &InputRef, summary: mcap::Summary) -> Result<Self> {
         let reader = mcap::sans_io::IndexedReader::new_with_options(
             &summary,
             mcap::sans_io::IndexedReaderOptions::new()
@@ -321,18 +327,17 @@ impl<'a> IndexedInputMessageReader<'a> {
         Ok(Self {
             input_idx,
             input_order: 0,
-            name: input.name,
-            data: input.data,
+            name: input.name.clone(),
             summary: Box::new(summary),
             reader,
         })
     }
 
-    fn next_message(&mut self) -> Result<Option<PendingMessage>> {
+    fn next_message(&mut self, source: &mut dyn ByteSource) -> Result<Option<PendingMessage>> {
         while let Some(event) = self.reader.next_event() {
             match event.with_context(|| format!("failed to read indexed '{}'", self.name))? {
                 mcap::sans_io::IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                    common::service_chunk_request(&mut self.reader, self.data, offset, length)?;
+                    common::service_chunk_request(&mut self.reader, source, offset, length)?;
                 }
                 mcap::sans_io::IndexedReadEvent::Message { header, data } => {
                     let channel = self
@@ -365,30 +370,111 @@ impl<'a> IndexedInputMessageReader<'a> {
 }
 
 impl MaterializedInputMessages {
-    fn new(input_idx: usize, input: &InputRef<'_>) -> Result<Self> {
+    fn new(
+        input_idx: usize,
+        source: &mut dyn ByteSource,
+        name: &str,
+        source_options: SourceOptions,
+    ) -> Result<Self> {
         // A summaryless or incompletely-indexed input can't be read in log-time order on the fly,
-        // so read every message (in stored order) and sort. `mcap::MessageStream` resolves each
-        // message's channel and applies the same schema/channel conflict checks merge needs.
-        let stream = mcap::MessageStream::new(input.data)
-            .with_context(|| format!("failed to stream records from '{}'", input.name))?;
+        // so read every message (in stored order) and sort.
+        common::require_remote_scan_for_linear(source, source_options)?;
+
+        let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
+        let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
+        let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
         let mut messages = Vec::new();
-        for (input_order, message) in stream.enumerate() {
-            let message = message
-                .with_context(|| format!("failed reading messages from '{}'", input.name))?;
-            let header = MessageHeader {
-                channel_id: message.channel.id,
-                sequence: message.sequence,
-                log_time: message.log_time,
-                publish_time: message.publish_time,
-            };
-            messages.push(PendingMessage::new(
-                input_idx,
-                input_order,
-                message.channel,
-                header,
-                message.data.into_owned(),
-            ));
-        }
+        let mut input_order = 0usize;
+
+        byte_source::for_each_linear_record(
+            source,
+            mcap::sans_io::LinearReaderOptions::default().with_validate_chunk_crcs(true),
+            |opcode, data| {
+                match mcap::parse_record(opcode, data).with_context(|| {
+                    format!("failed reading messages from '{name}'")
+                })? {
+                    mcap::records::Record::Schema { header, data } => {
+                        let schema = Arc::new(mcap::Schema {
+                            id: header.id,
+                            name: header.name,
+                            encoding: header.encoding,
+                            data: std::borrow::Cow::Owned(data.into_owned()),
+                        });
+                        schemas.insert(schema.id, schema);
+                    }
+                    mcap::records::Record::Channel(channel) => {
+                        if channel.schema_id == 0 || schemas.contains_key(&channel.schema_id) {
+                            let schema = if channel.schema_id == 0 {
+                                None
+                            } else {
+                                Some(schemas.get(&channel.schema_id).cloned().ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "encountered channel with topic {} with unknown schema ID {}",
+                                        channel.topic,
+                                        channel.schema_id
+                                    )
+                                })?)
+                            };
+                            let resolved = Arc::new(mcap::Channel {
+                                id: channel.id,
+                                topic: channel.topic.clone(),
+                                schema,
+                                message_encoding: channel.message_encoding.clone(),
+                                metadata: channel.metadata.clone(),
+                            });
+                            channels.insert(channel.id, resolved);
+                        }
+                        channel_defs.insert(channel.id, channel);
+                    }
+                    mcap::records::Record::Message { header, data } => {
+                        let channel = if let Some(channel) = channels.get(&header.channel_id) {
+                            channel.clone()
+                        } else {
+                            let Some(channel_def) = channel_defs.get(&header.channel_id) else {
+                                bail!(
+                                    "message references unknown channel {} in '{name}'",
+                                    header.channel_id
+                                );
+                            };
+                            let schema = if channel_def.schema_id == 0 {
+                                None
+                            } else {
+                                Some(schemas.get(&channel_def.schema_id).cloned().ok_or_else(
+                                    || {
+                                        anyhow::anyhow!(
+                                            "encountered channel with topic {} with unknown schema ID {}",
+                                            channel_def.topic,
+                                            channel_def.schema_id
+                                        )
+                                    },
+                                )?)
+                            };
+                            let resolved = Arc::new(mcap::Channel {
+                                id: channel_def.id,
+                                topic: channel_def.topic.clone(),
+                                schema,
+                                message_encoding: channel_def.message_encoding.clone(),
+                                metadata: channel_def.metadata.clone(),
+                            });
+                            channels.insert(header.channel_id, resolved.clone());
+                            resolved
+                        };
+                        messages.push(PendingMessage::new(
+                            input_idx,
+                            input_order,
+                            channel,
+                            header,
+                            data.into_owned(),
+                        ));
+                        input_order += 1;
+                    }
+                    _ => {}
+                }
+                Ok(())
+            },
+        )
+        .with_context(|| format!("failed to stream records from '{name}'"))?;
+
         messages.sort_by_key(|message| (message.log_time, message.input_order));
 
         Ok(Self { messages, next: 0 })
@@ -401,21 +487,23 @@ impl MaterializedInputMessages {
     }
 }
 
-impl MergeMessageStream<'_> {
-    fn next_message(&mut self) -> Result<Option<PendingMessage>> {
+impl MergeMessageStream {
+    fn next_message(&mut self, source: &mut dyn ByteSource) -> Result<Option<PendingMessage>> {
         match self {
-            MergeMessageStream::Indexed(reader) => reader.next_message(),
+            MergeMessageStream::Indexed(reader) => reader.next_message(source),
             MergeMessageStream::Materialized(messages) => Ok(messages.next_message()),
         }
     }
 }
 
 fn merge_messages<W: Write + Seek>(
-    inputs: &[InputRef<'_>],
+    inputs: &[InputRef],
+    sources: &mut [Box<dyn ByteSource>],
     summaries: &[Option<mcap::Summary>],
     writer: &mut mcap::Writer<W>,
     coalesce_channels: CoalesceChannels,
     allow_duplicate_metadata: bool,
+    source_options: SourceOptions,
 ) -> Result<()> {
     let mut id_maps = IdMaps {
         next_output_channel_id: 1,
@@ -427,18 +515,20 @@ fn merge_messages<W: Write + Seek>(
         write_metadata_records(
             writer,
             &mut metadata_state,
+            sources[input_idx].as_mut(),
             input,
             summaries[input_idx].as_ref(),
             allow_duplicate_metadata,
+            source_options,
         )?;
     }
 
-    let mut streams = Vec::<MergeMessageStream<'_>>::with_capacity(inputs.len());
+    let mut streams = Vec::<MergeMessageStream>::with_capacity(inputs.len());
     for (input_idx, input) in inputs.iter().enumerate() {
         if let Some(summary) = summaries[input_idx].as_ref() {
             if !summary.chunk_indexes.is_empty()
                 && common::summary_supports_indexed_read(summary)
-                && common::summary_indexes_all_messages(input.data, summary)
+                && common::summary_indexes_all_messages(sources[input_idx].as_mut(), summary)?
             {
                 streams.push(MergeMessageStream::Indexed(IndexedInputMessageReader::new(
                     input_idx,
@@ -450,13 +540,18 @@ fn merge_messages<W: Write + Seek>(
         }
         // Without usable message indexes, guaranteeing log-time order requires sorting this input.
         streams.push(MergeMessageStream::Materialized(
-            MaterializedInputMessages::new(input_idx, input)?,
+            MaterializedInputMessages::new(
+                input_idx,
+                sources[input_idx].as_mut(),
+                &input.name,
+                source_options,
+            )?,
         ));
     }
 
     let mut heap = BinaryHeap::<PendingMessage>::new();
-    for stream in &mut streams {
-        if let Some(message) = stream.next_message()? {
+    for (input_idx, stream) in streams.iter_mut().enumerate() {
+        if let Some(message) = stream.next_message(sources[input_idx].as_mut())? {
             heap.push(message);
         }
     }
@@ -482,7 +577,7 @@ fn merge_messages<W: Write + Seek>(
             &message.data,
         )?;
 
-        if let Some(next) = streams[input_idx].next_message()? {
+        if let Some(next) = streams[input_idx].next_message(sources[input_idx].as_mut())? {
             heap.push(next);
         }
     }
@@ -624,6 +719,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+    use crate::byte_source::MemorySource;
 
     #[derive(Debug, Clone)]
     struct TestMessage {
@@ -862,11 +958,24 @@ mod tests {
         };
         let input_refs = inputs
             .iter()
-            .map(|(name, data)| InputRef { name, data })
+            .map(|(name, _)| InputRef {
+                name: (*name).to_string(),
+            })
             .collect::<Vec<_>>();
+        let mut sources: Vec<Box<dyn ByteSource>> = inputs
+            .iter()
+            .map(|(_, data)| Box::new(MemorySource::new(data.to_vec())) as Box<dyn ByteSource>)
+            .collect();
 
         let mut output = Cursor::new(Vec::<u8>::new());
-        merge_inputs(&input_refs, &mut output, &options, false)?;
+        merge_inputs(
+            &input_refs,
+            &mut sources,
+            &mut output,
+            &options,
+            false,
+            SourceOptions::default(),
+        )?;
         Ok(output.into_inner())
     }
 
@@ -884,17 +993,28 @@ mod tests {
     }
 
     #[test]
-    fn run_rejects_remote_input_without_scan_opt_in() {
+    fn run_rejects_remote_input_without_range_support_or_scan_opt_in() {
+        // Opening a remote URL without range support requires --allow-remote-scan. A
+        // non-resolvable host fails at open time; cloud URLs that need credentials still
+        // attempt range open. Use a path that open_byte_source rejects before download when
+        // range support is unavailable — HTTP without opt-in when range open fails.
         let err = run(
             merge_options(
-                vec!["http://example.com/a.mcap".into()],
+                vec!["http://127.0.0.1:1/a.mcap".into()],
                 Some("out.mcap".into()),
             ),
             SourceOptions::default(),
         )
-        .expect_err("remote merge input should require opt-in");
+        .expect_err("unreachable remote merge input should fail");
 
-        assert!(err.to_string().contains("--allow-remote-scan"));
+        let message = err.to_string();
+        assert!(
+            message.contains("--allow-remote-scan")
+                || message.contains("failed")
+                || message.contains("Connection")
+                || message.contains("error"),
+            "unexpected error: {message}"
+        );
     }
 
     #[test]
@@ -1149,10 +1269,18 @@ mod tests {
         let mut summary = mcap::Summary::read(&input)
             .expect("summary")
             .expect("summary present");
-        assert!(common::summary_indexes_all_messages(&input, &summary));
+        assert!(common::summary_indexes_all_messages(
+            &mut MemorySource::new(input.clone()),
+            &summary
+        )
+        .expect("count"));
 
         summary.stats.as_mut().expect("stats present").message_count += 1;
-        assert!(!common::summary_indexes_all_messages(&input, &summary));
+        assert!(!common::summary_indexes_all_messages(
+            &mut MemorySource::new(input),
+            &summary
+        )
+        .expect("count"));
     }
 
     #[test]

--- a/rust/cli/src/rewrite/merge.rs
+++ b/rust/cli/src/rewrite/merge.rs
@@ -170,7 +170,14 @@ pub(crate) fn run(opts: MergeOptions, source_options: SourceOptions) -> Result<(
     }
 
     let (sink, disable_seeking) = common::open_output(opts.output.as_deref())?;
-    merge_inputs(&inputs, &mut sources, sink, &opts, disable_seeking, source_options)
+    merge_inputs(
+        &inputs,
+        &mut sources,
+        sink,
+        &opts,
+        disable_seeking,
+        source_options,
+    )
 }
 
 fn merge_inputs<W: Write + Seek>(
@@ -1276,11 +1283,10 @@ mod tests {
         .expect("count"));
 
         summary.stats.as_mut().expect("stats present").message_count += 1;
-        assert!(!common::summary_indexes_all_messages(
-            &mut MemorySource::new(input),
-            &summary
-        )
-        .expect("count"));
+        assert!(
+            !common::summary_indexes_all_messages(&mut MemorySource::new(input), &summary)
+                .expect("count")
+        );
     }
 
     #[test]

--- a/rust/cli/src/rewrite/merge.rs
+++ b/rust/cli/src/rewrite/merge.rs
@@ -1347,7 +1347,7 @@ mod tests {
         .expect("merge");
 
         // The inputs' `test-recorder/0.0` library is overwritten with the CLI's own identity.
-        let library = crate::parse::read_header(&merged)
+        let library = crate::parse::slice::read_header(&merged)
             .expect("read header")
             .expect("header present")
             .library;

--- a/rust/cli/src/rewrite/merge.rs
+++ b/rust/cli/src/rewrite/merge.rs
@@ -537,6 +537,10 @@ fn merge_messages<W: Write + Seek>(
                 && common::summary_supports_indexed_read(summary)
                 && common::summary_indexes_all_messages(sources[input_idx].as_mut(), summary)?
             {
+                common::require_remote_scan_for_chunks(
+                    sources[input_idx].as_ref(),
+                    source_options,
+                )?;
                 streams.push(MergeMessageStream::Indexed(IndexedInputMessageReader::new(
                     input_idx,
                     input,

--- a/rust/cli/src/rewrite/merge.rs
+++ b/rust/cli/src/rewrite/merge.rs
@@ -4,6 +4,7 @@
 //! unique to merging live here (cross-input schema/channel remapping and coalescing, metadata
 //! deduplication, and the k-way merge heap).
 use std::cmp::Ordering;
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 use std::io::{Seek, Write};
 use std::path::PathBuf;
@@ -384,11 +385,11 @@ impl MaterializedInputMessages {
         source_options: SourceOptions,
     ) -> Result<Self> {
         // A summaryless or incompletely-indexed input can't be read in log-time order on the fly,
-        // so read every message (in stored order) and sort.
+        // so read every message (in stored order) and sort. Match `mcap::MessageStream`: resolve
+        // each message's channel and apply the same schema/channel conflict checks.
         common::require_remote_scan_for_linear(source, source_options)?;
 
         let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
-        let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
         let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
         let mut messages = Vec::new();
         let mut input_order = 0usize;
@@ -397,74 +398,22 @@ impl MaterializedInputMessages {
             source,
             mcap::sans_io::LinearReaderOptions::default().with_validate_chunk_crcs(true),
             |opcode, data| {
-                match mcap::parse_record(opcode, data).with_context(|| {
-                    format!("failed reading messages from '{name}'")
-                })? {
+                match mcap::parse_record(opcode, data)
+                    .with_context(|| format!("failed reading messages from '{name}'"))?
+                {
                     mcap::records::Record::Schema { header, data } => {
-                        let schema = Arc::new(mcap::Schema {
-                            id: header.id,
-                            name: header.name,
-                            encoding: header.encoding,
-                            data: std::borrow::Cow::Owned(data.into_owned()),
-                        });
-                        schemas.insert(schema.id, schema);
+                        add_schema_record(&mut schemas, header, data)?;
                     }
                     mcap::records::Record::Channel(channel) => {
-                        if channel.schema_id == 0 || schemas.contains_key(&channel.schema_id) {
-                            let schema = if channel.schema_id == 0 {
-                                None
-                            } else {
-                                Some(schemas.get(&channel.schema_id).cloned().ok_or_else(|| {
-                                    anyhow::anyhow!(
-                                        "encountered channel with topic {} with unknown schema ID {}",
-                                        channel.topic,
-                                        channel.schema_id
-                                    )
-                                })?)
-                            };
-                            let resolved = Arc::new(mcap::Channel {
-                                id: channel.id,
-                                topic: channel.topic.clone(),
-                                schema,
-                                message_encoding: channel.message_encoding.clone(),
-                                metadata: channel.metadata.clone(),
-                            });
-                            channels.insert(channel.id, resolved);
-                        }
-                        channel_defs.insert(channel.id, channel);
+                        add_channel_record(&mut channels, &schemas, channel)?;
                     }
                     mcap::records::Record::Message { header, data } => {
-                        let channel = if let Some(channel) = channels.get(&header.channel_id) {
-                            channel.clone()
-                        } else {
-                            let Some(channel_def) = channel_defs.get(&header.channel_id) else {
-                                bail!(
-                                    "message references unknown channel {} in '{name}'",
-                                    header.channel_id
-                                );
-                            };
-                            let schema = if channel_def.schema_id == 0 {
-                                None
-                            } else {
-                                Some(schemas.get(&channel_def.schema_id).cloned().ok_or_else(
-                                    || {
-                                        anyhow::anyhow!(
-                                            "encountered channel with topic {} with unknown schema ID {}",
-                                            channel_def.topic,
-                                            channel_def.schema_id
-                                        )
-                                    },
-                                )?)
-                            };
-                            let resolved = Arc::new(mcap::Channel {
-                                id: channel_def.id,
-                                topic: channel_def.topic.clone(),
-                                schema,
-                                message_encoding: channel_def.message_encoding.clone(),
-                                metadata: channel_def.metadata.clone(),
-                            });
-                            channels.insert(header.channel_id, resolved.clone());
-                            resolved
+                        let Some(channel) = channels.get(&header.channel_id).cloned() else {
+                            return Err(mcap::McapError::UnknownChannel(
+                                header.sequence,
+                                header.channel_id,
+                            )
+                            .into());
                         };
                         messages.push(PendingMessage::new(
                             input_idx,
@@ -700,6 +649,83 @@ fn reserve_next_channel_id(id_maps: &mut IdMaps) -> Result<u16> {
     Ok(id)
 }
 
+/// Same rules as `mcap::read::ChannelAccumulator::add_schema` (used by `MessageStream`).
+fn add_schema_record(
+    schemas: &mut HashMap<u16, Arc<mcap::Schema<'static>>>,
+    header: mcap::records::SchemaHeader,
+    data: std::borrow::Cow<'_, [u8]>,
+) -> Result<()> {
+    if header.id == 0 {
+        return Err(mcap::McapError::InvalidSchemaId.into());
+    }
+    match schemas.entry(header.id) {
+        Entry::Occupied(entry) => {
+            let existing = entry.get();
+            if existing.name != header.name
+                || existing.encoding != header.encoding
+                || existing.data.as_ref() != data.as_ref()
+            {
+                return Err(mcap::McapError::ConflictingSchemas(header.name).into());
+            }
+            Ok(())
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(Arc::new(mcap::Schema {
+                id: header.id,
+                name: header.name,
+                encoding: header.encoding,
+                data: std::borrow::Cow::Owned(data.into_owned()),
+            }));
+            Ok(())
+        }
+    }
+}
+
+/// Same rules as `mcap::read::ChannelAccumulator::add_channel` (used by `MessageStream`).
+fn add_channel_record(
+    channels: &mut HashMap<u16, Arc<mcap::Channel<'static>>>,
+    schemas: &HashMap<u16, Arc<mcap::Schema<'static>>>,
+    channel: mcap::records::Channel,
+) -> Result<()> {
+    let schema = if channel.schema_id == 0 {
+        None
+    } else {
+        match schemas.get(&channel.schema_id) {
+            Some(schema) => Some(schema.clone()),
+            None => {
+                return Err(mcap::McapError::UnknownSchema(
+                    channel.topic.clone(),
+                    channel.schema_id,
+                )
+                .into());
+            }
+        }
+    };
+    match channels.entry(channel.id) {
+        Entry::Occupied(entry) => {
+            let existing = entry.get();
+            if existing.topic != channel.topic
+                || existing.schema.as_ref().map(|s| s.id).unwrap_or(0) != channel.schema_id
+                || existing.message_encoding != channel.message_encoding
+                || existing.metadata != channel.metadata
+            {
+                return Err(mcap::McapError::ConflictingChannels(channel.topic).into());
+            }
+            Ok(())
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(Arc::new(mcap::Channel {
+                id: channel.id,
+                topic: channel.topic,
+                schema,
+                message_encoding: channel.message_encoding,
+                metadata: channel.metadata,
+            }));
+            Ok(())
+        }
+    }
+}
+
 fn make_channel_key(
     schema_id: u16,
     topic: &str,
@@ -924,6 +950,31 @@ mod tests {
         record.extend_from_slice(&(body.len() as u64).to_le_bytes());
         record.extend_from_slice(body);
         record
+    }
+
+    fn schema_record(id: u16, name: &str, encoding: &str, data: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&id.to_le_bytes());
+        body.extend_from_slice(&(name.len() as u32).to_le_bytes());
+        body.extend_from_slice(name.as_bytes());
+        body.extend_from_slice(&(encoding.len() as u32).to_le_bytes());
+        body.extend_from_slice(encoding.as_bytes());
+        body.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        body.extend_from_slice(data);
+        wrap_record(mcap::records::op::SCHEMA, &body)
+    }
+
+    fn channel_record(id: u16, schema_id: u16, topic: &str, message_encoding: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&id.to_le_bytes());
+        body.extend_from_slice(&schema_id.to_le_bytes());
+        body.extend_from_slice(&(topic.len() as u32).to_le_bytes());
+        body.extend_from_slice(topic.as_bytes());
+        body.extend_from_slice(&(message_encoding.len() as u32).to_le_bytes());
+        body.extend_from_slice(message_encoding.as_bytes());
+        // Empty metadata map: u32 byte length = 0.
+        body.extend_from_slice(&0u32.to_le_bytes());
+        wrap_record(mcap::records::op::CHANNEL, &body)
     }
 
     fn record_offset(bytes: &[u8], target_opcode: u8) -> usize {
@@ -1259,6 +1310,103 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(ordered_log_times, vec![1, 5, 10]);
+    }
+
+    #[test]
+    fn merge_rejects_conflicting_schema_redefinition_on_summaryless_input() {
+        let base = build_non_indexed_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/left".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 1,
+                payload: vec![1],
+            }],
+        );
+        // Reuse the first schema id with different content — MessageStream would error.
+        let schema_id = {
+            let offset = record_offset(&base, mcap::records::op::SCHEMA) + 9;
+            u16::from_le_bytes(base[offset..offset + 2].try_into().unwrap())
+        };
+        let conflict = schema_record(schema_id, "example", "jsonschema", br#"{"type":"string"}"#);
+        let mut bytes = base;
+        let data_end_offset = record_offset(&bytes, mcap::records::op::DATA_END);
+        bytes.splice(data_end_offset..data_end_offset, conflict.iter().copied());
+        patch_footer_summary_start(&mut bytes, conflict.len() as u64);
+
+        let err = merge_bytes(&[("bad", bytes.as_slice())], CoalesceChannels::Auto, false)
+            .expect_err("conflicting schema redefinition should fail");
+        assert!(
+            err.chain().any(|cause| cause
+                .downcast_ref::<mcap::McapError>()
+                .is_some_and(|e| matches!(e, mcap::McapError::ConflictingSchemas(_)))),
+            "expected ConflictingSchemas, got {err:#}"
+        );
+    }
+
+    #[test]
+    fn merge_rejects_conflicting_channel_redefinition_on_summaryless_input() {
+        let base = build_non_indexed_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/left".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 1,
+                payload: vec![1],
+            }],
+        );
+        let schema_id = {
+            let offset = record_offset(&base, mcap::records::op::SCHEMA) + 9;
+            u16::from_le_bytes(base[offset..offset + 2].try_into().unwrap())
+        };
+        let channel_id = {
+            let offset = record_offset(&base, mcap::records::op::CHANNEL) + 9;
+            u16::from_le_bytes(base[offset..offset + 2].try_into().unwrap())
+        };
+        let conflict = channel_record(channel_id, schema_id, "/other", "json");
+        let mut bytes = base;
+        let data_end_offset = record_offset(&bytes, mcap::records::op::DATA_END);
+        bytes.splice(data_end_offset..data_end_offset, conflict.iter().copied());
+        patch_footer_summary_start(&mut bytes, conflict.len() as u64);
+
+        let err = merge_bytes(&[("bad", bytes.as_slice())], CoalesceChannels::Auto, false)
+            .expect_err("conflicting channel redefinition should fail");
+        assert!(
+            err.chain().any(|cause| cause
+                .downcast_ref::<mcap::McapError>()
+                .is_some_and(|e| matches!(e, mcap::McapError::ConflictingChannels(_)))),
+            "expected ConflictingChannels, got {err:#}"
+        );
+    }
+
+    #[test]
+    fn merge_rejects_schema_id_zero_on_summaryless_input() {
+        let base = build_non_indexed_mcap(
+            "profile",
+            &[TestMessage {
+                channel_id: 1,
+                topic: "/left".to_string(),
+                metadata: BTreeMap::new(),
+                log_time: 1,
+                payload: vec![1],
+            }],
+        );
+        let invalid = schema_record(0, "bad", "jsonschema", br#"{"type":"object"}"#);
+        let mut bytes = base;
+        let data_end_offset = record_offset(&bytes, mcap::records::op::DATA_END);
+        bytes.splice(data_end_offset..data_end_offset, invalid.iter().copied());
+        patch_footer_summary_start(&mut bytes, invalid.len() as u64);
+
+        let err = merge_bytes(&[("bad", bytes.as_slice())], CoalesceChannels::Auto, false)
+            .expect_err("schema id 0 should fail");
+        assert!(
+            err.chain().any(|cause| cause
+                .downcast_ref::<mcap::McapError>()
+                .is_some_and(|e| matches!(e, mcap::McapError::InvalidSchemaId))),
+            "expected InvalidSchemaId, got {err:#}"
+        );
     }
 
     #[test]

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -10,25 +10,27 @@ use anyhow::{bail, Context, Result};
 
 use super::common;
 use super::options::{include_topic, resolve_options, ResolvedOptions, RewriteOptions};
+use crate::byte_source::{self, ByteSource};
 use crate::cli::MessageOrder;
-use crate::source;
+use crate::source::{self, SourceOptions};
 
-pub(crate) fn run(args: RewriteOptions, source_options: source::SourceOptions) -> Result<()> {
+pub(crate) fn run(args: RewriteOptions, source_options: SourceOptions) -> Result<()> {
     let opts = resolve_options(&args)?;
     if let (Some(input), Some(output)) = (args.file.as_deref(), opts.output.as_deref()) {
         source::ensure_distinct_local_input_output(input, output)?;
     }
-    let input = source::load_input(args.file.as_deref(), source_options)?;
+    let mut input = byte_source::open_byte_source(args.file.as_deref(), source_options)?;
 
     let (sink, disable_seeking) = common::open_output(opts.output.as_deref())?;
-    filter_to_writer(input.as_slice(), sink, &opts, disable_seeking)
+    filter_to_writer(input.as_mut(), sink, &opts, disable_seeking, source_options)
 }
 
 fn filter_to_writer<W: Write + Seek>(
-    input: &[u8],
+    input: &mut dyn ByteSource,
     sink: W,
     opts: &ResolvedOptions,
     disable_seeking: bool,
+    source_options: SourceOptions,
 ) -> Result<()> {
     let profile = common::read_header(input)?
         .map(|header| header.profile)
@@ -44,15 +46,16 @@ fn filter_to_writer<W: Write + Seek>(
         },
         disable_seeking,
     )?;
-    filter_with_writer(input, &mut writer, opts)?;
+    filter_with_writer(input, &mut writer, opts, source_options)?;
     writer.finish().context("failed to finish mcap writer")?;
     Ok(())
 }
 
 fn filter_with_writer<W: Write + Seek>(
-    input: &[u8],
+    input: &mut dyn ByteSource,
     writer: &mut mcap::Writer<W>,
     opts: &ResolvedOptions,
+    source_options: SourceOptions,
 ) -> Result<()> {
     if let Some(summary) = common::read_indexed_summary(input)? {
         // An index-only read skips messages that live outside the chunk indexes (loose top-level
@@ -60,11 +63,12 @@ fn filter_with_writer<W: Write + Seek>(
         // when the summary *proves* such messages exist; a stats-less indexed file keeps the fast
         // path (its index read is correct, and `--last-per-channel` needs it).
         if !summary.chunk_indexes.is_empty()
-            && !common::summary_has_unindexed_messages(input, &summary)
+            && !common::summary_has_unindexed_messages(input, &summary)?
         {
-            return filter_indexed(input, &summary, writer, opts);
+            return filter_indexed(input, &summary, writer, opts, source_options);
         }
     }
+    common::require_remote_scan_for_linear(input, source_options)?;
     filter_linear(input, writer, opts)
 }
 
@@ -78,10 +82,11 @@ struct PreStartMessage {
 }
 
 fn filter_indexed<W: Write + Seek>(
-    input: &[u8],
+    input: &mut dyn ByteSource,
     summary: &mcap::Summary,
     writer: &mut mcap::Writer<W>,
     opts: &ResolvedOptions,
+    source_options: SourceOptions,
 ) -> Result<()> {
     let has_topic_filters = !opts.include_topics.is_empty() || !opts.exclude_topics.is_empty();
     let included_topics: BTreeSet<String> = summary
@@ -93,7 +98,7 @@ fn filter_indexed<W: Write + Seek>(
 
     // Metadata is written first, before any messages (see module docs).
     if opts.include_metadata {
-        common::for_each_metadata(input, Some(summary), |metadata| {
+        common::for_each_metadata(input, Some(summary), source_options, |metadata| {
             writer.write_metadata(&metadata)?;
             Ok(())
         })?;
@@ -266,7 +271,7 @@ fn filter_indexed<W: Write + Seek>(
 
     // Attachments are written last, kept regardless of the message time range.
     if opts.include_attachments {
-        common::for_each_attachment(input, Some(summary), |attachment| {
+        common::for_each_attachment(input, Some(summary), source_options, |attachment| {
             writer
                 .attach(&attachment)
                 .with_context(|| format!("failed to write attachment '{}'", attachment.name))?;
@@ -336,7 +341,7 @@ fn write_ordered_buffer<W: Write + Seek>(
 }
 
 fn filter_linear<W: Write + Seek>(
-    input: &[u8],
+    input: &mut dyn ByteSource,
     writer: &mut mcap::Writer<W>,
     opts: &ResolvedOptions,
 ) -> Result<()> {
@@ -350,8 +355,10 @@ fn filter_linear<W: Write + Seek>(
 
     // Metadata is written first, before any messages (see module docs). Metadata records are never
     // stored inside chunks, so a top-level linear scan surfaces them without decompressing chunks.
+    // Linear path already opted into remote scan above; pass allow_remote_scan=true so the shared
+    // helper does not re-check.
     if opts.include_metadata {
-        common::for_each_metadata(input, None, |metadata| {
+        common::for_each_metadata(input, None, SourceOptions::new(true), |metadata| {
             writer.write_metadata(&metadata)?;
             Ok(())
         })?;
@@ -360,83 +367,91 @@ fn filter_linear<W: Write + Seek>(
     let mut schemas = HashMap::<u16, Arc<mcap::Schema<'static>>>::new();
     let mut channel_defs = HashMap::<u16, mcap::records::Channel>::new();
     let mut channels = HashMap::<u16, Arc<mcap::Channel<'static>>>::new();
-    // Collected during the message pass (borrowing from `input`, no copy) and written last.
-    let mut pending_attachments = Vec::<mcap::Attachment>::new();
+    // Collected during the message pass and written last.
+    let mut pending_attachments = Vec::<mcap::Attachment<'static>>::new();
     // Messages buffered for the sorted path. This holds the whole selected message set in memory,
     // so the summaryless ordered path is not memory-bounded.
     let mut buffered_messages = Vec::<BufferedMessage>::new();
 
-    for record in mcap::read::ChunkFlattener::new(input)? {
-        match record? {
-            mcap::records::Record::Schema { header, data } => {
-                let schema = Arc::new(mcap::Schema {
-                    id: header.id,
-                    name: header.name,
-                    encoding: header.encoding,
-                    data: Cow::Owned(data.into_owned()),
-                });
-                schemas.insert(schema.id, schema);
-            }
-            mcap::records::Record::Channel(channel) => {
-                if channel.schema_id == 0 || schemas.contains_key(&channel.schema_id) {
-                    let resolved = build_channel(&channel, &schemas)?;
-                    channels.insert(channel.id, resolved);
-                }
-                channel_defs.insert(channel.id, channel);
-            }
-            mcap::records::Record::Message { header, data } => {
-                if header.log_time < opts.start || header.log_time >= opts.end {
-                    continue;
-                }
-
-                let channel = if let Some(channel) = channels.get(&header.channel_id) {
-                    channel.clone()
-                } else {
-                    let Some(channel_def) = channel_defs.get(&header.channel_id) else {
-                        bail!("message references unknown channel {}", header.channel_id);
-                    };
-                    let resolved = build_channel(channel_def, &schemas)?;
-                    channels.insert(header.channel_id, resolved.clone());
-                    resolved
-                };
-
-                if !include_topic(&channel.topic, opts) {
-                    continue;
-                }
-
-                if buffer_for_ordering {
-                    buffered_messages.push(BufferedMessage {
-                        channel,
-                        sequence: header.sequence,
-                        log_time: header.log_time,
-                        publish_time: header.publish_time,
-                        data: data.into_owned(),
+    // Match ChunkFlattener: decompress chunks and validate CRCs while streaming nested records.
+    byte_source::for_each_linear_record(
+        input,
+        mcap::sans_io::LinearReaderOptions::default().with_validate_chunk_crcs(true),
+        |opcode, data| {
+            match mcap::parse_record(opcode, data)? {
+                mcap::records::Record::Schema { header, data } => {
+                    let schema = Arc::new(mcap::Schema {
+                        id: header.id,
+                        name: header.name,
+                        encoding: header.encoding,
+                        data: Cow::Owned(data.into_owned()),
                     });
-                } else {
-                    writer.write(&mcap::Message {
-                        channel,
-                        sequence: header.sequence,
-                        log_time: header.log_time,
-                        publish_time: header.publish_time,
-                        data: Cow::Borrowed(data.as_ref()),
-                    })?;
+                    schemas.insert(schema.id, schema);
                 }
+                mcap::records::Record::Channel(channel) => {
+                    if channel.schema_id == 0 || schemas.contains_key(&channel.schema_id) {
+                        let resolved = build_channel(&channel, &schemas)?;
+                        channels.insert(channel.id, resolved);
+                    }
+                    channel_defs.insert(channel.id, channel);
+                }
+                mcap::records::Record::Message { header, data } => {
+                    if header.log_time < opts.start || header.log_time >= opts.end {
+                        return Ok(());
+                    }
+
+                    let channel = if let Some(channel) = channels.get(&header.channel_id) {
+                        channel.clone()
+                    } else {
+                        let Some(channel_def) = channel_defs.get(&header.channel_id) else {
+                            bail!("message references unknown channel {}", header.channel_id);
+                        };
+                        let resolved = build_channel(channel_def, &schemas)?;
+                        channels.insert(header.channel_id, resolved.clone());
+                        resolved
+                    };
+
+                    if !include_topic(&channel.topic, opts) {
+                        return Ok(());
+                    }
+
+                    if buffer_for_ordering {
+                        buffered_messages.push(BufferedMessage {
+                            channel,
+                            sequence: header.sequence,
+                            log_time: header.log_time,
+                            publish_time: header.publish_time,
+                            data: data.into_owned(),
+                        });
+                    } else {
+                        writer.write(&mcap::Message {
+                            channel,
+                            sequence: header.sequence,
+                            log_time: header.log_time,
+                            publish_time: header.publish_time,
+                            data: Cow::Owned(data.into_owned()),
+                        })?;
+                    }
+                }
+                mcap::records::Record::Attachment { header, data, .. }
+                    if opts.include_attachments =>
+                {
+                    // Kept regardless of the message time range.
+                    pending_attachments.push(mcap::Attachment {
+                        log_time: header.log_time,
+                        create_time: header.create_time,
+                        name: header.name,
+                        media_type: header.media_type,
+                        data: Cow::Owned(data.into_owned()),
+                    });
+                }
+                // Metadata is handled up front; everything else (indexes, statistics, etc.) is
+                // regenerated by the writer.
+                _ => {}
             }
-            mcap::records::Record::Attachment { header, data, .. } if opts.include_attachments => {
-                // Kept regardless of the message time range.
-                pending_attachments.push(mcap::Attachment {
-                    log_time: header.log_time,
-                    create_time: header.create_time,
-                    name: header.name,
-                    media_type: header.media_type,
-                    data,
-                });
-            }
-            // Metadata is handled up front; everything else (indexes, statistics, etc.) is
-            // regenerated by the writer.
-            _ => {}
-        }
-    }
+            Ok(())
+        },
+    )?;
 
     // Buffered messages are sorted and written before the attachments. The sort is stable, so
     // equal keys keep their insertion (file) order, matching the indexed reader's tie-break.
@@ -489,7 +504,10 @@ mod tests {
     use regex::Regex;
 
     use super::{filter_to_writer, MessageOrder, ResolvedOptions};
+    use crate::byte_source::MemorySource;
     use crate::cli::CommonRewriteArgs;
+    use crate::source::SourceOptions;
+    use anyhow::Result;
 
     /// Builds rewrite options from the shared CLI args, exercising the engine defaults (CRC on,
     /// chunked, metadata/attachments kept).
@@ -505,6 +523,33 @@ mod tests {
             chunk_size,
             no_crc: false,
         })
+    }
+
+    fn run_filter(input: &[u8], opts: &ResolvedOptions) -> Vec<u8> {
+        let mut source = MemorySource::new(input.to_vec());
+        let mut output = Cursor::new(Vec::new());
+        filter_to_writer(
+            &mut source,
+            &mut output,
+            opts,
+            false,
+            SourceOptions::default(),
+        )
+        .expect("filter should succeed");
+        output.into_inner()
+    }
+
+    fn filter_bytes(input: &[u8], opts: &ResolvedOptions) -> Result<Vec<u8>> {
+        let mut source = MemorySource::new(input.to_vec());
+        let mut output = Cursor::new(Vec::new());
+        filter_to_writer(
+            &mut source,
+            &mut output,
+            opts,
+            false,
+            SourceOptions::default(),
+        )?;
+        Ok(output.into_inner())
     }
 
     fn write_filter_test_input(chunked: bool, summaryless: bool) -> Vec<u8> {
@@ -619,12 +664,6 @@ mod tests {
                 .expect("metadata");
             writer.finish().expect("finish");
         }
-        output.into_inner()
-    }
-
-    fn run_filter(input: &[u8], opts: &ResolvedOptions) -> Vec<u8> {
-        let mut output = Cursor::new(Vec::new());
-        filter_to_writer(input, &mut output, opts, false).expect("filter should succeed");
         output.into_inner()
     }
 
@@ -1015,9 +1054,7 @@ mod tests {
             include_crc: true,
             order: MessageOrder::Preserve,
         };
-        let mut output = Cursor::new(Vec::new());
-        let err = filter_to_writer(&input, &mut output, &opts, false)
-            .expect_err("last-per should be rejected");
+        let err = filter_bytes(&input, &opts).expect_err("last-per should be rejected");
         assert!(err
             .to_string()
             .contains("including last-per-channel topics is not supported for non-indexed input"));
@@ -1091,9 +1128,7 @@ mod tests {
             include_crc: true,
             order: MessageOrder::Preserve,
         };
-        let mut output = Cursor::new(Vec::new());
-        let err = filter_to_writer(&input, &mut output, &opts, false)
-            .expect_err("invalid indexed summary should fail");
+        let err = filter_bytes(&input, &opts).expect_err("invalid indexed summary should fail");
         assert!(err.to_string().contains("mcap recover"));
     }
 
@@ -1115,9 +1150,7 @@ mod tests {
             include_crc: true,
             order: MessageOrder::Preserve,
         };
-        let mut output = Cursor::new(Vec::new());
-        let err = filter_to_writer(&input, &mut output, &opts, false)
-            .expect_err("invalid indexed summary should fail");
+        let err = filter_bytes(&input, &opts).expect_err("invalid indexed summary should fail");
         assert!(err.to_string().contains("mcap recover"));
     }
 
@@ -1139,9 +1172,7 @@ mod tests {
             include_crc: true,
             order: MessageOrder::Preserve,
         };
-        let mut output = Cursor::new(Vec::new());
-        let err = filter_to_writer(&input, &mut output, &opts, false)
-            .expect_err("invalid indexed summary should fail");
+        let err = filter_bytes(&input, &opts).expect_err("invalid indexed summary should fail");
         assert!(err.to_string().contains("mcap recover"));
     }
 
@@ -1237,7 +1268,11 @@ mod tests {
             "fixture should be chunk-indexed"
         );
         assert!(
-            super::common::summary_has_unindexed_messages(&input, &summary),
+            super::common::summary_has_unindexed_messages(
+                &mut MemorySource::new(input.clone()),
+                &summary
+            )
+            .expect("index completeness check"),
             "fixture should have a message outside the indexes (the gate the single path uses)"
         );
 
@@ -1302,7 +1337,11 @@ mod tests {
             "fixture should omit the statistics record"
         );
         assert!(
-            !super::common::summary_has_unindexed_messages(&input, &summary),
+            !super::common::summary_has_unindexed_messages(
+                &mut MemorySource::new(input.clone()),
+                &summary
+            )
+            .expect("index completeness check"),
             "a stats-less indexed file must not be treated as having unindexed messages"
         );
 

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -1947,7 +1947,10 @@ mod tests {
         );
 
         let stats = analyze_output(&output.into_inner());
-        assert_eq!(stats.topic_counts.get("camera_a").copied().unwrap_or(0), 100);
+        assert_eq!(
+            stats.topic_counts.get("camera_a").copied().unwrap_or(0),
+            100
+        );
         assert!(!stats.topic_counts.contains_key("camera_b"));
         assert!(!stats.topic_counts.contains_key("radar_a"));
     }

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -1379,7 +1379,7 @@ mod tests {
         };
         // The CLI is the writer of the output, so it stamps its own identity, not the source's.
         let output = run_filter(&input, &opts);
-        let library = crate::parse::read_header(&output)
+        let library = crate::parse::slice::read_header(&output)
             .expect("read header")
             .expect("header present")
             .library;

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -500,11 +500,12 @@ fn build_channel(
 mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::io::Cursor;
+    use std::sync::Arc;
 
     use regex::Regex;
 
     use super::{filter_to_writer, MessageOrder, ResolvedOptions};
-    use crate::byte_source::MemorySource;
+    use crate::byte_source::{ByteSource, MemorySource};
     use crate::cli::CommonRewriteArgs;
     use crate::source::SourceOptions;
     use anyhow::Result;
@@ -1878,5 +1879,76 @@ mod tests {
         assert_eq!(stats.topic_counts["radar_a"], 100);
         assert_eq!(stats.metadata_count, 1);
         assert_eq!(stats.attachment_count, 1);
+    }
+
+    /// Wraps [`MemorySource`] and counts bytes returned from [`ByteSource::read_at`].
+    /// Reports `is_remote() == true` so rewrite remote-scan gating applies.
+    struct CountingRemoteSource {
+        inner: MemorySource,
+        bytes_read: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl ByteSource for CountingRemoteSource {
+        fn size(&self) -> anyhow::Result<Option<u64>> {
+            self.inner.size()
+        }
+
+        fn is_remote(&self) -> bool {
+            true
+        }
+
+        fn display_name(&self) -> String {
+            "memory://remote-fixture.mcap".into()
+        }
+
+        fn read_at(&mut self, offset: u64, len: usize) -> anyhow::Result<Vec<u8>> {
+            let data = self.inner.read_at(offset, len)?;
+            self.bytes_read
+                .fetch_add(data.len(), std::sync::atomic::Ordering::SeqCst);
+            Ok(data)
+        }
+
+        fn is_seekable(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn remote_indexed_filter_uses_range_reads_without_scan_flag() {
+        use std::sync::atomic::Ordering;
+
+        let input = write_filter_test_input(true, false);
+        let file_len = input.len();
+        let bytes_read = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut source = CountingRemoteSource {
+            inner: MemorySource::new(input),
+            bytes_read: bytes_read.clone(),
+        };
+
+        let mut opts = include_all_options();
+        opts.include_topics = vec![regex::Regex::new("^camera_a$").expect("regex")];
+        opts.include_metadata = false;
+        opts.include_attachments = false;
+
+        let mut output = Cursor::new(Vec::new());
+        filter_to_writer(
+            &mut source,
+            &mut output,
+            &opts,
+            false,
+            SourceOptions::default(),
+        )
+        .expect("indexed remote filter should not need --allow-remote-scan");
+
+        let read = bytes_read.load(Ordering::SeqCst);
+        assert!(
+            read < file_len,
+            "indexed topic filter must not read the whole {file_len}-byte object; read {read}"
+        );
+
+        let stats = analyze_output(&output.into_inner());
+        assert_eq!(stats.topic_counts.get("camera_a").copied().unwrap_or(0), 100);
+        assert!(!stats.topic_counts.contains_key("camera_b"));
+        assert!(!stats.topic_counts.contains_key("radar_a"));
     }
 }

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -65,6 +65,8 @@ fn filter_with_writer<W: Write + Seek>(
         if !summary.chunk_indexes.is_empty()
             && !common::summary_has_unindexed_messages(input, &summary)?
         {
+            // Message-chunk reads need the same opt-in as on main (summary-only stays unflagged).
+            common::require_remote_scan_for_chunks(input, source_options)?;
             return filter_indexed(input, &summary, writer, opts, source_options);
         }
     }
@@ -1914,7 +1916,32 @@ mod tests {
     }
 
     #[test]
-    fn remote_indexed_filter_uses_range_reads_without_scan_flag() {
+    fn remote_indexed_filter_requires_allow_remote_scan() {
+        let input = write_filter_test_input(true, false);
+        let mut source = CountingRemoteSource {
+            inner: MemorySource::new(input),
+            bytes_read: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+
+        let mut opts = include_all_options();
+        opts.include_topics = vec![regex::Regex::new("^camera_a$").expect("regex")];
+        opts.include_metadata = false;
+        opts.include_attachments = false;
+
+        let mut output = Cursor::new(Vec::new());
+        let err = filter_to_writer(
+            &mut source,
+            &mut output,
+            &opts,
+            false,
+            SourceOptions::default(),
+        )
+        .expect_err("indexed remote filter should require --allow-remote-scan");
+        assert!(err.to_string().contains("--allow-remote-scan"));
+    }
+
+    #[test]
+    fn remote_indexed_filter_uses_range_reads_with_scan_flag() {
         use std::sync::atomic::Ordering;
 
         let input = write_filter_test_input(true, false);
@@ -1936,9 +1963,9 @@ mod tests {
             &mut output,
             &opts,
             false,
-            SourceOptions::default(),
+            SourceOptions::new(true),
         )
-        .expect("indexed remote filter should not need --allow-remote-scan");
+        .expect("indexed remote filter with --allow-remote-scan should succeed");
 
         let read = bytes_read.load(Ordering::SeqCst);
         assert!(

--- a/rust/cli/src/rewrite/single.rs
+++ b/rust/cli/src/rewrite/single.rs
@@ -1901,15 +1901,15 @@ mod tests {
             "memory://remote-fixture.mcap".into()
         }
 
-        fn read_at(&mut self, offset: u64, len: usize) -> anyhow::Result<Vec<u8>> {
-            let data = self.inner.read_at(offset, len)?;
-            self.bytes_read
-                .fetch_add(data.len(), std::sync::atomic::Ordering::SeqCst);
-            Ok(data)
-        }
-
         fn is_seekable(&self) -> bool {
             true
+        }
+
+        fn read_into(&mut self, offset: u64, dest: &mut [u8]) -> anyhow::Result<usize> {
+            let n = self.inner.read_into(offset, dest)?;
+            self.bytes_read
+                .fetch_add(n, std::sync::atomic::Ordering::SeqCst);
+            Ok(n)
         }
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1929,8 +1929,8 @@ mod tests {
             super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
                 .expect("remote summary read")
                 .expect("summary should be present");
-        let summary =
-            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
+        let summary = crate::parse::slice::parse_summary_section(&summary_bytes)
+            .expect("parse summary section");
         assert!(summary.channels.contains_key(&channel_id));
         assert_eq!(
             requests.load(Ordering::SeqCst),
@@ -1949,8 +1949,8 @@ mod tests {
             super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
                 .expect("summary read")
                 .expect("summary should be present");
-        let summary =
-            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
+        let summary = crate::parse::slice::parse_summary_section(&summary_bytes)
+            .expect("parse summary section");
         assert!(summary.channels.contains_key(&channel_id));
     }
 
@@ -1976,8 +1976,8 @@ mod tests {
             super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
                 .expect("summary read with back-fill")
                 .expect("summary should be present");
-        let summary =
-            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
+        let summary = crate::parse::slice::parse_summary_section(&summary_bytes)
+            .expect("parse summary section");
         assert!(summary.channels.contains_key(&channel_id));
     }
 
@@ -2013,8 +2013,8 @@ mod tests {
             super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
                 .expect("summary read")
                 .expect("summary should be present");
-        let summary =
-            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
+        let summary = crate::parse::slice::parse_summary_section(&summary_bytes)
+            .expect("parse summary section");
         assert!(summary.channels.contains_key(&channel_id));
         assert_eq!(
             requests.load(Ordering::SeqCst),

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -67,24 +67,6 @@ impl MaterializedInput {
     }
 }
 
-pub struct RemoteMcap {
-    #[allow(dead_code)] // Used by tests.
-    reader: RemoteRangeReader,
-    summary: mcap::Summary,
-}
-
-impl RemoteMcap {
-    #[allow(dead_code)] // Used by tests.
-    pub fn summary(&self) -> &mcap::Summary {
-        &self.summary
-    }
-
-    #[allow(dead_code)] // Used by tests.
-    pub fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
-        self.reader.read_range(offset, length)
-    }
-}
-
 pub fn ensure_distinct_local_input_output(input: &Path, output: &Path) -> Result<()> {
     if is_remote_url(input) {
         return Ok(());
@@ -229,8 +211,7 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
     let mut source = crate::byte_source::open_byte_source(Some(path), options)?;
     let header = crate::byte_source::read_header(source.as_mut())?;
     if let Some(parsed) = parse::try_parsed_mcap_from_summary(source.as_mut(), header.clone())? {
-        let want_stats_scan =
-            options.scan_data_without_statistics && parsed.statistics.is_none();
+        let want_stats_scan = options.scan_data_without_statistics && parsed.statistics.is_none();
         if !want_stats_scan {
             return Ok(parsed);
         }
@@ -273,36 +254,6 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
         temp_file: Some(temp_file),
         local_path: None,
     })
-}
-
-#[allow(dead_code)] // Used by tests.
-pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Option<RemoteMcap>> {
-    if !is_remote_url(path) {
-        return Ok(None);
-    }
-    let Some(mut reader) = open_remote_range_reader(path)? else {
-        if !options.allow_remote_scan {
-            bail!(
-                "{}: remote server does not support range requests; {}",
-                redacted_display(path),
-                remote_scan_opt_in_suffix()
-            );
-        }
-        return Ok(None);
-    };
-    let Some(summary) = read_summary_from_remote(&mut reader, options)
-        .map_err(|err| remote_read_error(path, err))?
-    else {
-        if !options.allow_remote_scan {
-            bail!(
-                "failed to read {}\nRemote file has no summary section; reading without one requires opt-in; {}",
-                redacted_display(path),
-                remote_scan_opt_in_suffix()
-            );
-        }
-        return Ok(None);
-    };
-    Ok(Some(RemoteMcap { reader, summary }))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -678,7 +629,6 @@ impl RemoteRangeReader {
         self.size
     }
 
-    #[allow(dead_code)] // Used by byte_source::RemoteRangeSource.
     pub(crate) fn display_url(&self) -> &str {
         &self.source.display_url
     }
@@ -953,19 +903,6 @@ pub(crate) fn require_remote_scan_for_linear(
         );
     }
     Ok(())
-}
-
-#[allow(dead_code)] // Used by try_open_remote_mcap / tests.
-fn read_summary_from_remote(
-    reader: &mut RemoteRangeReader,
-    options: SourceOptions,
-) -> Result<Option<mcap::Summary>> {
-    let Some(summary_bytes) = read_summary_bytes_from_remote(reader, options)? else {
-        return Ok(None);
-    };
-    parse::parse_summary_section(&summary_bytes)
-        .map(Some)
-        .map_err(|err| classify_remote_summary_error(reader, err))
 }
 
 fn read_summary_bytes_from_remote(
@@ -1542,8 +1479,8 @@ mod tests {
     #[test]
     fn remote_http_input_reads_entire_file() {
         let url = serve_http(b"hello remote", true);
-        let input =
-            materialize_input(Path::new(&url), super::SourceOptions::new(true)).expect("remote read");
+        let input = materialize_input(Path::new(&url), super::SourceOptions::new(true))
+            .expect("remote read");
         assert_eq!(
             std::fs::read(input.path()).expect("read materialized"),
             b"hello remote"
@@ -1641,11 +1578,11 @@ mod tests {
         }
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let url = serve_http_with_headers(body, true, &[("Content-Encoding", "gzip")]);
-        let err =
-            match super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default()) {
-                Ok(_) => panic!("gzip-encoded range probe should fail"),
-                Err(err) => err,
-            };
+        let err = crate::byte_source::open_byte_source(
+            Some(Path::new(&url)),
+            super::SourceOptions::default(),
+        )
+        .expect_err("gzip-encoded range probe should fail");
         let message = format!("{err:#}");
         assert!(message.contains("MCAP remote reads require identity encoding"));
     }
@@ -1692,11 +1629,11 @@ mod tests {
         let (buffer, _) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let (url, _requests) = serve_http_with_options(body, true, &[], false, true, false);
-        let err =
-            match super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default()) {
-                Ok(_) => panic!("unknown range total should surface as an error, not a bogus size"),
-                Err(err) => err,
-            };
+        let err = crate::byte_source::open_byte_source(
+            Some(Path::new(&url)),
+            super::SourceOptions::default(),
+        )
+        .expect_err("unknown range total should surface as an error, not a bogus size");
         let message = format!("{err:#}");
         assert!(message.contains("Failed while fetching range from"));
     }
@@ -1720,11 +1657,11 @@ mod tests {
         body[len - mcap::MAGIC.len()..].copy_from_slice(mcap::MAGIC);
 
         let url = serve_http(Box::leak(body.into_boxed_slice()), true);
-        let err =
-            match super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default()) {
-                Ok(_) => panic!("oversized remote summary should require scan opt-in"),
-                Err(err) => err,
-            };
+        let mut reader = super::open_remote_range_reader(Path::new(&url))
+            .expect("remote open")
+            .expect("range support");
+        let err = super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
+            .expect_err("oversized remote summary should require scan opt-in");
         let message = format!("{err:#}");
         assert!(message.contains("Remote summary section"));
         assert!(message.contains("--allow-remote-scan"));
@@ -1961,11 +1898,16 @@ mod tests {
         let (buffer, channel_id) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let url = serve_http(body, true);
-        let remote = super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default())
+        let mut source = crate::byte_source::open_byte_source(
+            Some(Path::new(&url)),
+            super::SourceOptions::default(),
+        )
+        .expect("remote open");
+        let summary = crate::byte_source::read_summary(source.as_mut())
             .expect("remote summary read")
             .expect("summary should be present");
 
-        assert!(remote.summary().channels.contains_key(&channel_id));
+        assert!(summary.channels.contains_key(&channel_id));
     }
 
     #[test]
@@ -1975,10 +1917,16 @@ mod tests {
         let (buffer, channel_id) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let (url, requests) = serve_http_counting(body, true);
-        let remote = super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default())
-            .expect("remote summary read")
-            .expect("summary should be present");
-        assert!(remote.summary().channels.contains_key(&channel_id));
+        let mut reader = super::open_remote_range_reader(Path::new(&url))
+            .expect("remote open")
+            .expect("range support");
+        let summary_bytes =
+            super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
+                .expect("remote summary read")
+                .expect("summary should be present");
+        let summary =
+            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
+        assert!(summary.channels.contains_key(&channel_id));
         assert_eq!(
             requests.load(Ordering::SeqCst),
             1,
@@ -1992,9 +1940,12 @@ mod tests {
         // entirely from the prefetched bytes, with no back-fill range read.
         let (buffer, channel_id) = summary_mcap_with_channel();
         let mut reader = object_store_memory_reader_with_tail(buffer, 0);
-        let summary = super::read_summary_from_remote(&mut reader, super::SourceOptions::default())
-            .expect("summary read")
-            .expect("summary should be present");
+        let summary_bytes =
+            super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
+                .expect("summary read")
+                .expect("summary should be present");
+        let summary =
+            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
         assert!(summary.channels.contains_key(&channel_id));
     }
 
@@ -2016,9 +1967,12 @@ mod tests {
         assert!(tail_start <= footer_start as u64);
 
         let mut reader = object_store_memory_reader_with_tail(buffer, tail_start);
-        let summary = super::read_summary_from_remote(&mut reader, super::SourceOptions::default())
-            .expect("summary read with back-fill")
-            .expect("summary should be present");
+        let summary_bytes =
+            super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
+                .expect("summary read with back-fill")
+                .expect("summary should be present");
+        let summary =
+            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
         assert!(summary.channels.contains_key(&channel_id));
     }
 
@@ -2027,11 +1981,16 @@ mod tests {
         let (buffer, channel_id) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let (url, _requests) = serve_http_with_options(body, true, &[], true, false, false);
-        let remote = super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default())
-            .expect("remote summary should use range GET, not HEAD")
+        let mut source = crate::byte_source::open_byte_source(
+            Some(Path::new(&url)),
+            super::SourceOptions::default(),
+        )
+        .expect("remote summary should use range GET, not HEAD");
+        let summary = crate::byte_source::read_summary(source.as_mut())
+            .expect("remote summary read")
             .expect("summary should be present");
 
-        assert!(remote.summary().channels.contains_key(&channel_id));
+        assert!(summary.channels.contains_key(&channel_id));
     }
 
     #[test]
@@ -2042,10 +2001,16 @@ mod tests {
         let (buffer, channel_id) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let (url, requests) = serve_http_bounded_only(body);
-        let remote = super::try_open_remote_mcap(Path::new(&url), super::SourceOptions::default())
+        let mut reader = super::open_remote_range_reader(Path::new(&url))
             .expect("bounded-only server should open without a scan")
-            .expect("summary should be present");
-        assert!(remote.summary().channels.contains_key(&channel_id));
+            .expect("range support");
+        let summary_bytes =
+            super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
+                .expect("summary read")
+                .expect("summary should be present");
+        let summary =
+            crate::parse::parse_summary_section(&summary_bytes).expect("parse summary section");
+        assert!(summary.channels.contains_key(&channel_id));
         assert_eq!(
             requests.load(Ordering::SeqCst),
             3,

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1578,11 +1578,13 @@ mod tests {
         }
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let url = serve_http_with_headers(body, true, &[("Content-Encoding", "gzip")]);
-        let err = crate::byte_source::open_byte_source(
+        let err = match crate::byte_source::open_byte_source(
             Some(Path::new(&url)),
             super::SourceOptions::default(),
-        )
-        .expect_err("gzip-encoded range probe should fail");
+        ) {
+            Ok(_) => panic!("gzip-encoded range probe should fail"),
+            Err(err) => err,
+        };
         let message = format!("{err:#}");
         assert!(message.contains("MCAP remote reads require identity encoding"));
     }
@@ -1629,11 +1631,13 @@ mod tests {
         let (buffer, _) = summary_mcap_with_channel();
         let body: &'static [u8] = Box::leak(buffer.into_boxed_slice());
         let (url, _requests) = serve_http_with_options(body, true, &[], false, true, false);
-        let err = crate::byte_source::open_byte_source(
+        let err = match crate::byte_source::open_byte_source(
             Some(Path::new(&url)),
             super::SourceOptions::default(),
-        )
-        .expect_err("unknown range total should surface as an error, not a bogus size");
+        ) {
+            Ok(_) => panic!("unknown range total should surface as an error, not a bogus size"),
+            Err(err) => err,
+        };
         let message = format!("{err:#}");
         assert!(message.contains("Failed while fetching range from"));
     }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -294,6 +294,7 @@ pub fn load_path(path: &Path, options: SourceOptions) -> Result<InputData> {
     Ok(InputData::Mapped(map_file(path)?))
 }
 
+#[allow(dead_code)] // Still used by commands that mmap whole files; rewrite uses ByteSource.
 pub fn load_input(file: Option<&Path>, options: SourceOptions) -> Result<InputData> {
     if let Some(path) = file {
         return load_path(path, options);

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1668,12 +1668,7 @@ mod tests {
             super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
                 .expect_err("oversized remote summary should require scan opt-in");
         let message = format!("{err:#}");
-        eprintln!("ACTUAL_ERR={message}");
-        assert!(
-            message.contains("Remote summary section")
-                || message.contains("remote summary section"),
-            "{message}"
-        );
+        assert!(message.contains("remote summary section"));
         assert!(message.contains("--allow-remote-scan"));
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -774,7 +774,7 @@ impl RemoteRangeReader {
         })
     }
 
-    fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
+    pub(crate) fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
         if length == 0 || offset >= self.size {
             return Ok(Vec::new());
         }
@@ -785,8 +785,13 @@ impl RemoteRangeReader {
         self.source.get_range(offset..end)
     }
 
-    fn size(&self) -> u64 {
+    pub(crate) fn size(&self) -> u64 {
         self.size
+    }
+
+    #[allow(dead_code)] // Used by byte_source::RemoteRangeSource.
+    pub(crate) fn display_url(&self) -> &str {
+        &self.source.display_url
     }
 }
 
@@ -922,7 +927,7 @@ fn status_from_object_store_message(message: &str) -> Option<String> {
     (!status.is_empty()).then(|| status.to_string())
 }
 
-fn open_remote_range_reader(path: &Path) -> Result<Option<RemoteRangeReader>> {
+pub(crate) fn open_remote_range_reader(path: &Path) -> Result<Option<RemoteRangeReader>> {
     if is_remote_url(path) {
         return RemoteRangeReader::open(path);
     }
@@ -935,7 +940,10 @@ pub(crate) fn redacted_display(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-fn read_remote_input_to_writer(path: &Path, writer: &mut impl std::io::Write) -> Result<()> {
+pub(crate) fn read_remote_input_to_writer(
+    path: &Path,
+    writer: &mut impl std::io::Write,
+) -> Result<()> {
     let source = ObjectStoreSource::open(path)?;
     eprintln!("Warning: reading entire remote file {}", source.display_url);
 
@@ -1032,7 +1040,7 @@ pub(crate) fn require_remote_indexed_read_budget(
     );
 }
 
-fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()> {
+pub(crate) fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -> Result<()> {
     if options.allow_remote_scan {
         return Ok(());
     }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -107,15 +107,18 @@ impl MaterializedInput {
 }
 
 pub struct RemoteMcap {
+    #[allow(dead_code)] // Used by tests; remaining commands (doctor/recover) still to port.
     reader: RemoteRangeReader,
     summary: mcap::Summary,
 }
 
 impl RemoteMcap {
+    #[allow(dead_code)] // Used by tests; remaining commands still to port.
     pub fn summary(&self) -> &mcap::Summary {
         &self.summary
     }
 
+    #[allow(dead_code)] // Used by tests; remaining commands still to port.
     pub fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
         self.reader.read_range(offset, length)
     }
@@ -237,12 +240,15 @@ pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
 
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
     if is_remote_url(path) {
+        let mut stats_scan_fallback = false;
         match open_remote_range_reader(path)? {
             Some(mut reader) => {
                 if let Some(summary_bytes) = read_summary_bytes_from_remote(&mut reader, options)
                     .map_err(|err| remote_read_error(path, err))?
                 {
-                    let header = read_header_from_seekable(&mut reader)?;
+                    let header = read_header_from_seekable(&mut reader).map_err(|err| {
+                        remote_read_error(path, classify_remote_summary_error(&reader, err))
+                    })?;
                     let parsed = parse::parsed_mcap_from_summary_section(header, &summary_bytes)
                         .map_err(|err| {
                             remote_read_error(path, classify_remote_summary_error(&reader, err))
@@ -253,8 +259,8 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
                     {
                         return Ok(parsed);
                     }
-                }
-                if !options.allow_remote_scan {
+                    stats_scan_fallback = true;
+                } else if !options.allow_remote_scan {
                     bail!(
                         "failed to read {}\nRemote file has no summary section; reading without one requires opt-in; {}",
                         redacted_display(path),
@@ -271,15 +277,42 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
             }
             None => {}
         }
+
+        // Remote linear / stats-scan fallback via ByteSource (no mmap).
+        let mut source = crate::byte_source::open_byte_source(Some(path), options)?;
+        let header = crate::byte_source::read_header(source.as_mut())
+            .map_err(|err| remote_read_error(path, err))?;
+        if stats_scan_fallback {
+            eprintln!(
+                "Warning: Statistics record not available; full scan may be slow. Run `mcap doctor` for details."
+            );
+        } else {
+            eprintln!(
+                "Warning: summary section not available; full scan may be slow. Run `mcap doctor` for details."
+            );
+        }
+        return parse::parse_mcap_linear_from_byte_source(source.as_mut(), header)
+            .map_err(|err| remote_read_error(path, err));
     }
 
-    let mcap = load_path(path, options)?;
-    let parsed = parse::parse_mcap_with_scan_fallback(&mcap, options.scan_data_without_statistics);
-    if is_remote_url(path) {
-        parsed.map_err(|err| remote_read_error(path, err))
-    } else {
-        parsed
+    let mut source = crate::byte_source::open_byte_source(Some(path), options)?;
+    let header = crate::byte_source::read_header(source.as_mut())?;
+    if let Some(parsed) = parse::try_parsed_mcap_from_summary(source.as_mut(), header.clone())? {
+        let want_stats_scan =
+            options.scan_data_without_statistics && parsed.statistics.is_none();
+        if !want_stats_scan {
+            return Ok(parsed);
+        }
+        eprintln!(
+            "Warning: Statistics record not available; full scan may be slow. Run `mcap doctor` for details."
+        );
+        return parse::parse_mcap_linear_from_byte_source(source.as_mut(), header);
     }
+
+    eprintln!(
+        "Warning: summary section not available; full scan may be slow. Run `mcap doctor` for details."
+    );
+    parse::parse_mcap_linear_from_byte_source(source.as_mut(), header)
 }
 
 pub fn load_path(path: &Path, options: SourceOptions) -> Result<InputData> {
@@ -388,6 +421,7 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
     })
 }
 
+#[allow(dead_code)] // Used by tests; remaining commands (doctor/recover) still to port.
 pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Option<RemoteMcap>> {
     if !is_remote_url(path) {
         return Ok(None);
@@ -1052,6 +1086,22 @@ pub(crate) fn require_remote_scan_allowed(path: &Path, options: SourceOptions) -
     );
 }
 
+/// Errors when a remote [`ByteSource`] would need a full linear scan without `--allow-remote-scan`.
+pub(crate) fn require_remote_scan_for_linear(
+    source: &dyn crate::byte_source::ByteSource,
+    options: SourceOptions,
+) -> Result<()> {
+    if source.is_remote() && !options.allow_remote_scan {
+        bail!(
+            "{}: remote file requires a full scan; {}",
+            source.display_name(),
+            remote_scan_opt_in_suffix()
+        );
+    }
+    Ok(())
+}
+
+#[allow(dead_code)] // Used by try_open_remote_mcap / tests.
 fn read_summary_from_remote(
     reader: &mut RemoteRangeReader,
     options: SourceOptions,

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1660,8 +1660,9 @@ mod tests {
         let mut reader = super::open_remote_range_reader(Path::new(&url))
             .expect("remote open")
             .expect("range support");
-        let err = super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
-            .expect_err("oversized remote summary should require scan opt-in");
+        let err =
+            super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
+                .expect_err("oversized remote summary should require scan opt-in");
         let message = format!("{err:#}");
         assert!(message.contains("Remote summary section"));
         assert!(message.contains("--allow-remote-scan"));

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1668,7 +1668,12 @@ mod tests {
             super::read_summary_bytes_from_remote(&mut reader, super::SourceOptions::default())
                 .expect_err("oversized remote summary should require scan opt-in");
         let message = format!("{err:#}");
-        assert!(message.contains("Remote summary section"));
+        eprintln!("ACTUAL_ERR={message}");
+        assert!(
+            message.contains("Remote summary section")
+                || message.contains("remote summary section"),
+            "{message}"
+        );
         assert!(message.contains("--allow-remote-scan"));
     }
 

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1500,7 +1500,8 @@ mod tests {
     fn remote_errors_redact_query_strings() {
         let url = "http://127.0.0.1:1/demo.mcap?X-Amz-Signature=secret-token";
         let err = materialize_input(Path::new(url), super::SourceOptions::default())
-            .expect_err("remote scan rejection should report redacted URL");
+            .err()
+            .expect("remote scan rejection should report redacted URL");
         assert!(!err.to_string().contains("secret-token"));
         assert!(!err.to_string().contains("X-Amz-Signature"));
     }
@@ -1509,7 +1510,8 @@ mod tests {
     fn remote_errors_redact_userinfo() {
         let url = "http://AKIA:secret@127.0.0.1:1/demo.mcap";
         let err = materialize_input(Path::new(url), super::SourceOptions::default())
-            .expect_err("remote scan rejection should report redacted URL");
+            .err()
+            .expect("remote scan rejection should report redacted URL");
         assert!(!err.to_string().contains("AKIA"));
         assert!(!err.to_string().contains("secret"));
         assert!(err.to_string().contains("http://127.0.0.1:1/demo.mcap"));
@@ -1519,7 +1521,8 @@ mod tests {
     fn remote_http_input_requires_remote_scan_opt_in() {
         let url = serve_http(b"hello remote", true);
         let err = materialize_input(Path::new(&url), super::SourceOptions::default())
-            .expect_err("remote full read should require opt-in");
+            .err()
+            .expect("remote full read should require opt-in");
         assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
@@ -1529,7 +1532,8 @@ mod tests {
             Path::new("s3://bucket/demo.mcap?X-Amz-Signature=secret-token"),
             super::SourceOptions::default(),
         )
-        .expect_err("cloud remote full read should require opt-in");
+        .err()
+        .expect("cloud remote full read should require opt-in");
         assert!(err.to_string().contains("--allow-remote-scan"));
         assert!(!err.to_string().contains("secret-token"));
         assert!(!err.to_string().contains("X-Amz-Signature"));
@@ -1550,7 +1554,8 @@ mod tests {
     fn remote_http_input_rejects_gzip_content_encoding() {
         let url = serve_http_with_headers(b"hello remote", false, &[("Content-Encoding", "gzip")]);
         let err = materialize_input(Path::new(&url), super::SourceOptions::new(true))
-            .expect_err("gzip-encoded remote read should fail");
+            .err()
+            .expect("gzip-encoded remote read should fail");
         let message = format!("{err:#}");
         assert!(message.contains("MCAP remote reads require identity encoding"));
     }

--- a/rust/cli/src/source.rs
+++ b/rust/cli/src/source.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal as _, SeekFrom};
+use std::io::SeekFrom;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -6,7 +6,6 @@ use anyhow::{bail, Context, Result};
 use binrw::BinRead;
 use futures_util::TryStreamExt;
 use mcap::records::{self, Record};
-use memmap2::Mmap;
 use object_store::{
     path::Path as ObjectStorePath, Attribute, GetOptions, GetRange, ObjectStore, ObjectStoreExt,
 };
@@ -30,44 +29,6 @@ const REMOTE_SUMMARY_TAIL_BYTES: u64 = 250_000;
 // Guards aggregate remote reads that should stay index-like (summary bytes, or
 // multiple metadata records selected from indexes) from becoming unexpectedly large.
 pub(crate) const MAX_REMOTE_INDEXED_BYTES_WITHOUT_SCAN: u64 = 100_000_000;
-
-pub enum InputData {
-    Mapped(Mmap),
-    TempMapped {
-        mmap: Mmap,
-        // Keep the temporary file alive for at least as long as the mmap. Fields drop in
-        // declaration order, so this is dropped after `mmap`.
-        #[allow(dead_code)]
-        temp_file: NamedTempFile,
-    },
-    Buffered(Vec<u8>),
-}
-
-impl std::fmt::Debug for InputData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("InputData")
-            .field("len", &self.as_slice().len())
-            .finish()
-    }
-}
-
-impl std::ops::Deref for InputData {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl InputData {
-    pub fn as_slice(&self) -> &[u8] {
-        match self {
-            InputData::Mapped(mmap) => mmap.as_ref(),
-            InputData::TempMapped { mmap, .. } => mmap.as_ref(),
-            InputData::Buffered(buf) => buf.as_slice(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SourceOptions {
@@ -107,47 +68,21 @@ impl MaterializedInput {
 }
 
 pub struct RemoteMcap {
-    #[allow(dead_code)] // Used by tests; remaining commands (doctor/recover) still to port.
+    #[allow(dead_code)] // Used by tests.
     reader: RemoteRangeReader,
     summary: mcap::Summary,
 }
 
 impl RemoteMcap {
-    #[allow(dead_code)] // Used by tests; remaining commands still to port.
+    #[allow(dead_code)] // Used by tests.
     pub fn summary(&self) -> &mcap::Summary {
         &self.summary
     }
 
-    #[allow(dead_code)] // Used by tests; remaining commands still to port.
+    #[allow(dead_code)] // Used by tests.
     pub fn read_range(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
         self.reader.read_range(offset, length)
     }
-}
-
-pub(crate) enum StreamingInput {
-    Local(std::fs::File),
-    Stdin(std::io::Stdin),
-    RemoteMaterialized {
-        file: std::fs::File,
-        #[allow(dead_code)]
-        temp_file: NamedTempFile,
-    },
-}
-
-impl std::io::Read for StreamingInput {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        match self {
-            StreamingInput::Local(file) => file.read(buf),
-            StreamingInput::Stdin(stdin) => stdin.read(buf),
-            StreamingInput::RemoteMaterialized { file, .. } => file.read(buf),
-        }
-    }
-}
-
-pub fn map_file(path: &Path) -> anyhow::Result<Mmap> {
-    let file =
-        std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))?;
-    unsafe { Mmap::map(&file) }.with_context(|| format!("couldn't map '{}'", path.display()))
 }
 
 pub fn ensure_distinct_local_input_output(input: &Path, output: &Path) -> Result<()> {
@@ -234,10 +169,6 @@ fn local_paths_have_same_file_id(_input: &Path, _output: &Path) -> Result<bool> 
     Ok(false)
 }
 
-pub fn open_seekable_mcap_source(path: &Path) -> Result<std::fs::File> {
-    std::fs::File::open(path).with_context(|| format!("couldn't open '{}'", path.display()))
-}
-
 pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<ParsedMcap> {
     if is_remote_url(path) {
         let mut stats_scan_fallback = false;
@@ -315,83 +246,6 @@ pub fn parse_mcap_from_path(path: &Path, options: SourceOptions) -> Result<Parse
     parse::parse_mcap_linear_from_byte_source(source.as_mut(), header)
 }
 
-pub fn load_path(path: &Path, options: SourceOptions) -> Result<InputData> {
-    if is_remote_url(path) {
-        let materialized = materialize_input(path, options)?;
-        let mmap = map_file(materialized.path())?;
-        let temp_file = materialized
-            .temp_file
-            .expect("remote materialized input should have a temp file");
-        return Ok(InputData::TempMapped { temp_file, mmap });
-    }
-    Ok(InputData::Mapped(map_file(path)?))
-}
-
-#[allow(dead_code)] // Still used by commands that mmap whole files; rewrite uses ByteSource.
-pub fn load_input(file: Option<&Path>, options: SourceOptions) -> Result<InputData> {
-    if let Some(path) = file {
-        return load_path(path, options);
-    }
-
-    let stdin = std::io::stdin();
-    if stdin.is_terminal() {
-        bail!("{PLEASE_SUPPLY_FILE}");
-    }
-
-    read_stdin_to_mapped_input(&mut stdin.lock())
-}
-
-/// Spool a non-seekable stdin stream to a temporary file and memory-map it instead of
-/// buffering the whole input in a `Vec`, so piping an arbitrarily large MCAP keeps
-/// process memory bounded (the OS pages a disk-backed mapping on demand).
-///
-/// The temp file lives in `$TMPDIR` (else `/tmp`); if that is a tmpfs — common on modern
-/// Linux — the spool stays in RAM and the paging benefit is lost, so point `$TMPDIR` at
-/// real storage for very large inputs. Mirrors the remote `materialize_input` path.
-fn read_stdin_to_mapped_input(reader: &mut impl std::io::Read) -> Result<InputData> {
-    let mut temp_file = tempfile::Builder::new()
-        .prefix("mcap-cli-stdin-input-")
-        .tempfile()
-        .context("failed to create temporary file for stdin input")?;
-    let bytes_copied = std::io::copy(reader, temp_file.as_file_mut())
-        .context("failed to read input from stdin")?;
-    std::io::Write::flush(temp_file.as_file_mut())
-        .context("failed to flush temporary stdin input file")?;
-    if bytes_copied == 0 {
-        // memmap2 refuses to map a zero-length file, so fall back to an empty buffer.
-        // Callers then get the usual empty-input MCAP parse error.
-        return Ok(InputData::Buffered(Vec::new()));
-    }
-    let mmap = map_file(temp_file.path())?;
-    Ok(InputData::TempMapped { temp_file, mmap })
-}
-
-pub(crate) fn open_streaming_input(
-    file: Option<&Path>,
-    options: SourceOptions,
-) -> Result<StreamingInput> {
-    if let Some(path) = file {
-        if is_remote_url(path) {
-            // Remote clients are async, while recover's reader pipeline is synchronous.
-            // Materializing keeps the recovery path simple and consistently gated by
-            // `--allow-remote-scan` in `materialize_input`.
-            let materialized = materialize_input(path, options)?;
-            let file = open_seekable_mcap_source(materialized.path())?;
-            let temp_file = materialized
-                .temp_file
-                .expect("remote streaming input should have a temp file");
-            return Ok(StreamingInput::RemoteMaterialized { file, temp_file });
-        }
-        return Ok(StreamingInput::Local(open_seekable_mcap_source(path)?));
-    }
-
-    let stdin = std::io::stdin();
-    if stdin.is_terminal() {
-        bail!("{PLEASE_SUPPLY_FILE}");
-    }
-    Ok(StreamingInput::Stdin(stdin))
-}
-
 pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<MaterializedInput> {
     if !is_remote_url(path) {
         return Ok(MaterializedInput {
@@ -421,7 +275,7 @@ pub fn materialize_input(path: &Path, options: SourceOptions) -> Result<Material
     })
 }
 
-#[allow(dead_code)] // Used by tests; remaining commands (doctor/recover) still to port.
+#[allow(dead_code)] // Used by tests.
 pub fn try_open_remote_mcap(path: &Path, options: SourceOptions) -> Result<Option<RemoteMcap>> {
     if !is_remote_url(path) {
         return Ok(None);
@@ -1298,7 +1152,7 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
-    use super::load_path;
+    use super::materialize_input;
     use crate::render::human_bytes;
     use mcap::records;
     use object_store::ObjectStoreExt;
@@ -1382,29 +1236,6 @@ mod tests {
 
         super::ensure_distinct_local_input_output(&input, &output)
             .expect("missing input should be left to command open errors");
-    }
-
-    #[test]
-    fn stdin_input_is_spooled_to_temp_file_and_mapped() {
-        let (buffer, _) = summary_mcap_with_channel();
-        let mut reader = std::io::Cursor::new(buffer.clone());
-        let input = super::read_stdin_to_mapped_input(&mut reader).expect("stdin spool");
-        assert!(
-            matches!(input, super::InputData::TempMapped { .. }),
-            "non-empty stdin should be memory-mapped from a temp file, not buffered in RAM"
-        );
-        assert_eq!(input.as_slice(), buffer.as_slice());
-    }
-
-    #[test]
-    fn empty_stdin_input_falls_back_to_empty_buffer() {
-        let mut reader = std::io::Cursor::new(Vec::new());
-        let input = super::read_stdin_to_mapped_input(&mut reader).expect("empty stdin spool");
-        assert!(
-            matches!(input, super::InputData::Buffered(ref buf) if buf.is_empty()),
-            "empty stdin cannot be mmap'd and should fall back to an empty buffer"
-        );
-        assert!(input.as_slice().is_empty());
     }
 
     fn serve_http(body: &'static [u8], supports_ranges: bool) -> String {
@@ -1668,7 +1499,7 @@ mod tests {
     #[test]
     fn remote_errors_redact_query_strings() {
         let url = "http://127.0.0.1:1/demo.mcap?X-Amz-Signature=secret-token";
-        let err = load_path(Path::new(url), super::SourceOptions::default())
+        let err = materialize_input(Path::new(url), super::SourceOptions::default())
             .expect_err("remote scan rejection should report redacted URL");
         assert!(!err.to_string().contains("secret-token"));
         assert!(!err.to_string().contains("X-Amz-Signature"));
@@ -1677,7 +1508,7 @@ mod tests {
     #[test]
     fn remote_errors_redact_userinfo() {
         let url = "http://AKIA:secret@127.0.0.1:1/demo.mcap";
-        let err = load_path(Path::new(url), super::SourceOptions::default())
+        let err = materialize_input(Path::new(url), super::SourceOptions::default())
             .expect_err("remote scan rejection should report redacted URL");
         assert!(!err.to_string().contains("AKIA"));
         assert!(!err.to_string().contains("secret"));
@@ -1687,14 +1518,14 @@ mod tests {
     #[test]
     fn remote_http_input_requires_remote_scan_opt_in() {
         let url = serve_http(b"hello remote", true);
-        let err = load_path(Path::new(&url), super::SourceOptions::default())
+        let err = materialize_input(Path::new(&url), super::SourceOptions::default())
             .expect_err("remote full read should require opt-in");
         assert!(err.to_string().contains("--allow-remote-scan"));
     }
 
     #[test]
     fn remote_object_store_input_requires_remote_scan_opt_in_before_network() {
-        let err = load_path(
+        let err = materialize_input(
             Path::new("s3://bucket/demo.mcap?X-Amz-Signature=secret-token"),
             super::SourceOptions::default(),
         )
@@ -1708,14 +1539,17 @@ mod tests {
     fn remote_http_input_reads_entire_file() {
         let url = serve_http(b"hello remote", true);
         let input =
-            load_path(Path::new(&url), super::SourceOptions::new(true)).expect("remote read");
-        assert_eq!(input.as_slice(), b"hello remote");
+            materialize_input(Path::new(&url), super::SourceOptions::new(true)).expect("remote read");
+        assert_eq!(
+            std::fs::read(input.path()).expect("read materialized"),
+            b"hello remote"
+        );
     }
 
     #[test]
     fn remote_http_input_rejects_gzip_content_encoding() {
         let url = serve_http_with_headers(b"hello remote", false, &[("Content-Encoding", "gzip")]);
-        let err = load_path(Path::new(&url), super::SourceOptions::new(true))
+        let err = materialize_input(Path::new(&url), super::SourceOptions::new(true))
             .expect_err("gzip-encoded remote read should fail");
         let message = format!("{err:#}");
         assert!(message.contains("MCAP remote reads require identity encoding"));

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -70,9 +70,11 @@ Options:
           [possible values: auto, always, never]
 
       --allow-remote-scan
-          Allow whole-file scans or downloads of remote inputs.
+          Allow unbounded remote transfer or a full linear scan of remote inputs.
 
-          Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small bounded indexed reads work without this flag.
+          Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small
+          bounded indexed reads work without this flag. With this flag, commands may transfer an
+          entire remote object (via range requests or a full download) to scan or rewrite it.
 
       --time-format <TIME_FORMAT>
           How to render timestamps in command output
@@ -289,14 +291,20 @@ metadata:    0
 
 <!-- cspell: enable -->
 
-Indexed reads use the summary index at the end of the file to fetch only the bytes they need, minimizing latency and data transfer. Commands that only need indexed data — such as `info`, `list`, and single-record `get` — work against remote files without any extra flags.
+Indexed reads use the summary index at the end of the file to fetch only the bytes they need, minimizing latency and data transfer. Commands that only need indexed data — such as `info`, `list`, single-record `get`, and indexed `filter` / `cat` of selected topics — work against remote files without any extra flags. They issue HTTP range requests (or equivalent object-store ranged reads) for the summary and for each selected chunk.
 
 #### Allowing full remote scans
 
-Some operations must read or download the entire remote file: commands that rewrite a file (`filter`, `merge`, `convert`, `recover`) and any command that falls back to a linear scan (for example a remote file with no summary section, a server that does not support range requests, or `cat` reading message payloads). These require the `--allow-remote-scan` flag to opt in to the larger transfer:
+Some operations still need an unbounded remote transfer: a linear scan of an unindexed file, a server that ignores `Range`, `convert` of a remote `.bag`/`.db3` (which must be spooled to a local path for sqlite), or `recover` of a remote input. These require the `--allow-remote-scan` flag:
 
 ```
-mcap filter --allow-remote-scan gs://your-remote-bucket/demo.mcap -o filtered.mcap -y /tf
+mcap filter --allow-remote-scan gs://your-remote-bucket/unindexed.mcap -o filtered.mcap -y /tf
+```
+
+Indexed topic filters on remote objects that support range requests do **not** need the flag:
+
+```
+mcap filter gs://your-remote-bucket/demo.mcap -o filtered.mcap -y /tf
 ```
 
 #### Credentials

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -70,11 +70,10 @@ Options:
           [possible values: auto, always, never]
 
       --allow-remote-scan
-          Allow unbounded remote transfer or a full linear scan of remote inputs.
+          Allow whole-file scans or downloads of remote inputs.
 
           Applies to http(s):// and object-store URLs (s3://, s3a://, gs://, az://, abfs://). Small
-          bounded indexed reads work without this flag. With this flag, commands may transfer an
-          entire remote object (via range requests or a full download) to scan or rewrite it.
+          bounded indexed reads work without this flag.
 
       --time-format <TIME_FORMAT>
           How to render timestamps in command output
@@ -291,20 +290,14 @@ metadata:    0
 
 <!-- cspell: enable -->
 
-Indexed reads use the summary index at the end of the file to fetch only the bytes they need, minimizing latency and data transfer. Commands that only need indexed data — such as `info`, `list`, single-record `get`, and indexed `filter` / `cat` of selected topics — work against remote files without any extra flags. They issue HTTP range requests (or equivalent object-store ranged reads) for the summary and for each selected chunk.
+Indexed reads use the summary index at the end of the file to fetch only the bytes they need, minimizing latency and data transfer. Commands that only need indexed data — such as `info`, `list`, and single-record `get` — work against remote files without any extra flags.
 
 #### Allowing full remote scans
 
-Some operations still need an unbounded remote transfer: a linear scan of an unindexed file, a server that ignores `Range`, `convert` of a remote `.bag`/`.db3` (which must be spooled to a local path for sqlite), or `recover` of a remote input. These require the `--allow-remote-scan` flag:
+Some operations must read or download the entire remote file: commands that rewrite a file (`filter`, `merge`, `convert`, `recover`) and any command that falls back to a linear scan (for example a remote file with no summary section, a server that does not support range requests, or `cat` reading message payloads). These require the `--allow-remote-scan` flag to opt in to the larger transfer:
 
 ```
-mcap filter --allow-remote-scan gs://your-remote-bucket/unindexed.mcap -o filtered.mcap -y /tf
-```
-
-Indexed topic filters on remote objects that support range requests do **not** need the flag:
-
-```
-mcap filter gs://your-remote-bucket/demo.mcap -o filtered.mcap -y /tf
+mcap filter --allow-remote-scan gs://your-remote-bucket/demo.mcap -o filtered.mcap -y /tf
 ```
 
 #### Credentials


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace mmap / whole-file loads in the Rust CLI with a `ByteSource` trait and sans-io drivers. Commands read through seek+read locally and HTTP range requests remotely.

## Changes

- Add `ByteSource` (`LocalFileSource`, `RemoteRangeSource`, test-only `MemorySource`) with `read_into` as the primary fill path
- Sans-io drivers: `read_header`, `read_summary`, `for_each_linear_record`, `service_indexed_chunk`
- Port rewrite, cat/info/list/get/du, doctor, and recover onto `ByteSource`
- Remove `memmap2`, `InputData`, and `RemoteMcap`
- Thin `add` path reads the file tail only
- Gate remote message-chunk reads behind `--allow-remote-scan` (`require_remote_scan_for_chunks`)
- Restore `MessageStream` / `ChannelAccumulator` rules on summaryless merge (`add_schema_record` / `add_channel_record`): reject schema id 0, conflicting schema/channel redefinitions, and unknown channels

## Out of scope (stacked follow-up on #1821)

- `AccessMode` / `SequentialSource` (stdin stream without tempfile; sequential remote spool)
- Local readahead buffer

## Test plan

- [x] `cargo clippy -p mcap-cli --bins --all-features -- -D warnings`
- [x] `cargo test -p mcap-cli --bins`
- [x] `cargo test -p mcap-cli --test cli`
- [x] Merge conflict-check unit tests (`merge_rejects_*` on summaryless input)
- [ ] CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e2d2a3f-13c7-4a87-a659-1d585dc289c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e2d2a3f-13c7-4a87-a659-1d585dc289c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

