### PR TITLE
typescript: forward optional read options through IReadable

### DIFF
--- a/typescript/core/src/CachedReadable.test.ts
+++ b/typescript/core/src/CachedReadable.test.ts
@@ -5,14 +5,18 @@ import type { IReadable } from "./types.ts";
  * Create a readable that simulates buffer reuse, like some IReadable implementations do.
  * Tracks read calls so tests can verify cache behavior.
  */
-function makeReadable(data: Uint8Array): IReadable & { reads: { offset: bigint; size: bigint }[] } {
+function makeReadable<TReadOptions = unknown>(
+  data: Uint8Array,
+): IReadable<TReadOptions> & {
+  reads: { offset: bigint; size: bigint; options?: TReadOptions }[];
+} {
   const reusableBuffer = new Uint8Array(data.byteLength);
-  const reads: { offset: bigint; size: bigint }[] = [];
+  const reads: { offset: bigint; size: bigint; options?: TReadOptions }[] = [];
   return {
     reads,
     size: async () => BigInt(data.byteLength),
-    read: async (offset, size) => {
-      reads.push({ offset, size });
+    read: async (offset, size, options) => {
+      reads.push({ offset, size, options });
       reusableBuffer.set(
         new Uint8Array(data.buffer, data.byteOffset + Number(offset), Number(size)),
       );
@@ -98,5 +102,15 @@ describe("CachedReadable", () => {
     expect(await cached.size()).toBe(16n);
     expect(await cached.size()).toBe(16n);
     expect(sizeCalls).toBe(1);
+  });
+
+  it("forwards read options to the underlying readable", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const readable = makeReadable(data);
+    const cached = new CachedReadable(readable, 1024);
+    const readOptions = { label: "test" };
+
+    await cached.read(0n, 4n, readOptions);
+    expect(readable.reads).toEqual([{ offset: 0n, size: 4n, options: readOptions }]);
   });
 });

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -1,9 +1,10 @@
 import type { IReadable } from "./types.ts";
 
 /**
- * Wraps an {@link IReadable} and caches the bytes returned from `read()` keyed by offset. Reads at
- * an offset that was previously cached return a subarray of the cached buffer instead of calling
- * the underlying readable.
+ * Wraps an {@link IReadable} and caches the bytes returned from `read()` keyed by offset. The
+ * `size` and `options` parameters of `read()` are not part of the cache key. Reads at an offset
+ * that was previously cached return a subarray of the cached buffer instead of calling the
+ * underlying readable.
  *
  * The cache is capped by `maxCacheSizeBytes`; once the cache is full, new reads pass through
  * without being cached. No eviction is performed.

--- a/typescript/core/src/CachedReadable.ts
+++ b/typescript/core/src/CachedReadable.ts
@@ -11,11 +11,11 @@ import type { IReadable } from "./types.ts";
  * Note: reads are cached by *exact* offset. A read that partially overlaps a cached range but
  * starts at a different offset will miss.
  */
-export class CachedReadable implements IReadable {
+export class CachedReadable<TReadOptions = unknown> implements IReadable<TReadOptions> {
   /**
    * The underlying source of the data to be cached.
    */
-  #readable: IReadable;
+  #readable: IReadable<TReadOptions>;
   /**
    * Cached data. Indexed by offset request and stored as a Uint8Array.
    * If the requested size is less than the cached data, the cached data is returned as a subarray.
@@ -35,7 +35,7 @@ export class CachedReadable implements IReadable {
    */
   #size: bigint | undefined;
 
-  constructor(readable: IReadable, maxCacheSizeBytes: number) {
+  constructor(readable: IReadable<TReadOptions>, maxCacheSizeBytes: number) {
     this.#readable = readable;
     this.#maxCacheSizeBytes = maxCacheSizeBytes;
   }
@@ -47,14 +47,14 @@ export class CachedReadable implements IReadable {
     return this.#size;
   }
 
-  async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+  async read(offset: bigint, size: bigint, options?: TReadOptions): Promise<Uint8Array> {
     const requestedSize = Number(size);
     const cached = this.#cache.get(offset);
     if (cached != undefined && cached.byteLength >= requestedSize) {
       return cached.byteLength === requestedSize ? cached : cached.subarray(0, requestedSize);
     }
 
-    const data = await this.#readable.read(offset, size);
+    const data = await this.#readable.read(offset, size, options);
 
     // The underlying readable is allowed to reuse its backing buffer across reads, so we must copy
     // the bytes before storing them in the cache.

--- a/typescript/core/src/ChunkCursor.ts
+++ b/typescript/core/src/ChunkCursor.ts
@@ -117,7 +117,10 @@ export class ChunkCursor {
     return this.#orderedMessageOffsets != undefined;
   }
 
-  async loadMessageIndexes(readable: IReadable): Promise<void> {
+  async loadMessageIndexes<TReadOptions>(
+    readable: IReadable<TReadOptions>,
+    readOptions?: TReadOptions,
+  ): Promise<void> {
     const reverse = this.#reverse;
     let messageIndexStartOffset: bigint | undefined;
     let relevantMessageIndexStartOffset: bigint | undefined;
@@ -146,6 +149,7 @@ export class ChunkCursor {
     const messageIndexes = await readable.read(
       relevantMessageIndexStartOffset,
       messageIndexEndOffset - relevantMessageIndexStartOffset,
+      readOptions,
     );
     const messageIndexesView = new DataView(
       messageIndexes.buffer,

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -1357,4 +1357,70 @@ describe("McapIndexedReader", () => {
     const reader = await McapIndexedReader.Initialize({ readable: makeReadable(builder.buffer) });
     await expect(collect(reader.readMessages())).resolves.toEqual([message1, message2]);
   });
+
+  it("passes readOptions to readable.read()", async () => {
+    const channel: TypedMcapRecord = {
+      type: "Channel",
+      id: 1,
+      schemaId: 0,
+      topic: "a",
+      messageEncoding: "utf12",
+      metadata: new Map(),
+    };
+    const message: TypedMcapRecords["Message"] = {
+      type: "Message",
+      channelId: channel.id,
+      sequence: 1,
+      logTime: 1n,
+      publishTime: 0n,
+      data: new Uint8Array(),
+    };
+
+    const chunk = new ChunkBuilder({ useMessageIndex: true });
+    chunk.addChannel(channel);
+    chunk.addMessage(message);
+
+    const builder = new McapRecordBuilder();
+    builder.writeMagic();
+    builder.writeHeader({ profile: "", library: "" });
+    const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
+      writeChunkWithMessageIndexes(builder, chunk),
+    ];
+    builder.writeDataEnd({ dataSectionCrc: 0 });
+
+    const summaryStart = BigInt(builder.length);
+    builder.writeChannel(channel);
+    for (const index of chunkIndexes) {
+      builder.writeChunkIndex(index);
+    }
+    builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
+    builder.writeMagic();
+
+    const receivedOptions: unknown[] = [];
+    const underlyingReadable = makeReadable(builder.buffer);
+    const recordingReadable = {
+      size: underlyingReadable.size.bind(underlyingReadable),
+      read: async (offset: bigint, size: bigint, options?: unknown) => {
+        receivedOptions.push(options);
+        return await underlyingReadable.read(offset, size);
+      },
+    };
+
+    const initializeOptions = { label: "init" };
+    const reader = await McapIndexedReader.Initialize({
+      readable: recordingReadable,
+      readOptions: initializeOptions,
+    });
+    expect(receivedOptions.length).toBeGreaterThan(0);
+    expect(receivedOptions.every((options) => options === initializeOptions)).toBe(true);
+
+    receivedOptions.length = 0;
+    const readMessagesOptions = { label: "messages" };
+    await expect(
+      collect(reader.readMessages({ readOptions: readMessagesOptions })),
+    ).resolves.toEqual([message]);
+    expect(receivedOptions.length).toBeGreaterThan(0);
+    expect(receivedOptions.every((options) => options === readMessagesOptions)).toBe(true);
+  });
+
 });

--- a/typescript/core/src/McapIndexedReader.test.ts
+++ b/typescript/core/src/McapIndexedReader.test.ts
@@ -1380,12 +1380,28 @@ describe("McapIndexedReader", () => {
     chunk.addChannel(channel);
     chunk.addMessage(message);
 
+    const metadata = {
+      name: "meta",
+      metadata: new Map([["k", "v"]]),
+    };
+    const attachment = {
+      name: "file",
+      logTime: 1n,
+      createTime: 2n,
+      mediaType: "text/plain",
+      data: new Uint8Array([1, 2, 3]),
+    };
+
     const builder = new McapRecordBuilder();
     builder.writeMagic();
     builder.writeHeader({ profile: "", library: "" });
     const chunkIndexes: TypedMcapRecords["ChunkIndex"][] = [
       writeChunkWithMessageIndexes(builder, chunk),
     ];
+    const metadataOffset = BigInt(builder.length);
+    const metadataLength = builder.writeMetadata(metadata);
+    const attachmentOffset = BigInt(builder.length);
+    const attachmentLength = builder.writeAttachment(attachment);
     builder.writeDataEnd({ dataSectionCrc: 0 });
 
     const summaryStart = BigInt(builder.length);
@@ -1393,6 +1409,20 @@ describe("McapIndexedReader", () => {
     for (const index of chunkIndexes) {
       builder.writeChunkIndex(index);
     }
+    builder.writeMetadataIndex({
+      offset: metadataOffset,
+      length: metadataLength,
+      name: metadata.name,
+    });
+    builder.writeAttachmentIndex({
+      offset: attachmentOffset,
+      length: attachmentLength,
+      logTime: attachment.logTime,
+      createTime: attachment.createTime,
+      dataSize: BigInt(attachment.data.byteLength),
+      name: attachment.name,
+      mediaType: attachment.mediaType,
+    });
     builder.writeFooter({ summaryStart, summaryOffsetStart: 0n, summaryCrc: 0 });
     builder.writeMagic();
 
@@ -1421,6 +1451,21 @@ describe("McapIndexedReader", () => {
     ).resolves.toEqual([message]);
     expect(receivedOptions.length).toBeGreaterThan(0);
     expect(receivedOptions.every((options) => options === readMessagesOptions)).toBe(true);
-  });
 
+    receivedOptions.length = 0;
+    const readMetadataOptions = { label: "metadata" };
+    await expect(
+      collect(reader.readMetadata({ readOptions: readMetadataOptions })),
+    ).resolves.toEqual([{ ...metadata, type: "Metadata" }]);
+    expect(receivedOptions.length).toBeGreaterThan(0);
+    expect(receivedOptions.every((options) => options === readMetadataOptions)).toBe(true);
+
+    receivedOptions.length = 0;
+    const readAttachmentsOptions = { label: "attachments" };
+    await expect(
+      collect(reader.readAttachments({ readOptions: readAttachmentsOptions })),
+    ).resolves.toEqual([{ ...attachment, type: "Attachment" }]);
+    expect(receivedOptions.length).toBeGreaterThan(0);
+    expect(receivedOptions.every((options) => options === readAttachmentsOptions)).toBe(true);
+  });
 });

--- a/typescript/core/src/McapIndexedReader.ts
+++ b/typescript/core/src/McapIndexedReader.ts
@@ -8,8 +8,8 @@ import { MCAP_MAGIC } from "./constants.ts";
 import { parseMagic, parseRecord } from "./parse.ts";
 import type { DecompressHandlers, IReadable, TypedMcapRecords } from "./types.ts";
 
-type McapIndexedReaderArgs = {
-  readable: IReadable;
+type McapIndexedReaderArgs<TReadOptions = unknown> = {
+  readable: IReadable<TReadOptions>;
   chunkIndexes: readonly TypedMcapRecords["ChunkIndex"][];
   attachmentIndexes: readonly TypedMcapRecords["AttachmentIndex"][];
   metadataIndexes: readonly TypedMcapRecords["MetadataIndex"][];
@@ -33,7 +33,7 @@ type McapIndexedReaderArgs = {
   messageIndexCacheSizeBytes?: number;
 };
 
-export class McapIndexedReader {
+export class McapIndexedReader<TReadOptions = unknown> {
   readonly chunkIndexes: readonly TypedMcapRecords["ChunkIndex"][];
   readonly attachmentIndexes: readonly TypedMcapRecords["AttachmentIndex"][];
   readonly metadataIndexes: readonly TypedMcapRecords["MetadataIndex"][] = [];
@@ -47,8 +47,8 @@ export class McapIndexedReader {
   readonly dataEndOffset: bigint;
   readonly dataSectionCrc?: number;
 
-  #readable: IReadable;
-  #messageIndexReadable: IReadable;
+  #readable: IReadable<TReadOptions>;
+  #messageIndexReadable: IReadable<TReadOptions>;
   #decompressHandlers?: DecompressHandlers;
 
   #messageStartTime: bigint | undefined;
@@ -56,7 +56,7 @@ export class McapIndexedReader {
   #attachmentStartTime: bigint | undefined;
   #attachmentEndTime: bigint | undefined;
 
-  private constructor(args: McapIndexedReaderArgs) {
+  private constructor(args: McapIndexedReaderArgs<TReadOptions>) {
     this.#readable = args.readable;
     this.chunkIndexes = args.chunkIndexes;
     this.attachmentIndexes = args.attachmentIndexes;
@@ -103,12 +103,13 @@ export class McapIndexedReader {
     return new Error(`${message} [library=${this.header.library}]`);
   }
 
-  static async Initialize({
+  static async Initialize<TReadOptions = unknown>({
     readable,
     decompressHandlers,
     messageIndexCacheSizeBytes,
+    readOptions,
   }: {
-    readable: IReadable;
+    readable: IReadable<TReadOptions>;
 
     /**
      * When a compressed chunk is encountered, the entry in `decompressHandlers` corresponding to the
@@ -124,7 +125,11 @@ export class McapIndexedReader {
      * that later queries against different channels can be served from the cache.
      */
     messageIndexCacheSizeBytes?: number;
-  }): Promise<McapIndexedReader> {
+    /**
+     * Opaque options passed to each `readable.read()` call during initialization.
+     */
+    readOptions?: TReadOptions;
+  }): Promise<McapIndexedReader<TReadOptions>> {
     const size = await readable.size();
 
     let header: TypedMcapRecords["Header"];
@@ -133,6 +138,7 @@ export class McapIndexedReader {
       const headerPrefix = await readable.read(
         0n,
         BigInt(MCAP_MAGIC.length + /* Opcode.HEADER */ 1 + /* record content length */ 8),
+        readOptions,
       );
       const headerPrefixView = new DataView(
         headerPrefix.buffer,
@@ -147,7 +153,11 @@ export class McapIndexedReader {
       const headerReadLength =
         /* Opcode.HEADER */ 1n + /* record content length */ 8n + headerContentLength;
 
-      const headerRecord = await readable.read(BigInt(MCAP_MAGIC.length), headerReadLength);
+      const headerRecord = await readable.read(
+        BigInt(MCAP_MAGIC.length),
+        headerReadLength,
+        readOptions,
+      );
       headerEndOffset = BigInt(MCAP_MAGIC.length) + headerReadLength;
       const headerReader = new Reader(
         new DataView(headerRecord.buffer, headerRecord.byteOffset, headerRecord.byteLength),
@@ -190,7 +200,7 @@ export class McapIndexedReader {
         throw errorWithLibrary(`File size (${size}) is too small to be valid MCAP`);
       }
       footerOffset = size - footerAndMagicReadLength;
-      const footerBuffer = await readable.read(footerOffset, footerAndMagicReadLength);
+      const footerBuffer = await readable.read(footerOffset, footerAndMagicReadLength, readOptions);
 
       footerAndMagicView = new DataView(
         footerBuffer.buffer,
@@ -260,6 +270,7 @@ export class McapIndexedReader {
     const dataEndAndSummarySection = await readable.read(
       dataEndOffset,
       footerOffset - dataEndOffset,
+      readOptions,
     );
     if (footer.summaryCrc !== 0) {
       let summaryCrc = crc32Init();
@@ -345,7 +356,7 @@ export class McapIndexedReader {
       throw errorWithLibrary(`${indexReader.bytesRemaining()} bytes remaining in index section`);
     }
 
-    return new McapIndexedReader({
+    return new McapIndexedReader<TReadOptions>({
       readable,
       chunkIndexes,
       attachmentIndexes,
@@ -370,6 +381,7 @@ export class McapIndexedReader {
       endTime?: bigint;
       reverse?: boolean;
       validateCrcs?: boolean;
+      readOptions?: TReadOptions;
     } = {},
   ): AsyncGenerator<TypedMcapRecords["Message"], void, void> {
     const {
@@ -378,6 +390,7 @@ export class McapIndexedReader {
       endTime = this.#messageEndTime,
       reverse = false,
       validateCrcs,
+      readOptions,
     } = args;
 
     if (startTime == undefined || endTime == undefined) {
@@ -425,7 +438,7 @@ export class McapIndexedReader {
     for (let cursor; (cursor = chunkCursors.peek()); ) {
       if (!cursor.hasMessageIndexes()) {
         // If we encounter a chunk whose message indexes have not been loaded yet, load them and re-organize the heap.
-        await cursor.loadMessageIndexes(this.#messageIndexReadable);
+        await cursor.loadMessageIndexes(this.#messageIndexReadable, readOptions);
         if (cursor.hasMoreMessages()) {
           chunkCursors.replace(cursor);
         } else {
@@ -438,6 +451,7 @@ export class McapIndexedReader {
       if (!chunkView) {
         chunkView = await this.#loadChunkData(cursor.chunkIndex, {
           validateCrcs: validateCrcs ?? true,
+          readOptions,
         });
         chunkViewCache.set(cursor.chunkIndex.chunkStartOffset, chunkView);
       }
@@ -483,15 +497,20 @@ export class McapIndexedReader {
   async *readMetadata(
     args: {
       name?: string;
+      readOptions?: TReadOptions;
     } = {},
   ): AsyncGenerator<TypedMcapRecords["Metadata"], void, void> {
-    const { name } = args;
+    const { name, readOptions } = args;
 
     for (const metadataIndex of this.metadataIndexes) {
       if (name != undefined && metadataIndex.name !== name) {
         continue;
       }
-      const metadataData = await this.#readable.read(metadataIndex.offset, metadataIndex.length);
+      const metadataData = await this.#readable.read(
+        metadataIndex.offset,
+        metadataIndex.length,
+        readOptions,
+      );
       const metadataReader = new Reader(
         new DataView(metadataData.buffer, metadataData.byteOffset, metadataData.byteLength),
       );
@@ -514,6 +533,7 @@ export class McapIndexedReader {
       startTime?: bigint;
       endTime?: bigint;
       validateCrcs?: boolean;
+      readOptions?: TReadOptions;
     } = {},
   ): AsyncGenerator<TypedMcapRecords["Attachment"], void, void> {
     const {
@@ -522,6 +542,7 @@ export class McapIndexedReader {
       startTime = this.#attachmentStartTime,
       endTime = this.#attachmentEndTime,
       validateCrcs,
+      readOptions,
     } = args;
 
     if (startTime == undefined || endTime == undefined) {
@@ -541,6 +562,7 @@ export class McapIndexedReader {
       const attachmentData = await this.#readable.read(
         attachmentIndex.offset,
         attachmentIndex.length,
+        readOptions,
       );
       const attachmentReader = new Reader(
         new DataView(attachmentData.buffer, attachmentData.byteOffset, attachmentData.byteLength),
@@ -559,11 +581,12 @@ export class McapIndexedReader {
 
   async #loadChunkData(
     chunkIndex: TypedMcapRecords["ChunkIndex"],
-    options?: { validateCrcs: boolean },
+    options?: { validateCrcs: boolean; readOptions?: TReadOptions },
   ): Promise<DataView> {
     const chunkData = await this.#readable.read(
       chunkIndex.chunkStartOffset,
       chunkIndex.chunkLength,
+      options?.readOptions,
     );
     const chunkReader = new Reader(
       new DataView(chunkData.buffer, chunkData.byteOffset, chunkData.byteLength),

--- a/typescript/core/src/McapWriter.ts
+++ b/typescript/core/src/McapWriter.ts
@@ -140,15 +140,18 @@ export class McapWriter {
    * call, however it does require an eventual call to `end()` to produce a properly indexed MCAP
    * file.
    */
-  static async InitializeForAppending(
-    readWrite: IReadable & ISeekableWriter,
-    options: Omit<McapWriterOptions, "writable" | "startChannelId">,
+  static async InitializeForAppending<TReadOptions = unknown>(
+    readWrite: IReadable<TReadOptions> & ISeekableWriter,
+    options: Omit<McapWriterOptions, "writable" | "startChannelId"> & {
+      readOptions?: TReadOptions;
+    },
   ): Promise<McapWriter> {
-    const reader = await McapIndexedReader.Initialize({ readable: readWrite });
+    const { readOptions, ...writerOptions } = options;
+    const reader = await McapIndexedReader.Initialize({ readable: readWrite, readOptions });
     await readWrite.seek(reader.dataEndOffset);
     await readWrite.truncate();
 
-    const writer = new McapWriter({ ...options, writable: readWrite });
+    const writer = new McapWriter({ ...writerOptions, writable: readWrite });
     writer.#appendMode = true;
     writer.#dataSectionCrc =
       // Invert the CRC value so we can continue updating it with new data; it will be inverted

--- a/typescript/core/src/types.ts
+++ b/typescript/core/src/types.ts
@@ -135,8 +135,11 @@ export type DecompressHandlers = {
 
 /**
  * IReadable describes a random-access reader interface.
+ *
+ * `TReadOptions` is an opaque value that the caller passes to each `read()` call.
+ * A custom implementation can use it for per-read data.
  */
-export interface IReadable {
+export interface IReadable<TReadOptions = unknown> {
   size(): Promise<bigint>;
-  read(offset: bigint, size: bigint): Promise<Uint8Array>;
+  read(offset: bigint, size: bigint, options?: TReadOptions): Promise<Uint8Array>;
 }


### PR DESCRIPTION
### Changelog
typescript: allow passing optional arguments to an IReadable implementation

### Docs
None

### Description
This PR extends `IReadable.read()` with an optional argument. Callers can pass extra context to a custom `IReadable`. One use case is to pass tracing information.

`McapIndexedReader` forwards the same value through `Initialize`, `readMessages`, `readMetadata`, and 

Example:

```ts
type ReadOptions = { tracingId: string };

class MyReadable implements IReadable<ReadOptions> {
  // ...

  async read(offset: bigint, size: bigint, options?: ReadOptions): Promise<Uint8Array> {
    console.log(options);
    // ...
  }
}

const readable = new MyReadable(/* ... */);
const reader = await McapIndexedReader.Initialize({ readable });

for await (const message of reader.readMessages({
  topics: ["foo"],
  readOptions: { tracingId: "abc123" },
})) {
  // ...
}
```
