### PR TITLE
typescript: bump core to 2.2.2

### DIFF
--- a/typescript/core/package.json
+++ b/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcap/core",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "MCAP file support in TypeScript",
   "license": "MIT",
   "repository": {

--- a/typescript/core/src/version.ts
+++ b/typescript/core/src/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = "2.2.1";
+export const VERSION = "2.2.2";
 export const LIBRARY_IDENTIFIER = `mcap-typescript/${VERSION}`;


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Bumps the typescript `@mcap/core` package to  version `2.2.2`.

Notable changes since the last release: 

- forward optional read options through IReadable (#1835)
- upgrade eslint to v9 (#1802)
- upgrade NPM dependencies (#1794)
- Standardize writer library strings (#1702)