### PR TITLE
rust: serialize summaries from ordered writer IDs

### DIFF
--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -1199,7 +1199,13 @@ impl<W: Write + Seek> Writer<W> {
             writer,
             &Record::DataEnd(records::DataEnd { data_section_crc }),
         )?;
-        write_summary_and_footer_magic(writer, &summary, &self.options)?;
+        write_summary_and_footer_magic(
+            writer,
+            &summary,
+            &self.all_schema_ids,
+            &self.all_channel_ids,
+            &self.options,
+        )?;
         Ok(summary)
     }
 
@@ -1293,39 +1299,10 @@ impl<W: Write + Seek> Drop for Writer<W> {
 fn write_summary_and_footer_magic<W: Write + Seek>(
     writer: &mut W,
     summary: &Summary,
+    schema_ids: &BTreeMap<u16, u16>,
+    channel_ids: &BTreeMap<u16, u16>,
     options: &WriteOptions,
 ) -> McapResult<()> {
-    let mut all_channels: Vec<_> = summary
-        .channels
-        .iter()
-        .map(|(&id, channel)| {
-            let schema_id = channel.schema.as_ref().map(|schema| schema.id).unwrap_or(0);
-            records::Channel {
-                id,
-                schema_id,
-                topic: channel.topic.clone(),
-                message_encoding: channel.message_encoding.clone(),
-                metadata: channel.metadata.clone(),
-            }
-        })
-        .collect();
-    // Summary uses HashMaps for fast lookup, so impose a stable order when serializing it.
-    all_channels.sort_unstable_by_key(|channel| channel.id);
-
-    let mut schemas: Vec<_> = summary.schemas.iter().collect();
-    schemas.sort_unstable_by_key(|(&id, _)| id);
-    let all_schemas: Vec<_> = schemas
-        .into_iter()
-        .map(|(&id, schema)| Record::Schema {
-            header: records::SchemaHeader {
-                id,
-                name: schema.name.clone(),
-                encoding: schema.encoding.clone(),
-            },
-            data: schema.data.clone(),
-        })
-        .collect();
-
     let summary_start = writer.stream_position()?;
     let summary_offset_start;
     // Let's get a CRC of the summary section.
@@ -1341,10 +1318,24 @@ fn write_summary_and_footer_magic<W: Write + Seek>(
     }
 
     // Write all schemas.
-    if options.repeat_schemas && !all_schemas.is_empty() {
+    if options.repeat_schemas && !schema_ids.is_empty() {
         let schemas_start: u64 = summary_start;
-        for schema in all_schemas.iter() {
-            write_record(&mut ccw, schema)?;
+        for &id in schema_ids.keys() {
+            let schema = summary
+                .schemas
+                .get(&id)
+                .expect("all schema IDs must be present in the summary");
+            write_record(
+                &mut ccw,
+                &Record::Schema {
+                    header: records::SchemaHeader {
+                        id,
+                        name: schema.name.clone(),
+                        encoding: schema.encoding.clone(),
+                    },
+                    data: schema.data.clone(),
+                },
+            )?;
         }
         summary_end = posit(&mut ccw)?;
         offsets.push(records::SummaryOffset {
@@ -1355,10 +1346,24 @@ fn write_summary_and_footer_magic<W: Write + Seek>(
     }
 
     // Write all channels.
-    if options.repeat_channels && !all_channels.is_empty() {
+    if options.repeat_channels && !channel_ids.is_empty() {
         let channels_start = summary_end;
-        for channel in all_channels {
-            write_record(&mut ccw, &Record::Channel(channel))?;
+        for &id in channel_ids.keys() {
+            let channel = summary
+                .channels
+                .get(&id)
+                .expect("all channel IDs must be present in the summary");
+            let schema_id = channel.schema.as_ref().map(|schema| schema.id).unwrap_or(0);
+            write_record(
+                &mut ccw,
+                &Record::Channel(records::Channel {
+                    id,
+                    schema_id,
+                    topic: channel.topic.clone(),
+                    message_encoding: channel.message_encoding.clone(),
+                    metadata: channel.metadata.clone(),
+                }),
+            )?;
         }
         summary_end = posit(&mut ccw)?;
         offsets.push(records::SummaryOffset {

--- a/rust/mcap/src/write.rs
+++ b/rust/mcap/src/write.rs
@@ -1295,7 +1295,7 @@ fn write_summary_and_footer_magic<W: Write + Seek>(
     summary: &Summary,
     options: &WriteOptions,
 ) -> McapResult<()> {
-    let all_channels: Vec<_> = summary
+    let mut all_channels: Vec<_> = summary
         .channels
         .iter()
         .map(|(&id, channel)| {
@@ -1309,9 +1309,13 @@ fn write_summary_and_footer_magic<W: Write + Seek>(
             }
         })
         .collect();
-    let all_schemas: Vec<_> = summary
-        .schemas
-        .iter()
+    // Summary uses HashMaps for fast lookup, so impose a stable order when serializing it.
+    all_channels.sort_unstable_by_key(|channel| channel.id);
+
+    let mut schemas: Vec<_> = summary.schemas.iter().collect();
+    schemas.sort_unstable_by_key(|(&id, _)| id);
+    let all_schemas: Vec<_> = schemas
+        .into_iter()
         .map(|(&id, schema)| Record::Schema {
             header: records::SchemaHeader {
                 id,
@@ -2047,6 +2051,43 @@ mod tests {
         assert!(summary.attachment_indexes.is_empty());
         assert!(summary.metadata_indexes.is_empty());
         assert_eq!(summary.chunk_indexes.len(), 1);
+    }
+
+    #[test]
+    fn summary_schemas_and_channels_are_sorted_by_id() {
+        let file = Cursor::new(Vec::new());
+        let mut writer = WriteOptions::new()
+            .use_chunks(false)
+            .create(file)
+            .expect("failed to construct writer");
+
+        for id in [8, 3, 13, 1, 5, 2, 11, 6, 4, 12, 7, 10, 9] {
+            writer
+                .add_schema_with_id(id, &format!("schema {id}"), "jsonschema", &[])
+                .expect("failed to add schema");
+            writer
+                .add_channel_with_id(id, id, &format!("topic {id}"), "json", &BTreeMap::new())
+                .expect("failed to add channel");
+        }
+
+        writer.finish().expect("failed to finish writer");
+        let data = writer.into_inner().into_inner();
+        let mut in_summary = false;
+        let mut schema_ids = Vec::new();
+        let mut channel_ids = Vec::new();
+
+        for record in LinearReader::new(&data).expect("failed to construct reader") {
+            match record.expect("failed to read record") {
+                Record::DataEnd(_) => in_summary = true,
+                Record::Schema { header, .. } if in_summary => schema_ids.push(header.id),
+                Record::Channel(channel) if in_summary => channel_ids.push(channel.id),
+                _ => {}
+            }
+        }
+
+        let expected_ids: Vec<_> = (1..=13).collect();
+        assert_eq!(schema_ids, expected_ids);
+        assert_eq!(channel_ids, expected_ids);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

- Rust: serialize repeated schema and channel records through the writer's existing ordered ID maps

### Description

This stacked patch includes and builds on #1837. It keeps the public `Summary` maps as `HashMap`s for constant-time lookup, but uses `Writer::all_schema_ids` and `Writer::all_channel_ids` as the serialization order. These maps are already `BTreeMap`s.

This removes the temporary vectors and sorting from the serialization path. Schema and channel records are constructed and written one at a time in numeric ID order, so cloned record data is bounded to one record at a time.

The #1837 head is on a contributor fork, so GitHub cannot use that head branch as this repository PR's base. Review commit `9b92b21e7` for only the follow-up change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2798035-420b-429f-a11a-7dc71117cebd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2798035-420b-429f-a11a-7dc71117cebd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

