### PR TITLE
python: add `Writer.flush()` to finish the open chunk on demand

### DIFF
--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -501,9 +501,8 @@ class Writer:
 
     def flush(self):
         """Finishes the chunk in progress, if any, and writes everything buffered so far to
-        the output stream -- the Python counterpart of the C++ writer's ``closeLastChunk()`` and
-        the TypeScript writer's ``flush()``. Call it on a timer to bound how many messages a
-        crash can lose regardless of ``chunk_size``; a chunk with no messages is not written.
+        the output stream. A chunk with no messages is not written. Compression works per
+        chunk, so flushing often reduces the compression ratio.
         """
         self.__finalize_chunk()
         self.__flush()

--- a/python/mcap/mcap/writer.py
+++ b/python/mcap/mcap/writer.py
@@ -499,6 +499,15 @@ class Writer:
         self.__chunk_indices.append(chunk_index)
         self.__chunk_builder.reset()
 
+    def flush(self):
+        """Finishes the chunk in progress, if any, and writes everything buffered so far to
+        the output stream -- the Python counterpart of the C++ writer's ``closeLastChunk()`` and
+        the TypeScript writer's ``flush()``. Call it on a timer to bound how many messages a
+        crash can lose regardless of ``chunk_size``; a chunk with no messages is not written.
+        """
+        self.__finalize_chunk()
+        self.__flush()
+
     def __maybe_finalize_chunk(self):
         if self.__chunk_builder and self.__chunk_builder.count > self.__chunk_size:
             self.__finalize_chunk()

--- a/python/mcap/tests/test_writer_flush.py
+++ b/python/mcap/tests/test_writer_flush.py
@@ -1,0 +1,52 @@
+from io import BytesIO
+
+from mcap.exceptions import EndOfFile
+from mcap.reader import make_reader
+from mcap.records import Message
+from mcap.stream_reader import StreamReader
+from mcap.writer import Writer
+
+
+def test_flush_finishes_the_open_chunk_without_reaching_chunk_size():
+    output = BytesIO()
+    writer = Writer(output, chunk_size=1024 * 1024)
+    writer.start()
+    schema_id = writer.register_schema(name="s", encoding="jsonschema", data=b"{}")
+    channel_id = writer.register_channel(
+        topic="/t", message_encoding="json", schema_id=schema_id
+    )
+    for i in range(10):
+        writer.add_message(channel_id, log_time=i, data=b"{}", publish_time=i)
+    before = len(output.getvalue())
+    writer.flush()
+    after = len(output.getvalue())
+    assert (
+        after > before
+    ), "flush() must write the open chunk even though chunk_size was not reached"
+    # The bytes written so far are a readable prefix: a crash after this point loses nothing
+    # of these ten messages. flush() writes no footer, so neither reader convenience class
+    # applies (both require one, to find the summary section or to know the stream ended) --
+    # read the low-level record stream directly and stop at the expected truncation.
+    prefix = StreamReader(BytesIO(output.getvalue()), emit_chunks=False)
+    messages = []
+    try:
+        for record in prefix.records:
+            if isinstance(record, Message):
+                messages.append(record)
+    except EndOfFile:
+        pass
+    assert len(messages) == 10
+    writer.finish()
+
+
+def test_flush_with_no_open_chunk_writes_no_chunk():
+    output = BytesIO()
+    writer = Writer(output)
+    writer.start()
+    before = len(output.getvalue())
+    writer.flush()
+    assert len(output.getvalue()) == before
+    writer.finish()
+    summary = make_reader(BytesIO(output.getvalue())).get_summary()
+    assert summary is not None and summary.statistics is not None
+    assert summary.statistics.chunk_count == 0


### PR DESCRIPTION
The Python `Writer` finalizes a chunk only when its size exceeds `chunk_size` (`__maybe_finalize_chunk`); there is no public way to close the chunk in progress. The C++ writer has `McapWriter::closeLastChunk()` and the TypeScript writer has `flush()` for exactly this — a recorder that wants large chunks for compression but a bounded crash-loss window calls it on a timer. This adds `Writer.flush()`: finish the open chunk if it holds any message, then write the buffered records to the stream. No behaviour changes for callers that never call it; `finish()` is unchanged. Two tests: `flush()` writes the open chunk below `chunk_size` and the written prefix is readable by a linear scan; `flush()` with no open chunk writes nothing.

Context: a companion-robot recorder (Python, pydantic messages as JSON channels) measured its crash-loss window as one chunk's fill time plus a 1 s file flush; with 64 KiB chunks at ~50 KB/s that is ≈ 2.4 s, and the alternative — 8 KiB chunks — doubles the file. `flush()` on the timer makes the window the timer alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
